### PR TITLE
Point to helm chart!

### DIFF
--- a/docs/guides/launch/kubernetes.md
+++ b/docs/guides/launch/kubernetes.md
@@ -92,13 +92,13 @@ spec:
 
 Before you can launch a run on k8s, you need to deploy an agent to your cluster.
 
-### Cluster configuration
-
-In order to run a launch agent in your cluster, you will need to create a few other resources in your cluster. Here, these are all laid out separately but the purpose of demonstration, but you can aggregate them into a single file and apply them all at once.
-
 :::tip
-You can find k8s manifests containing the resources below prepared for specific kubernetes services like EKS or GKE in our sdk repo [here](https://github.com/wandb/wandb/tree/main/wandb/sdk/launch/deploys).
+It is **strongly recommended** that you install the launch agent through the [official helm repository](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent). Consult the [`README.md` in the chart directory](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent/README.md) for detailed instructions on how to configure and deploy your agent.
 :::
+
+### Manual cluster configuration
+
+In order to run a launch agent in your cluster without the use of Helm, you will need to create a few other resources in your cluster. Here, these are all laid out separately but the purpose of demonstration, but you can aggregate them into a single file and apply them all at once.
 
 #### Namespace
 


### PR DESCRIPTION
## Description

We are now recommending anyone install the launch agent from our official helm chart. I'm modifying the k8s docs to point to this. I am keeping the old documentation for anyone who hates helm and wants a detailed guide to the required resources.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
