### PR TITLE
clarify that the metric is only required when using bayes

### DIFF
--- a/docs/guides/sweeps/define-sweep-configuration.md
+++ b/docs/guides/sweeps/define-sweep-configuration.md
@@ -31,7 +31,7 @@ The following code snippets demonstrate examples of how to define a Sweep config
 
 ```python
 sweep_configuration = {
-    'method': 'random',
+    'method': 'bayes',
     'name': 'sweep',
     'metric': {
         'goal': 'minimize', 
@@ -84,6 +84,8 @@ wandb.log({
         'val_loss': validation_loss
       })
 ```
+
+Defining the metric in the sweep configuration is only required when using the bayes method for the sweep. 
 
 ### Sweep configuration structure
 


### PR DESCRIPTION
## Description

This clarifies that the user only needs to specify the metric to optimise in the sweep configuration when using the bases method. It also changes the example configuration from random to bayes in the example as it includes the metric.

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
