### PR TITLE
Fixed page title when 404 returned

### DIFF
--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Translate, { translate } from '@docusaurus/Translate';
+import { PageMetadata } from '@docusaurus/theme-common';
+
+export default function NotFound() {
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page Not Found',
+        })}
+      />
+      <main className="container margin-vert--xl">
+        <div className="row">
+          <div className="col col--6 col--offset-3">
+            <h1 className="hero__title">
+              <Translate
+                id="theme.NotFound.title"
+                description="The title of the 404 page">
+                Page Not Found
+              </Translate>
+            </h1>
+            <p>
+              <Translate
+                id="theme.NotFound.p1"
+                description="The first paragraph of the 404 page">
+                We could not find what you were looking for.
+              </Translate>
+            </p>
+            <p>
+              <Translate
+                id="theme.NotFound.p2"
+                description="The second paragraph of the 404 page">
+                Please contact the owner of the site that linked you to the
+                original URL and let them know their link is broken.
+              </Translate>
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/theme/NotFound/index.js
+++ b/src/theme/NotFound/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import NotFoundContent from '@theme/NotFound/Content';
+export default function Index() {
+  const title = translate({
+    id: 'theme.NotFound.title',
+    message: 'Page Not Found',
+  });
+  return (
+    <>
+      <PageMetadata title={title} />
+      <Layout>
+        <NotFoundContent />
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
## Description

Requests to a page that is not available (i.e. 404) normally returns a page that has “Page not found” as the page title. This is useful since we can use GA4 (for e.g.) to track 404. [For example, see this report. ](https://analytics.google.com/analytics/web/#/p351919496/reports/explorer?params=_u..nav%3Dmaui%26_u.dateOption%3Dlast90Days%26_u.comparisonOption%3Ddisabled%26_r.explorerCard..filterTerm%3Dpage%20not%20found%26_r.explorerCard..startRow%3D0&r=5214260481&collectionId=5214248225)

As of 09.25.2024 we lost this functionality. It’s unclear why. One hypothesis is the Docusaurus migration  [from v2-> v3 that took place on 09.25](https://github.com/wandb/docodile/commit/25266555e688f6ed2b9ca88e62d6155c6db66355). 

 

Action item:

Fix how Docusaurus (or future site?) handles requests that return 404. Namely, page title should have “Page not found”.

## Ticket

https://wandb.atlassian.net/browse/DOCS-1033

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
