### PR TITLE
Mention markdown/diff mode in tables examples

### DIFF
--- a/docs/guides/data-vis/intro.md
+++ b/docs/guides/data-vis/intro.md
@@ -60,7 +60,7 @@ Interact with audio Tables in[ this report](https://wandb.ai/stacey/cshanty/repo
 
 ### Text
 
-Browse text samples from training data or generated output, dynamically group by relevant fields, and align your evaluation across model variants or experiment settings. Explore a simple character-based RNN for generating Shakespeare in [this report →](https://wandb.ai/stacey/nlg/reports/Visualize-Text-Data-Predictions--Vmlldzo1NzcwNzY)
+Browse text samples from training data or generated output, dynamically group by relevant fields, and align your evaluation across model variants or experiment settings. Render text as Markdown or use visual diff mode to compare texts. Explore a simple character-based RNN for generating Shakespeare in [this report →](https://wandb.ai/stacey/nlg/reports/Visualize-Text-Data-Predictions--Vmlldzo1NzcwNzY)
 
 ![Doubling the size of the hidden layer yields some more creative prompt completions.](@site/static/images/data_vis/shakesamples.png)
 


### PR DESCRIPTION
## Description

- [x] Mention markdown, diff capabilities in Text Tables section
- [x] (external) Update the associated [report](https://wandb.ai/stacey/nlg/reports/Visualize-Text-Data-Predictions--Vmlldzo1NzcwNzY) to exercise diff mode (see `response` column in various tables)

## Ticket

N/A

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
