### PR TITLE
changing relsize of monospace font from 95% to 85%

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,7 +16,7 @@
   --ifm-color-primary-light: #33925d;
   --ifm-color-primary-lighter: #359962;
   --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
+  --ifm-code-font-size: 85%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-hover-overlay: rgba(0, 150, 173, 0.1);
   --ifm-font-weight-semibold: 400;


### PR DESCRIPTION
## Description

Changing relative size of monospace fonts from 95% to 85%

## Ticket


## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
