### PR TITLE
Removes unclear model link from Artifacts landing page.

### DIFF
--- a/docs/guides/artifacts/intro.md
+++ b/docs/guides/artifacts/intro.md
@@ -21,7 +21,7 @@ You can use artifacts throughout your entire ML workflow as inputs and outputs o
 
 | Use Case               | Input                       | Output                       |
 |------------------------|-----------------------------|------------------------------|
-| Model Training         | Dataset (training and validation data)     | Trained [Model](../models.md)                |
+| Model Training         | Dataset (training and validation data)     | Trained Model                |
 | Dataset Pre-Processing | Dataset (raw data)          | Dataset (pre-processed data) |
 | Model Evaluation       | Model + Dataset (test data) | [W&B Table](../tables/intro.md)                        |
 | Model Optimization     | Model                       | Optimized Model              |

--- a/docs/guides/artifacts/intro.md
+++ b/docs/guides/artifacts/intro.md
@@ -38,7 +38,7 @@ Create an artifact with four lines of code:
 
 ```python
 run = wandb.init(project="artifacts-example", job_type="add-dataset")
-run.log_artifact(artifact "./dataset.h5", "my_data", "dataset" ) # Logs the artifact version "my_data:v0" as a dataset with data from dataset.h5
+run.log_artifact(artifact data = "./dataset.h5", naame = "my_data", type= "dataset" ) # Logs the artifact version "my_data:v0" as a dataset with data from dataset.h5
 ```
 
 :::tip

--- a/docs/guides/artifacts/intro.md
+++ b/docs/guides/artifacts/intro.md
@@ -37,8 +37,8 @@ Create an artifact with four lines of code:
 
 
 ```python
-run = wandb.init(project="artifacts-example", job_type="add-dataset")
-run.log_artifact(data = "./dataset.h5", name = "my_data", type= "dataset" ) # Logs the artifact version "my_data" as a dataset with data from dataset.h5
+run = wandb.init(project = "artifacts-example", job_type = "add-dataset")
+run.log_artifact(data = "./dataset.h5", name = "my_data", type = "dataset" ) # Logs the artifact version "my_data" as a dataset with data from dataset.h5
 ```
 
 :::tip

--- a/docs/guides/artifacts/intro.md
+++ b/docs/guides/artifacts/intro.md
@@ -38,7 +38,7 @@ Create an artifact with four lines of code:
 
 ```python
 run = wandb.init(project="artifacts-example", job_type="add-dataset")
-run.log_artifact(artifact data = "./dataset.h5", naame = "my_data", type= "dataset" ) # Logs the artifact version "my_data:v0" as a dataset with data from dataset.h5
+run.log_artifact(data = "./dataset.h5", name = "my_data", type= "dataset" ) # Logs the artifact version "my_data" as a dataset with data from dataset.h5
 ```
 
 :::tip

--- a/docs/guides/artifacts/intro.md
+++ b/docs/guides/artifacts/intro.md
@@ -38,9 +38,7 @@ Create an artifact with four lines of code:
 
 ```python
 run = wandb.init(project="artifacts-example", job_type="add-dataset")
-artifact = wandb.Artifact(name="my_data", type="dataset")
-artifact.add_file(local_path="./dataset.h5")  # Add dataset file to artifact
-run.log_artifact(artifact)  # Logs the artifact version "my_data:v0"
+run.log_artifact(artifact "./dataset.h5", "my_data", "dataset" ) # Logs the artifact version "my_data:v0" as a dataset with data from dataset.h5
 ```
 
 :::tip


### PR DESCRIPTION
## Description

Removes unclear model link from the table in the Artifacts landing page.
Bonus: also adds one-line artifact logging to the landing page, replacing sub-optimal code. Sneaky.

## Ticket

N/A

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
