### PR TITLE
FIx construct-an-artifact.md table for adding multiple files

### DIFF
--- a/docs/guides/artifacts/construct-an-artifact.md
+++ b/docs/guides/artifacts/construct-an-artifact.md
@@ -158,7 +158,7 @@ The proceeding API calls produce the proceeding artifact content:
 | API Call                                    | Resulting artifact                                     |
 | ------------------------------------------- | ------------------------------------------------------ |
 | `artifact.add_dir('images')`                | <p><code>cat.png</code></p><p><code>dog.png</code></p> |
-| `artifact.add_dir('images', name='images')` | `name='images')images/cat.pngimages/dog.png`           |
+| `artifact.add_dir('images', name='images')` | <p><code>images/cat.png</code></p><p><code>images/dog.png</code></p> |
 | `artifact.new_file('hello.txt')`            | `hello.txt`                                            |
 
 ### Add a URI reference


### PR DESCRIPTION
https://docs.wandb.ai/guides/artifacts/construct-an-artifact#add-multiple-files

For the API call: artifact.add_dir('images', name='images'), the right column showed a strange output that looks to be a typo: name='images')images/cat.pngimages/dog.png

## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
