### PR TITLE
proposed fix for search crash issue by using useSearchLinkCreator

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -6,7 +6,7 @@ import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
 import Link from '@docusaurus/Link';
 import Head from '@docusaurus/Head';
 import {isRegexpStringMatch} from '@docusaurus/theme-common';
-import {useSearchPage} from '@docusaurus/theme-common/internal';
+import {useSearchLinkCreator} from '@docusaurus/theme-common';
 import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
 import {useAlgoliaContextualFacetFilters} from '@docusaurus/theme-search-algolia/client';
 import Translate from '@docusaurus/Translate';
@@ -51,7 +51,7 @@ type ResultsFooterProps = {
 };
 
 function ResultsFooter({state, onClose}: ResultsFooterProps) {
-  const {generateSearchPageLink} = useSearchPage();
+  const generateSearchPageLink = useSearchLinkCreator();
 
   return (
     <Link to={generateSearchPageLink(state.query)} onClick={onClose}>


### PR DESCRIPTION
## Description

Seems docusaurus upgrade splits useSearchPage into useSearchLinkCreator and useSearchQueryString .
Update code to use useSearchQueryString

## Ticket

n/a

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ X] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [X ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ X] I merged the latest changes from `main` into my feature branch before submitting this PR.
