### PR TITLE
Lint debugging

### DIFF
--- a/docs/guides/artifacts/create-a-new-artifact-version.md
+++ b/docs/guides/artifacts/create-a-new-artifact-version.md
@@ -286,13 +286,17 @@ Putting it all together, the code examples above look like:
 
 ```python
 with wandb.init(job_type="modify dataset") as run:
-	saved_artifact = run.use_artifact("my_artifact:latest") # fetch artifact and input it into your run
-	draft_artifact = saved_artifact.new_draft() # create a draft version
+    saved_artifact = run.use_artifact(
+        "my_artifact:latest"
+    )  # fetch artifact and input it into your run
+    draft_artifact = saved_artifact.new_draft()  # create a draft version
 
-	# modify a subset of files in the draft version
-	draft_artifact.add_file("file_to_add.txt")
-	draft_artifact.remove('dir_to_remove/') 
-	run.log_artifact(artifact) # log your changes to create a new version and mark it as output to your run
+    # modify a subset of files in the draft version
+    draft_artifact.add_file("file_to_add.txt")
+    draft_artifact.remove("dir_to_remove/")
+    run.log_artifact(
+        artifact
+    )  # log your changes to create a new version and mark it as output to your run
 ```
 
   </TabItem>

--- a/docs/guides/artifacts/track-external-files.md
+++ b/docs/guides/artifacts/track-external-files.md
@@ -44,7 +44,7 @@ W&B Artifacts support any Amazon S3 compatible interface — including MinIO! Th
 
 Assume we have a bucket with the following structure:
 
-```
+```bash
 s3://my-bucket
 +-- datasets/
 |		+-- mnist/
@@ -58,8 +58,8 @@ Under `mnist/` we have our dataset, a collection of images. Lets track it with a
 import wandb
 
 run = wandb.init()
-artifact = wandb.Artifact('mnist', type='dataset')
-artifact.add_reference('s3://my-bucket/datasets/mnist')
+artifact = wandb.Artifact("mnist", type="dataset")
+artifact.add_reference("s3://my-bucket/datasets/mnist")
 run.log_artifact(artifact)
 ```
 :::caution
@@ -90,7 +90,7 @@ Panels might fail to render in the App UI for private buckets. If your company h
 import wandb
 
 run = wandb.init()
-artifact = run.use_artifact('mnist:latest', type='dataset')
+artifact = run.use_artifact("mnist:latest", type="dataset")
 artifact_dir = artifact.download()
 ```
 
@@ -107,12 +107,12 @@ Based on your use case, read the instructions to enable object versioning: [AWS]
 The following code example demonstrates a simple workflow you can use to track a dataset in Amazon S3, GCS, or Azure that feeds into a training job:
 
 ```python
- import wandb
+import wandb
 
 run = wandb.init()
 
-artifact = wandb.Artifact('mnist', type='dataset')
-artifact.add_reference('s3://my-bucket/datasets/mnist')
+artifact = wandb.Artifact("mnist", type="dataset")
+artifact.add_reference("s3://my-bucket/datasets/mnist")
 
 # Track the artifact and mark it as an input to
 # this run in one swoop. A new artifact version
@@ -132,17 +132,13 @@ import wandb
 
 run = wandb.init()
 
-# Training here... 
+# Training here...
 
-s3_client = boto3.client('s3')
-s3_client.upload_file(
-    'my_model.h5', 
-    'my-bucket', 
-    'models/cnn/my_model.h5'
-    )
+s3_client = boto3.client("s3")
+s3_client.upload_file("my_model.h5", "my-bucket", "models/cnn/my_model.h5")
 
-model_artifact = wandb.Artifact('cnn', type='model')
-model_artifact.add_reference('s3://my-bucket/models/cnn/')
+model_artifact = wandb.Artifact("cnn", type="model")
+model_artifact.add_reference("s3://my-bucket/models/cnn/")
 run.log_artifact(model_artifact)
 ```
 
@@ -159,7 +155,7 @@ Another common pattern for fast access to datasets is to expose an NFS mount poi
 
 Assume we have a filesystem mounted at `/mount` with the following structure:
 
-```
+```bash
 mount
 +-- datasets/
 |		+-- mnist/
@@ -173,8 +169,8 @@ Under `mnist/` we have our dataset, a collection of images. Let's track it with 
 import wandb
 
 run = wandb.init()
-artifact = wandb.Artifact('mnist', type='dataset')
-artifact.add_reference('file:///mount/datasets/mnist/')
+artifact = wandb.Artifact("mnist", type="dataset")
+artifact.add_reference("file:///mount/datasets/mnist/")
 run.log_artifact(artifact)
 ```
 
@@ -192,10 +188,7 @@ Downloading a reference artifact is simple:
 import wandb
 
 run = wandb.init()
-artifact = run.use_artifact(
-    'entity/project/mnist:latest', 
-    type='dataset'
-    )
+artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
 artifact_dir = artifact.download()
 ```
 
@@ -208,8 +201,8 @@ import wandb
 
 run = wandb.init()
 
-artifact = wandb.Artifact('mnist', type='dataset')
-artifact.add_reference('file:///mount/datasets/mnist/')
+artifact = wandb.Artifact("mnist", type="dataset")
+artifact.add_reference("file:///mount/datasets/mnist/")
 
 # Track the artifact and mark it as an input to
 # this run in one swoop. A new artifact version
@@ -231,10 +224,9 @@ run = wandb.init()
 
 # Training here...
 
-with open('/mount/cnn/my_model.h5') as f:
-	# Output our model file.
+# Write model to disk
 
-model_artifact = wandb.Artifact('cnn', type='model')
-model_artifact.add_reference('file:///mount/cnn/my_model.h5')
+model_artifact = wandb.Artifact("cnn", type="model")
+model_artifact.add_reference("file:///mount/cnn/my_model.h5")
 run.log_artifact(model_artifact)
 ```

--- a/docs/guides/integrations/mmdetection.md
+++ b/docs/guides/integrations/mmdetection.md
@@ -53,8 +53,9 @@ wandb login
   </TabItem>
   <TabItem value="notebook">
 
-```python
-wandb.login()
+
+```notebook
+!pip install wandb
 ```
 
 

--- a/docs/guides/integrations/mmdetection.md
+++ b/docs/guides/integrations/mmdetection.md
@@ -44,11 +44,9 @@ If you are using Weights and Biases for the first time you might want to check o
 
 ```bash
 pip install wandb
-```
-
-```bash
 wandb login
 ```
+
 
   </TabItem>
   <TabItem value="notebook">
@@ -56,6 +54,7 @@ wandb login
 
 ```notebook
 !pip install wandb
+wandb.login()
 ```
 
 

--- a/docs/guides/integrations/mmdetection.md
+++ b/docs/guides/integrations/mmdetection.md
@@ -41,9 +41,12 @@ If you are using Weights and Biases for the first time you might want to check o
   ]}>
   <TabItem value="cli">
 
-```
-pip install wandb
 
+```bash
+pip install wandb
+```
+
+```bash
 wandb login
 ```
 
@@ -51,10 +54,9 @@ wandb login
   <TabItem value="notebook">
 
 ```python
-!pip install wandb
-
 wandb.login()
 ```
+
 
   </TabItem>
 </Tabs>
@@ -69,20 +71,24 @@ You can get started with Weights and Biases by adding the `MMDetWandbHook` to th
 
 ```python
 import wandb
+
 ...
 
-config_file = 'mmdetection/configs/path/to/config.py'
+config_file = "mmdetection/configs/path/to/config.py"
 cfg = Config.fromfile(config_file)
 
 cfg.log_config.hooks = [
-    dict(type='TextLoggerHook'),
-    dict(type='MMDetWandbHook',
-         init_kwargs={'project': 'mmdetection'},
-         interval=10,
-         log_checkpoint=True,
-         log_checkpoint_metadata=True,
-         num_eval_images=100,
-         bbox_score_thr=0.3)]
+    dict(type="TextLoggerHook"),
+    dict(
+        type="MMDetWandbHook",
+        init_kwargs={"project": "mmdetection"},
+        interval=10,
+        log_checkpoint=True,
+        log_checkpoint_metadata=True,
+        num_eval_images=100,
+        bbox_score_thr=0.3,
+    ),
+]
 ```
 
 | Name                      | Description                                                                                                                                                             |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,7 @@ The following code snippets demonstrate how to install and log into W&B using th
 
 Install the CLI and Python library for interacting with the Weights and Biases API:
 
-```
+```bash
 pip install wandb
 ```
 
@@ -38,7 +38,8 @@ pip install wandb
 
 Install the CLI and Python library for interacting with the Weights and Biases API:
 
-```python
+
+```notebook
 !pip install wandb
 ```
 
@@ -59,13 +60,13 @@ Install the CLI and Python library for interacting with the Weights and Biases A
 
 Next, log in to W&B:
 
-```
+```bash
 wandb login
 ```
 
 Or if you are using [W&B Server:](./guides/hosting)
 
-```
+```bash
 wandb login --host=http://wandb.your-shared-local-host.com
 ```
 
@@ -97,36 +98,14 @@ run = wandb.init(
     config={
         "learning_rate": 0.01,
         "epochs": 10,
-    })
+    },
+)
 ```
 
-
-<!-- ```python
-run = wandb.init(project="my-awesome-project")
-``` -->
 
 A [run](./guides/runs) is the basic building block of W&B. You will use them often to [track metrics](./guides/track), [create logs](./guides/artifacts), [create jobs](./guides/launch), and more.
 
 
-<!-- ## Track metrics -->
-<!-- Pass a dictionary to the `config` parameter with key-value pairs of hyperparameter name and values when you initialize a run object:
-
-```python
-  # Track hyperparameters and run metadata
-  config={
-      "learning_rate": lr,
-      "epochs": epochs,
-  }
-``` -->
-
-
-<!-- Use [`wandb.log()`](./ref/python/log.md) to track metrics:
-
-```python
-wandb.log({'accuracy': acc, 'loss': loss})
-```
-
-Anything you log with `wandb.log` is stored in the run object that was most recently initialized. -->
 
 
 
@@ -138,13 +117,13 @@ Note that we added code that mimics machine learning training.
 ```python
 # train.py
 import wandb
-import random # for demo script
+import random  # for demo script
 
 # highlight-next-line
 wandb.login()
 
-epochs=10
-lr=0.01
+epochs = 10
+lr = 0.01
 
 # highlight-start
 run = wandb.init(
@@ -154,16 +133,17 @@ run = wandb.init(
     config={
         "learning_rate": lr,
         "epochs": epochs,
-    })
-# highlight-end    
+    },
+)
+# highlight-end
 
 offset = random.random() / 5
 print(f"lr: {lr}")
 
 # simulating a training run
 for epoch in range(2, epochs):
-    acc = 1 - 2 ** -epoch - random.random() / epoch - offset
-    loss = 2 ** -epoch + random.random() / epoch + offset
+    acc = 1 - 2**-epoch - random.random() / epoch - offset
+    loss = 2**-epoch + random.random() / epoch + offset
     print(f"epoch={epoch}, accuracy={acc}, loss={loss}")
     # highlight-next-line
     wandb.log({"accuracy": acc, "loss": loss})
@@ -189,10 +169,7 @@ Follow the procedure outlined below to set up an alert:
 2. Add [`wandb.alert()`](./guides/runs/alert.md) to your code.
 
 ```python
-wandb.alert(
-    title="Low accuracy", 
-    text=f"Accuracy {acc} is below threshold {thresh}"
-)
+wandb.alert(title="Low accuracy", text=f"Accuracy {acc} is below threshold {thresh}")
 ```
 You will receive an email or Slack alert when your alert criteria is met. For example, the proceeding image demonstrates a Slack alert:
 


### PR DESCRIPTION
## Description

Debugging why lint checker is failing commits for numerous doc pages. 

Discovery: TL;DR markdown code snippets not marked properly. Biggest culprit are some code blocks that say "python" when they should say "notebook".

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
