### PR TITLE
Lighting warning when using wandb.log

### DIFF
--- a/docs/guides/integrations/lightning.md
+++ b/docs/guides/integrations/lightning.md
@@ -28,7 +28,7 @@ trainer = Trainer(logger=wandb_logger)
 
 Instead, log the Trainer's `global_step` like your other metrics, like so:
 
-`wandb.log({"accuracy":0.99, "trainer/global_step": step}`
+`wandb.log({"accuracy":0.99, "trainer/global_step": step})`
 :::
 
 ## Sign up and Log in to wandb

--- a/docs/guides/integrations/lightning.md
+++ b/docs/guides/integrations/lightning.md
@@ -24,7 +24,11 @@ trainer = Trainer(logger=wandb_logger)
 ![Interactive dashboards accessible anywhere, and more!](@site/static/images/integrations/n6P7K4M.gif)
 
 :::info
-**Lightning's Trainer global_step:** Please note that the `WandbLogger` logs to W&B using the Trainer's `global_step`. If you are making additional calls to `wandb.log`, please pass the Trainer's `global_step` using the `step` argument: `wandb.log({"accuracy":0.7, step=current_global_step})
+**Using wandb.log():** Please note that the `WandbLogger` logs to W&B using the Trainer's `global_step`. If you are making additional calls to `wandb.log` directly in your code, **do not** use the `step` argument in `wandb.log()`. 
+
+Instead, log the Trainer's `global_step` like your other metrics, like so:
+
+`wandb.log({"accuracy":0.99, "trainer/global_step": step}`
 :::
 
 ## Sign up and Log in to wandb


### PR DESCRIPTION
Added a warning in PyTorch Lightning not to pass a step argument to wandb.log

<img width="633" alt="Screenshot 2023-06-01 at 23 29 03" src="https://github.com/wandb/docodile/assets/20516801/5640424f-9cc1-4dff-894b-632265340625">
