### PR TITLE
Remove Qualified pixel

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -35,10 +35,3 @@
   });
   
 </script>
-<!-- Qualified -->
-<script>
-  (function(w,q){w['QualifiedObject']=q;w[q]=w[q]||function(){
-  (w[q].q=w[q].q||[]).push(arguments)};})(window,'qualified')
-  </script>
-  <script async src="https://js.qualified.com/qualified.js?token=GMjrmCoq7HvrWi46"></script>
-<!-- End Qualified -->


### PR DESCRIPTION
Permanently prevents the chat agent from showing up in the docs; action item derived from chat w/them in which their rep said:

"Got it, thank you. I would recommend we go ahead and remove the Qualified JS from the docs page. Since it's not a SPA, this should remove the ability for the experience to "follow" the visitor to the docs page"
