### PR TITLE
Fixed `wandb.Table.MAX_ROWS` in Log Tables section

### DIFF
--- a/docs/guides/track/log/log-tables.md
+++ b/docs/guides/track/log/log-tables.md
@@ -101,7 +101,7 @@ Each time a table is logged to the same key, a new version of the table is creat
 :::info
 To log more than 200,000 rows, you can override the limit with:
 
-`wandb.Table.MAX_ROWS = X`
+`wandb.Table.MAX_ARTIFACTS_ROWS = X`
 
 However, this would likely cause performance issues, such as slower queries, in the UI.
 :::


### PR DESCRIPTION
The variable that needs to be overriden to log more than 200,000 rows is `wandb.Table.MAX_ARTIFACT_ROWS` and not `wandb.Table.MAX_ROWS`. Confirmed by Tim [here](https://weightsandbiases.slack.com/archives/C01ECAXNRTL/p1684858808716539?thread_ts=1684807786.829949&cid=C01ECAXNRTL) 

## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
