### PR TITLE
added job_type flag to wandb sync CLI

### DIFF
--- a/docs/ref/cli/wandb-sync.md
+++ b/docs/ref/cli/wandb-sync.md
@@ -15,6 +15,7 @@ Upload an offline training directory to W&B
 | --id | The run you want to upload to. |
 | -p, --project | The project you want to upload to. |
 | -e, --entity | The entity to scope to. |
+| --job_type | Specifies the type of run for grouping related runs together. |
 | --sync-tensorboard / --no-sync-tensorboard | Stream tfevent files to wandb. |
 | --include-globs | Comma seperated list of globs to include. |
 | --exclude-globs | Comma seperated list of globs to exclude. |


### PR DESCRIPTION
## Description

adding the job_type flag + details to wandb sync CLI docs 

[Fixes WB-15895](https://wandb.atlassian.net/browse/WB-15895)

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
