### PR TITLE
hugo-WIP J2-D2-3PO contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ nvm install 20
 nvm use 20
 npm install
 go mod init docsy
-hugo mod get -u
 ```
 
 ## Running the website locally
 
 ```bash
+hugo mod get -u
 hugo server
 ```
 

--- a/content/guides/core/artifacts/create-a-new-artifact-version.md
+++ b/content/guides/core/artifacts/create-a-new-artifact-version.md
@@ -9,9 +9,6 @@ title: Create an artifact version
 weight: 6
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Create a new artifact version with a single [run](../runs/intro.md) or collaboratively with distributed runs. You can optionally create a new artifact version from a previous version known as an [incremental artifact](#create-a-new-artifact-version-from-an-existing-version).
 
 {{% alert %}}
@@ -21,10 +18,8 @@ We recommend that you create an incremental artifact when you need to apply chan
 ## Create new artifact versions from scratch
 There are two ways to create a new artifact version: from a single run and from distributed runs. They are defined as follows:
 
-
 * **Single run**: A single run provides all the data for a new version. This is the most common case and is best suited when the run fully recreates the needed data. For example: outputting saved models or model predictions in a table for analysis.
 * **Distributed runs**: A set of runs collectively provides all the data for a new version. This is best suited for distributed jobs which have multiple runs generating data, often in parallel. For example: evaluating a model in a distributed manner, and outputting the predictions.
-
 
 W&B will create a new artifact and assign it a `v0` alias if you pass a name to the `wandb.Artifact` API that does not exist in your project. W&B checksums the contents when you log again to the same artifact. If the artifact changed, W&B saves a new version `v1`.  
 
@@ -37,19 +32,14 @@ Log a new version of an Artifact with a single run that produces all the files i
 
 Based on your use case, select one of the tabs below to create a new artifact version inside or outside of a run:
 
-<Tabs
-  defaultValue="inside"
-  values={[
-    {label: 'Inside a run', value: 'inside'},
-    {label: 'Outside a run', value: 'outside'},
-  ]}>
-  <TabItem value="inside">
+{{< tabpane text=true >}}
 
+{{% tab header="Inside a run" value="inside" %}}
 Create an artifact version within a W&B run:
 
-1. Create a run with `wandb.init`. (Line 1)
-2. Create a new artifact or retrieve an existing one with `wandb.Artifact` . (Line 2)
-3. Add files to the artifact with `.add_file`. (Line 9)
+1. Create a run with `wandb.init`. (Line 1)  
+2. Create a new artifact or retrieve an existing one with `wandb.Artifact` . (Line 2)  
+3. Add files to the artifact with `.add_file`. (Line 9)  
 4. Log the artifact to the run with `.log_artifact`. (Line 10)
 
 ```python showLineNumbers
@@ -61,14 +51,13 @@ with wandb.init() as run:
     artifact.add_file("image1.png")
     run.log_artifact(artifact)
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="outside">
-
+{{% tab header="Outside a run" value="outside" %}}
 Create an artifact version outside of a W&B run:
 
-1. Create a new artifact or retrieve an existing one with `wanb.Artifact`. (Line 1)
-2. Add files to the artifact with `.add_file`. (Line 4)
+1. Create a new artifact or retrieve an existing one with `wanb.Artifact`. (Line 1)  
+2. Add files to the artifact with `.add_file`. (Line 4)  
 3. Save the artifact with `.save`. (Line 5)
 
 ```python showLineNumbers
@@ -77,24 +66,23 @@ artifact = wandb.Artifact("artifact_name", "artifact_type")
 # `.add`, `.add_file`, `.add_dir`, and `.add_reference`
 artifact.add_file("image1.png")
 artifact.save()
-```  
-  </TabItem>
-</Tabs>
+```
+{{% /tab %}}
+
+{{< /tabpane >}}
 
 
 ### Distributed runs
 
 Allow a collection of runs to collaborate on a version before committing it. This is in contrast to single run mode described above where one run provides all the data for a new version.
 
-
 {{% alert %}}
-1. Each run in the collection needs to be aware of the same unique ID (called `distributed_id`) in order to collaborate on the same version. By default, if present, W&B uses the run's `group` as set by `wandb.init(group=GROUP)` as the `distributed_id`.
-2. There must be a final run that "commits" the version, permanently locking its state.
+1. Each run in the collection needs to be aware of the same unique ID (called `distributed_id`) in order to collaborate on the same version. By default, if present, W&B uses the run's `group` as set by `wandb.init(group=GROUP)` as the `distributed_id`.  
+2. There must be a final run that "commits" the version, permanently locking its state.  
 3. Use `upsert_artifact` to add to the collaborative artifact and `finish_artifact` to finalize the commit.
 {{% /alert %}}
 
 Consider the following example. Different runs (labelled below as **Run 1**, **Run 2**, and **Run 3**) add a different image file to the same artifact with `upsert_artifact`.
-
 
 #### Run 1:
 
@@ -132,8 +120,6 @@ with wandb.init() as run:
 ```
 
 
-
-
 ## Create a new artifact version from an existing version
 
 Add, modify, or remove a subset of files from a previous artifact version without the need to re-index the files that didn't change. Adding, modifying, or removing a subset of files from a previous artifact version creates a new artifact version known as an *incremental artifact*.
@@ -142,49 +128,36 @@ Add, modify, or remove a subset of files from a previous artifact version withou
 
 Here are some scenarios for each type of incremental change you might encounter:
 
-- add: you periodically add a new subset of files to a dataset after collecting a new batch.
-- remove: you discovered several duplicate files and want to remove them from your artifact.
+- add: you periodically add a new subset of files to a dataset after collecting a new batch.  
+- remove: you discovered several duplicate files and want to remove them from your artifact.  
 - update: you corrected annotations for a subset of files and want to replace the old files with the correct ones.
 
 You could create an artifact from scratch to perform the same function as an incremental artifact. However, when you create an artifact from scratch, you will need to have all the contents of your artifact on your local disk. When making an incremental change, you can add, remove, or modify a single file without changing the files from a previous artifact version.
-
 
 {{% alert %}}
 You can create an incremental artifact within a single run or with a set of runs (distributed mode).
 {{% /alert %}}
 
-
 Follow the procedure below to incrementally change an artifact:
 
 1. Obtain the artifact version you want to perform an incremental change on:
 
-<Tabs
-  defaultValue="inside"
-  values={[
-    {label: 'Inside a run', value: 'inside'},
-    {label: 'Outside of a run', value: 'outside'},
-  ]}>
-  <TabItem value="inside">
+{{< tabpane text=true >}}
 
+{{% tab header="Inside a run" value="inside" %}}
 ```python
 saved_artifact = run.use_artifact("my_artifact:latest")
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="outside">
-
-
+{{% tab header="Outside of a run" value="outside" %}}
 ```python
 client = wandb.Api()
 saved_artifact = client.artifact("my_artifact:latest")
 ```
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
-
-
-
-
+{{< /tabpane >}}
 
 2. Create a draft with:
 
@@ -196,16 +169,9 @@ draft_artifact = saved_artifact.new_draft()
 
 Select one of the tabs for an example on how to perform each of these changes:
 
+{{< tabpane text=true >}}
 
-<Tabs
-  defaultValue="add"
-  values={[
-    {label: 'Add', value: 'add'},
-    {label: 'Remove', value: 'remove'},
-    {label: 'Modify', value: 'modify'},
-  ]}>
-  <TabItem value="add">
-
+{{% tab header="Add" value="add" %}}
 Add a file to an existing artifact version with the `add_file` method:
 
 ```python
@@ -215,10 +181,9 @@ draft_artifact.add_file("file_to_add.txt")
 {{% alert %}}
 You can also add multiple files by adding a directory with the `add_dir` method.
 {{% /alert %}}
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="remove">
-
+{{% tab header="Remove" value="remove" %}}
 Remove a file from an existing artifact version with the `remove` method:
 
 ```python
@@ -228,61 +193,42 @@ draft_artifact.remove("file_to_remove.txt")
 {{% alert %}}
 You can also remove multiple files with the `remove` method by passing in a directory path.
 {{% /alert %}}
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="modify">
-
+{{% tab header="Modify" value="modify" %}}
 Modify or replace contents by removing the old contents from the draft and adding the new contents back in:
 
 ```python
 draft_artifact.remove("modified_file.txt")
 draft_artifact.add_file("modified_file.txt")
 ```
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
-
-<!-- {{% alert %}}
-The method to add or modify an artifact are the same. Entries are replaced (as opposed to duplicated), when you pass a filename for an entry that already exists.
-{{% /alert %}} -->
+{{< /tabpane >}}
 
 4. Lastly, log or save your changes. The following tabs show you how to save your changes inside and outside of a W&B run. Select the tab that is appropriate for your use case:
 
+{{< tabpane text=true >}}
 
-<Tabs
-  defaultValue="inside"
-  values={[
-    {label: 'Inside a run', value: 'inside'},
-    {label: 'Outside of a run', value: 'outside'},
-  ]}>
-  <TabItem value="inside">
-
+{{% tab header="Inside a run" value="inside" %}}
 ```python
 run.log_artifact(draft_artifact)
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="outside">
-
-
+{{% tab header="Outside of a run" value="outside" %}}
 ```python
 draft_artifact.save()
 ```
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
-
+{{< /tabpane >}}
 
 Putting it all together, the code examples above look like: 
 
-<Tabs
-  defaultValue="inside"
-  values={[
-    {label: 'Inside a run', value: 'inside'},
-    {label: 'Outside of a run', value: 'outside'},
-  ]}>
-  <TabItem value="inside">
+{{< tabpane text=true >}}
 
+{{% tab header="Inside a run" value="inside" %}}
 ```python
 with wandb.init(job_type="modify dataset") as run:
     saved_artifact = run.use_artifact(
@@ -297,11 +243,9 @@ with wandb.init(job_type="modify dataset") as run:
         artifact
     )  # log your changes to create a new version and mark it as output to your run
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="outside">
-
-
+{{% tab header="Outside of a run" value="outside" %}}
 ```python
 client = wandb.Api()
 saved_artifact = client.artifact("my_artifact:latest")  # load your artifact
@@ -312,6 +256,6 @@ draft_artifact.remove("deleted_file.txt")
 draft_artifact.add_file("modified_file.txt")
 draft_artifact.save()  # commit changes to the draft
 ```
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
+{{< /tabpane >}}

--- a/content/guides/core/artifacts/download-and-use-an-artifact.md
+++ b/content/guides/core/artifacts/download-and-use-an-artifact.md
@@ -8,29 +8,19 @@ title: Download and use artifacts
 weight: 3
 ---
 
-Download and use an artifact that is already stored on the W&B server or construct an artifact object and pass it in to for de-duplication as necessary.
+Download and use an artifact that is already stored on the W&B server or construct an artifact object and pass it in for de-duplication as necessary.
 
 {{% alert %}}
 Team members with view-only seats cannot download artifacts.
 {{% /alert %}}
 
-
 ### Download and use an artifact stored on W&B
 
 Download and use an artifact stored in W&B either inside or outside of a W&B Run. Use the Public API ([`wandb.Api`](../../ref/python/public-api/api.md)) to export (or update data) already saved in W&B. For more information, see the W&B [Public API Reference guide](../../ref/python/public-api/README.md).
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+{{< tabpane text=true >}}
 
-<Tabs
-  defaultValue="insiderun"
-  values={[
-    {label: 'During a run', value: 'insiderun'},
-    {label: 'Outside of a run', value: 'outsiderun'},
-    {label: 'W&B CLI', value: 'CLI'},
-  ]}>
-  <TabItem value="insiderun">
-
+{{% tab header="During a run" value="insiderun" %}}
 First, import the W&B Python SDK. Next, create a W&B [Run](../../ref/python/run.md):
 
 ```python
@@ -39,7 +29,7 @@ import wandb
 run = wandb.init(project="<example>", job_type="<job-type>")
 ```
 
-Indicate the artifact you want to use with the [`use_artifact`](../../ref/python/run.md#use_artifact) method. This returns a run object. In the proceeding code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
+Indicate the artifact you want to use with the [`use_artifact`](../../ref/python/run.md#use_artifact) method. This returns a run object. The following code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
 
 ```python
 artifact = run.use_artifact("bike-dataset:latest")
@@ -51,9 +41,9 @@ Use the object returned to download all the contents of the artifact:
 datadir = artifact.download()
 ```
 
-You can optionally pass a path to the root parameter to download the contents of the artifact to a specific directory. For more information, see the [Python SDK Reference Guide](../../ref/python/artifact.md#download).
+You can optionally pass a path to the `root` parameter to download the contents of the artifact to a specific directory. For more information, see the [Python SDK Reference Guide](../../ref/python/artifact.md#download).
 
-Use the [`get_path`](../../ref/python/artifact.md#get_path) method to download only subset of files:
+Use the [`get_path`](../../ref/python/artifact.md#get_path) method to download only a subset of files:
 
 ```python
 path = artifact.get_path(name)
@@ -61,14 +51,13 @@ path = artifact.get_path(name)
 
 This fetches only the file at the path `name`. It returns an `Entry` object with the following methods:
 
-* `Entry.download`: Downloads file from the artifact at path `name`
+* `Entry.download`: Downloads file from the artifact at path `name`  
 * `Entry.ref`: If `add_reference` stored the entry as a reference, returns the URI
 
 References that have schemes that W&B knows how to handle get downloaded just like artifact files. For more information, see [Track external files](../../guides/artifacts/track-external-files.md).
-  
-  </TabItem>
-  <TabItem value="outsiderun">
-  
+{{% /tab %}}
+
+{{% tab header="Outside of a run" value="outsiderun" %}}
 First, import the W&B SDK. Next, create an artifact from the Public API Class. Provide the entity, project, artifact, and alias associated with that artifact:
 
 ```python
@@ -84,18 +73,18 @@ Use the object returned to download the contents of the artifact:
 artifact.download()
 ```
 
-You can optionally pass a path the `root` parameter to download the contents of the artifact to a specific directory. For more information, see the [API Reference Guide](../../ref/python/artifact.md#download).
-  
-  </TabItem>
-  <TabItem value="CLI">
+You can optionally pass a path to the `root` parameter to download the contents of the artifact to a specific directory. For more information, see the [API Reference Guide](../../ref/python/artifact.md#download).
+{{% /tab %}}
 
-Use the `wandb artifact get` command to download an artifact from the W&B server.
+{{% tab header="W&B CLI" value="CLI" %}}
+Use the `wandb artifact get` command to download an artifact from the W&B server:
 
 ```
 $ wandb artifact get project/artifact:alias --root mnist/
 ```
-  </TabItem>
-</Tabs>
+{{% /tab %}}
+
+{{< /tabpane >}}
 
 ### Partially download an artifact
 
@@ -104,17 +93,20 @@ You can optionally download part of an artifact based on a prefix. Using the `pa
 ```python
 artifact = run.use_artifact("bike-dataset:latest")
 
-artifact.download(path_prefix="bike.png") # downloads only bike.png
+artifact.download(path_prefix="bike.png")  # downloads only bike.png
 ```
 
 Alternatively, you can download files from a certain directory:
 
 ```python
-artifact.download(path_prefix="images/bikes/") # downloads files in the images/bikes directory
+artifact.download(
+    path_prefix="images/bikes/"
+)  # downloads files in the images/bikes directory
 ```
+
 ### Use an artifact from a different project
 
-Specify the name of artifact along with its project name to reference an artifact. You can also reference artifacts across entities by specifying the name of the artifact with its entity name.
+Specify the name of the artifact along with its project name to reference an artifact. You can also reference artifacts across entities by specifying the name of the artifact with its entity name.
 
 The following code example demonstrates how to query an artifact from another project as input to the current W&B run.
 
@@ -133,7 +125,7 @@ artifact = run.use_artifact("my-entity/my-project/artifact:alias")
 
 ### Construct and use an artifact simultaneously
 
-Simultaneously construct and use an artifact. Create an artifact object and pass it to use_artifact. This creates an artifact in W&B if it does not exist yet. The [`use_artifact`](../../ref/python/run.md#use_artifact) API is idempotent, so you can call it as many times as you like.
+Simultaneously construct and use an artifact. Create an artifact object and pass it to `use_artifact`. This creates an artifact in W&B if it does not exist yet. The [`use_artifact`](../../ref/python/run.md#use_artifact) API is idempotent, so you can call it as many times as you like.
 
 ```python
 import wandb

--- a/content/guides/core/artifacts/manage-data/ttl.md
+++ b/content/guides/core/artifacts/manage-data/ttl.md
@@ -7,9 +7,9 @@ menu:
 title: Manage artifact data retention
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/kas-artifacts-ttl-colab/colabs/wandb-artifacts/WandB_Artifacts_Time_to_live_TTL_Walkthrough.ipynb" >}}
+
+## Manage artifact data retention
 
 Schedule when artifacts are deleted from W&B with W&B Artifact time-to-live (TTL) policy. When you delete an artifact, W&B marks that artifact as a *soft-delete*. In other words, the artifact is marked for deletion but files are not immediately deleted from storage. For more information on how W&B deletes artifacts, see the [Delete artifacts](./delete-artifacts.md) page.
 
@@ -18,6 +18,7 @@ Check out [this](https://www.youtube.com/watch?v=hQ9J6BoVmnc) video tutorial to 
 {{% alert %}}
 W&B deactivates the option to set a TTL policy for model artifacts linked to the Model Registry. This is to help ensure that linked models do not accidentally expire if used in production workflows.
 {{% /alert %}}
+
 {{% alert %}}
 * Only team admins can view a [team's settings](../app/settings-page/team-settings.md) and access team level TTL settings such as (1) permitting who can set or edit a TTL policy or (2) setting a team default TTL.  
 * If you do not see the option to set or edit a TTL policy in an artifact's details in the W&B App UI or if setting a TTL programmatically does not successfully change an artifact's TTL property, your team admin has not given you permissions to do so. 
@@ -36,6 +37,7 @@ You can check an Artifact's type on the [W&B platform](../artifacts/explore-and-
 
 ```python
 import wandb
+
 run = wandb.init(project="<my-project-name>")
 artifact = run.use_artifact(artifact_or_name="<my-artifact-name>")
 print(artifact.type)
@@ -101,18 +103,12 @@ Use the W&B App UI or the W&B Python SDK to define a TTL policy for an artifact 
 When you modify an artifact's TTL, the time the artifact takes to expire is still calculated using the artifact's `createdAt` timestamp.
 {{% /alert %}}
 
-<Tabs
-  defaultValue="python"
-  values={[
-    {label: 'Python SDK', value: 'python'},
-    {label: 'W&B App', value: 'app'},
-  ]}>
-  <TabItem value="python">
+{{< tabpane text=true >}}
 
+{{% tab header="Python SDK" value="python" %}}
 1. [Fetch your artifact](./download-and-use-an-artifact.md).
 2. Pass in a time delta to the artifact's `ttl` attribute. 
 3. Update the artifact with the [`save`](../../ref/python/run.md#save) method.
-
 
 The following code snippet shows how to set a TTL policy for an artifact:
 ```python
@@ -125,10 +121,9 @@ artifact.save()
 ```
 
 The preceding code example sets the TTL policy to two years.
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="app">
-
+{{% tab header="W&B App" value="app" %}}
 1. Navigate to your W&B project in the W&B App UI.
 2. Select the artifact icon on the left panel.
 3. From the list of artifacts, expand the artifact type you 
@@ -140,10 +135,9 @@ The preceding code example sets the TTL policy to two years.
 9. Select the **Update TTL** button to save your changes.
 
 {{< img src="/images/artifacts/edit_ttl_ui.gif" alt="" >}}
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
-
+{{< /tabpane >}}
 
 ### Set default TTL policies for a team
 
@@ -163,27 +157,15 @@ Set a default TTL policy for your team. Default TTL policies apply to all existi
 
 {{< img src="/images/artifacts/set_default_ttl.gif" alt="" >}}
 
-
-
 ## Deactivate a TTL policy
 Use the W&B Python SDK or W&B App UI to deactivate a TTL policy for a specific artifact version.
-<!-- 
-{{% alert %}}
-Artifacts with TTL turned off will not inherit an artifact collection's TTL. Refer to (## Inherit TTL Policy) on how to delete artifact TTL and inherit from the collection level TTL.
-{{% /alert %}} -->
 
-<Tabs
-  defaultValue="python"
-  values={[
-    {label: 'Python SDK', value: 'python'},
-    {label: 'W&B App', value: 'app'},
-  ]}>
-  <TabItem value="python">
+{{< tabpane text=true >}}
 
+{{% tab header="Python SDK" value="python" %}}
 1. [Fetch your artifact](./download-and-use-an-artifact.md).
 2. Set the artifact's `ttl` attribute to `None`.
 3. Update the artifact with the [`save`](../../ref/python/run.md#save) method.
-
 
 The following code snippet shows how to turn off a TTL policy for an artifact:
 ```python
@@ -191,11 +173,9 @@ artifact = run.use_artifact("<my-entity/my-project/my-artifact:alias>")
 artifact.ttl = None
 artifact.save()
 ```
+{{% /tab %}}
 
-
-  </TabItem>
-  <TabItem value="app">
-
+{{% tab header="W&B App" value="app" %}}
 1. Navigate to your W&B project in the W&B App UI.
 2. Select the artifact icon on the left panel.
 3. From the list of artifacts, expand the artifact type you 
@@ -207,34 +187,25 @@ artifact.save()
 9. Select the **Update TTL** button to save your changes.
 
 {{< img src="/images/artifacts/remove_ttl_polilcy.gif" alt="" >}}
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
-
-
+{{< /tabpane >}}
 
 ## View TTL policies
 View TTL policies for artifacts with the Python SDK or with the W&B App UI.
 
-<Tabs
-  defaultValue="python"
-  values={[
-    {label: 'Python SDK', value: 'python'},
-    {label: 'W&B App', value: 'app'},
-  ]}>
-  <TabItem value="python">
+{{< tabpane text=true >}}
 
+{{% tab header="Python SDK" value="python" %}}
 Use a print statement to view an artifact's TTL policy. The following example shows how to retrieve an artifact and view its TTL policy:
 
 ```python
 artifact = run.use_artifact("<my-entity/my-project/my-artifact:alias>")
 print(artifact.ttl)
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="app">
-
-
+{{% tab header="W&B App" value="app" %}}
 View a TTL policy for an artifact with the W&B App UI.
 
 1. Navigate to the W&B App at [https://wandb.ai](https://wandb.ai).
@@ -245,6 +216,6 @@ View a TTL policy for an artifact with the W&B App UI.
 Within the collection view you can see all of the artifacts in the selected collection. Within the `Time to Live` column you will see the TTL policy assigned to that artifact. 
 
 {{< img src="/images/artifacts/ttl_collection_panel_ui.png" alt="" >}}
+{{% /tab %}}
 
-  </TabItem>
-</Tabs>
+{{< /tabpane >}}

--- a/content/guides/core/artifacts/update-an-artifact.md
+++ b/content/guides/core/artifacts/update-an-artifact.md
@@ -13,23 +13,13 @@ Pass desired values to update the `description`, `metadata`, and `alias` of an a
 Use the W&B Public API ([`wandb.Api`](../../ref/python/public-api/api.md)) to update an artifact outside of a run. Use the Artifact API ([`wandb.Artifact`](../../ref/python/artifact.md)) to update an artifact during a run.
 
 {{% alert color="secondary" %}}
-You can not update the alias of artifact linked to a model in Model Registry.
+You can not update the alias of an artifact linked to a model in Model Registry.
 {{% /alert %}}
 
+{{< tabpane text=true >}}
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs
-  defaultValue="duringrun"
-  values={[
-    {label: 'During a Run', value: 'duringrun'},
-    {label: 'Outside of a Run', value: 'outsiderun'},
-    {label: 'With Collections', value: 'withcollections'}
-  ]}>
-  <TabItem value="duringrun">
-
-The proceeding code example demonstrates how to update the description of an artifact using the [`wandb.Artifact`](../../ref/python/artifact.md) API:
+{{% tab header="During a Run" value="duringrun" %}}
+The following code example demonstrates how to update the description of an artifact using the [`wandb.Artifact`](../../ref/python/artifact.md) API:
 
 ```python
 import wandb
@@ -39,10 +29,10 @@ artifact = run.use_artifact("<artifact-name>:<alias>")
 artifact.description = "<description>"
 artifact.save()
 ```
-  </TabItem>
-  <TabItem value="outsiderun">
+{{% /tab %}}
 
-The proceeding code example demonstrates how to update the description of an artifact using the `wandb.Api` API:
+{{% tab header="Outside of a Run" value="outsiderun" %}}
+The following code example demonstrates how to update the description of an artifact using the `wandb.Api` API:
 
 ```python
 import wandb
@@ -74,13 +64,14 @@ artifact.save()
 ```
 
 For more information, see the Weights and Biases [Artifact API](../../ref/python/artifact.md).
-  </TabItem>
-  
-  <TabItem value="withcollections">
+{{% /tab %}}
+
+{{% tab header="With Collections" value="withcollections" %}}
 You can also update an Artifact collection in the same way as a singular artifact:
 
 ```python
 import wandb
+
 run = wandb.init(project="<example>")
 api = wandb.Api()
 artifact = api.artifact_collection(type="<type-name>", collection="<collection-name>")
@@ -88,7 +79,8 @@ artifact.name = "<new-collection-name>"
 artifact.description = "<This is where you'd describe the purpose of your collection.>"
 artifact.save()
 ```
-For more information, see the [Artifacts Collection](../../ref/python/public-api/api) reference.
 
-  </TabItem>
-</Tabs>
+For more information, see the [Artifacts Collection](../../ref/python/public-api/api) reference.
+{{% /tab %}}
+
+{{< /tabpane >}}

--- a/content/guides/core/reports/clone-and-export-reports.md
+++ b/content/guides/core/reports/clone-and-export-reports.md
@@ -7,30 +7,23 @@ menu:
 title: Clone and export reports
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-## Export reports
-
-Export a report as a PDF or LaTeX. Within your report, select the kebab icon to expand the dropdown menu. Choose **Download and** select either PDF or LaTeX output format.
+Export a report as a PDF or LaTeX. Within your report, select the kebab icon to expand the dropdown menu. Choose **Download** and select either PDF or LaTeX output format.
 
 ## Cloning reports
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Python SDK', value: 'python'}
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
+
+{{% tab header="App UI" value="app" %}}
 
 Within your report, select the kebab icon to expand the dropdown menu. Choose the **Clone this report** button. Pick a destination for your cloned report in the modal. Choose **Clone report**.
 
 {{< img src="/images/reports/clone_reports.gif" alt="" >}}
 
 Clone a report to reuse a project's template and format. Cloned projects are visible to your team if you clone a project within the team's account. Projects cloned within an individual's account are only visible to that user.
-  </TabItem>
-  <TabItem value="python">
+
+{{% /tab %}}
+
+{{% tab header="Python SDK" value="python" %}}
 
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb" >}}
 
@@ -64,5 +57,7 @@ new_report.blocks = (
 )
 new_report.save()
 ```
-  </TabItem>
-</Tabs>
+
+{{% /tab %}}
+
+{{< /tabpane >}}

--- a/content/guides/core/reports/create-a-report.md
+++ b/content/guides/core/reports/create-a-report.md
@@ -8,24 +8,15 @@ title: Create a report
 weight: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Create a report interactively with the W&B App UI or programmatically with the W&B Python SDK.
 
 {{% alert %}}
 See this [Google Colab for an example](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb).
 {{% /alert %}}
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Report tab', value: 'reporttab'},
-    {label: 'W&B Python SDK', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
+{{% tab header="App UI" value="app" %}}
 1. Navigate to your project workspace in the W&B App.
 2. Click **Create report** in the upper right corner of your workspace.
 
@@ -36,43 +27,41 @@ See this [Google Colab for an example](https://colab.research.google.com/github/
 {{< img src="/images/reports/create_a_report_modal.png" alt="" >}}
 
 4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. Once you click **Create report,** a draft report will be available in the report tab to continue working on.
+{{% /tab %}}
 
-
-  </TabItem>
-  <TabItem value="reporttab">
-
+{{% tab header="Report tab" value="reporttab" %}}
 1. Navigate to your project workspace in the W&B App.
-2. Select to the **Reports** tab (clipboard image) in your project.
+2. Select the **Reports** tab (clipboard image) in your project.
 3. Select the **Create Report** button on the report page. 
 
 {{< img src="/images/reports/create_report_button.png" alt="" >}}
-  </TabItem>
-  <TabItem value="sdk">
+{{% /tab %}}
 
+{{% tab header="W&B Python SDK" value="sdk" %}}
 Create a report programmatically with the `wandb` library. 
 
 1. Install W&B SDK and Workspaces API:
 ```bash
 pip install wandb wandb-workspaces
 ```
-2. Next, import workspaces
+2. Next, import workspaces:
 ```python
 import wandb
 import wandb_workspaces.reports.v2 as wr
 ```
 3. Create a report with `wandb_workspaces.reports.v2.Report`. Create a report instance with the Report Class Public API ([`wandb.apis.reports`](/ref/python/public-api/api#reports)). Specify a name for the project.
 
-
 ```python
 report = wr.Report(project="report_standard")
 ```
 
-4. Save the report. Reports are not uploaded to the W&B server until you call the .`save()` method:
+4. Save the report. Reports are not uploaded to the W&B server until you call the `.save()` method:
 
 ```python
 report.save()
 ```
 
 For information on how to edit a report interactively with the App UI or programmatically, see [Edit a report](/guides/reports/edit-a-report).
-  </TabItem>
-</Tabs>
+{{% /tab %}}
+
+{{< /tabpane >}}

--- a/content/guides/core/reports/edit-a-report.md
+++ b/content/guides/core/reports/edit-a-report.md
@@ -9,24 +9,20 @@ title: Edit a report
 weight: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Edit a report interactively with the App UI or programmatically with the W&B SDK.
 
-Reports consist of _blocks_. Blocks make up the body of a report. Within these blocks you can add text, images, embedded visualizations, plots from experiments and run, and panels grids.
+Reports consist of _blocks_. Blocks make up the body of a report. Within these blocks you can add text, images, embedded visualizations, plots from experiments and runs, and panel grids.
 
 _Panel grids_ are a specific type of block that hold panels and _run sets_. Run sets are a collection of runs logged to a project in W&B. Panels are visualizations of run set data.
 
-
 {{% alert %}}
-Check out the [Programmatic workspaces tutorial](../../tutorials/workspaces.md) for a step by step example on how create and customize a saved workspace view.
+Check out the [Programmatic workspaces tutorial](../../tutorials/workspaces.md) for a step-by-step example on how to create and customize a saved workspace view.
 {{% /alert %}}
 
 {{% alert %}}
 Ensure that you have `wandb-workspaces` installed in addition to the W&B Python SDK if you want to programmatically edit a report:
 
-```pip
+```bash
 pip install wandb wandb-workspaces
 ```
 {{% /alert %}}
@@ -35,27 +31,20 @@ pip install wandb wandb-workspaces
 
 Each panel grid has a set of run sets and a set of panels. The run sets at the bottom of the section control what data shows up on the panels in the grid. Create a new panel grid if you want to add charts that pull data from a different set of runs.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
-Enter a forward slash (`/`) in the report to display a dropdown menu. Select **Add panel** to add a panel. You can add any panel that is supported by W&B; including a line plot, scatter plot or parallel coordinates chart.
+{{% tab header="App UI" value="app" %}}
 
-
+Enter a forward slash (`/`) in the report to display a dropdown menu. Select **Add panel** to add a panel. You can add any panel that is supported by W&B, including a line plot, scatter plot, or parallel coordinates chart.
 
 {{< img src="/images/reports/demo_report_add_panel_grid.gif" alt="Add charts to a report" >}}
-  
-  </TabItem>
-  <TabItem value="sdk">
+{{% /tab %}}
+
+{{% tab header="Workspaces API" value="sdk" %}}
 
 Add plots to a report programmatically with the SDK. Pass a list of one or more plot or chart objects to the `panels` parameter in the `PanelGrid` Public API Class. Create a plot or chart object with its associated Python Class.
 
-
-The proceeding examples demonstrates how to create a line plot and scatter plot.
+The following examples demonstrate how to create a line plot and scatter plot:
 
 ```python
 import wandb
@@ -81,32 +70,29 @@ report.save()
 ```
 
 For more information about available plots and charts you can add to a report programmatically, see `wr.panels`.
-  </TabItem>
-</Tabs>
+{{% /tab %}}
 
+{{< /tabpane >}}
 
 ### Add run sets
 
 Add run sets from projects interactively with the App UI or the W&B SDK.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
-Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose Panel Grid. This will automatically import the run set from the project the report was created from.
-  </TabItem>
-  <TabItem value="sdk">
+{{% tab header="App UI" value="app" %}}
 
-Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. The proceeding procedure describes how to add a runset:
+Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Panel Grid**. This will automatically import the run set from the project the report was created from.
+{{% /tab %}}
+
+{{% tab header="Workspaces API" value="sdk" %}}
+
+Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. The following procedure describes how to add a runset:
 
 1. Create a `wr.Runset()` object instance. Provide the name of the project that contains the runsets for the project parameter and the entity that owns the project for the entity parameter.
 2. Create a `wr.PanelGrid()` object instance. Pass a list of one or more runset objects to the `runsets` parameter.
 3. Store one or more `wr.PanelGrid()` object instances in a list.
-4. Update the report instance blocks attribute with the list of panel grid instances.
+4. Update the report instance's `blocks` attribute with the list of panel grid instances.
 
 ```python
 import wandb
@@ -130,6 +116,7 @@ You can optionally add runsets and panels with one call to the SDK:
 
 ```python
 import wandb
+import wandb_workspaces.reports.v2 as wr
 
 report = wr.Report(
     project="report-editing",
@@ -139,78 +126,36 @@ report = wr.Report(
 
 panel_grids = wr.PanelGrid(
     panels=[
-        wr.LinePlot(
-            title="line title",
-            x="x",
-            y=["y"],
-            range_x=[0, 100],
-            range_y=[0, 100],
-            log_x=True,
-            log_y=True,
-            title_x="x axis title",
-            title_y="y axis title",
-            ignore_outliers=True,
-            groupby="hyperparam1",
-            groupby_aggfunc="mean",
-            groupby_rangefunc="minmax",
-            smoothing_factor=0.5,
-            smoothing_type="gaussian",
-            smoothing_show_original=True,
-            max_runs_to_show=10,
-            plot_type="stacked-area",
-            font_size="large",
-            legend_position="west",
-        ),
-        wr.ScatterPlot(
-            title="scatter title",
-            x="y",
-            y="y",
-            # z='x',
-            range_x=[0, 0.0005],
-            range_y=[0, 0.0005],
-            # range_z=[0,1],
-            log_x=False,
-            log_y=False,
-            # log_z=True,
-            running_ymin=True,
-            running_ymean=True,
-            running_ymax=True,
-            font_size="small",
-            regression=True,
-        ),
+        wr.LinePlot(x="x", y=["y"]),
+        wr.ScatterPlot(x="y", y="y"),
     ],
     runsets=[wr.RunSet(project="<project-name>", entity="<entity-name>")],
 )
 
-
 report.blocks = [panel_grids]
 report.save()
-``` 
-  </TabItem>
-</Tabs>
+```
+{{% /tab %}}
 
+{{< /tabpane >}}
 
 ### Add code blocks
 
 Add code blocks to your report interactively with the App UI or with the W&B SDK.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
+{{% tab header="App UI" value="app" %}}
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown choose **Code**.
 
-Select the name of the programming language on the right hand of the code block. This will expand a dropdown. From the dropdown, select your programming language syntax. You can choose from Javascript, Python, CSS, JSON, HTML, Markdown, and YAML.
-  </TabItem>
-  <TabItem value="sdk">
+Select the name of the programming language on the right-hand side of the code block. This will expand a dropdown. From the dropdown, select your programming language syntax. You can choose from JavaScript, Python, CSS, JSON, HTML, Markdown, and YAML.
+{{% /tab %}}
 
-Use the `wr.CodeBlock` Class to create a code block programmatically. Provide the name of the language and the code you want to display for the language and code parameters, respectively.
+{{% tab header="Workspaces API" value="sdk" %}}
 
-For example the proceeding example demonstrates a list in YAML file:
+Use the `wr.CodeBlock` Class to create a code block programmatically. Provide the name of the language and the code you want to display for the `language` and `code` parameters, respectively.
+
+The following example demonstrates a list in YAML format:
 
 ```python
 import wandb
@@ -227,51 +172,27 @@ report.blocks = [
 report.save()
 ```
 
-This will render a code block similar to:
-
-```yaml
-this:
-- is
-- a
-cool:
-- yaml
-- file
-```
-
-The proceeding example demonstrates a Python code block:
+The following example demonstrates a Python code block:
 
 ```python
-report = wr.Report(project="report-editing")
-
-
-report.blocks = [wr.CodeBlock(code=["Hello, World!"], language="python")]
-
+report.blocks = [wr.CodeBlock(code=["print('Hello, World!')"], language="python")]
 report.save()
 ```
+{{% /tab %}}
 
-This will render a code block similar to:
+{{< /tabpane >}}
 
-```md
-Hello, World!
-```
-  </TabItem>
-</Tabs>
-
-### Markdown
+### Add markdown
 
 Add markdown to your report interactively with the App UI or with the W&B SDK.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
+{{% tab header="App UI" value="app" %}}
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown choose **Markdown**.
-  </TabItem>
-  <TabItem value="sdk">
+{{% /tab %}}
+
+{{% tab header="Workspaces API" value="sdk" %}}
 
 Use the `wandb.apis.reports.MarkdownBlock` Class to create a markdown block programmatically. Pass a string to the `text` parameter:
 
@@ -284,31 +205,25 @@ report = wr.Report(project="report-editing")
 report.blocks = [
     wr.MarkdownBlock(text="Markdown cell with *italics* and **bold** and $e=mc^2$")
 ]
+report.save()
 ```
+{{% /tab %}}
 
-This will render a markdown block similar to:
+{{< /tabpane >}}
 
-{{< img src="/images/reports/markdown.png" alt="" >}}
-  </TabItem>
-</Tabs>
-
-### HTML elements
+### Add HTML elements
 
 Add HTML elements to your report interactively with the App UI or with the W&B SDK.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
+{{% tab header="App UI" value="app" %}}
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown select a type of text block. For example, to create an H2 heading block, select the `Heading 2` option.
-  </TabItem>
-  <TabItem value="sdk">
+{{% /tab %}}
 
-Pass a list of one or more HTML elements to `wandb.apis.reports.blocks` attribute. The proceeding example demonstrates how to create an H1, H2, and an unordered list:
+{{% tab header="Workspaces API" value="sdk" %}}
+
+Pass a list of one or more HTML elements to the `wandb.apis.reports.blocks` attribute. The following example demonstrates how to create an H1, H2, and an unordered list:
 
 ```python
 import wandb
@@ -324,52 +239,39 @@ report.blocks = [
 
 report.save()
 ```
+{{% /tab %}}
 
-This will render a HTML elements  to the following:
-
-
-{{< img src="/images/reports/render_html.png" alt="" >}}
-
-  </TabItem>
-</Tabs>
+{{< /tabpane >}}
 
 ### Embed rich media links
 
 Embed rich media within the report with the App UI or with the W&B SDK.
 
-<Tabs
-  defaultValue="app"
-  values={[
-    {label: 'App UI', value: 'app'},
-    {label: 'Workspaces API', value: 'sdk'},
-  ]}>
-  <TabItem value="app">
+{{< tabpane text=true >}}
 
-Copy and past URLs into reports to embed rich media within the report. The following animations demonstrate how to copy and paste URLs from Twitter, YouTube and SoundCloud
+{{% tab header="App UI" value="app" %}}
+
+Copy and paste URLs into reports to embed rich media within the report. The following animations demonstrate how to copy and paste URLs from Twitter, YouTube, and SoundCloud.
 
 #### Twitter
-
 Copy and paste a Tweet link URL into a report to view the Tweet within the report.
 
 {{< img src="/images/reports/twitter.gif" alt="" >}}
 
-####
-
-#### Youtube
-
+#### YouTube
 Copy and paste a YouTube video URL link to embed a video in the report.
 
 {{< img src="/images/reports/youtube.gif" alt="" >}}
 
 #### SoundCloud
-
 Copy and paste a SoundCloud link to embed an audio file into a report.
 
 {{< img src="/images/reports/soundcloud.gif" alt="" >}}
-  </TabItem>
-  <TabItem value="sdk">
+{{% /tab %}}
 
-Pass a list of one or more embedded media objects to the `wandb.apis.reports.blocks` attribute. The proceeding example demonstrates how to embed video and Twitter media into a report:
+{{% tab header="Workspaces API" value="sdk" %}}
+
+Pass a list of one or more embedded media objects to the `wandb.apis.reports.blocks` attribute. The following example demonstrates how to embed video and Twitter media into a report:
 
 ```python
 import wandb
@@ -380,13 +282,14 @@ report = wr.Report(project="report-editing")
 report.blocks = [
     wr.Video(url="https://www.youtube.com/embed/6riDJMI-Y8U"),
     wr.Twitter(
-        embed_html='<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The voice of an angel, truly. <a href="https://twitter.com/hashtag/MassEffect?src=hash&amp;ref_src=twsrc%5Etfw">#MassEffect</a> <a href="https://t.co/nMev97Uw7F">pic.twitter.com/nMev97Uw7F</a></p>&mdash; Mass Effect (@masseffect) <a href="https://twitter.com/masseffect/status/1428748886655569924?ref_src=twsrc%5Etfw">August 20, 2021</a></blockquote>\n'
+        embed_html='<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The voice of an angel, truly. <a href="https://twitter.com/hashtag/MassEffect?src=hash&amp;ref_src=twsrc%5Etfw">#MassEffect</a> <a href="https://t.co/nMev97Uw7F">pic.twitter.com/nMev97Uw7F</a></p>&mdash; Mass Effect (@masseffect) <a href="https://twitter.com/masseffect/status/1428748886655569924?ref_src=twsrc%5Etfw">August 20, 2021</a></blockquote>'
     ),
 ]
 report.save()
 ```
-  </TabItem>
-</Tabs>
+{{% /tab %}}
+
+{{< /tabpane >}}
 
 ### Duplicate and delete panel grids
 
@@ -402,6 +305,6 @@ Select a panel grid and press `delete` on your keyboard to delete a panel grid.
 
 ### Collapse headers to organize Reports
 
-Collapse headers in a Report to hide content within a text block. When the report is loaded, only headers that are expanded will show content. Collapsing headers in reports can help organize your content and prevent excessive data loading. The proceeding gif demonstrates the process.
+Collapse headers in a Report to hide content within a text block. When the report is loaded, only headers that are expanded will show content. Collapsing headers in reports can help organize your content and prevent excessive data loading. The following gif demonstrates the process:
 
 {{< img src="/images/reports/collapse_headers.gif" alt="" >}}

--- a/content/guides/quickstart.md
+++ b/content/guides/quickstart.md
@@ -9,9 +9,6 @@ url: quickstart
 weight: 2
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 Install W&B and start tracking your machine learning experiments in minutes.
 
 ## 1. Create an account and install W&B
@@ -23,45 +20,44 @@ Before you get started, make sure you create an account and install W&B:
 
 The following code snippets demonstrate how to install and log into W&B using the W&B CLI and Python Library:
 
-<Tabs
-  defaultValue="notebook"
-  values={[
-    {label: 'Notebook', value: 'notebook'},
-    {label: 'Command Line', value: 'cli'},
-  ]}>
-  <TabItem value="cli">
+{{< tabpane text=true >}}
+{{% tab header="GitHub repository dispatch" value="github" %}}
+... Markdown contents ...
+{{% /tab %}}
 
+{{% tab header="Microsoft Teams notification" value="microsoft"%}}
+... Markdown contents ...
+{{% /tab %}}
+{{< /tabpane >}}
+
+## 1. Install W&B CLI and Library
+
+{{< tabpane text=true >}}
+
+{{% tab header="Command Line" value="cli" %}}
 Install the CLI and Python library for interacting with the Weights and Biases API:
 
 ```bash
 pip install wandb
 ```
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="notebook">
-
+{{% tab header="Notebook" value="notebook" %}}
 Install the CLI and Python library for interacting with the Weights and Biases API:
-
 
 ```notebook
 !pip install wandb
 ```
+{{% /tab %}}
 
+{{< /tabpane >}}
 
-  </TabItem>
-</Tabs>
 
 ## 2. Log in to W&B
 
+{{< tabpane text=true >}}
 
-<Tabs
-  defaultValue="notebook"
-  values={[
-    {label: 'Notebook', value: 'notebook'},
-    {label: 'Command Line', value: 'cli'},
-  ]}>
-  <TabItem value="cli">
-
+{{% tab header="Command Line" value="cli" %}}
 Next, log in to W&B:
 
 ```bash
@@ -77,10 +73,9 @@ wandb login --relogin --host=http://your-shared-local-host.com
 If needed, ask your deployment admin for the hostname.
 
 Provide [your API key](https://wandb.ai/authorize) when prompted.
+{{% /tab %}}
 
-  </TabItem>
-  <TabItem value="notebook">
-
+{{% tab header="Notebook" value="notebook" %}}
 Next, import the W&B Python SDK and log in:
 
 ```python
@@ -88,8 +83,10 @@ wandb.login()
 ```
 
 Provide [your API key](https://wandb.ai/authorize) when prompted.
-  </TabItem>
-</Tabs>
+{{% /tab %}}
+
+{{< /tabpane >}}
+
 
 
 ## 3. Start a run and track hyperparameters


### PR DESCRIPTION
## DO NOT MERGE YET

This PR is @J2-D2-3PO 's contribution branch for `hugo-WIP`. It does the following

- Update local setup instructions: Running `hugo serve` without updating modules can fail due to missing or outdated dependencies. Add `hugo mod get -u` before serving the site to resolve static file errors (e.g., permission denied on `prism.css`).
- Convert docs with Docusaurus tabs listed in **Tab conversion checklist** to use Hugo format

## Tab conversion checklist

- [x] content/guides/core/artifacts/create-a-new-artifact-version.md
- [x] content/guides/core/artifacts/download-and-use-an-artifact.md
- [x] content/guides/core/artifacts/manage-data/ttl.md
- [x] content/guides/core/artifacts/update-an-artifact.md
- [x] content/guides/core/reports/clone-and-export-reports.md
- [x] content/guides/core/reports/create-a-report.md
- [x] content/guides/core/reports/edit-a-report.md
- [x] content/guides/quickstart.md
- [ ] content/guides/core/tables/tables-walkthrough.md
- [ ] content/guides/core/tables/visualize-tables.md
- [ ] content/guides/hosting/data-security/secure-storage-connector.md
- [ ] content/guides/hosting/hosting-options/self-managed/bare-metal.md
- [ ] content/guides/hosting/hosting-options/self-managed/kubernetes-operator/_index.md
- [ ] content/guides/hosting/iam/access-management/manage-organization.md
- [ ] content/guides/hosting/iam/authentication/ldap.md
- [ ] content/guides/hosting/iam/authentication/sso.md
- [ ] content/guides/integrations/add-wandb-to-any-library.md
- [ ] content/guides/integrations/autotrain.md
- [ ] content/guides/integrations/deepchem.md
- [ ] content/guides/integrations/diffusers.md
- [ ] content/guides/integrations/huggingface.md
- [ ] content/guides/integrations/kubeflow-pipelines-kfp.md
- [ ] content/guides/integrations/lightning.md
- [ ] content/guides/integrations/metaflow.md
- [ ] content/guides/integrations/mmengine.md
- [ ] content/guides/integrations/paddledetection.md
- [ ] content/guides/integrations/paddleocr.md
- [ ] content/guides/integrations/pytorch-geometric.md
- [ ] content/guides/integrations/scikit.md
- [ ] content/guides/integrations/spacy.md
- [ ] content/guides/integrations/torchtune.md
- [ ] content/guides/integrations/ultralytics.md

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
