### PR TITLE
fixing pr_curve example code

### DIFF
--- a/docs/guides/app/features/custom-charts/intro.md
+++ b/docs/guides/app/features/custom-charts/intro.md
@@ -135,7 +135,7 @@ plot = wandb.plot.pr_curve(
     ground_truth, predictions,
     labels=None, classes_to_plot=None)
     
-wandb.log({"pr":})
+wandb.log({"pr": plot})
 ```
 
 You can log this whenever your code has access to:


### PR DESCRIPTION
## Description

The example code provided for wandb.plot.pr_curve was broken. The wandb.log() statement was missing the created plot as the value. This PR fixes this. 

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
