### PR TITLE
Prism "copy" button fix

### DIFF
--- a/layouts/shortcodes/prism.html
+++ b/layouts/shortcodes/prism.html
@@ -13,11 +13,15 @@
     {{- if $file -}} data-src="{{- $file -}}" data-download-link {{ end }}
     data-break-lines="50"
 >
+{{- if $file -}}
+{{- .Inner -}}
+{{- else -}}
 <code class="drop-tokens language-{{- .Get "language" | default "shell" -}}"
         {{- with .Get "prefix" }} data-prefix="{{- . -}}" {{- end -}}
         {{- with .Get "copy" }} data-copy="{{- . -}}" {{- end -}}
     >
     {{- .Inner -}}
     </code>
+{{- end -}}
 </pre>
 </figure>


### PR DESCRIPTION
Fixes HTML bug in instances where an external file is being loaded in the `prism` shortcode. 

Fixes DOCS-1227

To test go to https://prism-fix.docodile.pages.dev/guides/artifacts/project-scoped-automations/ , then search for "Bash script" and try to copy the code block that features the "Download" button. The code does make it to your clipboard, unlike the live version at https://docs.wandb.ai/guides/artifacts/project-scoped-automations/