### PR TITLE
Override Docsy lastmod template to remove subject

### DIFF
--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,10 @@
+{{ if and .GitInfo .Site.Params.github_repo -}}
+<div class="td-page-meta__lastmod">
+  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+  {{ with .GitInfo }} {{/* Trim WS */ -}}
+    <a data-proofer-ignore href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+      ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
+    </a>
+  {{- end }}
+</div>
+{{ end -}}


### PR DESCRIPTION
Override Docsy lastmod template to remove subject

![Screenshot 2025-01-24 at 2 40 14 PM](https://github.com/user-attachments/assets/c238a242-3471-49d7-ad76-2b03ee278545)

Adapted from https://github.com/google/docsy/blob/a854cb315ac2885f8e27a5780d3c320a30d1b457/layouts/partials/page-meta-lastmod.html#L2

## Ticket


Ref: https://weightsandbiases.slack.com/archives/C081R4TDAH1/p1737746004048749
