### PR TITLE
replacing RunSet with Runset in reports api edit report

### DIFF
--- a/docs/guides/reports/edit-a-report.md
+++ b/docs/guides/reports/edit-a-report.md
@@ -97,9 +97,9 @@ Enter a forward slash (`/`) in the report to display a dropdown menu. From the d
   </TabItem>
   <TabItem value="sdk">
 
-Add run sets from projects with the `wr.RunSet()` and `wr.PanelGrid` Classes. The proceeding procedure describes how to add a runset:
+Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. The proceeding procedure describes how to add a runset:
 
-1. Create a `wr.RunSet()` object instance. Provide the name of the project that contains the runsets for the project parameter and the entity that owns the project for the entity parameter.
+1. Create a `wr.Runset()` object instance. Provide the name of the project that contains the runsets for the project parameter and the entity that owns the project for the entity parameter.
 2. Create a `wr.PanelGrid()` object instance. Pass a list of one or more runset objects to the `runsets` parameter.
 3. Store one or more `wr.PanelGrid()` object instances in a list.
 4. Update the report instance blocks attribute with the list of panel grid instances.
@@ -115,7 +115,7 @@ report = wr.Report(
 )
 
 panel_grids = wr.PanelGrid(
-    runsets=[wr.RunSet(project='<project-name>', entity='<entity-name>')]
+    runsets=[wr.Runset(project='<project-name>', entity='<entity-name>')]
 )
 
 report.blocks = [panel_grids]
@@ -174,7 +174,7 @@ panel_grids = wr.PanelGrid(
                 regression=True,
             )
 				],
-	runsets=[wr.RunSet(project='<project-name>', entity='<entity-name>')]
+	runsets=[wr.Runset(project='<project-name>', entity='<entity-name>')]
 		)
 
 report.blocks = [panel_grids]

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/reports/edit-a-report.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/reports/edit-a-report.md
@@ -94,9 +94,9 @@ App UIまたはWeights & Biases SDKを使って、プロジェクトからイン
   </TabItem>
   <TabItem value="sdk">
 
-`wr.RunSet()` および `wr.PanelGrid` クラスを使用して、プロジェクトからランセットを追加します。以下の手順でランセットを追加する方法を説明します。
+`wr.Runset()` および `wr.PanelGrid` クラスを使用して、プロジェクトからランセットを追加します。以下の手順でランセットを追加する方法を説明します。
 
-1. `wr.RunSet()` オブジェクトのインスタンスを作成します。プロジェクトパラメータにランセットが含まれるプロジェクトの名前を指定し、エンティティパラメータにプロジェクトの所有者であるエンティティを指定します。
+1. `wr.Runset()` オブジェクトのインスタンスを作成します。プロジェクトパラメータにランセットが含まれるプロジェクトの名前を指定し、エンティティパラメータにプロジェクトの所有者であるエンティティを指定します。
 2. `wr.PanelGrid()` オブジェクトのインスタンスを作成します。`runsets` パラメータに1つ以上のランセットオブジェクトのリストを渡します。
 3. 1つ以上の `wr.PanelGrid()` オブジェクトのインスタンスをリストに格納します。
 4. リスト内のパネルグリッドインスタンスでレポートインスタンスのブロック属性を更新します。
@@ -112,7 +112,7 @@ import wandb.apis.reports as wr
 )
 
 panel_grids = wr.PanelGrid(
-    runsets=[wr.RunSet(project='<プロジェクト名>', entity='<エンティティ名>')]
+    runsets=[wr.Runset(project='<プロジェクト名>', entity='<エンティティ名>')]
 )
 
 report.blocks = [panel_grids]
@@ -171,7 +171,7 @@ panel_grids = wr.PanelGrid(
                 regression=True,
             )
 				],
-	runsets=[wr.RunSet(project='<プロジェクト名>', entity='<エンティティ名>')]
+	runsets=[wr.Runset(project='<プロジェクト名>', entity='<エンティティ名>')]
 		)
 
 report.blocks = [panel_grids]


### PR DESCRIPTION
## Description


Changed RusSet to Runset in reports code blocks and commentary in docs [edit-a-report.md] in docs  local development server -- a user was copying code and getting attribute error as the python class attribute is .Runset rather than .RunSet see SDK code [here](https://github.com/wandb/wandb/blob/8cd312cf11072f04ebd0a318e6232a786c0c4f94/wandb/apis/reports/runset.py#L10C8-L10C8) 

We have a couple of typos (RunSet) in [edit-a-report.md](https://github.com/wandb/docodile/blob/main/docs/guides/reports/edit-a-report.md) These typos are fixed by PR. Where the typos exist in code blocks they are causing code examples to crash -- a user from Adobe was working through docs and running into this. 






Not testing in  local development server as these are minor changes. 


## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
