### PR TITLE
Tensorboard integration workspace example was not showing integration

### DIFF
--- a/docs/guides/integrations/tensorboard.md
+++ b/docs/guides/integrations/tensorboard.md
@@ -24,7 +24,7 @@ wandb.init(project='my-project', sync_tensorboard=True)
 wandb.finish()
 ```
 
-[**See here for an example of Tensorboard hosted in Weights & Biases**](https://wandb.ai/morgan/tensorboard\_demo/runs/1grhu7uq/tensorboard)
+[**See here for an example of Tensorboard hosted in Weights & Biases**](https://wandb.ai/rymc/simple-tensorboard-example/runs/oab614zf/tensorboard)
 
 Once your wandb run finishes, your TensorBoard event files will then be uploaded to Weights & Biases. These metrics will **also be logged** in native Weights & Biases charts along with a host of useful information such as your machines CPU or GPU utilization, the git state, the terminal command used, and much more.
 


### PR DESCRIPTION
## Description

The tensorboard integration workspace example was not showing the integration in the linked workspace. This PR replaces the URL with one that demonstrates the integration.  

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn build:prod`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
