### PR TITLE
add GCS deployment as server option which can use secrets

### DIFF
--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -59,8 +59,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
   * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
-If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B and the timeline for integration with AWS Secrets Manager. 
-:::
+If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B.:::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:
 

--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -56,7 +56,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCS deployment 
+  * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
 If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B and the timeline for integration with AWS Secrets Manager. 

--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -56,7 +56,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCP deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
+  * W&B Server in an Azure or GCP deployment (store secrets in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
 Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.:::

--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -56,7 +56,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
+  * W&B Server in an Azure or GCP deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
 Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.:::

--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -59,7 +59,9 @@ To use a secret in your webhook, you must first add that secret to your team's s
   * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
-If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B.:::
+Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.:::
+
+
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:
 

--- a/docs/guides/artifacts/project-scoped-automations.md
+++ b/docs/guides/artifacts/project-scoped-automations.md
@@ -56,10 +56,10 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure deployment
+  * W&B Server in an Azure or GCS deployment 
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
-If you are on deployment type or environment not listed above, connect with your account team to discuss what options are available for using secrets in W&B and the timeline for integration with GCP's and AWS's secret store. 
+If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B and the timeline for integration with AWS Secrets Manager. 
 :::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -46,10 +46,10 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure deployment
+  * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
-If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B and the timeline for integration with GCP's and AWS's secret store. 
+If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B. 
 :::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -46,7 +46,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
+  * W&B Server in an Azure or GCP deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
 Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -46,7 +46,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are available if you use:
   * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCP deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
+  * W&B Server in an Azure or GCP deployment (store secrets in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
 Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -49,7 +49,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
   * W&B Server in an Azure or GCS deployment (secrets to be stored in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
 
-If you are on deployment type or environment not listed above, please connect with your account team to discuss what options are available for using secrets in W&B. 
+Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.
 :::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:


### PR DESCRIPTION
## Description

The updated GCP terraform that includes GCP Secret Manager support is merged and available for customers to use. This PR is to update the docs accordingly.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
