### PR TITLE
Launch->SageMaker builds containers not customers

### DIFF
--- a/docs/guides/launch/sagemaker.md
+++ b/docs/guides/launch/sagemaker.md
@@ -64,7 +64,7 @@ environment:
 	region: <aws-region>  # E.g. us-east-2
 ```
 
-Any containers you want to run in SageMaker will need to be stored in your Elastic Container Registry (ECR). If you want your agent to build new customers and push them to ECR for you, you will need to add a `registry` block to your agent config.
+Any containers you want to run in SageMaker will need to be stored in your Elastic Container Registry (ECR). If you want your agent to build new containers and push them to ECR for you, you will need to add a `registry` block to your agent config.
 
 ```yaml
 registry:


### PR DESCRIPTION
## Description

This corrects a reference from building customers to containers in the Launch SageMaker docs.

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
