### PR TITLE
replaced hyperlink with the correct link to langchain docs

### DIFF
--- a/docs/guides/prompts/quickstart.md
+++ b/docs/guides/prompts/quickstart.md
@@ -29,7 +29,7 @@ This Quickstart guide will walk you how to use [Trace](intro.md) to visualize an
 
 With a 1-line environment variable from LangChain, W&B Trace will continuously log calls to a LangChain Model, Chain, or Agent. 
 
-Note that you can also see the documentation for W&B Trace in the [LangChain documentation](https://python.langchain.com/docs/ecosystem/integrations/agent_with_wandb_tracing).
+Note that you can also see the documentation for W&B Trace in the [LangChain documentation](https://python.langchain.com/docs/integrations/providers/wandb_tracing).
 
 For this quickstart, we will use a LangChain Math Agent:
 


### PR DESCRIPTION
## Description

the link to the wandb tracing - langchain docs was incorrect (https://python.langchain.com/docs/integrations/providers/agent_with_wandb_tracing) so i replaced it with the appropriate  link: https://python.langchain.com/docs/integrations/providers/wandb_tracing

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ x] I merged the latest changes from `main` into my feature branch before submitting this PR.
