### PR TITLE
fix(docs) :adding n to os.e<n>viron in hugging face docs page code cell

### DIFF
--- a/docs/guides/integrations/huggingface.md
+++ b/docs/guides/integrations/huggingface.md
@@ -15,8 +15,8 @@ The [Hugging Face Transformers](https://huggingface.co/transformers/) library ma
 ## 🤗 Next-level logging in few lines
 
 ```python
-os.eviron["WANDB_PROJECT"] = "<my-amazing-project>" # name your W&B project 
-os.eviron["WANDB_LOG_MODEL"] = "checkpoint" # log all model checkpoints
+os.environ["WANDB_PROJECT"] = "<my-amazing-project>" # name your W&B project 
+os.environ["WANDB_LOG_MODEL"] = "checkpoint" # log all model checkpoints
 
 from transformers import TrainingArguments, Trainer
 


### PR DESCRIPTION
## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

🤗 🤗 🤗 

## Ticket support reference 52951 -- customer reported typoe in Hugging Face Docs [here](https://docs.wandb.ai/guides/integrations/huggingface#-next-level-logging-in-few-lines) 

```python
os.eviron["WANDB_PROJECT"] = "<my-amazing-project>" # name your W&B project 
os.eviron["WANDB_LOG_MODEL"] = "checkpoint" # log all model checkpoints
```
corrected to:

```python
os.environ["WANDB_PROJECT"] = "<my-amazing-project>" # name your W&B project 
os.environ["WANDB_LOG_MODEL"] = "checkpoint" # log all model checkpoints
```

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

No local build is required as this fixes a single char typo.

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
