### PR TITLE
Allows LLMOps and MLOps in Vale.

### DIFF
--- a/.github/styles/config/vocabularies/Docs/accept.txt
+++ b/.github/styles/config/vocabularies/Docs/accept.txt
@@ -30,8 +30,10 @@ Keras
 Kubeflow
 Kubernetes
 [Ll]atents
+LLMOps
 MMEngine
 MMDetection
+MLOps
 [Nn]amespace
 [Oo]perator
 Optuna


### PR DESCRIPTION
## Description

Adds LLM and MLOps to the Vale allowlist.

## Ticket

N/A

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
