### PR TITLE
Update add_reference docstring to reflect that local references also …

### DIFF
--- a/docs/ref/python/artifact.md
+++ b/docs/ref/python/artifact.md
@@ -180,8 +180,7 @@ blank.
 |  `uri` |  The URI path of the reference to add. The URI path can be an object returned from `Artifact.get_entry` to store a reference to another artifact's entry. |
 |  `name` |  The path within the artifact to place the contents of this reference. |
 |  `checksum` |  Whether or not to checksum the resource(s) located at the reference URI. Checksumming is strongly recommended as it enables automatic integrity validation, however it can be disabled to speed up artifact creation. |
-|  `max_objects` |  The maximum number of objects to consider when adding a reference that points to directory or bucket store prefix. By default, the maximum number of objects allowed for Amazon S3 and GCS is 10,000. Other URI schemas do not have a maximum. |
-
+|  `max_objects` |  The maximum number of objects to consider when adding a reference. All forms of a URI path, regardless of schema, enforce this maximum. The maximum number of objects allowed for Amazon S3 and GCS is 10,000. 
 | Returns |  |
 | :--- | :--- |
 |  The added manifest entries. |

--- a/docs/ref/python/artifact.md
+++ b/docs/ref/python/artifact.md
@@ -180,7 +180,7 @@ blank.
 |  `uri` |  The URI path of the reference to add. The URI path can be an object returned from `Artifact.get_entry` to store a reference to another artifact's entry. |
 |  `name` |  The path within the artifact to place the contents of this reference. |
 |  `checksum` |  Whether or not to checksum the resource(s) located at the reference URI. Checksumming is strongly recommended as it enables automatic integrity validation, however it can be disabled to speed up artifact creation. |
-|  `max_objects` |  The maximum number of objects to consider when adding a reference. All forms of a URI path, regardless of schema, enforce this maximum. The maximum number of objects allowed for Amazon S3 and GCS is 10,000. 
+|  `max_objects` |  The maximum number of objects to consider when adding a reference that points to directory, bucket store prefix, or local path. By default, the maximum number of objects allowed for Amazon S3 and GCS is 10,000. Other URI schemas do not have a maximum.
 | Returns |  |
 | :--- | :--- |
 |  The added manifest entries. |


### PR DESCRIPTION
…contain max_objects

## Description

We currently tell users in the docs that local file references (Other URI schemas do not have a maximum.) 

## Ticket

[Does this PR fix an existing issue? If yes, provide a link to the ticket here:
](https://wandb.atlassian.net/browse/WB-17514)

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
