### PR TITLE
Added note about launch queues and jobs needing same entity

### DIFF
--- a/docs/guides/launch/create-job.md
+++ b/docs/guides/launch/create-job.md
@@ -18,7 +18,7 @@ Once you have one or more jobs created, you can add them to a [launch queue](./c
 
 
 :::tip
-Similar to [launch queues](./create-job.md), a launch job belongs to a W&B entity. Both the launch queue and the jobs you want to enqueue must belong to the same W&B entity.
+Similar to [launch queues](./create-queue.md), a launch job belongs to a W&B entity. Both the launch queue and the jobs you want to enqueue must belong to the same W&B entity.
 :::
 
 

--- a/docs/guides/launch/create-job.md
+++ b/docs/guides/launch/create-job.md
@@ -7,11 +7,22 @@ import TabItem from '@theme/TabItem';
 
 # Create a job
 
-A job is a complete blueprint of how to perform a step in your ML workflow, like training a model, running an evaluation, or deploying a model to an inference server. For more information, see the [details of launched jobs section](launch-jobs.md#view-details-of-launched-jobs).
+A job is a complete blueprint of how to perform a step in your ML workflow, like training a model, running an evaluation, or deploying a model to an inference server. Each job contains contextual information about the run it is being created from, including the source code, entrypoint, software dependencies, hyperparameters, dataset version, and so on.
+
 
 :::info
 `wandb>=0.13.8` is required in order to create jobs.
 :::
+
+Once you have one or more jobs created, you can add them to a [launch queue](./create-queue.md). W&B will then execute your jobs based on your queue configuration. See the [Launch a job](./launch-jobs.md) section for information on how to add jobs to your queue.
+
+
+:::tip
+Similar to [launch queues](./create-job.md), a launch job belongs to a W&B entity. Both the launch queue and the jobs you want to enqueue must belong to the same W&B entity.
+:::
+
+
+
 
 ## How do I create a job?
 
@@ -84,7 +95,7 @@ By default, W&B automatically creates a job name for you. The name is generated 
 :::note
 For docker image jobs, the image tag is automatically added as an alias to the job.
 :::
-## Making your code job-friendly
+## Make your code job-friendly
 
 Jobs are parameterized by the values in your `wandb.config`. When your job is executed and `wandb.init` is called, your `wandb.config` will be populated with the values specified for this run. This means it's important that you use the `wandb.config` to store and access all of the parameters that you want to be able to vary between runs.
 

--- a/docs/guides/launch/create-queue.md
+++ b/docs/guides/launch/create-queue.md
@@ -5,20 +5,30 @@ displayed_sidebar: default
 
 # Create a queue
 
-**Launch queues** are first-in, first-out (FIFO) queues where users can configure and submit their jobs to be executed by any polling launch agents. Each item in a launch queue consists of a job and settings for the parameters of that job. Launch queues are owned by either a W&B or W&B Team. Follow this guide to learn how to create and configure a launch queue.
+**Launch queues** are first-in, first-out (FIFO) configurable queues you can submit your jobs to. The jobs are then executed by any polling launch agents. Each item in a launch queue consists of a job and settings for the parameters of that job.  
+
+:::tip
+Similar to [launch jobs](./create-job.md), a launch queue belongs to a W&B entity. Both the launch queue and the jobs you want to enqueue must belong to the same W&B entity.
+:::
+
+
+Follow this guide to learn how to create, configure, and view launch queues.
 
 ## Create a queue
 
-Navigate to [wandb.ai/launch](https://wandb.ai/launch). Click **create queue** button in the top right of the screen to start creating a new launch queue.
+1. Navigate to [wandb.ai/launch](https://wandb.ai/launch). 
+2. Click **create queue** button in the top right of the screen to start creating a new launch queue.
 
 When you click the button, a drawer will slide from the right side of your screen and present you with some options for your new queue:
 
-* **Entity**: the owner of the queue, which can either be your W&B account or any W&B team you are a member of. For this tutorial, we recommend setting up a personal queue.
-* **Queue name**: the name of the queue. Make this whatever you want!
+* **Entity**: the owner of the queue. The entity can either be your W&B account or any W&B team you are a member of.
+* **Queue name**: the name of the queue. 
 * **Resource**: the compute resource type for jobs in this queue.
 * **Configuration**: default resource configurations for all jobs placed on this queue. Used to configure the compute resources that any job in this queue will run on. These defaults can be overridden when you enqueue a job.
 
 ![](/images/launch/create-queue.gif)
+
+3. Select **Create queue** to create the queue.
 
 ## Queue configuration
 

--- a/docs/guides/launch/launch-jobs.md
+++ b/docs/guides/launch/launch-jobs.md
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 Use W&B launch to queue jobs for execution by a launch agent. The following guide demonstrates how to submit runs to a queue.
 
+:::tip
+Both the launch queue and the jobs you want to enqueue must belong to the same W&B entity.
+:::
+
 ## Add jobs to your queue
 Add jobs to your queue interactively with the W&B App or programmatically with the CLI.
 


### PR DESCRIPTION
## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.
We’ve seen repeated user errors where they try to push jobs created with one entity (team, for most users) to queues owned by another team.  We could reduce this by adding sections to the docs in the Launch a run [sic?] and Create a queue sections.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here: https://wandb.atlassian.net/browse/DOCS-677?atlOrigin=eyJpIjoiZTI4NzIwYTIyNTJjNDg5ZGI1ZDViYzJhMzY0N2MyMzgiLCJwIjoiaiJ9

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
