### PR TITLE
Removed Launch from supoprtlanding page

### DIFF
--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -65,11 +65,11 @@ Browse articles by category.
     </a>
   {{< /card >}}
   {{< card >}}
-    <a href="/launch/launch-faq/">
+    <a href="index_sweeps">
       <div className="card-icon-left" style="backgroundImage: url('/images/support/white-icon-category-multimodal.svg')"></div>
       <div className="card-icon-right" style="backgroundImage: url('/images/support/white-icon-forward-next.svg')"></div>
-      <h2 className="card-title">Launch</h2>
-      <p className="card-content">Manage compute resources and run machine learning jobs at scale</p>
+      <h2 className="card-title">Sweeps</h2>
+      <p className="card-content">Automate hyperparameter search</p>
     </a>
   {{< /card >}}
 {{< /cardpane >}}


### PR DESCRIPTION
## Description

Removes Launch title card from Support landing page.

## Ticket

Does this PR fix an existing issue? If yes, provide a link to the ticket here:

## Checklist

Check if your PR fulfills the following requirements. Put an `X` in the boxes that apply.

- [ ] Files I edited were previewed on my local development server with `yarn start`. My changes did not break the local preview.
- [ ] Build (`yarn docusaurus build`) was run locally and successfully without errors or warnings.
- [ ] I merged the latest changes from `main` into my feature branch before submitting this PR.
