### PR TITLE
Fix Registry Enable link

### DIFF
--- a/content/guides/models/registry/_index.md
+++ b/content/guides/models/registry/_index.md
@@ -13,7 +13,7 @@ cascade:
 
 
 {{% alert %}}
-W&B Registry is now in public preview. Visit [this]({{< relref "#enable-wb-registry" >}}) section to learn how to enable it for your deployment type.
+W&B Registry is now in public preview. Visit [this]({{< relref "./#enable-wb-registry" >}}) section to learn how to enable it for your deployment type.
 {{% /alert %}}
 
 


### PR DESCRIPTION
## Description

What does the pull request do? 
Fixes the hyperlink to the "Enable W&B Registry" section for the top callout on Registry homepage.

## Ticket

Does this PR fix an existing issue? If yes, provide a link here.
