### PR TITLE
adding warning to call teardown after sweeps within the same process

### DIFF
--- a/docs/guides/sweeps/start-sweep-agents.md
+++ b/docs/guides/sweeps/start-sweep-agents.md
@@ -81,7 +81,14 @@ Next, start the sweep job. Provide the sweep ID generated from sweep initiation.
 sweep_id, count = "dtzl1o7u", 10
 wandb.agent(sweep_id, count=count)
 ```
+
+:::caution
+If you start a new run after the sweep agent has finished, within the same script or notebook, then you should call `wandb.teardown()` before starting the new run.
+:::
+
+
   </TabItem>
+
   <TabItem value="cli">
 
 First, initialize your sweep with the [`wandb sweep`](../../ref/cli/wandb-sweep.md) command. For more information, see [Initialize sweeps](./initialize-sweeps.md).


### PR DESCRIPTION
## Description

This adds a caution to the docs after the code sample for starting an agent within a script or notebook. This caution lets users know that if they want to start a new run within the same script or notebook, they must call wandb.teardown() before initialising the new run. 

## Ticket
NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
