### PR TITLE
remove info on legacy callback

### DIFF
--- a/docs/guides/integrations/keras.md
+++ b/docs/guides/integrations/keras.md
@@ -2,14 +2,9 @@
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](http://wandb.me/intro-keras)
 
-:::info
-For  our legacy Keras `WandbCallback`, scroll down to the `WandbCallback` section.
-:::
-
-
 ## The Weights & Biases Keras Callbacks
 
-We have added three new callbacks for Keras and TensorFlow users, available from `wandb` v0.13.4
+We have added three new callbacks for Keras and TensorFlow users, available from `wandb` v0.13.4. For the legacy `WandbCallback` scroll down.
 
 ### Callbacks
 


### PR DESCRIPTION
## Description

This PR removes this:

<img width="625" alt="image" src="https://user-images.githubusercontent.com/31141479/230716151-f6d1ee8f-41b5-42cf-a28f-d364c6c2a629.png">


## Ticket
Does this PR fix an existing issue? If yes, provide a link to the ticket here:


## Checklist
Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply. 

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
