### PR TITLE
fix: Formatting and linting for Keras Reference docs

### DIFF
--- a/docs/ref/python/integrations/keras/wandbmetricslogger.md
+++ b/docs/ref/python/integrations/keras/wandbmetricslogger.md
@@ -10,10 +10,10 @@
 
 ```python
 WandbMetricsLogger(
- log_freq: Union[LogStrategy, int] = "epoch",
- initial_global_step: int = 0,
- \*args,
- **kwargs
+    log_freq: Union[LogStrategy, int] = "epoch",
+    initial_global_step: int = 0,
+    *args,
+    **kwargs
 ) -> None
 ```
 
@@ -22,9 +22,9 @@ WandbMetricsLogger(
 that callback methods take as argument to wandb.
 
 This callback automatically logs the following to a W&B run page:
-\* system (CPU/GPU/TPU) metrics,
-\* train and validation metrics defined in `model.compile`,
-\* learning rate (both for a fixed value or a learning rate scheduler)
+* system (CPU/GPU/TPU) metrics,
+* train and validation metrics defined in `model.compile`,
+* learning rate (both for a fixed value or a learning rate scheduler)
 
 #### Notes:
 
@@ -32,13 +32,14 @@ This callback automatically logs the following to a W&B run page:
 If you resume training by passing `initial_epoch` to `model.fit` and
 you are using a learning rate scheduler, make sure to pass
 `initial_global_step` to `WandbMetricsLogger`. The `initial_global_step`
-is `step_size \* initial_step`, where `step_size` is number of training
+is `step_size * initial_step`, where `step_size` is number of training
 steps per epoch. `step_size` can be calculated as the product of the
 cardinality of the training dataset and the batch size.
 
-| Arguments | |
+| Args | |
 | :--- | :--- |
-| log_freq ("epoch", "batch", or int): if "epoch", logs metrics at the end of each epoch. If "batch", logs metrics at the end of each batch. If an integer, logs metrics at the end of that many batches. Defaults to "epoch". initial_global_step (int): Use this argument to correcly log the learning rate when you resume training from some `initial_epoch`, and a learning rate scheduler is used. This can be computed as `step_size \* initial_step`. Defaults to 0. |
+| `log_freq` | ("epoch", "batch", or int) if "epoch", logs metrics at the end of each epoch. If "batch", logs metrics at the end of each batch. If an integer, logs metrics at the end of that many batches. Defaults to "epoch". |
+| `initial_global_step` | (int) Use this argument to correcly log the learning rate when you resume training from some `initial_epoch`, and a learning rate scheduler is used. This can be computed as `step_size * initial_step`. Defaults to 0. |
 
 
 
@@ -46,29 +47,16 @@ cardinality of the training dataset and the batch size.
 
 ### `set_model`
 
-
-
 ```python
 set_model(
- model
+    model
 )
 ```
-
-
-
 
 ### `set_params`
 
-
-
 ```python
 set_params(
- params
+    params
 )
 ```
-
-
-
-
-
-

--- a/docs/ref/python/integrations/keras/wandbmodelcheckpoint.md
+++ b/docs/ref/python/integrations/keras/wandbmodelcheckpoint.md
@@ -10,20 +10,18 @@
 
 ```python
 WandbModelCheckpoint(
- filepath: Union[str, os.PathLike],
- monitor: str = "val_loss",
- verbose: int = 0,
- save_best_only: bool = (False),
- save_weights_only: bool = (False),
- mode: Mode = "auto",
- save_freq: Union[SaveStrategy, int] = "epoch",
- options: Optional[str] = None,
- initial_value_threshold: Optional[float] = None,
- **kwargs
+    filepath: Union[str, os.PathLike],
+    monitor: str = "val_loss",
+    verbose: int = 0,
+    save_best_only: bool = (False),
+    save_weights_only: bool = (False),
+    mode: Mode = "auto",
+    save_freq: Union[SaveStrategy, int] = "epoch",
+    options: Optional[str] = None,
+    initial_value_threshold: Optional[float] = None,
+    **kwargs
 ) -> None
 ```
-
-
 
 and uploads it to W&B as a `wandb.Artifact`.
 
@@ -46,44 +44,32 @@ This callback provides the following features:
 
 | Arguments | |
 | :--- | :--- |
-| filepath (Union[str, os.PathLike]): path to save the model file. monitor (str): The metric name to monitor. verbose (int): Verbosity mode, 0 or 1. Mode 0 is silent, and mode 1 displays messages when the callback takes an action. save_best_only (bool): if `save_best_only=True`, it only saves when the model is considered the "best" and the latest best model according to the quantity monitored will not be overwritten. save_weights_only (bool): if True, then only the model's weights will be saved. mode (Mode): one of {'auto', 'min', 'max'}. For `val_acc`, this should be `max`, for `val_loss` this should be `min`, etc. save_weights_only (bool): if True, then only the model's weights will be saved save_freq (Union[SaveStrategy, int]): `epoch` or integer. When using `'epoch'`, the callback saves the model after each epoch. When using an integer, the callback saves the model at end of this many batches. Note that when monitoring validation metrics such as `val_acc` or `val_loss`, save_freq must be set to "epoch" as those metrics are only available at the end of an epoch. options (Optional[str]): Optional `tf.train.CheckpointOptions` object if `save_weights_only` is true or optional `tf.saved_model.SaveOptions` object if `save_weights_only` is false. initial_value_threshold (Optional[float]): Floating point initial "best" value of the metric to be monitored. |
-
-
-
-
-
-| Attributes | |
-| :--- | :--- |
-
+| `filepath` | (Union[str, os.PathLike]) path to save the model file. |
+| `monitor` | (str) The metric name to monitor. |
+| `verbose` | (int) Verbosity mode, 0 or 1. Mode 0 is silent, and mode 1 displays messages when the callback takes an action. |
+| `save_best_only` | (bool) if `save_best_only=True`, it only saves when the model is considered the "best" and the latest best model according to the quantity monitored will not be overwritten. |
+| `save_weights_only` | (bool) if True, then only the model's weights will be saved. |
+| `mode` | (Mode) one of {'auto', 'min', 'max'}. For `val_acc`, this should be `max`, for `val_loss` this should be `min`, etc. |
+| `save_weights_only` | (bool) if True, then only the model's weights will be saved. |
+| `save_freq` | (Union[SaveStrategy, int]) `epoch` or integer. When using `'epoch'`, the callback saves the model after each epoch. When using an integer, the callback saves the model at end of this many batches. Note that when monitoring validation metrics such as `val_acc` or `val_loss`, `save_freq` must be set to "epoch" as those metrics are only available at the end of an epoch. |
+| `options` | (Optional[str]) Optional `tf.train.CheckpointOptions` object if `save_weights_only` is true or optional `tf.saved_model.SaveOptions` object if `save_weights_only` is false. |
+| `initial_value_threshold` | (Optional[float]) Floating point initial "best" value of the metric to be monitored. |
 
 
 ## Methods
 
 ### `set_model`
 
-
-
 ```python
 set_model(
- model
+    model
 )
 ```
-
-
-
 
 ### `set_params`
 
-
-
 ```python
 set_params(
- params
+    params
 )
 ```
-
-
-
-
-
-


### PR DESCRIPTION
## Description
What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

This PR fixes the code formatting and linting. Making these changes because Keras is a top priority for growth integration push this quarter and would like to have clean documentation for whoever click on it.

Covers:

- `WandbEvalCallback`
- `WandbMetricsLogger`
- `WandbModelCheckpoint`

## Ticket
Does this PR fix an existing issue? If yes, provide a link to the ticket here:


## Checklist
Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply. 

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
