### PR TITLE
Update recommended sort_buffer_size for mysql for bare metal installs

### DIFF
--- a/docs/guides/hosting/self-managed/bare-metal.md
+++ b/docs/guides/hosting/self-managed/bare-metal.md
@@ -101,7 +101,7 @@ innodb_flush_log_at_trx_commit = 1
 binlog_row_image = 'MINIMAL'
 ```
 
-Due to some changes in the way that MySQL 8.0 handles `sort_buffer_size`, you might need to update the `sort_buffer_size` parameter from its default value of `262144`. Our recommendation is to set the value to `64000000(64MB)` in order for the database to efficiently work with the W&B application. Note that, this only works with MySQL versions 8.0.28 and above.
+Due to some changes in the way that MySQL 8.0 handles `sort_buffer_size`, you might need to update the `sort_buffer_size` parameter from its default value of `262144`. Our recommendation is to set the value to `67108864(64MiB)` in order for the database to efficiently work with the W&B application. Note that, this only works with MySQL versions 8.0.28 and above.
 
 ### Database considerations
 
@@ -130,7 +130,7 @@ innodb_online_alter_log_max_size = 268435456
 sync_binlog = 1
 innodb_flush_log_at_trx_commit = 1
 binlog_row_image = 'MINIMAL'
-sort_buffer_size = 64000000
+sort_buffer_size = 67108864
 ```
 
 ## Object Store

--- a/docs/guides/hosting/self-managed/bare-metal.md
+++ b/docs/guides/hosting/self-managed/bare-metal.md
@@ -101,7 +101,7 @@ innodb_flush_log_at_trx_commit = 1
 binlog_row_image = 'MINIMAL'
 ```
 
-Due to some changes in the way that MySQL 8.0 handles `sort_buffer_size`, you might need to update the `sort_buffer_size` parameter from its default value of `262144`. Our recommendation is to set the value to `33554432(32MiB)` in order for the database to efficiently work with the W&B application. Note that, this only works with MySQL versions 8.0.28 and above.
+Due to some changes in the way that MySQL 8.0 handles `sort_buffer_size`, you might need to update the `sort_buffer_size` parameter from its default value of `262144`. Our recommendation is to set the value to `64000000(64MB)` in order for the database to efficiently work with the W&B application. Note that, this only works with MySQL versions 8.0.28 and above.
 
 ### Database considerations
 
@@ -130,7 +130,7 @@ innodb_online_alter_log_max_size = 268435456
 sync_binlog = 1
 innodb_flush_log_at_trx_commit = 1
 binlog_row_image = 'MINIMAL'
-sort_buffer_size = 33554432
+sort_buffer_size = 64000000
 ```
 
 ## Object Store


### PR DESCRIPTION
## Description

Fixes recommended sort_buffer_size for mysql for bare metal installs

## Ticket

No

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ x] I merged the latest changes from `main` into my feature branch before submitting this PR.
