### PR TITLE
fixed syntax error in code example

### DIFF
--- a/docs/guides/integrations/tensorflow.md
+++ b/docs/guides/integrations/tensorflow.md
@@ -18,7 +18,7 @@ If you need to log additional custom metrics that aren't being logged to TensorB
 
 Setting the step argument in `wandb.log` is disabled when syncing Tensorboard. If you'd like to set a different step count, you can log the metrics with a step metric as:
 
-`wandb.log({"custom": 0.8, "global_step"=global_step})`
+`wandb.log({"custom": 0.8, "global_step":global_step}, step=global_step)`
 
 ## TensorFlow Hook
 


### PR DESCRIPTION
## Description

fixed a syntax error by correcting this line:

`wandb.log({"custom": 0.8, "global_step"=global_step})` ### this errors out 

to 

### this fixes the error - but logging the step explicitly via "global_step":global_step` is optional
`wandb.log({"custom": 0.8, "global_step":global_step}, step=global_step)` 

## Ticket

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
