### PR TITLE
packageManager addition

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
   },
   "engines": {
     "node": ">=16.14"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
CloudFlare build v2 requires a `packageManager` field or it defaults to a too-high `yarn` verison. Adding.