### PR TITLE
Fix image in weave_models_registry.md

### DIFF
--- a/content/tutorials/weave_models_registry.md
+++ b/content/tutorials/weave_models_registry.md
@@ -15,7 +15,7 @@ This notebook shows how to use W&B Weave together with W&B Models. Specifically,
 
 Find the public workspace for both W&B Models and W&B Weave [here](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/evaluations).
 
-<img src="/images/tutorials/weave_models_workflow.jpg"  alt="Weights & Biases" />
+{{< img src="/images/tutorials/weave_models_workflow.jpg"  alt="Weights & Biases" >}}
 
 The workflow covers the following steps:
 


### PR DESCRIPTION
Raw image calls don't pull images out of `assets` and into the build output; we must use the `{{< img >}}` tag for all image references that aren't pointing at files that live in `static`

## Description

What does the pull request do? 

## Ticket

Does this PR fix an existing issue? If yes, provide a link here.
