### PR TITLE
Fixed link

### DIFF
--- a/docs/guides/launch/setup-launch-sagemaker.md
+++ b/docs/guides/launch/setup-launch-sagemaker.md
@@ -15,7 +15,7 @@ Launch jobs sent to a W&B Launch queue connected to Amazon SageMaker are execute
 Amazon SageMaker [uses Docker images to execute training jobs](https://docs.aws.amazon.com/SageMaker/latest/dg/your-algorithms-training-algo-dockerfile.html). Images pulled by SageMaker must be stored in the Amazon Elastic Container Registry (ECR). This means that the image you use for training must be stored on ECR. 
 
 :::note
-This guide shows how to execute SageMaker Training Jobs. For information on how to deploy to models for inference on Amazon SageMaker, see [this example Launch job](https://github.com/wandb/launch-jobs/tree/main/jobs/deploy_to_SageMaker_endpoints).
+This guide shows how to execute SageMaker Training Jobs. For information on how to deploy to models for inference on Amazon SageMaker, see [this example Launch job](https://github.com/wandb/launch-jobs/tree/main/jobs/deploy_to_sagemaker_endpoints).
 :::
 
 


### PR DESCRIPTION
## Description

Fixes broken link in the [launch for sagemaker page](https://docs.wandb.ai/guides/launch/setup-launch-sagemaker)

https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1717070653138059

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
