### PR TITLE
Fix incomplete sentences in models/access_controls.md

### DIFF
--- a/docs/guides/models/access_controls.md
+++ b/docs/guides/models/access_controls.md
@@ -12,8 +12,9 @@ For example, you could set the aliases `staging` and `production` as Protected A
 
 ## Features
 The access controls add two new features:
-1. **Model Registry Admins**: Give members of your team admin permissions for the model registry. These admins can define and use protected aliases.
-2. **Protected Aliases**: A protected alias such as 
+1. **Model Registry Admins**: Give specific members of your team admin permissions for the model registry. These admins can define and use protected aliases, and non-admins will be blocked from adding and removing protected aliases from model versions (both in the UI and programatically).
+2. **Protected Aliases**: Define a list of aliases that only admins can manage. For example, you might use the **production** alias to indicate a model being deployed, and only a few members of your team should be able to make that decision.
+ 
 
 
 ## How to set up access control


### PR DESCRIPTION
## Description

Completed an unfinished sentence inside Model Reg RBAC [guide](https://docs.wandb.ai/guides/models/access_controls#features):

![image (14)](https://github.com/wandb/docodile/assets/40642416/98c1d8fd-9294-4d8d-8845-7068debc59f2)

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
