### PR TITLE
Add redirects for inadvertently updated query-panels URL change

### DIFF
--- a/content/guides/models/app/features/panels/query-panels/_index.md
+++ b/content/guides/models/app/features/panels/query-panels/_index.md
@@ -11,6 +11,7 @@ cascade:
 title: Query panels
 ---
 
+
 {{% alert %}}
 Looking for W&B Weave? W&B's suite of tools for Generative AI application building? Find the docs for weave here: [wandb.me/weave](https://wandb.github.io/weave/?utm_source=wandb_docs&utm_medium=docs&utm_campaign=weave-nudge).
 {{% /alert %}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -276,11 +276,12 @@
 /guides/track/save-restore /guides/artifacts 301
 /guides/track/summary-metrics /guides/track/log/log-summary 301
 /guides/troubleshooting/network /guides/technical-faq 301
-/weave /guides/app/features/panels/query-panel 301
-/guides/app/features/panels/weave /guides/app/features/panels/query-panel 301
-/weave/boards /guides/app/features/panels/query-panel 301
+/guides/app/features/panels/query-panel /guides/app/features/panels/query-panels 301
+/weave /guides/app/features/panels/query-panels 301
+/guides/app/features/panels/weave /guides/app/features/panels/query-panels 301
+/weave/boards /guides/app/features/panels/query-panels 301
 /weave/streamtable /guides/app/features/panels/query-panel 301
-/guides/app/features/panels/weave/embedding-projector /guides/app/features/panels/query-panel/embedding-projector 301
+/guides/app/features/panels/weave/embedding-projector /guides/app/features/panels/query-panels/embedding-projector 301
 /guides/platform /guides/core 301
 /weave/prod-mon /guides/core 301
 /home / 301


### PR DESCRIPTION
Add redirects for inadvertently updated query-panels URL change

Report:
- https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1740498684214059
- https://weightsandbiases.slack.com/archives/C050NM2AVMW/p1740498648501249

Links for testing:
- https://query-panel-redirect.docodile.pages.dev/guides/app/features/panels/query-panel/ should redirect to https://query-panel-redirect.docodile.pages.dev/guides/app/features/panels/query-panels/
- https://query-panel-redirect.docodile.pages.dev/guides/app/features/panels/query-panel/embedding-projector/ should redirect to https://query-panel-redirect.docodile.pages.dev/guides/app/features/panels/query-panels/embedding-projector/