### PR TITLE
Add info on WANDB_SWEEP_ID

### DIFF
--- a/content/guides/models/track/environment-variables.md
+++ b/content/guides/models/track/environment-variables.md
@@ -27,6 +27,9 @@ WANDB_PROJECT=$project
 ```python
 # If you don't want your script to sync to the cloud
 os.environ["WANDB_MODE"] = "offline"
+
+# Add sweep ID tracking to Run objects and related classes
+os.environ["WANDB_SWEEP_ID"] = "b05fq58z"
 ```
 
 ## Optional environment variables
@@ -62,6 +65,7 @@ Use these optional environment variables to do things like set up authentication
 | **WANDB_RUN_ID**          | Set this to a globally unique string (per project) corresponding to a single run of your script. It must be no longer than 64 characters. All non-word characters will be converted to dashes. This can be used to resume an existing run in cases of failure.      |
 | **WANDB_SILENT**           | Set this to **true** to silence wandb log statements. If this is set all logs will be written to **WANDB_DIR**/debug.log               |
 | **WANDB_SHOW_RUN**        | Set this to **true** to automatically open a browser with the run url if your operating system supports it.        |
+| **WANDB_SWEEP_ID**        | Add sweep ID tracking to `Run` objects and related classes, and display in the UI.           |
 | **WANDB_TAGS**             | A comma separated list of tags to be applied to the run.                 |
 | **WANDB_USERNAME**         | The username of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team.               |
 | **WANDB_USER_EMAIL**      | The email of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team.            |


### PR DESCRIPTION
{Short description}

{More details, or remove this line}

https://wandb.atlassian.net/browse/DOCS-786

Add WANDB_SWEEP_ID info to env vars table and usage sample in /guides/track/environment-variables/

Confirm that tests pass and this change is ready for review:
- [x] Local `hugo serve`
- [ ] Local `vale ./content`
