### PR TITLE
Removed activity dashboard references

### DIFF
--- a/docs/guides/app/features/teams.md
+++ b/docs/guides/app/features/teams.md
@@ -119,13 +119,12 @@ The proceeding table lists permissions that apply to all artifacts across a give
 | Download artifact|           | X           | X          |
 
 ### System settings (W&B Server only)
-System permissions allow you to manage members, create and modify teams, adjust system settings, and view user activity. These privileges enable you to effectively administer and maintain the W&B instance.
+System permissions allow you to manage members, create and modify teams, and adjust system settings. These privileges enable you to effectively administer and maintain the W&B instance.
 
 | Permissions              | View-Only | Team Member | Team Admin | System Admin | 
 | ------------------------ | --------- | ----------- | ---------- | ------------ |
 | Configure system settings|           |             |            | X            |
 | Create/delete teams      |           |             |            | X            |
-| View activity dashboard  |           |             |            | X            |
 
 ### Team service account behavior
 


### PR DESCRIPTION
## Description

The activity dashboard was removed in 0.56. This PR removes references to it.

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
