### PR TITLE
Tutorials: Removed old content about deprecated feature

### DIFF
--- a/docs/tutorials/artifacts.md
+++ b/docs/tutorials/artifacts.md
@@ -707,33 +707,6 @@ model = train_and_log(train_config)
 evaluate_and_log()
 ```
 
-### 🔁 The Graph View
-
-Notice that we changed the `type` of the `Artifact`:
-these `Run`s used a `model`, rather than `dataset`.
-`Run`s that produce `model`s will be separated
-from those that produce `dataset`s in the graph view on the Artifacts page.
-
-Go check it out! As before, you'll want to head to the Run page,
-select the "Artifacts" tab from the left sidebar,
-pick an `Artifact`,
-and then click the "Graph View" tab.
-
-
-### 💣 Exploded Graphs
-
-You may have noticed a button labeled "Explode". Don't click that, as it will set off a small bomb underneath your humble author's desk in the W&B HQ!
-
-Just kidding. It "explodes" the graph in a much gentler way:
-`Artifact`s and `Run`s become separated at the level of a single instance,
-rather than a `type`:
-the nodes are not `dataset` and `load-data`, but `dataset:mnist-raw:v1` and `load-data:sunny-smoke-1`, and so on.
-
-This provides total insight into your pipeline,
-with logged metrics, metadata, and more
-all at your fingertips --
-you're only limited by what you choose to log with us.
-
 
 
 


### PR DESCRIPTION
## Description

Rmoves content from artifact tutorial for a feature that doesn't exist. 

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
