### PR TITLE
fix spacing for w&b

### DIFF
--- a/src/components/CTAButtons/CTAButtons.tsx
+++ b/src/components/CTAButtons/CTAButtons.tsx
@@ -36,7 +36,7 @@ const buttonProps = {
 
 const content = {
     colab: 'Try in Colab',
-    product: 'Try in W & B',
+    product: 'Try in W&B',
     github: 'Try the code',
     event: 'Docs button clicked'
 }


### PR DESCRIPTION
## Description

Corrects the spacing for the W&B cta buttons to align with brand guidlines

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
