### PR TITLE
Add info about openai version for W&B autolog integration for OpenAI

### DIFF
--- a/docs/guides/integrations/other/openai-api.md
+++ b/docs/guides/integrations/other/openai-api.md
@@ -11,6 +11,10 @@ import TabItem from '@theme/TabItem';
 
 Use the Weights & Biases OpenAI API integration to log requests, responses, token counts and model metadata with 1 line of code for all OpenAI models, including fine-tuned models.
 
+:::info
+The Weights and Biases autolog integration works with `openai <= 0.28.1`. Please install the correct version of `openai` by doing `pip install openai==0.28.1`.
+:::
+
 **[Try in a Colab Notebook here →](https://github.com/wandb/examples/blob/master/colabs/openai/OpenAI_API_Autologger_Quickstart.ipynb)**
 
 With just 1 line of code you can now automatically log inputs and outputs from the OpenAI Python SDK to Weights & Biases! 
@@ -29,7 +33,7 @@ import os
 import openai
 from wandb.integration.openai import autolog
 
-autolog({"project":"gpt5"})
+autolog({"project": "gpt5"})
 ```
 
 You can optionally pass a dictionary with argument that `wandb.init()` accepts to `autolog`. This includes a project name, team name, entity, and more. For more information about [`wandb.init`](../../../ref/python/init.md), see the API Reference Guide.

--- a/docs/guides/integrations/other/openai-api.md
+++ b/docs/guides/integrations/other/openai-api.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 Use the Weights & Biases OpenAI API integration to log requests, responses, token counts and model metadata with 1 line of code for all OpenAI models, including fine-tuned models.
 
 :::info
-The Weights and Biases autolog integration works with `openai <= 0.28.1`. Please install the correct version of `openai` by doing `pip install openai==0.28.1`.
+The W&B autolog integration works with `openai <= 0.28.1`. Install the correct version of `openai` with `pip install openai==0.28.1`.
 :::
 
 **[Try in a Colab Notebook here →](https://github.com/wandb/examples/blob/master/colabs/openai/OpenAI_API_Autologger_Quickstart.ipynb)**


### PR DESCRIPTION
## Description

This PR adds an info callout about using openai version <=0.28.1 for using the autolog integration.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
