### PR TITLE
Added titles to Server Docs

### DIFF
--- a/docs/guides/hosting/hosting-options/self-managed.md
+++ b/docs/guides/hosting/hosting-options/self-managed.md
@@ -4,6 +4,8 @@ description: Deploying W&B in production
 displayed_sidebar: default
 ---
 
+# Self managed
+
 :::info
 W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](./saas_cloud.md) or [W&B Dedicated Cloud](./dedicated_cloud.md) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
 :::

--- a/docs/guides/hosting/self-managed/aws-tf.md
+++ b/docs/guides/hosting/self-managed/aws-tf.md
@@ -4,6 +4,8 @@ description: Hosting W&B Server on AWS.
 displayed_sidebar: default
 ---
 
+# AWS
+
 :::info
 W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](../hosting-options/saas_cloud.md) or [W&B Dedicated Cloud](../hosting-options//dedicated_cloud.md) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
 :::

--- a/docs/guides/hosting/self-managed/azure-tf.md
+++ b/docs/guides/hosting/self-managed/azure-tf.md
@@ -4,6 +4,8 @@ description: Hosting W&B Server on Azure.
 displayed_sidebar: default
 ---
 
+# Azure
+
 :::info
 W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](../hosting-options/saas_cloud.md) or [W&B Dedicated Cloud](../hosting-options//dedicated_cloud.md) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
 :::

--- a/docs/guides/hosting/self-managed/bare-metal.md
+++ b/docs/guides/hosting/self-managed/bare-metal.md
@@ -6,6 +6,8 @@ displayed_sidebar: default
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+# Install on on-prem infra
+
 :::info
 W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](../hosting-options/saas_cloud.md) or [W&B Dedicated Cloud](../hosting-options//dedicated_cloud.md) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
 :::

--- a/docs/guides/hosting/self-managed/gcp-tf.md
+++ b/docs/guides/hosting/self-managed/gcp-tf.md
@@ -4,6 +4,8 @@ description: Hosting W&B Server on GCP.
 displayed_sidebar: default
 ---
 
+# GCP
+
 :::info
 W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](../hosting-options/saas_cloud.md) or [W&B Dedicated Cloud](../hosting-options//dedicated_cloud.md) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
 :::


### PR DESCRIPTION
## Description

Some W&B Platform (Server) docs were missing H1 titles.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
