### PR TITLE
Adding details of when service accounts log runs to what team and whe…

### DIFF
--- a/docs/guides/app/features/teams.md
+++ b/docs/guides/app/features/teams.md
@@ -49,7 +49,6 @@ Select a team role when you invite colleagues to join a team. There are four tea
 
 - **Admin**: Team admins can add and remove other admins or team members. They have permissions to modify all projects and full deletion permissions. This includes, but is not limited to, deleting runs, projects, artifacts, and sweeps.
 - **Member**: A regular member of the team. A team member is invited by email by the team admin. A team member cannot invite other members. Team members can only delete runs and sweep runs created by that member. Suppose you have two members A and B. Member B moves a Run from team B's project to a different project owned by Member A. Member A can not delete the Run Member B moved to Member A's project. Only the member that creates the Run, or the team admin, can delete the run.
-
 - **Service (Enterprise-only feature)**: A service worker, an API key useful for using W&B with your run automation tools. If you use the API key from a service account for your team, make sure to set the environment variable **WANDB_USERNAME** to attribute runs to the correct user.
 - **View-Only (Enterprise-only feature)**: View-Only members can view assets within the team such as runs, reports, and workspaces. They can follow and comment on reports, but they can not create, edit, or delete project overview, reports, or runs. View-Only members do not have an API key.
 
@@ -119,6 +118,11 @@ With system permissions, you have the ability to manage members, create and modi
 | Create/delete teams      |           |             |            | X            |
 | View activity dashboard  |           |             |            | X            |
 
+### Team Service Account Behavior
+
+* When you configure a team in your training environment, you can use a service account from that team to log runs in either of private or public projects within that team. Additionally, you can attribute those runs to a user if **WANDB_USERNAME** or **WANDB_USER_EMAIL** variable is configured in your environment and the referenced user is part of that team.
+* When you **do not** configure a team in your training environment and use a service account, the runs would be logged to the named project within that service account's parent team. In this case as well, you can attribute the runs to a user if **WANDB_USERNAME** or **WANDB_USER_EMAIL** variable is configured in your environment and the referenced user is part of the service account's parent team.
+* A service account can not be used to log runs to a private project in a team different from its parent team, but it can be used to log runs to public projects in other teams.
 
 #### Add Social Badges to your Intro
 

--- a/docs/guides/hosting/manage-users.md
+++ b/docs/guides/hosting/manage-users.md
@@ -89,6 +89,9 @@ When you invite a user to a team you can assign them one of the following roles:
 | View-Only | A view-only member of your team, invited by email by the team admin. A view-only member only has read access to the team and its contents.                                                                                                                                                       |
 | Service   | A service worker or service account is an API key that is useful for utilizing W&B with your run automation tools. If you use an API key from a service account for your team, ensure that the environment variable `WANDB_USERNAME` is set to correctly attribute runs to the appropriate user. |
 
+:::note
+Refer to [Team Service Account Behavior](../app/features/teams.md#team-service-account-behavior) for more information.
+:::
 
 ### Invite members to a team
 Use the Team's settings page to invite members.

--- a/docs/guides/technical-faq/general.md
+++ b/docs/guides/technical-faq/general.md
@@ -79,6 +79,8 @@ We'll then set up an Auth0 connection with the above details and enable SSO.
 
 A service account (Enterprise-only feature) is an API key that has permissions to write to your team, but is not associated with a particular user. Among other things, service accounts are useful for tracking automated jobs logged to wandb, like periodic retraining, nightly builds, and so on. If you'd like, you can associate a username with one of these machine-launched runs with the [environment variable](../track/environment-variables.md) `WANDB_USERNAME`.
 
+Refer to [Team Service Account Behavior](../app/features/teams.md#team-service-account-behavior) for more information.
+
 You can get the API key in your Team Settings page `/teams/<your-team-name>` where you invite new team members. Select service and click create to add a service account.
 
 ![Create a service account on your team settings page for automated jobs](/images/technical_faq/what_is_service_account.png)


### PR DESCRIPTION
…oning Dedicated Cloud & Self-managed to remove doubts

## Description

It adds details on when a service account can log runs to a project and in what team, and when is user attribution successful.

## Ticket

No ticket.

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings. - It threw totally unrelated TypeError: Invalid URL errors.
- [X ] I merged the latest changes from `main` into my feature branch before submitting this PR.
