### PR TITLE
Add requirement for AWS_REGION to reference artifact documentation

### DIFF
--- a/docs/guides/artifacts/track-external-files.md
+++ b/docs/guides/artifacts/track-external-files.md
@@ -76,6 +76,8 @@ W&B will use the default mechanism to look for credentials based on the cloud pr
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |
 
+For AWS, if the bucket is not located in the configured user's default region, the `AWS_REGION` environment variable must be set to match the bucket region.
+
 Interact with this artifact similarly to a normal artifact. In the App UI, you can look through the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact.
 
 :::caution

--- a/docs/guides/artifacts/track-external-files.md
+++ b/docs/guides/artifacts/track-external-files.md
@@ -76,7 +76,7 @@ W&B will use the default mechanism to look for credentials based on the cloud pr
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |
 
-For AWS, if the bucket is not located in the configured user's default region, the `AWS_REGION` environment variable must be set to match the bucket region.
+For AWS, if the bucket is not located in the configured user's default region, you must set the `AWS_REGION` environment variable to match the bucket region.
 
 Interact with this artifact similarly to a normal artifact. In the App UI, you can look through the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact.
 


### PR DESCRIPTION
## Descriptio

State that `AWS_REGION` needs to be set in order to access buckets in non-default regions.

## Ticket

Addresses [WB-17840](https://wandb.atlassian.net/browse/WB-17840)

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.


[WB-17840]: https://wandb.atlassian.net/browse/WB-17840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ