### PR TITLE
[For London] Adds quick langchain docs section

### DIFF
--- a/docs/guides/integrations/langchain.md
+++ b/docs/guides/integrations/langchain.md
@@ -1,0 +1,10 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# LangChain
+
+[LangChain](https://python.langchain.com/) is a framework for developing applications powered by language models.
+
+## Using LangChain in Weights & Biases
+
+To use the Weights & Biases LangChain integration please see our [W&B Prompts Quickstart](../prompts/quickstart.md)

--- a/docs/guides/integrations/langchain.md
+++ b/docs/guides/integrations/langchain.md
@@ -8,3 +8,5 @@ import TabItem from '@theme/TabItem';
 ## Using LangChain in Weights & Biases
 
 To use the Weights & Biases LangChain integration please see our [W&B Prompts Quickstart](../prompts/quickstart.md)
+
+Or try our [Google Colab Jupyter notebook](http://wandb.me/prompts-quickstart)

--- a/sidebars.js
+++ b/sidebars.js
@@ -327,6 +327,7 @@ const sidebars = {
         'guides/integrations/other/hydra',
         'guides/integrations/keras',
         'guides/integrations/other/kubeflow-pipelines-kfp',
+        'guides/integrations/langchain',
         'guides/integrations/lightgbm',
         'guides/integrations/other/metaflow',
         'guides/integrations/mmdetection',


### PR DESCRIPTION
As our new W&B Prompts work is fairly LangChain dependent, we should have a placeholder LangChain section to maximise visibility of the LangChain integration - in case people come to the docs looking for it, and don't discover W&B Prompts.

The LangChain section in W&B Prompts gives enough guidance for someone to get started with W&B and LangChain.

We can fill out this section in more detail after London.

### Screenshot
<img width="1095" alt="Screenshot 2023-04-20 at 02 12 08" src="https://user-images.githubusercontent.com/20516801/233232256-8302a06d-89b7-496e-b86b-d535d5f403c6.png">

