### PR TITLE
Try to fix Lychee github action error

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "1 0 1 * *" # 12:01 on the 1st of each month
+    - cron: "1 0 2 * *" # 12:01 on the 1st of each month
 
 jobs:
   linkChecker:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,6 +1,9 @@
 name: Lychee check
 on:
-  pull_request:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 14 * * *"
 
 jobs:
   linkChecker:
@@ -8,13 +11,53 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
+      # Cache lychee results (e.g. to avoid hitting rate limits)
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      # check URLs with Lychee
       - uses: actions/checkout@v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: "content/**.md"
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: >-
+            --accept 200,429
+            --base content
+            --cache
+            --max-cache-age 1d
+            --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+            --max-concurrency 5
+            --verbose
+            --no-progress
+            --retry-count 1
+            --retry-delay 2
+            --scheme https
+            --scheme http
+            './content/*.md'
+            './content/*.html'
           fail: false
+        env:
+          # to be used in case rate limits are surpassed
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Save lychee cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
@@ -23,30 +66,3 @@ jobs:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
           labels: report, automated issue
-
-  lychee:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          files: "**.md"
-
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v1.10.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --base content --scheme https --scheme http --verbose --no-cache --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" --max-concurrency 5 --retry-count 3 --retry-delay 2 ${{ steps.changed-files.outputs.all_changed_files }}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Create PR comment with link reults
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: lychee
-          recreate: true
-          path: ./lychee/out.md

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,10 +1,29 @@
 name: Lychee check
 on:
   pull_request:
-    paths:
-      - '**.md'
 
 jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+
   lychee:
     runs-on: ubuntu-latest
     steps:
@@ -21,11 +40,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: > 
-          --scheme https --scheme http --verbose --no-cache
-          --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-          --max-concurrency 5 --retry-count 3 --retry-delay 2
-          ${{ steps.changed-files.outputs.all_changed_files }}
+          args: --base content --scheme https --scheme http --verbose --no-cache --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" --max-concurrency 5 --retry-count 3 --retry-delay 2 ${{ steps.changed-files.outputs.all_changed_files }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "41 14 * * *"
+    - cron: "1 0 1 * *" # 12:01 on the 1st of each month
 
 jobs:
   linkChecker:
@@ -11,13 +11,6 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
-      # Cache lychee results (e.g. to avoid hitting rate limits)
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
       # check URLs with Lychee
       - uses: actions/checkout@v4
 
@@ -35,7 +28,7 @@ jobs:
           args: >-
             --accept 200,429
             --base content
-            --cache
+            --no-cache
             --max-cache-age 1d
             --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
             --max-concurrency 5
@@ -51,13 +44,6 @@ jobs:
         env:
           # to be used in case rate limits are surpassed
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Save lychee cache
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: .lycheecache
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0


### PR DESCRIPTION
This fixes the Lychee GitHub action so it doesn't fail on each PR

- Do not run as a PR check
- Run against `main` using a cron schedule, for 12:01 AM on the 1st of each month
- Ignore 429 errors
- Adjust the syntax for specifying args
- Give it permission to create GH issues
- Upgrade the action