### PR TITLE
Temporarily set Docusaurus to ignore broken links.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,8 @@ const config = {
   tagline: 'The developer-first MLOps platform',
   url: 'https://docs.wandb.ai/',
   baseUrl: '/',
-  onBrokenLinks: 'throw',
+  // onBrokenLinks: 'throw',
+  onBrokenLinks: 'ignore',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/docs-favicon.png',
 


### PR DESCRIPTION
Need to inspect some of the reference guide pages. This is the error showing up:

```
[ERROR] Unable to build website for locale en.
[ERROR] Error: Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /:
   -> linking to /docs/guides/intro

- On source page path = /ref/java/wandbrun:
   -> linking to ../../guides/track/log/ (resolved as: /guides/track/log/)

- On source page path = /ref/python/sweep:
   -> linking to wandb.ai/settings (resolved as: /ref/python/wandb.ai/settings)

- On source page path = /ref/weave/:
   -> linking to ../app/features/panels/weave (resolved as: /ref/app/features/panels/weave)
.
.
.
  
```