### PR TITLE
Update integration namespaces as per wandv release v0.17.0

### DIFF
--- a/docs/guides/integrations/keras.md
+++ b/docs/guides/integrations/keras.md
@@ -37,7 +37,7 @@ Using this provides:
 
 ```python
 import wandb
-from wandb.keras import WandbMetricsLogger
+from wandb.integration.keras import WandbMetricsLogger
 
 # Initialize a new W&B run
 wandb.init(config={"bs": 12})
@@ -76,7 +76,7 @@ This callback should be used in conjunction with `WandbMetricsLogger`.
 
 ```python
 import wandb
-from wandb.keras import WandbMetricsLogger, WandbModelCheckpoint
+from wandb.integration.keras import WandbMetricsLogger, WandbModelCheckpoint
 
 # Initialize a new W&B run
 wandb.init(config={"bs": 12})
@@ -154,7 +154,7 @@ For example, we have implemented `WandbClfEvalCallback` below for an image class
 
 ```python
 import wandb
-from wandb.keras import WandbMetricsLogger, WandbEvalCallback
+from wandb.integration.keras import WandbMetricsLogger, WandbEvalCallback
 
 
 # Implement your model prediction visualization callback
@@ -238,7 +238,7 @@ Use the W&B library [`WandbCallback`](https://docs.wandb.ai/ref/python/integrati
 
 ```python
 import wandb
-from wandb.keras import WandbCallback
+from wandb.integration.keras import WandbCallback
 
 wandb.init(config={"hyper": "parameter"})
 

--- a/docs/guides/integrations/lightgbm.md
+++ b/docs/guides/integrations/lightgbm.md
@@ -8,7 +8,7 @@ displayed_sidebar: default
 The `wandb` library includes a special callback for [LightGBM](https://lightgbm.readthedocs.io/en/latest/). It's also easy to use the generic logging features of Weights & Biases to track large experiments, like hyperparameter sweeps.
 
 ```python
-from wandb.lightgbm import wandb_callback, log_summary
+from wandb.integration.lightgbm import wandb_callback, log_summary
 import lightgbm as lgb
 
 # Log metrics to W&B

--- a/docs/guides/integrations/xgboost.md
+++ b/docs/guides/integrations/xgboost.md
@@ -16,7 +16,7 @@ The `wandb` library has a `WandbCallback` callback for logging metrics, configs 
 Logging XGBoost metrics, configs and booster models to Weights & Biases is as easy as passing the `WandbCallback` to XGBoost:
 
 ```python
-from wandb.xgboost import WandbCallback
+from wandb.integration.xgboost import WandbCallback
 import xgboost as XGBClassifier
 
 ...

--- a/docs/tutorials/keras.md
+++ b/docs/tutorials/keras.md
@@ -29,7 +29,7 @@ import tensorflow_datasets as tfds
 
 # Weights and Biases related imports
 import wandb
-from wandb.keras import WandbMetricsLogger
+from wandb.integration.keras import WandbMetricsLogger
 ```
 
 If this is your first time using W&B or you are not logged in, the link that appears after running `wandb.login()` will take you to sign-up/login page. Signing up for a [free account](https://wandb.ai/signup) is as easy as a few clicks.

--- a/docs/tutorials/keras_models.md
+++ b/docs/tutorials/keras_models.md
@@ -27,8 +27,8 @@ import tensorflow_datasets as tfds
 
 # Weights and Biases related imports
 import wandb
-from wandb.keras import WandbMetricsLogger
-from wandb.keras import WandbModelCheckpoint
+from wandb.integration.keras import WandbMetricsLogger
+from wandb.integration.keras import WandbModelCheckpoint
 ```
 
 If this is your first time using W&B or you are not logged in, the link that appears after running `wandb.login()` will take you to sign-up/login page. Signing up for a [free account](https://wandb.ai/signup) is as easy as a few clicks.

--- a/docs/tutorials/keras_tables.md
+++ b/docs/tutorials/keras_tables.md
@@ -28,9 +28,9 @@ import tensorflow_datasets as tfds
 
 # Weights and Biases related imports
 import wandb
-from wandb.keras import WandbMetricsLogger
-from wandb.keras import WandbModelCheckpoint
-from wandb.keras import WandbEvalCallback
+from wandb.integration.keras import WandbMetricsLogger
+from wandb.integration.keras import WandbModelCheckpoint
+from wandb.integration.keras import WandbEvalCallback
 ```
 
 If this is your first time using W&B or you are not logged in, the link that appears after running `wandb.login()` will take you to sign-up/login page. Signing up for a [free account](https://wandb.ai/signup) is as easy as a few clicks.

--- a/docs/tutorials/lightgbm.md
+++ b/docs/tutorials/lightgbm.md
@@ -48,7 +48,7 @@ from sklearn.metrics import mean_squared_error
 
 ```python
 import wandb
-from wandb.lightgbm import wandb_callback, log_summary
+from wandb.integration.lightgbm import wandb_callback, log_summary
 
 wandb.login()
 ```

--- a/docs/tutorials/xgboost.md
+++ b/docs/tutorials/xgboost.md
@@ -360,7 +360,7 @@ To log all our xgboost model parameters we used the `WandbCallback`. This will .
 
 
 ```python
-from wandb.xgboost import WandbCallback
+from wandb.integration.xgboost import WandbCallback
 
 # Initialize the XGBoostClassifier with the WandbCallback
 xgbmodel = xgb.XGBClassifier(


### PR DESCRIPTION
## Description

Update namespaces for the keras, xgboost, and lightgbm integrations as per [SDK Release - v0.17.0](https://github.com/wandb/wandb/releases/tag/v0.17.0).

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
