### PR TITLE
add link to Traces-in-Weave colab in Prompts guide

### DIFF
--- a/docs/guides/prompts/intro.md
+++ b/docs/guides/prompts/intro.md
@@ -12,6 +12,10 @@ Use W&B Prompts to visualize and inspect the execution flow of your LLMs, analyz
 
 W&B Prompts complements [W&B Experiments](../track/intro.md) and [W&B Tables](../tables/intro.md) to give an LLM developer everything they need to explore and experiment with confidence.
 
+:::info
+Want to check out the future of Prompts in our new interactive toolkit, Weave? We'd love your feedback. [**Try this colab→**](https://colab.research.google.com/github/wandb/weave/blob/master/examples/prompts/trace_debugging/trace_quickstart_langchain.ipynb)
+:::
+
 <!-- ## Prompts Product Suite
 
 [Trace](#Trace) is the first of our Prompts tools -->


### PR DESCRIPTION
## Description

This PR adds a link to the latest example colab of using Prompts (more specifically Traces) in Weave near the start of the Prompts Guide. This will give new users trying Prompts in Weave the option to preview/give feedback on the new experience. cc @scottire 

## Ticket

N/A — shipping Traces in Weave

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
