### PR TITLE
add nvidia info to launch docker setup

### DIFF
--- a/docs/guides/launch/setup-launch-docker.md
+++ b/docs/guides/launch/setup-launch-docker.md
@@ -54,13 +54,31 @@ docker run \
   --gpus all
 ```
 
-:::note
+Volumes can be specified either as a list of strings, or a single string. Use a list if you specify multiple volumes.
 
-- Volumes can be specified either as a list of strings, or a single string. Use a list if you specify multiple volumes.
+Docker automatically passes environment variables, that are not assigned a value, from the launch agent environment. This means that, if the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that environment variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
 
-- Docker automatically passes environment variables, that are not assigned a value, through from the launch agent environment. This means that, if the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that environment variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
+The `--gpus` flag of the `docker run` command allows you to specify GPUs that are available to a Docker container. For more information on how to use the `gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
 
+
+:::tip
+* Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) to use GPUs within a Docker container.
+* If you build images from a code or artifact-sourced job, you can override the base image used by the [agent](#configure-a-launch-agent-on-a-local-machine) to include the NVIDIA Container Toolkit.
+  For example, within your launch queue, you can override the base image to `tensorflow/tensorflow:latest-gpu`:
+
+  ```json
+  {
+    "builder": {
+      "accelerator": {
+        "base_image": "tensorflow/tensorflow:latest-gpu"
+      }
+    }
+  }
+  ```
 :::
+
+
+
 
 ## Create a queue
 
@@ -82,45 +100,6 @@ Configure the launch agent with a YAML config file named `launch-config.yaml`. B
 You can use the W&B CLI to specify core configurable options for the launch agent (instead of the config YAML file): maximum number of jobs, W&B entity, and launch queues. See the [`wandb launch-agent`](../../ref/cli/wandb-launch-agent.md) command for more information.
 :::
 
-### Enable Nvidia GPU on Docker
-
-In order to use GPU from within a Docker container, you must install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker). To test your toolkit install, try running:
-
-```bash
-docker run --gpus all nvidia/cuda:11.0-base nvidia-smi
-```
-
-If you see the output from `nvidia-smi`, then your toolkit should be installed correctly!
-
-The `--gpus` flag of the `docker run` command allows you to specify which GPU are available to a container.
-Use the `gpus` key in the launch queue configuration to specify the value that will be passed to `--gpus` when the agent runs your job on Docker. See [configure a Docker queue](#configure-a-docker-queue) for more information on customizing `docker run` argument set by the agent.
-
-:::tip
-To have each run use all available GPU, add the following assignment in your launch queue configuration:
-
-```json
-{
-  "gpus": "all"
-}
-```
-
-If you are building images from a code or artifact-sourced job, you can also override the base image used by the agent to include the NVIDIA Container Toolkit. For example, to set the base image to `tensorflow/tensorflow:latest-gpu` set:
-
-```json
-{
-  "builder": {
-    "accelerator": {
-      "base_image": "tensorflow/tensorflow:latest-gpu"
-    }
-  }
-}
-```
-
-in your launch queue configuration.
-
-:::
-
-For more information on how to use the `gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
 
 ## Core agent config options
 

--- a/docs/guides/launch/setup-launch-docker.md
+++ b/docs/guides/launch/setup-launch-docker.md
@@ -1,16 +1,18 @@
 ---
 displayed_sidebar: default
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Set up for Docker
+
 The following guide describes how to configure W&B Launch to utilize Docker on a local machine for both the launch agent environment and the queue's target resource.
 
-Using Docker to execute jobs and as the launch agent's environment on the same local machine is particularly useful if your compute is installed on a machine that does not have a cluster management system (such as Kubernetes). 
+Using Docker to execute jobs and as the launch agent's environment on the same local machine is particularly useful if your compute is installed on a machine that does not have a cluster management system (such as Kubernetes).
 
 :::tip
-This set up is common for users who perform experiments on their local machine, or that have a remote machine that they SSH in to, to submit launch jobs. 
+This set up is common for users who perform experiments on their local machine, or that have a remote machine that they SSH in to, to submit launch jobs.
 :::
 
 When you use Docker with W&B Launch, W&B will first build an image, and then build and run a container from that image. The image is built with the Docker `docker run <image-uri>` command. The queue configuration is interpreted as additional arguments that are passed to the `docker run` command.
@@ -32,14 +34,11 @@ There are two syntax transformations that take place:
 
 For example, the following queue configuration:
 
-```json 
+```json
 {
-    "env": [
-        "MY_ENV_VAR=value",
-        "MY_EXISTING_ENV_VAR"
-    ],
-    "volume": "/mnt/datasets:/mnt/datasets",
-		"rm": true
+  "env": ["MY_ENV_VAR=value", "MY_EXISTING_ENV_VAR"],
+  "volume": "/mnt/datasets:/mnt/datasets",
+  "rm": true
 }
 ```
 
@@ -54,9 +53,11 @@ docker run \
 ```
 
 :::note
-* Volumes can be specified either as a list of strings, or a single string. Use a list if you specify multiple volumes.
 
-* Docker automatically passes environment variables, that are not assigned a value, through from the launch agent environment. This means that, if the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that environment variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
+- Volumes can be specified either as a list of strings, or a single string. Use a list if you specify multiple volumes.
+
+- Docker automatically passes environment variables, that are not assigned a value, through from the launch agent environment. This means that, if the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that environment variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
+
 :::
 
 ## Create a queue
@@ -71,8 +72,7 @@ Create a queue that uses Docker as compute resource with the W&B CLI:
 6. Define your Docker queue configuration in the **Configuration** field.
 7. Click on the **Create Queue** button to create the queue.
 
-
-## Configure a launch agent on a local machine 
+## Configure a launch agent on a local machine
 
 Configure the launch agent with a YAML config file named `launch-config.yaml`. By default, W&B will check for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent.
 
@@ -80,17 +80,44 @@ Configure the launch agent with a YAML config file named `launch-config.yaml`. B
 You can use the W&B CLI to specify core configurable options for the launch agent (instead of the config YAML file): maximum number of jobs, W&B entity, and launch queues. See the [`wandb launch-agent`](../../ref/cli/wandb-launch-agent.md) command for more information.
 :::
 
+### Nvidia GPU
+
+In order to use GPU from within a Docker container, you must install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker). To test your toolkit install, try running:
+
+```bash
+docker run --gpus all nvidia/cuda:11.0-base nvidia-smi
+```
+
+If you see the output from `nvidia-smi`, then your toolkit should be installed correctly!
+
+The `--gpus` flag of the `docker run` command allows you to specify which GPU are available to a container.
+Use the `gpus` key in the launch queue configuration to specify the value that will be passed to `--gpus` when the agent runs your job on Docker. See [configure a Docker queue](#configure-a-docker-queue) for more information on customizing `docker run` argument set by the agent.
+
+:::tip
+To have each run use all available GPU, add:
+
+```json
+{
+  "gpus": "all"
+}
+```
+
+to your launch queue configuration.
+:::
+
+For more information on how to use the `gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
+
 ## Core agent config options
 
 The following tabs demonstrate how to specify the core config agent options with the W&B CLI and with a YAML config file:
 
 <Tabs
-  defaultValue="CLI"
-  values={[
-    {label: 'W&B CLI', value: 'CLI'},
-    {label: 'Config file', value: 'config'},
-  ]}>
-  <TabItem value="CLI">
+defaultValue="CLI"
+values={[
+{label: 'W&B CLI', value: 'CLI'},
+{label: 'Config file', value: 'config'},
+]}>
+<TabItem value="CLI">
 
 ```bash
 wandb launch-agent -q <queue-name> --max-jobs <n>
@@ -108,7 +135,8 @@ queues:
   </TabItem>
 </Tabs>
 
-## Docker image builders 
+## Docker image builders
+
 The launch agent on your machine can be configured to build Docker images. By default, these images are stored on your machine’s local image repository. To enable your launch agent to build Docker images, set the `builder` key in the launch agent config to `docker`:
 
 ```yaml title="launch-config.yaml"
@@ -116,10 +144,11 @@ builder:
 	type: docker
 ```
 
-## Cloud registries 
+## Cloud registries
+
 You might want to connect your launch agent with a cloud registry. Connecting your launch agent to a cloud registry enables you to:
-* Share built images with others
-* Limit the amount of data stored on your local machine 
 
-To learn more about how connect the launch agent with a cloud registry, see the [Advanced agent set](./setup-agent-advanced.md) up page. 
+- Share built images with others
+- Limit the amount of data stored on your local machine
 
+To learn more about how connect the launch agent with a cloud registry, see the [Advanced agent set](./setup-agent-advanced.md) up page.

--- a/docs/guides/launch/setup-launch-docker.md
+++ b/docs/guides/launch/setup-launch-docker.md
@@ -38,7 +38,8 @@ For example, the following queue configuration:
 {
   "env": ["MY_ENV_VAR=value", "MY_EXISTING_ENV_VAR"],
   "volume": "/mnt/datasets:/mnt/datasets",
-  "rm": true
+  "rm": true,
+  "gpus": "all"
 }
 ```
 
@@ -49,7 +50,8 @@ docker run \
   --env MY_ENV_VAR=value \
   --env MY_EXISTING_ENV_VAR \
   --volume "/mnt/datasets:/mnt/datasets" \
-  --rm <image-uri>
+  --rm <image-uri> \
+  --gpus all
 ```
 
 :::note
@@ -80,7 +82,7 @@ Configure the launch agent with a YAML config file named `launch-config.yaml`. B
 You can use the W&B CLI to specify core configurable options for the launch agent (instead of the config YAML file): maximum number of jobs, W&B entity, and launch queues. See the [`wandb launch-agent`](../../ref/cli/wandb-launch-agent.md) command for more information.
 :::
 
-### Nvidia GPU
+### Enable Nvidia GPU on Docker
 
 In order to use GPU from within a Docker container, you must install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker). To test your toolkit install, try running:
 
@@ -94,7 +96,7 @@ The `--gpus` flag of the `docker run` command allows you to specify which GPU ar
 Use the `gpus` key in the launch queue configuration to specify the value that will be passed to `--gpus` when the agent runs your job on Docker. See [configure a Docker queue](#configure-a-docker-queue) for more information on customizing `docker run` argument set by the agent.
 
 :::tip
-To have each run use all available GPU, add:
+To have each run use all available GPU, add the following assignment in your launch queue configuration:
 
 ```json
 {
@@ -102,7 +104,20 @@ To have each run use all available GPU, add:
 }
 ```
 
-to your launch queue configuration.
+If you are building images from a code or artifact-sourced job, you can also override the base image used by the agent to include the NVIDIA Container Toolkit. For example, to set the base image to `tensorflow/tensorflow:latest-gpu` set:
+
+```json
+{
+  "builder": {
+    "accelerator": {
+      "base_image": "tensorflow/tensorflow:latest-gpu"
+    }
+  }
+}
+```
+
+in your launch queue configuration.
+
 :::
 
 For more information on how to use the `gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).


### PR DESCRIPTION
## Description

In the launch docs overhaul we accidentally lost the section dedicated to setting up the nvidia container toolkit.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
