### PR TITLE
Fixing the categorization of role assignment SCIM endpoints

### DIFF
--- a/docs/guides/hosting/iam/automate_iam.md
+++ b/docs/guides/hosting/iam/automate_iam.md
@@ -6,7 +6,7 @@ displayed_sidebar: default
 
 ## SCIM API
 
-Use SCIM API to manage users, and the teams they belong to, in an efficient and repeatable manner. You can also use the SCIM API to manage custom roles or assign roles to users in your W&B organization. Role endpoints are not part of the official SCIM schema. W&B adds role endpoints to support automated management of custom roles and to assign roles to users in W&B organizations.
+Use SCIM API to manage users, and the teams they belong to, in an efficient and repeatable manner. You can also use the SCIM API to manage custom roles or assign roles to users in your W&B organization. Role endpoints are not part of the official SCIM schema. W&B adds role endpoints to support automated management of custom roles.
 
 SCIM API is especially useful if you want to:
 

--- a/docs/guides/hosting/iam/automate_iam.md
+++ b/docs/guides/hosting/iam/automate_iam.md
@@ -17,7 +17,7 @@ There are broadly three categories of SCIM API - **User**, **Group**, and **Role
 
 ### User SCIM API
 
-[User SCIM API](./scim.md#user-resource) allows for creating, deactivating, getting the details of a user, or listing all users in a W&B organization.
+[User SCIM API](./scim.md#user-resource) allows for creating, deactivating, getting the details of a user, or listing all users in a W&B organization. This API also supports assigning predefined or custom roles to users in an organization.
 
 :::info
 Deactivate a user within a W&B organization with the `DELETE User` endpoint. Deactivated users can no longer sign in. However, deactivated users still appears in the organization's user list.
@@ -37,9 +37,9 @@ There is no notion of a `group of users having the same role` within W&B. A W&B 
 W&B maps Group SCIM API endpoints to W&B teams because of the similarity between groups and W&B teams.
 :::
 
-### Custom role and role assignment API
+### Custom role API
 
-[Custom role and role assignment SCIM API](./scim.md#role-resource) allows for managing custom roles, including creating, listing, or updating custom roles in an organization. This API also supports assigning predefined or custom roles to users in an organization.
+[Custom role SCIM API](./scim.md#role-resource) allows for managing custom roles, including creating, listing, or updating custom roles in an organization.
 
 :::caution
 Delete a custom role with caution.
@@ -47,12 +47,6 @@ Delete a custom role with caution.
 Delete a custom role within a W&B organization with the `DELETE Role` endpoint. The predefined role that the custom role inherits is assigned to all users that are assigned the custom role before the operation.
 
 Update the inherited role for a custom role with the `PUT Role` endpoint. This operation doesn't affect any of the existing, that is, non-inherited custom permissions in the custom role.
-:::
-
-:::caution
-The request type and path for the role assignment APIs are same as for the update custom role permissions API. Both types of APIs implement the `PATCH Role` endpoint. Difference is that the URI for role assignment APIs expects a `:userId` parameter, while the URI for custom role API expects a `:roleId`. Expected request bodies for both types of APIs are also different. 
-
-Be careful with the parameter value in the URI and the request body such that those map to the intended operation.
 :::
 
 ## W&B Python SDK API

--- a/docs/guides/hosting/iam/scim.md
+++ b/docs/guides/hosting/iam/scim.md
@@ -191,6 +191,147 @@ DELETE /scim/Users/abc
 
 - Reactivating a previously deactivated user is currently unsupported in the SCIM API.
 
+### Assign organization-level role to user
+
+- **Endpoint**: **`<host-url>/scim/Users/{userId}`**
+- **Method**: PATCH
+- **Description**: Assign an organization-level role to a user. The role can be one of `admin`, `viewer` or `member` as described [here](./manage-users#invite-users). For Public Cloud, ensure that you have configured the correct organization for SCIM API in user settings.
+- **Supported Fields**:
+
+| Field | Type | Required |
+| --- | --- | --- |
+| op | String | Type of operation. The only allowed value is `replace`. |
+| path | String | The scope at which role assignment operation takes effect. The only allowed value is `organizationRole`. |
+| value | String | The predefined organization-level role to assign to the user. It can be one of `admin`, `viewer` or `member`. This field is case insensitive for predefined roles. |
+- **Request Example**:
+
+```bash
+PATCH /scim/Users/abc
+```
+
+```json
+{
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+        {
+            "op": "replace",
+            "path": "organizationRole",
+            "value": "admin" // will set the user's organization-scoped role to admin
+        }
+    ]
+}
+```
+
+- **Response Example**:
+This returns the User object.
+
+```bash
+(Status 200)
+```
+
+```json
+{
+    "active": true,
+    "emails": {
+        "Value": "dev-user1@test.com",
+        "Display": "",
+        "Type": "",
+        "Primary": true
+    },
+    "id": "abc",
+    "meta": {
+        "resourceType": "User",
+        "created": "2023-10-01T00:00:00Z",
+        "lastModified": "2023-10-01T00:00:00Z",
+        "location": "Users/abc"
+    },
+    "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "dev-user1",
+    "teamRoles": [  // Returns the user's roles in all the teams that they are a part of
+        {
+            "teamName": "team1",
+            "roleName": "admin"
+        }
+    ],
+    "organizationRole": "admin" // Returns the user's role at the organization scope
+}
+```
+
+### Assign team-level role to user
+
+- **Endpoint**: **`<host-url>/scim/Users/{userId}`**
+- **Method**: PATCH
+- **Description**: Assign a team-level role to a user. The role can be one of `admin`, `viewer`, `member` or a custom role as described [here](./manage-users#team-roles). For Public Cloud, ensure that you have configured the correct organization for SCIM API in user settings.
+- **Supported Fields**:
+
+| Field | Type | Required |
+| --- | --- | --- |
+| op | String | Type of operation. The only allowed value is `replace`. |
+| path | String | The scope at which role assignment operation takes effect. The only allowed value is `teamRoles`. |
+| value | Object array | A one-object array where the object consists of `teamName` and `roleName` attributes. The `teamName` is the name of the team where the user holds the role, and `roleName` can be one of `admin`, `viewer`, `member` or a custom role. This field is case insensitive for predefined roles and case sensitive for custom roles. |
+- **Request Example**:
+
+```bash
+PATCH /scim/Users/abc
+```
+
+```json
+{
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+        {
+            "op": "replace",
+            "path": "teamRoles",
+            "value": [
+                {
+                    "roleName": "admin", // role name is case insensitive for predefined roles and case sensitive for custom roles
+                    "teamName": "team1" // will set the user's role in the team team1 to admin
+                }
+            ]
+        }
+    ]
+}
+```
+
+- **Response Example**:
+This returns the User object.
+
+```bash
+(Status 200)
+```
+
+```json
+{
+    "active": true,
+    "emails": {
+        "Value": "dev-user1@test.com",
+        "Display": "",
+        "Type": "",
+        "Primary": true
+    },
+    "id": "abc",
+    "meta": {
+        "resourceType": "User",
+        "created": "2023-10-01T00:00:00Z",
+        "lastModified": "2023-10-01T00:00:00Z",
+        "location": "Users/abc"
+    },
+    "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "dev-user1",
+    "teamRoles": [  // Returns the user's roles in all the teams that they are a part of
+        {
+            "teamName": "team1",
+            "roleName": "admin"
+        }
+    ],
+    "organizationRole": "admin" // Returns the user's role at the organization scope
+}
+```
+
 ## Group resource
 
 The SCIM group resource maps to W&B teams, that is, when you create a SCIM group in a W&B deployment, it creates a W&B team. Same applies to other group endpoints.
@@ -658,12 +799,6 @@ DELETE /scim/Roles/abc
 | value | Object array | Array of permission objects where each object includes a `name` string field that has value of the form `w&bobject:operation`. For example, a permission object for delete operation on W&B runs would have `name` as `run:delete`. |
 - **Request Example**:
 
-:::caution
-The request path for the update custom role permissions API is same as for role assignment APIs, that is, the [PATCH - Assign organization-level role to user](#assign-organization-level-role-to-user) and [PATCH - Assign team-level role to user](#assign-team-level-role-to-user) operations. Difference is that the URI for custom role APIs expects a `:roleId` parameter, while the URI for role assignment APIs expects a `:userId`. Expected request bodies for both types of APIs are also different. 
-
-Be careful with the parameter value in the URI and the request body such that those map to the intended operation.
-:::
-
 ```bash
 PATCH /scim/Roles/abc
 ```
@@ -790,158 +925,5 @@ PUT /scim/Roles/abc
     "schemas": [
         ""
     ]
-}
-```
-
-### Assign organization-level role to user
-
-- **Endpoint**: **`<host-url>/scim/Roles/{userId}`**
-- **Method**: PATCH
-- **Description**: Assign an organization-level role to a user. The role can be one of `admin`, `viewer` or `member` as described [here](./manage-users#invite-users). For Public Cloud, ensure that you have configured the correct organization for SCIM API in user settings.
-- **Supported Fields**:
-
-| Field | Type | Required |
-| --- | --- | --- |
-| op | String | Type of operation. The only allowed value is `replace`. |
-| path | String | The scope at which role assignment operation takes effect. The only allowed value is `organizationRole`. |
-| value | String | The predefined organization-level role to assign to the user. It can be one of `admin`, `viewer` or `member`. This field is case insensitive for predefined roles. |
-- **Request Example**:
-
-:::caution
-The request path for the role assignment API is same as for custom role APIs, especially the [PATCH - Update custom role permissions](#update-custom-role-permissions) operation. Difference is that the URI for role assignment API expects a `:userId` parameter, while the URI for custom role API expects a `:roleId`. Expected request bodies for both APIs are also different. 
-
-Be careful with the parameter value in the URI and the request body such that those map to the intended operation.
-:::
-
-```bash
-PUT /scim/Roles/abc
-```
-
-```json
-{
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-    "Operations": [
-        {
-            "op": "replace",
-            "path": "organizationRole",
-            "value": "admin" // will set the user's organization-scoped role to admin
-        }
-    ]
-}
-```
-
-- **Response Example**:
-This returns a User object, like in case of [user resource](#user-resource).
-
-```bash
-(Status 200)
-```
-
-```json
-{
-    "active": true,
-    "emails": {
-        "Value": "dev-user1@test.com",
-        "Display": "",
-        "Type": "",
-        "Primary": true
-    },
-    "id": "abc",
-    "meta": {
-        "resourceType": "User",
-        "created": "2023-10-01T00:00:00Z",
-        "lastModified": "2023-10-01T00:00:00Z",
-        "location": "Users/abc"
-    },
-    "schemas": [
-        "urn:ietf:params:scim:schemas:core:2.0:User"
-    ],
-    "userName": "dev-user1",
-    "teamRoles": [  // Returns the user's roles in all the teams that they are a part of
-        {
-            "teamName": "team1",
-            "roleName": "admin"
-        }
-    ],
-    "organizationRole": "admin" // Returns the user's role at the organization scope
-}
-```
-
-### Assign team-level role to user
-
-- **Endpoint**: **`<host-url>/scim/Roles/{userId}`**
-- **Method**: PATCH
-- **Description**: Assign a team-level role to a user. The role can be one of `admin`, `viewer`, `member` or a custom role as described [here](./manage-users#team-roles). For Public Cloud, ensure that you have configured the correct organization for SCIM API in user settings.
-- **Supported Fields**:
-
-| Field | Type | Required |
-| --- | --- | --- |
-| op | String | Type of operation. The only allowed value is `replace`. |
-| path | String | The scope at which role assignment operation takes effect. The only allowed value is `teamRoles`. |
-| value | Object array | A one-object array where the object consists of `teamName` and `roleName` attributes. The `teamName` is the name of the team where the user holds the role, and `roleName` can be one of `admin`, `viewer`, `member` or a custom role. This field is case insensitive for predefined roles and case sensitive for custom roles. |
-- **Request Example**:
-
-:::caution
-The request path for the role assignment API is same as for custom role APIs, especially the [PATCH - Update custom role permissions](#update-custom-role-permissions) operation. Difference is that the URI for role assignment API expects a `:userId` parameter, while the URI for custom role API expects a `:roleId`. Expected request bodies for both APIs are also different. 
-
-Be careful with the parameter value in the URI and the request body such that those map to the intended operation.
-:::
-
-```bash
-PUT /scim/Roles/abc
-```
-
-```json
-{
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-    "Operations": [
-        {
-            "op": "replace",
-            "path": "teamRoles",
-            "value": [
-                {
-                    "roleName": "admin", // role name is case insensitive for predefined roles and case sensitive for custom roles
-                    "teamName": "team1" // will set the user's role in the team team1 to admin
-                }
-            ]
-        }
-    ]
-}
-```
-
-- **Response Example**:
-This returns a User object, like in case of [user resource](#user-resource).
-
-```bash
-(Status 200)
-```
-
-```json
-{
-    "active": true,
-    "emails": {
-        "Value": "dev-user1@test.com",
-        "Display": "",
-        "Type": "",
-        "Primary": true
-    },
-    "id": "abc",
-    "meta": {
-        "resourceType": "User",
-        "created": "2023-10-01T00:00:00Z",
-        "lastModified": "2023-10-01T00:00:00Z",
-        "location": "Users/abc"
-    },
-    "schemas": [
-        "urn:ietf:params:scim:schemas:core:2.0:User"
-    ],
-    "userName": "dev-user1",
-    "teamRoles": [  // Returns the user's roles in all the teams that they are a part of
-        {
-            "teamName": "team1",
-            "roleName": "admin"
-        }
-    ],
-    "organizationRole": "admin" // Returns the user's role at the organization scope
 }
 ```


### PR DESCRIPTION
## Description

It fixes the categorization of role assignment SCIM endpoints in the doc. Those are incorrectly listed in the Roles section when those should be in Users section. It also fixes the URI path for those endpoints.

## Ticket

NA

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
