### PR TITLE
Update log_model.md to note legacy Model Registry compatibility

### DIFF
--- a/docs/guides/track/log/log-models.md
+++ b/docs/guides/track/log/log-models.md
@@ -156,7 +156,7 @@ See [`use_model`](../../../ref/python/run.md#use_model) in the API Reference gui
 ## Log and link a model to the W&B Model Registry
 
 :::info
-The [`link_model`](../../../ref/python/run.md#link_model) method is currently only compatible with the legacy model registry, which will soon be deprecated. To learn how to link a model artifact to the new edition of model registry, visit the Registry [docs](https://docs.wandb.ai/guides/registry/link_version). 
+The [`link_model`](../../../ref/python/run.md#link_model) method is currently only compatible with the legacy W&B Model Registry, which will soon be deprecated. To learn how to link a model artifact to the new edition of model registry, visit the Registry [docs](../../registry/link_version.md). 
 :::
 
 Use the [`link_model`](../../../ref/python/run.md#link_model) method to log model file(s) to a W&B run and link it to the [W&B Model Registry](../../model_registry/intro.md). If no registered model exists, W&B will create a new one for you with the name you provide for the `registered_model_name` parameter. 

--- a/docs/guides/track/log/log-models.md
+++ b/docs/guides/track/log/log-models.md
@@ -154,6 +154,11 @@ downloaded_model_path = run.use_model(name = f"{model_artifact_name}:{alias}")
 See [`use_model`](../../../ref/python/run.md#use_model) in the API Reference guide for more information on possible parameters and return type.
 
 ## Log and link a model to the W&B Model Registry
+
+:::info
+The [`link_model`](../../../ref/python/run.md#link_model) method is currently only compatible with the legacy model registry, which will soon be deprecated. To learn how to link a model artifact to the new edition of model registry, visit the Registry [docs](https://docs.wandb.ai/guides/registry/link_version). 
+:::
+
 Use the [`link_model`](../../../ref/python/run.md#link_model) method to log model file(s) to a W&B run and link it to the [W&B Model Registry](../../model_registry/intro.md). If no registered model exists, W&B will create a new one for you with the name you provide for the `registered_model_name` parameter. 
 
 :::tip


### PR DESCRIPTION
Updated the log_model.md file to include information about the upcoming deprecation of the legacy model registry and the current compatibility of the `link_model` method. Added a note directing users to the Registry documentation for instructions on linking a model artifact to the new edition of the model registry. This ensures users are aware of the impending changes and can access the latest guidance.

Details:
- Added a section in the log_model.md file under an info block to notify users about the limited compatibility of the link_model method.
- Informed users that the legacy model registry will soon be deprecated.
- Provided a link to the latest Registry documentation for up-to-date instructions on linking model artifacts.

## Description

What does the pull request do? If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
