### PR TITLE
Removed wandb.require. Again.

### DIFF
--- a/docs/guides/reports/create-a-report.md
+++ b/docs/guides/reports/create-a-report.md
@@ -56,9 +56,6 @@ Create a report programmatically with the `wandb` library.
 ```python
 import wandb
 import wandb.apis.reports as wr
-
-# W&B requirement to avoid accidental report modification
-wandb.require("report-editing")
 ```
 
 Create a report instance with the Report Class Public API ([`wandb.apis.reports`](https://docs.wandb.ai/ref/python/public-api/api#reports)). Specify a name for the project.


### PR DESCRIPTION
## Description

Removes wandb.require(), because it's a very sticky line of code apparently.

## Ticket

[DOCS-785](https://wandb.atlassian.net/jira/software/projects/DOCS/boards/28/backlog?selectedIssue=DOCS-785)

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.


[DOCS-785]: https://wandb.atlassian.net/browse/DOCS-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ