### PR TITLE
Update quickstart to use link_model.md

### DIFF
--- a/docs/guides/model_registry/quickstart.md
+++ b/docs/guides/model_registry/quickstart.md
@@ -4,7 +4,7 @@ displayed_sidebar: default
 ---
 # Quickstart
 
-Try the model registry in one minute. This quickstart will show you how to log a model version and link to a registered model.
+Try the model registry in one minute. This quickstart will show you how to log a model version and link it to a registered model. Visit [this](https://docs.wandb.ai/guides/track/log/log-models#log-and-link-a-model-to-the-wb-model-registry) guide to learn more about the model APIs used below. 
 
 Copy and paste the following code sample into your Jupyter Notebook or in a Python script.
 
@@ -21,13 +21,8 @@ with wandb.init(project="models_quickstart") as run:
     with open("my_model.h5", "w") as f:
         f.write("Model: " + str(random.random()))
 
-    # Save the dummy model to W&B
-    best_model = wandb.Artifact(f"model_{run.id}", type="model")
-    best_model.add_file("my_model.h5")
-    run.log_artifact(best_model)
-
-    # Link the model to the Model Registry
-    run.link_artifact(best_model, "model-registry/My Registered Model")
+    # Save the model file to W&B and link the model to the Model Registry
+    run.link_model(path="my_model.h5", registered-model-name="Bookmarked-Model-Checkpoints")
 
     run.finish()
 ```


### PR DESCRIPTION
## Description

- update model registry quickstart to use link_model
- adds link to new log model guide

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
