### PR TITLE
fix(docs): Docs reflect that log_code with wandb-path prefix bug fixed

### DIFF
--- a/docs/guides/launch/create-job.md
+++ b/docs/guides/launch/create-job.md
@@ -57,7 +57,7 @@ run = wandb.init()
 run.log_code(".", include_fn=lambda path: path.endswith(".py"))
 ```
 :::note
-By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories. (`<project_root>/.wandb` and `<project_root/wandb`)
+By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories: `<project_root>/.wandb` and `<project_root>/wandb`
 :::
 </TabItem>
 

--- a/docs/guides/launch/create-job.md
+++ b/docs/guides/launch/create-job.md
@@ -57,7 +57,7 @@ run = wandb.init()
 run.log_code(".", include_fn=lambda path: path.endswith(".py"))
 ```
 :::note
-Ensure that `wandb` is not in the path to the created file. This will prevent a code artifact from being created, and therefore a job from being created.
+By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories. (`<project_root>/.wandb` and `<project_root/wandb`)
 :::
 </TabItem>
 

--- a/docs/guides/launch/walkthrough.md
+++ b/docs/guides/launch/walkthrough.md
@@ -42,7 +42,7 @@ with wandb.init(config=config, project="launch-quickstart"):
 ```
 
 :::note
-By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories. (`<project_root>/.wandb` and `<project_root/wandb`)
+By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories: `<project_root>/.wandb` and `<project_root>/wandb`
 :::
 
 To install dependencies and run the script, execute the following commands in your terminal:

--- a/docs/guides/launch/walkthrough.md
+++ b/docs/guides/launch/walkthrough.md
@@ -42,7 +42,7 @@ with wandb.init(config=config, project="launch-quickstart"):
 ```
 
 :::note
-Ensure that `wandb` is not in the path to the created file. This will prevent a code artifact from being created, and therefore a job from being created.
+By default, `Run.log_code()` ignores all paths under the `wandb` library's metadata directories. (`<project_root>/.wandb` and `<project_root/wandb`)
 :::
 
 To install dependencies and run the script, execute the following commands in your terminal:


### PR DESCRIPTION
# DEPENDS ON RELEASE OF https://github.com/wandb/wandb/pull/6095
# Expected 9/5/2023

## Description


Update docs to reflect changes from https://github.com/wandb/wandb/pull/6095

(Previously having .wandb or wandb anywhere in the absolute path would, by default, ignore files.  Now correctly only ignores `wandb` and `.wandb` directly under `project_root`)

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
