### PR TITLE
Fix metrics averaged time

### DIFF
--- a/docs/guides/technical-faq/metrics-and-performance.md
+++ b/docs/guides/technical-faq/metrics-and-performance.md
@@ -8,7 +8,7 @@ displayed_sidebar: default
 
 ### How often are system metrics collected?
 
-By default, metrics are collected every 2 seconds and averaged over a 30-second period. If you need higher resolution metrics, email us a [contact@wandb.com](mailto:contact@wandb.com).
+By default, metrics are collected every 2 seconds and averaged over a 15-second period. If you need higher resolution metrics, email us a [contact@wandb.com](mailto:contact@wandb.com).
 
 ### Can I just log metrics, no code or dataset examples?
 


### PR DESCRIPTION
Metrics are averaged every 15 seconds rather than 30 (code [here](https://github.com/wandb/wandb/blob/c2c594f61d964d516314cf0099fbed3800436936/wandb/sdk/wandb_settings.py#L680))

## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
