### PR TITLE
Settings ->  models permission table fix

### DIFF
--- a/docs/guides/app/features/teams.md
+++ b/docs/guides/app/features/teams.md
@@ -78,7 +78,7 @@ The proceeding table lists permissions that apply to all projects across a given
 | Add aliases                |           | X           | X              | X |
 | Add models to the registry |           | X           | X              | X |
 | View models in the registry| X         | X           | X              | X |
-|Download models             |           | X           | X              | X |
+|Download models             | X         | X           | X              | X |
 |Add/Remove Registry Admins  |           |             | X              | X | 
 |Add/Remove Protected Aliases|           |             | X              |   | 
 


### PR DESCRIPTION
## Description

Missing "Download models"

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [X] I merged the latest changes from `main` into my feature branch before submitting this PR.
