### PR TITLE
Reapply #940 Added custom security context config to the operator config reference after Hugo migration

### DIFF
--- a/content/guides/hosting/hosting-options/self-managed/kubernetes-operator/_index.md
+++ b/content/guides/hosting/hosting-options/self-managed/kubernetes-operator/_index.md
@@ -764,6 +764,59 @@ global:
     -----END CERTIFICATE-----
 ```
 
+### Custom security context
+
+Each W&B component supports custom security context configurations of the following form:
+
+```yaml
+pod:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 0
+    fsGroup: 1001
+    fsGroupChangePolicy: Always
+    seccompProfile:
+      type: RuntimeDefault
+container:
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false 
+```
+
+{{% alert %}}
+The only valid value for `runAsGroup:` is `0`. Any other value is an error.
+{{% /alert %}}
+
+
+To configure the application pod, add a section `app` to your configuration:
+
+```yaml
+global:
+  ...
+app:
+  pod:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 0
+      fsGroup: 1001
+      fsGroupChangePolicy: Always
+      seccompProfile:
+        type: RuntimeDefault
+  container:
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false 
+```
+The same concept applies to `console`, `weave`, `otel`, `weave-trace`, `flat-run-fields-updater` and `parquet`.
+
 ## Configuration Reference for W&B Operator
 
 This section describes configuration options for W&B Kubernetes operator (`wandb-controller-manager`). The operator receives its configuration in the form of a YAML file. 


### PR DESCRIPTION
## Description

Reapply #940 Added custom security context config to the operator config reference after Hugo migration

- Minor edit to use the new Alert shortcode and adjust some copy

## Ticket

Ref: https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1737554162612699
