### PR TITLE
Updated docsearc to only index English

### DIFF
--- a/docsearchConfig.json
+++ b/docsearchConfig.json
@@ -1,8 +1,9 @@
 {
   "index_name": "docodile",
-  "start_urls": ["https://docs.wandb.ai"],
   "sitemaps": ["https://docs.wandb.ai/sitemap.xml"],
-  "sitemap_alternate_links": true,
+  "start_urls": ["https://docs.wandb.ai"],
+  "stop_urls": ["https://docs.wandb.ai/ja", "https://docs.wandb.ai/ko"],
+  "sitemap_alternate_links": false,
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -81,7 +81,7 @@ function DocSearch({
   externalUrlRegex,
   ...props
 }: DocSearchProps) {
-  const {siteMetadata, i18n} = useDocusaurusContext();
+  const {siteMetadata} = useDocusaurusContext();
 
   const contextualSearchFacetFilters =
     useAlgoliaContextualFacetFilters() as FacetFilters;
@@ -176,12 +176,6 @@ function DocSearch({
 
   const transformItems = useRef<DocSearchModalProps['transformItems']>(items =>
     items.filter(item => {
-      if (i18n.currentLocale === 'en'){ 
-        return i18n.locales.every( locale => !item.url.includes(`/${locale}/`) ) 
-      } else {
-        return item.url.includes(`/${i18n.currentLocale}/`)
-      }
-    }).map(item => {
       // If Algolia contains a external domain, we should navigate without
       // relative URL
       if (isRegexpStringMatch(externalUrlRegex, item.url)) {


### PR DESCRIPTION
## Description

Update doc search to only look at English sitemap. 

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
