### PR TITLE
remove an extra square bracket typo

### DIFF
--- a/docs/guides/prompts/intro.md
+++ b/docs/guides/prompts/intro.md
@@ -5,7 +5,7 @@ description: Tools for the development of LLM-powered applications
 displayed_sidebar: default
 ---
 :::info
-Introducing Weave: Track, Debug, Evaluate & Monitor Generative AI Applications. To learn more, find the docs for Weave here: [wandb.me/weave](https://wandb.me/weave)].
+Introducing Weave: Track, Debug, Evaluate & Monitor Generative AI Applications. To learn more, find the docs for Weave here: [wandb.me/weave](https://wandb.me/weave).
 :::
 
 W&B Prompts is a suite of LLMOps tools built for the development of LLM-powered applications. Use W&B Prompts to visualize and inspect the execution flow of your LLMs, analyze the inputs and outputs of your LLMs, view the intermediate results and securely store and manage your prompts and LLM chain configurations.

--- a/docs/guides/prompts_platform.md
+++ b/docs/guides/prompts_platform.md
@@ -4,7 +4,7 @@ displayed_sidebar: default
 # LLMs
 
 :::info
-Introducing Weave: Track, Debug, Evaluate & Monitor Generative AI Applications. To learn more, find the docs for Weave here: [wandb.me/weave](https://wandb.me/weave)].
+Introducing Weave: Track, Debug, Evaluate & Monitor Generative AI Applications. To learn more, find the docs for Weave here: [wandb.me/weave](https://wandb.me/weave).
 :::
 
 Evaluating the performance of Large Language Models (LLMs) can be difficult. Use W&B Prompts and LLM Monitoring to streamline the evaluation process, providing a visual way to analyze your generative models.


### PR DESCRIPTION
## Description

Fixes typo - extra trailing square bracket in info box.

<img width="612" alt="Screenshot 2024-04-23 at 10 44 30 AM" src="https://github.com/wandb/docodile/assets/112953339/08eb00c1-1783-4887-835a-e26949a872de">

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
