### PR TITLE
Add video embeds

### DIFF
--- a/docs/guides/integrations/intro.md
+++ b/docs/guides/integrations/intro.md
@@ -12,8 +12,10 @@ Weights & Biases integrations make it fast and easy to set up experiment trackin
 
 ### Related Links
 
-* [Examples](https://github.com/wandb/examples): Working, end-to-end Google Colabs and script examples for all of our integrations
-* [Video Tutorials](https://www.youtube.com/playlist?list=PLD80i8An1OEGajeVo15ohAQYF1Ttle0lk): Learn to use W&B with YouTube videos for PyTorch, Keras, and more.
+* [Examples](https://github.com/wandb/examples): Try the code with notebook and script examples for each integration
+* [Video Tutorials](https://www.youtube.com/playlist?list=PLD80i8An1OEGajeVo15ohAQYF1Ttle0lk): Learn to use W&B with YouTube video tutorials
+
+<iframe width="668" height="376" src="https://www.youtube.com/embed/hmewPDNUNJs?list=PLD80i8An1OEGajeVo15ohAQYF1Ttle0lk" title="Log Your First Run With W&amp;B" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## Guides for Specific Integrations
 

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -31,11 +31,12 @@ This diagram outlines the relationship between W&B products.
 
 ## Are you a first-time user of W&B?
 
-If this is your first time using W&B we suggest you explore the following:
+<iframe width="100%" height="330" src="https://www.youtube.com/embed/tHAFujRhZLA" title="Weights &amp; Biases End-to-End Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-1. Experience W&B in action, [run an example introduction project with Google Colab](http://wandb.me/intro).
-1. Read through the [Quickstart](../quickstart.md) for a quick overview of how and where to add W&B to your code.
-1. Read [How does W&B work?](#how-does-weights--biases-work) This section provides an overview of the building blocks of W&B.
+Start exploring W&B with these resources:
+
+1. [Intro Notebook](http://wandb.me/intro): Run quick sample code to track experiments in 5 minutes
+2. [Quickstart](../quickstart.md): Read a quick overview of how and where to add W&B to your code
 1. Explore our [Integrations guide](./integrations/intro.md) and our [W&B Easy Integration YouTube](https://www.youtube.com/playlist?list=PLD80i8An1OEGDADxOBaH71ZwieZ9nmPGC) playlist for information on how to integrate W&B with your preferred machine learning framework.
 1. View the [API Reference guide](../ref/README.md) for technical specifications about the W&B Python Library, CLI, and Weave operations.
 


### PR DESCRIPTION
## Description

Add embedded YouTube videos to intro pages for 
1. the end-to-end demo video on the front page of the What is W&B docs
2. the playlist of integrations videos in the Integrations front page

## Before
<img width="2056" alt="image" src="https://github.com/wandb/docodile/assets/6355078/305be555-fd84-489d-a3e5-407f65beb40b">

## After
<img width="2056" alt="image" src="https://github.com/wandb/docodile/assets/6355078/7acd4903-9f64-4357-a2a0-f5639295fd52">


## Ticket

https://wandb.atlassian.net/browse/DOCS-789

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
