### PR TITLE
fix: change configmap name in launch k8s docs

### DIFF
--- a/docs/guides/launch/kubernetes.md
+++ b/docs/guides/launch/kubernetes.md
@@ -202,7 +202,7 @@ Lastly, you will need to create a configmap in the `wandb` namespace that contai
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wandb-launch-agent-config
+  name: wandb-launch-configmap
   namespace: wandb
 data:
   launch-config.yaml: |


### PR DESCRIPTION
## Description

Fixes a variable name discrepancy in the launch k8s docs

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
