### PR TITLE
Fix weird leftnav carets

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -270,9 +270,8 @@ const sidebars = {
     {
       type: 'category',
       label: 'W&B Weave',
-      items: [
-        'guides/weave_platform',
-      ],
+      link: { type: 'doc', id: 'guides/weave_platform'},
+      items: [],
     },
     {
       type: 'category',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,7 +113,6 @@ a:hover {
 
 .menu__link {
   font-size: 16px;
-  margin-right: 16px;
 }
 .menu__list-item-collapsible--active .menu__caret:hover {
   background: none;
@@ -255,11 +254,11 @@ a.theme-edit-this-page {
 }
 
 .menu__list .menu__list a.menu__link {
-  padding: 3px 0 3px 13px;
+  padding: 0px 5px 5px;
 }
 
 .menu__list .menu__list .menu__caret {
-  padding: 0 6px;
+  padding: 0px 5px;
 }
 
 .menu__list-item:not(:first-child){


### PR DESCRIPTION
## Description

Fixes menu items that have carets aligned differently based on whether or not they have child topics.
Also eliminates the "W&B Weave" sub-menu, which only had one page, in favor of a simple page that users only have to click once to see. 

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
