### PR TITLE
Added how to set title in wandb.plot_table()

### DIFF
--- a/docs/guides/track/log/plots.md
+++ b/docs/guides/track/log/plots.md
@@ -235,10 +235,12 @@ fields = {"x": "step",
 
 # Use the table to populate the new custom chart preset
 # To use your own saved chart preset, change the vega_spec_name
+# To edit the title, change the string_fields
 my_custom_chart = wandb.plot_table(
     vega_spec_name="carey/new_chart",
     data_table=table,
-    fields=fields)
+    fields=fields, 
+    string_fields={"title": "Height Histogram"})
 ```
 
 [Run the code →](https://tiny.cc/custom-charts)


### PR DESCRIPTION
## Description

A user from OpenAI was having some confusion as to how to include a title via the `wandb.plot_table()` function - the field to edit (string_fields) is not clearly shown in the docs

## Ticket

[Slack thread](https://weightsandbiases.slack.com/archives/CCYQNTK9V/p1692655660833889)

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
