### PR TITLE
Removed licnese info while we update the content/docs

### DIFF
--- a/docs/guides/hosting/hosting-options/intro.md
+++ b/docs/guides/hosting/hosting-options/intro.md
@@ -18,7 +18,7 @@ The following shared responsibility matrix outlines the respective responsibilit
 
 ![](/images/hosting/shared_responsibility_matrix.png)
 
-## Obtain your license
+<!-- ## Obtain your license
 
 You need a W&B license to complete your configuration of a W&B server. Open the [Deploy Manager](https://deploy.wandb.ai/deploy) to generate a free license. 
 
@@ -35,4 +35,4 @@ The URL will redirect you to a **Get a License for W&B Local** form. Provide the
 
 A page with an overview of your deployment along with licenses associated to the instance will be displayed.
 
-For information on how to set up your deployment type, see [our How-to guides](../how-to-guides/intro.md) section.
+For information on how to set up your deployment type, see [our How-to guides](../how-to-guides/intro.md) section. -->


### PR DESCRIPTION
## Description

Temporarily removed confusing license info in W&B Server Docs. See Slack thread:
https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1711464107890919

## Ticket

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
