### PR TITLE
Adds link to the tutorial video in the getting started section

### DIFF
--- a/docs/guides/registry/intro.md
+++ b/docs/guides/registry/intro.md
@@ -67,6 +67,9 @@ Based on your deployment type, satisfy the following conditions to enable W&B Re
 
 Depending on your use case, explore the following resources to get started with the W&B Registry:
 
+- Check out the tutorial video:
+    - [Getting started with Registry from Weights & Biases](https://www.youtube.com/watch?v=p4XkVOsjIeM)
+
 - Take the W&B [Model CI/CD](https://www.wandb.courses/courses/enterprise-model-management) course and learn how to:
     - Use W&B Registry to manage and version your artifacts, track lineage, and promote models through different lifecycle stages
     - Automate your model management workflows using webhooks and launch jobs.


### PR DESCRIPTION
## Description

Added tutorial video link which became available today to "Resources to get started" section. This link replaces the old video link which was outdated and previously removed from the page.

Preferred due date: July 25 or 26 if possible.

## Ticket

No ticket available. Content changes only.

## Checklist

Page edits made in-place. I have previewed the document on Github to validate, but have not checked out code on a local server.

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
