### PR TITLE
Updates Prompts, openai and lightning

### DIFF
--- a/docs/guides/integrations/lightning.md
+++ b/docs/guides/integrations/lightning.md
@@ -23,6 +23,10 @@ trainer = Trainer(logger=wandb_logger)
 
 ![Interactive dashboards accessible anywhere, and more!](@site/static/images/integrations/n6P7K4M.gif)
 
+:::info
+**Lightning's Trainer global_step:** Please note that the `WandbLogger` logs to W&B using the Trainer's `global_step`. If you are making additional calls to `wandb.log`, please pass the Trainer's `global_step` using the `step` argument: `wandb.log({"accuracy":0.7, step=current_global_step})
+:::
+
 ## Sign up and Log in to wandb
 
 a) [**Sign up**](https://wandb.ai/site) for a free account
@@ -261,7 +265,7 @@ wandb_logger.log_image(key="samples", images=["img_1.jpg", "img_2.jpg"])
 trainer.logger.experiment.log({
     "samples": [wandb.Image(img, caption=caption) 
     for (img, caption) in my_images]
-})
+}, step = current_trainer_global_step)
 ```
   </TabItem>
   <TabItem value="text">

--- a/docs/guides/integrations/other/openai.md
+++ b/docs/guides/integrations/other/openai.md
@@ -9,16 +9,22 @@ import TabItem from '@theme/TabItem';
 
 # OpenAI API
 
-:::info
-**Beta Integration**: This is a new feature, and we're actively working on making this better. Please reach out if you have any feedback — contact@wandb.com
-:::
+Weights & Biases has 2 OpenAI integrations
 
-OpenAI’s API gives practitioners access to GPT-4, an incredibly powerful natural language model that can be applied to virtually any task that involves understanding or generating natural language.
+1. **[OpenAI Python SDK API](#log-openai-api-calls-in-1-line-of-code):** Log requests, responses, token counts and model metadata with 1 line of code for all OpenAI models
+
+2. **[OpenAI GPT-3 Fine-tuning](#log-openai-fine-tunes-to-wb):** Log your GPT-3 fine-tuning metrics and configuration to Weights & Biases to analyse and understand the performance of your newly fine-tuned models. 
+
 
 ## Log OpenAI API calls in 1 line of code
+
+**[Try in a Colab Notebook here →](https://github.com/wandb/examples/blob/master/colabs/openai/OpenAI_API_Autologger_Quickstart.ipynb)**
+
 With just 1 line of code you can now automatically log inputs and outputs from the OpenAI Python SDK to Weights & Biases! 
 
 ![](/images/integrations/open_ai_autolog.png)
+
+Once you start logging your API inputs and outputs you can quickly evaluate the performance of difference prompts, compare different model settings (such as temperature), and track other usage metrics such as token usage.
 
 To get started, pip install the `wandb` library, then follow the steps below:
 
@@ -68,6 +74,9 @@ autolog.disable()
 
 Now your inputs and completions will be logged to Weights & Biases, ready for analysis or to be shared with colleagues.
 
+
+
+
 ## Log OpenAI fine-tunes to W&B
 
 If you use OpenAI's API to [fine-tune GPT-3](https://beta.openai.com/docs/guides/fine-tuning), you can now use the W&B integration to track experiments, models, and datasets in your central dashboard.
@@ -76,12 +85,12 @@ If you use OpenAI's API to [fine-tune GPT-3](https://beta.openai.com/docs/guides
 
 All it takes is one line: `openai wandb sync`
 
-## :sparkles: Check out interactive examples
+### :sparkles: Check out interactive examples
 
 * [Demo Colab](http://wandb.me/openai-colab)
 * [Report - GPT-3 Exploration and Fine-Tuning Tips](http://wandb.me/openai-report)
 
-## :tada: Sync your fine-tunes with one line!
+### :tada: Sync your fine-tunes with one line!
 
 Make sure you are using latest version of openai and wandb.
 
@@ -136,7 +145,7 @@ In addition your training and validation files are logged and versioned, as well
 
 ![](/images/integrations/open_ai_validation_files.png)
 
-## :gear: Optional arguments
+### :gear: Optional arguments
 
 | Argument                 | Description                                                                                                               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
@@ -147,7 +156,7 @@ In addition your training and validation files are logged and versioned, as well
 | --force                  | Forces logging and overwrite existing wandb run of the same fine-tune.                                                    |
 | \*\*kwargs\_wandb\_init  | In python, any additional argument is directly passed to [`wandb.init()`](../../../ref/python/init.md)                    |
 
-## 🔍 Inspect sample predictions
+### 🔍 Inspect sample predictions
 
 Use [Tables](../../data-vis/intro.md) to better visualize sample predictions and compare models.
 

--- a/docs/guides/prompts/intro.md
+++ b/docs/guides/prompts/intro.md
@@ -2,7 +2,7 @@
 slug: /guides/prompts
 description: Tools for the development of LLM-powered applications
 ---
-# Prompts
+# Prompts for LLMs
 
 Weights & Biases Prompts is a suite of LLMOps tools built for the development of LLM-powered applications.
 Use W&B Prompts to visualize and inspect the execution flow of your LLMs, analyze the inputs and outputs of your LLMs, view the intermediate results and securely store and manage your prompts and LLM chain configurations.
@@ -54,6 +54,13 @@ The Model Architecture view provides details about the structure of the chain an
 
 * If this is your first time using W&B Prompts, we recommend you go through the [Quickstart](./quickstart.md) guide.
 * Try our [Google Colab Jupyter notebook](http://wandb.me/prompts-quickstart) for an example of how.
+
+## More LLMs tools
+
+Weights and Biases also has lightweight integrations for:
+* [LangChain](../guides/integrations/langchain)
+* [OpenAI API](../guides/integrations/openai)
+* [Hugging Face Transformers](../guides/integrations/huggingface)
 
 <!-- Add link to colab -->
 

--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -2,7 +2,7 @@
 description: The Prompts Quickstart shows how to visualise and debug the execution flow of your LLM chains and pipelines
 ---
 
-# Quickstart
+# Prompts Quickstart
 
 [**Try in a Colab Notebook here →**](http://wandb.me/prompts-quickstart)
 
@@ -10,7 +10,7 @@ description: The Prompts Quickstart shows how to visualise and debug the executi
   <title>Prompts Quickstart</title>
 </head>
 
-This Quickstart guide will walk you how to use [Trace](intro.md) to visualize and debug calls to LangChain or any other LLM Chain.
+This Quickstart guide will walk you how to use [Trace](intro.md) to visualize and debug calls to LangChain or any other LLM Chain or Pipeline.
 
 <!-- This Quickstart guide will walk you how to use Weights & Biases (W&B) Prompts tools to visualise and debug the execution flow of your LLM chains or pipelines. -->
 
@@ -18,7 +18,9 @@ This Quickstart guide will walk you how to use [Trace](intro.md) to visualize an
 ## Use Trace with LangChain
 
 :::info
-**Versions**: Ensure your `langchain` package version is `0.0.158` or later and that your `wandb` package version is `0.15.2` or later.
+**Versions** Please use `wandb >= 0.15.3` and `langchain >= 0.0.188` when using `WandbTracer` 
+
+**LangChain:** Note that from `langchain >= 0.0.188` the W&B Prompts integration for LangChain can now be found in the `langchain` library. Please see the [LangChain documentation](https://python.langchain.com/en/latest/integrations/agent_with_wandb_tracing.html) for more.
 :::
 
 W&B Trace will continuously log calls to a [LangChain Model](https://python.langchain.com/en/latest/modules/models.html), [Chain](https://python.langchain.com/en/latest/modules/chains.html), or [Agent](https://python.langchain.com/en/latest/modules/agents.html).
@@ -109,9 +111,9 @@ First, create a span object. Import `trace_tree` from the `wandb.sdk.data_types`
 ```python
 from wandb.sdk.data_types import trace_tree
 
-# span = trace_tree.Span(name="Example Span")
-# Parent Span - Create a span for your high level agent
-agent_span = trace_tree.Span(name="Auto-GPT", span_kind = trace_tree.SpanKind.AGENT)
+# Root Span - Create a span for your high level agent
+root_span = trace_tree.Span(name="Auto-GPT", 
+  span_kind = trace_tree.SpanKind.AGENT)
 ```
 
 Spans can be of type `AGENT`, `CHAIN`, `TOOL` or `LLM`
@@ -135,15 +137,16 @@ llm_span = trace_tree.Span(
 )
 
 chain_span.add_child_span(llm_span)
-agent_span.add_child_span(tool_span)
-agent_span.add_child_span(chain_span)
+root_span.add_child_span(tool_span)
+root_span.add_child_span(chain_span)
 ```
 
 ### 3. Add the inputs and outputs
 
-Populate spans with the input and output data. The following code 
+Populate spans with the input and output data as well as any metadata: 
 
 ```python
+# add the Inputs and Outputs to the span as dictionaries
 tool_span.add_named_result(
   {"input": "search: google founded in year"}, 
   {"response": "1998"}
@@ -157,27 +160,48 @@ chain_span.add_named_result(
 llm_span.add_named_result(
   {"system": "you are a helpful assistant", 
     "input": "calculate: 2023 - 1998"}, 
-  {"response": "25", "tokens_used": 218}
+  {"response": "25"}
 )
 
-agent_span.add_named_result(
+root_span.add_named_result(
   {"user": "How old is google?"},
   {"response": "25 years old"}
 )
 ```
 
-### 4. Log the spans to W&B Trace 
+### 4. Add metadata, status, start and end time to a Span
 
-Log your span to W&B with the run.log() method. W&B will create a Trace Table, Trace Timeline, and Model Architecture for you to view in the W&B App UI.
+Any span can also have metadata, status, status messages, start and end timestamps:
+
+```python
+# add metadata to the span using .attributes
+tokens_used = 284
+llm_span.attributes = {"token_usage": tokens_used}
+
+# often you want to add the same metadata to different spans
+root_span.attributes = {"token_usage": tokens_used}
+
+# add a status code and any message to any span
+root_span.status_code = trace_tree.StatusCode.ERROR  # or SUCCESS
+root_span.status_message = "Error: there was an error"
+
+# add the start and end timestamp for any span, in milliseconds 
+root_span.start_time_ms = 1685649600011
+root_span.end_time_ms = 1685649611000
+```
+
+### 5. Log the spans to W&B Trace 
+
+Log your span to W&B with the run.log() method. W&B will create a Trace Table and Trace Timeline for you to view in the W&B App UI.
 
 
 ```python
 import wandb 
 
-trace = trace_tree.WBTraceTree(agent_span)
+trace = trace_tree.WBTraceTree(root_span)
 run = wandb.init(project="wandb_prompts")
 run.log({"trace": trace})
 run.finish()
 ```
-### 5. View the trace
+### 6. View the trace
 Click on the W&B run link that is generated to see the trace of your LLM on the W&B App UI.


### PR DESCRIPTION
Added
- Prompts: renamed Prompts page
- Prompts: Warning that the LangChain integration has moved to LangChain
- Prompts: Added more detail to the low-level Tracer api example
- Prompts: Added list of other relevant LLM integrations
- OpenAI: Improve the docs and added a colab link
- Lightning: Added a warning about using wandb.log and the need to pass the correct step argument

Tested with `yarn start` 

## Screenshots

<img width="662" alt="Screenshot 2023-06-01 at 22 37 57"
 src="https://github.com/wandb/docodile/assets/20516801/45f78177-438e-40a7-9033-203c13184764">


<img width="752" alt="Screenshot 2023-06-01 at 22 38 10" src="https://github.com/wandb/docodile/assets/20516801/cb33c763-8739-4e83-82a9-1a905f7f64ed">


<img width="842" alt="Screenshot 2023-06-01 at 22 37 36" src="https://github.com/wandb/docodile/assets/20516801/428d11d5-5fe4-4ef3-88bb-eb4784e9e9ac">


<img width="620" alt="Screenshot 2023-06-01 at 22 38 59" src="https://github.com/wandb/docodile/assets/20516801/aae9e914-4451-4934-9180-bb112538560e">
