### PR TITLE
Add disclaimer that storing secrets via k8s delegates security to customer

### DIFF
--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -45,6 +45,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 :::info
 * Only W&B Admins can create, edit, or delete a secret.
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
+* Secrets are also available if you use [W&B Server](../hosting/intro.md) in an Azure or GCP deployment. Connect with your W&B account team to discuss how you can use secrets in W&B if you use a different deployment type.
 :::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:
@@ -69,13 +70,13 @@ Once you create a secret, you can access that secret in your W&B workflows with 
 :::
 
 :::caution
-Secrets are available if you use either:
-* W&B SaaS public cloud or 
-* W&B Server in an Azure or GCP deployment. 
+Considerations if you use secrets in W&B Server:
 
-Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.
+You are responsible for configuring security measures that satisfy your security needs. 
 
-You are responsible for configuring security measures that satisfy your security needs. W&B strongly recommends that you store secrets in a W&B instance of a secrets manager provided by AWS, GCP, or Azure. Secret managers provided by AWS, GCP, and Azure are configured with advanced security capabilities.  
+W&B strongly recommends that you store secrets in a W&B instance of a cloud secrets manager provided by AWS, GCP, or Azure. Secret managers provided by AWS, GCP, and Azure are configured with advanced security capabilities.  
+
+W&B does not recommend that you use a Kubernetes cluster as the backend of your secrets store. Consider a Kubernetes cluster only if you are not able to use a W&B instance of a cloud secrets manager (AWS, GCP, or Azure), and you understand how to prevent security vulnerabilities that can occur if you use a cluster.
 :::
 
 ### Configure a webhook

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -75,9 +75,7 @@ Secrets are available if you use either:
 
 Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.
 
-<!-- Store secrets in a W&B instance of the cloud provider's respective secrets manager) -->
-
-You are responsible for configuring security measures that satisfy your security needs. W&B strongly recommends that you use a secrets manager provided by AWS, GCP, or Azure. Secret managers provided by AWS, GCP, and Azure are configured with advanced security capabilities.  
+You are responsible for configuring security measures that satisfy your security needs. W&B strongly recommends that you store secrets in a W&B instance of a secrets manager provided by AWS, GCP, or Azure. Secret managers provided by AWS, GCP, and Azure are configured with advanced security capabilities.  
 :::
 
 ### Configure a webhook

--- a/docs/guides/model_registry/automation.md
+++ b/docs/guides/model_registry/automation.md
@@ -44,12 +44,7 @@ To use a secret in your webhook, you must first add that secret to your team's s
 
 :::info
 * Only W&B Admins can create, edit, or delete a secret.
-* Secrets are available if you use:
-  * W&B SaaS public cloud; or
-  * W&B Server in an Azure or GCP deployment (store secrets in a W&B instance of the cloud provider's respective secrets manager)
 * Skip this section if the external server you send HTTP POST requests to does not use secrets.  
-
-Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.
 :::
 
 There are two types of secrets W&B suggests that you create when you use a webhook automation:
@@ -71,6 +66,18 @@ Specify the secrets you want to use for your webhook automation when you configu
 
 :::tip
 Once you create a secret, you can access that secret in your W&B workflows with `$`.
+:::
+
+:::caution
+Secrets are available if you use either:
+* W&B SaaS public cloud or 
+* W&B Server in an Azure or GCP deployment. 
+
+Connect with your W&B account team to discuss how you can use secrets in W&B if you are on a deployment type or environment not listed above.
+
+<!-- Store secrets in a W&B instance of the cloud provider's respective secrets manager) -->
+
+You are responsible for configuring security measures that satisfy your security needs. W&B strongly recommends that you use a secrets manager provided by AWS, GCP, or Azure. Secret managers provided by AWS, GCP, and Azure are configured with advanced security capabilities.  
 :::
 
 ### Configure a webhook


### PR DESCRIPTION
## Description

First draft of note about delegating responsibility to customers for managing secrets.

## Ticket

https://wandb.atlassian.net/browse/DOCS-795?atlOrigin=eyJpIjoiNDM0NDNjODYyOWViNGU4YTlmOWNmOGI5ODUzZWE4YWMiLCJwIjoiaiJ9

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
