### PR TITLE
Mention other possible run/run queue item states

### DIFF
--- a/docs/guides/hosting/how-to-guides/basic-setup.md
+++ b/docs/guides/hosting/how-to-guides/basic-setup.md
@@ -59,7 +59,7 @@ You need a license to complete your configuration of a W&B server. [**Open the D
 ### Add a license to your Local host
 
 1. Copy your license from your Deployment and navigate back to your W&B server's localhost: ![](/images/hosting/add_license_local_host.png)
-2. Add it to your local settings by pasting it into the `/system-admin` page of your localhost:\
+2. Add it to your local settings by pasting it into the `/system-admin` page of your localhost:
    ![](@site/static/images/hosting/License.gif)
 
 ### Upgrades

--- a/docs/guides/launch/launch-jobs.md
+++ b/docs/guides/launch/launch-jobs.md
@@ -96,9 +96,11 @@ Find additional information about the jobs such as the:
 
 | Status | Description |
 | --- | --- |
-| **-- Idle** | The run is in a queue with no active agents. |
-| **Claimed** | The run has been picked up by an agent but has not yet started. |
+| **Idle** | The run is in a queue with no active agents. |
+| **Queued** | The run is in a queue waiting for an agent to process it. |
+| **Starting** | The run has been picked up by an agent but has not yet started. |
 | **Running** | The run is currently executing. |
 | **Killed** | The job was killed by the user. |
+| **Crashed** | The run stopped sending data or did not successfully start. |
 | **Failed** | The run ended with a non-zero exit code. |
 | **Finished** | The job completed successfully. |


### PR DESCRIPTION
## Description
A docs update corresponding to code change https://github.com/wandb/core/pull/14322
Mentions two additional states a user might see, "queued" and "crashed". A new state "starting" is added in the above PR and replaces (undocumented) internal ones from the user perspective.

The `--` on Idle is actually an icon, I don't think it should be included here.

The `hosting/how-to-guides/basic-setup.md` fixes a typo. (Unrelated to above)

## Checklist
Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply. 

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn build:prod`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
