### PR TITLE
fixing small error where artifact was referenced instead of run

### DIFF
--- a/docs/guides/artifacts/explore-and-traverse-an-artifact-graph.md
+++ b/docs/guides/artifacts/explore-and-traverse-an-artifact-graph.md
@@ -74,7 +74,7 @@ import wandb
 
 api = wandb.Api()
 
-artifact = api.run("entity/project/run_id")
+run = api.run("entity/project/run_id")
 ```
 
 Use the [`logged_artifacts`](../../ref/python/public-api/run.md#logged_artifacts) and [`used_artifacts`](../../ref/python/public-api/run.md#used_artifacts) methods to walk the graph from a given run:


### PR DESCRIPTION
## Description

changes this line to:

run = api.run("entity/project/run_id") 

instead of the original 

artifact = api.run("entity/project/run_id")

so that the code example of calling .logged_artifacts() [here](https://docs.wandb.ai/guides/artifacts/explore-and-traverse-an-artifact-graph) is valid

## Ticket


## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ X] I merged the latest changes from `main` into my feature branch before submitting this PR.
