### PR TITLE
Update Prompts docs for new LangChain usage pattern in wandb 0.15.2

### DIFF
--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -65,12 +65,15 @@ questions = [
 
 for question in questions:
   try:
-    answer = math_agent.run(question, callbacks=[WandbTracer(wandb_config)])
+    answer = math_agent.run(question, 
+                            callbacks=[WandbTracer(wandb_config)])
     print(answer)
   except Exception as e:
     print(e)
     pass
 ```
+
+If you had previously created a dictionary for your `wandb.init` arguments, you can pass it to `WandbTracer` here now as shown.
 
 Once the chain execution completes, any call to your LangChain object will be logged to the W&B Trace. 
 

--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -18,10 +18,10 @@ This Quickstart guide will walk you how to use [Trace](intro.md) to visualize an
 ## Use Trace with LangChain
 
 :::info
-**Versions**: Please ensure you're `langchain` package version is `0.0.158` or later and your `wandb` package version is `0.15.2` or later
+**Versions**: Ensure your `langchain` package version is `0.0.158` or later and that your `wandb` package version is `0.15.2` or later.
 :::
 
-With a simple callback, W&B Trace will continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
+W&B Trace will continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
 
 Follow the steps below to visualize and debug a LangChain chain. For this demo, we will use a LangChain Math agent.
 

--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -17,6 +17,10 @@ This Quickstart guide will walk you how to use [Trace](intro.md) to visualize an
 
 ## Use Trace with LangChain
 
+:::info
+**Versions**: Please ensure you're `langchain` package version is `0.0.158` or later and your `wandb` package version is `0.15.2` or later
+:::
+
 With one line of code W&B Trace will automatically and continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
 
 Follow the steps below to visualize and debug LangChain. For this demo, we will use a LangChain Math agent.
@@ -31,11 +35,11 @@ from wandb.integration.langchain import WandbTracer
 wandb_config = {"project": "wandb_prompts_quickstart"}
 ```
 
-You can optionally define a dictionary with arguments for `wandb.init()` that will later be passed to WandbTracer. This includes a project name, team name, entity, and more. For more information about [`wandb.init`](../../ref/python/init.md), see the API Reference Guide.
+You can optionally define a dictionary with arguments for `wandb.init()` that will later be passed to `WandbTracer`. This includes a project name, team name, entity, and more. For more information about [`wandb.init`](../../ref/python/init.md), see the API Reference Guide.
 
 
 ### 2. Set up your LangChain Agent
-Import an OpenAI Langchain Agent and create a math tool(function) with `load_tools`.  Next create a math agent with the [`initialize_agent`](https://python.langchain.com/en/latest/_modules/langchain/agents/initialize.html) method and pass the tool object to `initialize_agent`:
+Import an OpenAI model and create a math tool with `load_tools`. Next create a math agent with the [`initialize_agent`](https://python.langchain.com/en/latest/_modules/langchain/agents/initialize.html) method and pass the tool and model objects to `initialize_agent`:
 
 ```python
 from langchain.llms import OpenAI
@@ -46,9 +50,9 @@ tools = load_tools(["llm-math"], llm=llm)
 math_agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION)
 ```
 
-### 3. Pass `WandbTracer` as a callback
+### 3. Pass WandbTracer as a callback
 
-Passing `WandbTracer` to the agent's `callbacks` argument will enable every call made to the agent (in this example, `math_agent`) to be logged to Weights & Biases once the execution is complete.
+Pass `WandbTracer` to the agent's `callbacks` argument in the `.run` method. This will enable every call made to the agent (in this example, `math_agent`) to be logged to Weights & Biases once the execution is complete.
 
 The parameters used to create objects are also logged:
 
@@ -68,7 +72,7 @@ for question in questions:
     pass
 ```
 
-Once the chain execution completes, any call to your LangChain object is logged to the W&B Trace. 
+Once the chain execution completes, any call to your LangChain object will be logged to the W&B Trace. 
 
 ### 4. View the trace
 

--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -21,20 +21,18 @@ With one line of code W&B Trace will automatically and continuously log calls to
 
 Follow the steps below to visualize and debug LangChain. For this demo, we will use a LangChain Math agent.
 
-### 1. Import and initialize WandbTracer
+### 1. Import WandbTracer
 
-First, import `WandbTracer` from `wandb.integration.langchain`.  Then call the `init()` method to make W&B start watching for calls to LangChain Models, Chains, or Agents.
+First, import `WandbTracer` from `wandb.integration.langchain`.
 
 ```python
 from wandb.integration.langchain import WandbTracer
 
-WandbTracer.init({"project": "wandb_prompts"})
+wandb_config = {"project": "wandb_prompts_quickstart"}
 ```
 
-You can optionally pass a dictionary with argument that `wandb.init()` accepts to `WandbTracer.init`. This includes a project name, team name, entity, and more. For more information about [`wandb.init`](../../ref/python/init.md), see the API Reference Guide.
+You can optionally define a dictionary with arguments for `wandb.init()` that will later be passed to WandbTracer. This includes a project name, team name, entity, and more. For more information about [`wandb.init`](../../ref/python/init.md), see the API Reference Guide.
 
-
-Once the chain execution completes, any call to a LangChain object is logged automatically to the W&B Trace. 
 
 ### 2. Set up your LangChain Agent
 Import an OpenAI Langchain Agent and create a math tool(function) with `load_tools`.  Next create a math agent with the [`initialize_agent`](https://python.langchain.com/en/latest/_modules/langchain/agents/initialize.html) method and pass the tool object to `initialize_agent`:
@@ -48,9 +46,9 @@ tools = load_tools(["llm-math"], llm=llm)
 math_agent = initialize_agent(tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION)
 ```
 
-### 3. Make calls to your Agent
+### 3. Pass `WandbTracer` as a callback
 
-Every call made to the agent (in this example, `math_agent`) is logged once the execution is complete.
+Passing `WandbTracer` to the agent's `callbacks` argument will enable every call made to the agent (in this example, `math_agent`) to be logged to Weights & Biases once the execution is complete.
 
 The parameters used to create objects are also logged:
 
@@ -63,12 +61,14 @@ questions = [
 
 for question in questions:
   try:
-    answer = math_agent.run(question)
+    answer = math_agent.run(question, callbacks=[WandbTracer(wandb_config)])
     print(answer)
   except Exception as e:
     print(e)
     pass
 ```
+
+Once the chain execution completes, any call to your LangChain object is logged to the W&B Trace. 
 
 ### 4. View the trace
 

--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -21,9 +21,9 @@ This Quickstart guide will walk you how to use [Trace](intro.md) to visualize an
 **Versions**: Please ensure you're `langchain` package version is `0.0.158` or later and your `wandb` package version is `0.15.2` or later
 :::
 
-With one line of code W&B Trace will automatically and continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
+With a simple callback, W&B Trace will continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
 
-Follow the steps below to visualize and debug LangChain. For this demo, we will use a LangChain Math agent.
+Follow the steps below to visualize and debug a LangChain chain. For this demo, we will use a LangChain Math agent.
 
 ### 1. Import WandbTracer
 


### PR DESCRIPTION
## Updating docs to new usage patter
- Update LangChain section in Prompts quickstart for new usage pattern
- Add version warning to upgrade to 0.15.2 wandb and 0.0.155 LangChain

<img width="1116" alt="Screenshot 2023-05-05 at 19 04 39" src="https://user-images.githubusercontent.com/20516801/236534432-2e1631d0-74bc-4d32-adc3-59a9f2e8cf38.png">


<img width="1103" alt="Screenshot 2023-05-05 at 19 04 46" src="https://user-images.githubusercontent.com/20516801/236534443-9d6b9c20-fb65-43cd-93ec-bb51038231d3.png">
