### PR TITLE
fix: Update relative URL logic so search doesn't break

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -175,7 +175,7 @@ function DocSearch({
   }).current;
 
   const transformItems = useRef<DocSearchModalProps['transformItems']>(items =>
-    items.filter(item => {
+    items.map(item => {
       // If Algolia contains a external domain, we should navigate without
       // relative URL
       if (isRegexpStringMatch(externalUrlRegex, item.url)) {


### PR DESCRIPTION
## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

Previously we were using the wrong JS function to transform URLs to relative links. This should fix that so searching and hitting enter on the keyboard should work.

**Note**: this changes some functionality. Previously clicking an article in the search list opened a new tab, and now it stays on the same tab but navigates to the new page

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
