### PR TITLE
fix(integrations): remove hint to add `trainer/global_step` while logging image

### DIFF
--- a/docs/guides/integrations/lightning.md
+++ b/docs/guides/integrations/lightning.md
@@ -232,9 +232,7 @@ The `WandbLogger` has `log_image`, `log_text` and `log_table` methods for loggin
 
 You can also directly call `wandb.log` or `trainer.logger.experiment.log` to log other media types such as Audio, Molecules, Point Clouds, 3D Objects and more.
 
-:::info
-When using `wandb.log` or `trainer.logger.experiment.log` within your `trainer` make sure to also include`"global_step": trainer.global_step` in the dictionary being passed. That way, you can line up the information you're currently logging with information logged via other methods.
-:::
+
 
 <Tabs
   defaultValue="images"


### PR DESCRIPTION
This PR fixes an issue in the docs where we provide the hint to the user to add the `trainer/global_step` while logging media using the integrations' logger.


## Description
The issue was raised in the following slack thread.
https://weightsandbiases.slack.com/archives/C04B42ERP61/p1676278803251139

## Ticket
Does this PR fix an existing issue? If yes, provide a link to the ticket here:


## Checklist
Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply. 

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
