### PR TITLE
Update how to delete an artifact collection code snippet

### DIFF
--- a/docs/guides/artifacts/delete-artifacts.md
+++ b/docs/guides/artifacts/delete-artifacts.md
@@ -101,7 +101,7 @@ To delete an artifact collection:
 3. Select the kebab dropdown next to the artifact collection name.
 4. Choose Delete.
 
-You can also delete artifact version programmatically with the [delete()](../../ref/python/artifact.md#delete) method. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively:
+You can also delete artifact collection programmatically with the [delete()](../../ref/python/artifact.md#delete) method. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively:
 
 ```python
 import wandb

--- a/docs/guides/artifacts/delete-artifacts.md
+++ b/docs/guides/artifacts/delete-artifacts.md
@@ -101,7 +101,7 @@ To delete an artifact collection:
 3. Select the kebab dropdown next to the artifact collection name.
 4. Choose Delete.
 
-You can also delete artifact version programmatically with the [delete()](../../ref/python/artifact.md#delete) method. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively. Replace the `<>` with the name of your artifact:
+You can also delete artifact version programmatically with the [delete()](../../ref/python/artifact.md#delete) method. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively:
 
 ```python
 import wandb
@@ -109,12 +109,9 @@ import wandb
 # Provide your entity and a project name when you
 # use wandb.Api methods.
 api = wandb.Api(overrides={"project": "project", "entity": "entity"})
-
-artifact_name = "<>"  # provide artifact name
-artifact = api.artifact(artifact_name)
-artifact.collection.delete()
+collection = api.artifact_collection("<artifact_type>", "entity/project/artifact_collection_name")
+collection.delete()
 ```
-
 
 ## How to enable garbage collection based on how W&B is hosted
 Garbage collection is enabled by default if you use W&B's shared cloud. Based on how you host W&B, you might need to take additional steps to enable garbage collection, this includes:


### PR DESCRIPTION
## Description

Updates code snippet for deleting an artifact collection to fetch the collection object from the api and calling delete it. This makes more sense because it handles the case where an artifact collection is empty, and in this case you can't query for the version in order to retrieve the collection. The updated snippet shows how to access the collection directly instead of via the artifact version. 
## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
