### PR TITLE
fixing single typo letter permutation

### DIFF
--- a/docs/guides/hosting/audit-logging.md
+++ b/docs/guides/hosting/audit-logging.md
@@ -61,7 +61,7 @@ The following table describes possible actions that can be recorded by W&B:
 |-----|-----|
 | artifact:create             | Artifact is created.
 | artifact:delete             | Artifact is deleted.
-| artifact:read               | Aritfact is read.
+| artifact:read               | Artifact is read.
 | project:delete              | Project is deleted.
 | project:read                | Project is read.
 | report:read                 | Report is read.


### PR DESCRIPTION
## Description

permutes i and t in aritfacts -- artifacts (typo in docs)

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
