### PR TITLE
Removed extra call

### DIFF
--- a/docs/guides/artifacts/update-an-artifact.md
+++ b/docs/guides/artifacts/update-an-artifact.md
@@ -36,8 +36,6 @@ import wandb
 
 run = wandb.init(project="<example>", job_type="<job-type>")
 artifact = run.use_artifact("<artifact-name>:<alias>")
-
-run.use_artifact(artifact)
 artifact.description = "<description>"
 artifact.save()
 ```


### PR DESCRIPTION
## Description

Forgot to remove an extra "use_artifact" call. related to: https://github.com/wandb/docodile/pull/721/files

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
