### PR TITLE
Remove core req in example code snippet

### DIFF
--- a/docs/guides/app/features/anon.md
+++ b/docs/guides/app/features/anon.md
@@ -19,8 +19,6 @@ For example, the proceeding code snippet shows how to create and log an artifact
 ```python
 import wandb
 
-wandb.require("core")
-
 run = wandb.init(anonymous="allow")
 
 artifact = wandb.Artifact(name="art1", type="foo")


### PR DESCRIPTION
## Description

Removes `wandb.require("core")` from artifact creation and logging code snippet since it is not necessary.

## Ticket

https://wandb.atlassian.net/browse/DOCS-1034

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [x] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [x] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [x] I merged the latest changes from `main` into my feature branch before submitting this PR.
