### PR TITLE
Adding new params to the openai-finetuning integration

### DIFF
--- a/docs/guides/integrations/other/openai-fine-tuning.md
+++ b/docs/guides/integrations/other/openai-fine-tuning.md
@@ -59,6 +59,8 @@ WandbLogger.sync(
     project="OpenAI-Fine-Tune",
     entity=None,
     overwrite=False,
+    model_artifact_name="model-metadata",
+    model_artifact_type="model",
     **kwargs_wandb_init
 )
 ```
@@ -74,6 +76,8 @@ WandbLogger.sync(
 | entity                   | Weights & Biases Username or team name where you're sending runs. By default, your default entity is used, which is usually your username. |
 | overwrite                | Forces logging and overwrite existing wandb run of the same fine-tune job. By default this is False.                                                |
 | wait_for_job_success     | Once an OpenAI fine-tuning job is started it usually takes a bit of time. To ensure that your metrics are logged to W&B as soon as the fine-tune job is finished, this setting will check every 60 seconds for the status of the fine-tune job to change to "succeeded". Once the fine-tune job is detected as being successful, the metrics will be synced automatically to W&B. Set to True by default.                                                    |
+| model_artifact_name      | The name of the model artifact that is logged. Defaults to `"model-metadata"`.                    |
+| model_artifact_type      | The type of the model artifact that is logged. Defaults to `"model"`.                    |
 | \*\*kwargs\_wandb\_init  | Aany additional argument passed directly to [`wandb.init()`](../../../ref/python/init.md)                    |
 
 ## Dataset Versioning and Visualization


### PR DESCRIPTION
## Description

Adds documentation for the 2 new params added in [this PR](https://github.com/wandb/wandb/pull/7644)
## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X ] I merged the latest changes from `main` into my feature branch before submitting this PR.
