### PR TITLE
fix: removing whitespace in export of environment variables, as whitespace will cause an error

### DIFF
--- a/docs/guides/hosting/how-to-guides/basic-setup.md
+++ b/docs/guides/hosting/how-to-guides/basic-setup.md
@@ -31,7 +31,7 @@ Follow the procedure below to send metrics to the shared private instance. Ensur
 2. Set the environment variable `WANDB_BASE_URL` to the address of the local instance:
 
 ```python
-export WANDB_BASE_URL = "http://wandb.your-shared-local-host.com"
+export WANDB_BASE_URL="http://wandb.your-shared-local-host.com"
 ```
 
 In an automated environment, you can set the `WANDB_API_KEY`. Find your key at [wandb.your-shared-local-host.com/authorize](http://wandb.your-shared-local-host.com/authorize).
@@ -45,7 +45,7 @@ wandb login --cloud
 or
 
 ```bash
-export WANDB_BASE_URL = "https://api.wandb.ai"
+export WANDB_BASE_URL="https://api.wandb.ai"
 ```
 
 You can also switch to your cloud API key, available at [https://wandb.ai/settings](https://wandb.ai/settings) when you are logged in to your cloud-hosted wandb account in your browser.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/hosting/how-to-guides/basic-setup.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/hosting/how-to-guides/basic-setup.md
@@ -30,7 +30,7 @@ wandb server start
 
 - 環境変数`WANDB_BASE_URL`をローカルインスタンスのアドレスに設定します:
 ```python
-export WANDB_BASE_URL = "http://wandb.your-shared-local-host.com"
+export WANDB_BASE_URL="http://wandb.your-shared-local-host.com"
 ```
 
 自動化された環境では、`WANDB_API_KEY` を [wandb.your-shared-local-host.com/authorize](http://wandb.your-shared-local-host.com/authorize) でアクセスできるように設定できます。
@@ -44,7 +44,7 @@ wandb login --cloud
 または
 
 ```python
-export WANDB_BASE_URL = "https://api.wandb.ai"
+export WANDB_BASE_URL="https://api.wandb.ai"
 ```
 
 また、ブラウザでクラウド上のwandbアカウントにログインしている場合、[https://wandb.ai/settings](https://wandb.ai/settings) でクラウドAPIキーに切り替えることもできます。


### PR DESCRIPTION
## Description

The documentation for setting a custom WANDB_BASE_URL and WANDB_API_KEY environment variables have whitespaces around the = operator which will cause them to not work on many shells. 

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
