### PR TITLE
Fix a nit after [DOCS-1091]

### DIFF
--- a/docs/guides/app/features/panels/intro.md
+++ b/docs/guides/app/features/panels/intro.md
@@ -38,7 +38,7 @@ You can add panels to your workspace, either globally or at the section level.
 To add a panel:
 
 1. To add a panel globally, click **Add panels** in the control bar near the panel search field.
-1. To add a panel directly to a section instead, click the section's action `...` menu, then click **+ Add panels**.
+1. To add a panel directly to a section instead, click the section's action `...` menu, then click **Add panels**.
 1. Select the type of panel to add.
 ![](/images/app_ui/add_single_panel.gif)
 


### PR DESCRIPTION
## Description

Remove a stray `+` introduced in [DOCS-1091]

[DOCS-1091]: https://wandb.atlassian.net/browse/DOCS-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ