### PR TITLE
chore(sweeps): add more verbose information for nested sweep configurations

### DIFF
--- a/docs/guides/sweeps/define-sweep-configuration.md
+++ b/docs/guides/sweeps/define-sweep-configuration.md
@@ -589,3 +589,50 @@ command:
 ```
   </TabItem>
 </Tabs>
+
+### Nested Parameters
+
+The sweep configuration format supports specifying nested parameters. To delineate a nested parameter, use an additional `parameters` key under the top level parameter name. Multi-level nesting is allowed. For a complete sweep configuration example: 
+
+```yaml
+program: train.py
+method: bayes
+metric:
+  name: val_loss
+  goal: minimize
+top_level_param:
+  min: 0
+  max: 5
+nested_param:
+  parameters:  # required key
+    learning_rate:
+      values: [0.01, 0.001]
+    double_nested_param:
+      parameters:  # <--
+        x:
+          value: 0.9
+        y: 
+          value: 0.8
+```
+
+The above configuration might result in the following run config (in `train.py`):
+
+```json
+{
+  "top_level_param": 0,
+  "nested_param": {
+    "learning_rate": 0.01,
+    "double_nested_param": {
+      "x": 0.9,
+      "y": 0.8
+    }
+  }
+}
+```
+
+:::warning
+Nested parameters **overwrite** keys specified in run configurations.
+
+For example, take this run: `run = wandb.init(config={"nested_param": {"manual_key": 1}})`. If running in a sweep with the above sweep configuration, the `nested_param.manual_key` will **not** be available in the run. Instead, the `run.config` will look exactly like the json above.
+:::
+

--- a/docs/guides/sweeps/define-sweep-configuration.md
+++ b/docs/guides/sweeps/define-sweep-configuration.md
@@ -229,12 +229,19 @@ Describe the hyperparameters to explore during the sweep. For each hyperparamete
   <TabItem value="nested">
 
   ```yaml
-  optimizer:
-      parameters:
+  top_level_param:
+    min: 0
+    max: 5
+  nested_param:
+      parameters:  # required key
           learning_rate:
               values: [0.01, 0.001]
-          momentum:
-              value: 0.9
+          double_nested_param:
+            parameters:  # <--
+              x:
+                value: 0.9
+              y: 
+                value: 0.8
   ```
 
   </TabItem>

--- a/docs/guides/sweeps/define-sweep-configuration.md
+++ b/docs/guides/sweeps/define-sweep-configuration.md
@@ -630,9 +630,35 @@ The above configuration might result in the following run config (in `train.py`)
 }
 ```
 
-:::warning
-Nested parameters **overwrite** keys specified in run configurations.
+:::caution
+Nested parameters overwrite keys specified in a run configuration.
 
-For example, take this run: `run = wandb.init(config={"nested_param": {"manual_key": 1}})`. If running in a sweep with the above sweep configuration, the `nested_param.manual_key` will **not** be available in the run. Instead, the `run.config` will look exactly like the json above.
+For example, suppose you initialize a W&B run with the following configuration:
+
+```python
+run = wandb.init(config = {
+  "nested_param": { 
+    "manual_key": 1
+    }
+  }
+)
+```
+
+If you then create a sweep with the following sweep configuration:
+
+```json
+{
+  "top_level_param": 0,
+  "nested_param": {
+    "learning_rate": 0.01,
+    "double_nested_param": {
+      "x": 0.9,
+      "y": 0.8
+    }
+  }
+}
+```
+
+The `nested_param.manual_key` that was passed when the W&B run was initialized will not be available. Instead, the `run.config` will look exactly like the JSON code snippet shown above.
 :::
 


### PR DESCRIPTION
## Description

- add more verbose example of nested keys in the parameter tab
- add new section explicitly walking through a nested config
- add warning for nested key handling

## Ticket

https://wandb.atlassian.net/browse/WB-16663

<img width="1299" alt="Screenshot 2023-12-26 at 9 51 09 AM" src="https://github.com/wandb/docodile/assets/19414170/33d3c0d0-d0de-4f76-abc1-065ac75ce6e1">


<img width="1215" alt="Screenshot 2023-12-26 at 9 51 21 AM" src="https://github.com/wandb/docodile/assets/19414170/c844fd03-b719-46bc-b214-71c0a1c70cd5">


## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
