### PR TITLE
Add note that W&B Importer requires py38+

### DIFF
--- a/docs/guides/track/public-api-guide.md
+++ b/docs/guides/track/public-api-guide.md
@@ -14,6 +14,10 @@ import TabItem from '@theme/TabItem';
 
 Export data or import data from MLFlow or between W&B instances with W&B Public APIs.
 
+:::info
+This feature requires python>=3.8
+:::
+
 ## Import Data from MLFlow
 
 W&B supports importing data from MLFlow, including experiments, runs, artifacts, metrics, and other metadata.
@@ -21,6 +25,7 @@ W&B supports importing data from MLFlow, including experiments, runs, artifacts,
 Install dependencies:
 
 ```shell
+# note: this requires py38+
 pip install wandb[importers]
 ```
 
@@ -85,6 +90,7 @@ This feature is in beta, and only supports importing from the W&B public cloud.
 Install dependencies:
 
 ```sh
+# note: this requires py38+
 pip install wandb[importers]
 ```
 


### PR DESCRIPTION
## Description

Add note that W&B Importer requires py38+

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
