### PR TITLE
Add diagram to registry access page

### DIFF
--- a/content/guides/models/registry/configure_registry.md
+++ b/content/guides/models/registry/configure_registry.md
@@ -11,7 +11,7 @@ A registry admin can [configure registry roles]({{< relref "configure_registry.m
 
 ## Diagram
 
-This diagram illustrates the hierarchical permission structure in Weights & Biases (W&B), showing the relationships between Organization, Team, and Registry roles and how permissions are inherited. Users receive the highest permission level between their individual assignment and team membership, with Registry roles limited to three fixed types (Admin, Member, Viewer) that determine what actions users can perform. 
+This diagram illustrates the hierarchical permission structure in W&B, showing the relationships between Organization, Team, and Registry roles and how permissions are inherited. Users receive the highest permission level between their individual assignment and team membership, with Registry roles limited to three fixed types (Admin, Member, Viewer) that determine what actions users can perform. 
 
 {{< alert >}}
 The permissions for teams and registries are separate. For example, being an admin on a team does not make a user an admin on a registry.

--- a/content/guides/models/registry/configure_registry.md
+++ b/content/guides/models/registry/configure_registry.md
@@ -19,8 +19,7 @@ The permissions for teams and registries are separate. For example, being an adm
 
 ```mermaid
 flowchart TD
-    %% Stack all subgraphs vertically
-    
+
     subgraph OrgRoles["Organization Roles"]
         OA["Organization Admin"]
         OM["Organization Member"]

--- a/content/guides/models/registry/configure_registry.md
+++ b/content/guides/models/registry/configure_registry.md
@@ -9,6 +9,66 @@ weight: 3
 
 A registry admin can [configure registry roles]({{< relref "configure_registry.md#configure-registry-roles" >}}), [add users]({{< relref "configure_registry.md#add-a-user-or-a-team-to-a-registry" >}}), or [remove users]({{< relref "configure_registry.md#remove-a-user-or-team-from-a-registry" >}}) from a registry by configuring the registry's settings.
 
+## Diagram
+
+This diagram illustrates the hierarchical permission structure in Weights & Biases (W&B), showing the relationships between Organization, Team, and Registry roles and how permissions are inherited. Users receive the highest permission level between their individual assignment and team membership, with Registry roles limited to three fixed types (Admin, Member, Viewer) that determine what actions users can perform.
+
+```mermaid
+flowchart TD
+    %% Stack all subgraphs vertically
+    
+    subgraph OrgRoles["Organization Roles"]
+        OA["Organization Admin"]
+        OM["Organization Member"]
+        OV["Organization Viewer"]
+    end
+    
+    OrgRoles --> TeamRoles
+    
+    subgraph TeamRoles["Team Roles"]
+        TA["Team Admin"]
+        TM["Team Member"]
+        TV["Team Viewer"]
+        TC["Team Custom Roles"]
+    end
+    
+    TeamRoles --> RegRoles
+    
+    subgraph RegRoles["Registry Roles"]
+        RA["Registry Admin"]
+        RM["Registry Member"]
+        RV["Registry Viewer"]
+    end
+    
+    RegRoles --> ImportantNotes
+    
+    subgraph ImportantNotes["Important Notes"]
+        Note1["Team roles have NO impact<br>on Registry roles"]
+        Note2["Registry belongs to Organization,<br>not Teams"]
+        Note3["Only 3 fixed Registry roles:<br>Admin, Member, Viewer<br>(no custom roles)"]
+    end
+    
+    ImportantNotes --> InheritanceRule
+    
+    subgraph InheritanceRule["Inheritance Rule"]
+        Inherit["User gets highest permission level<br>between individual assignment<br>and team membership<br><br>Example: If user has Viewer role<br>but is in a team with Member role,<br>they get Member permissions"]
+    end
+    
+    %% Default role assignment connections
+    OA -->|"Default: Admin"| RA
+    OM -->|"Default: Viewer"| RV
+    OV -->|"Default: Viewer"| RV
+    
+    %% Team assignment
+    TeamNode["Team"] -->|"Default: Viewer"| RV
+    
+    style OrgRoles fill:#ddf,stroke:#333,stroke-width:1px
+    style TeamRoles fill:#dfd,stroke:#333,stroke-width:1px
+    style RegRoles fill:#fdf,stroke:#333,stroke-width:1px
+    style ImportantNotes fill:#fdd,stroke:#333,stroke-width:1px
+    style InheritanceRule fill:#ddf,stroke:#333,stroke-width:1px
+```
+
 ## Manage users
 
 ### Add a user or a team

--- a/content/guides/models/registry/configure_registry.md
+++ b/content/guides/models/registry/configure_registry.md
@@ -54,8 +54,6 @@ flowchart TD
     style OrgRoles fill:#ddf,stroke:#333,stroke-width:1px
     style TeamRoles fill:#dfd,stroke:#333,stroke-width:1px
     style RegRoles fill:#fdf,stroke:#333,stroke-width:1px
-    style ImportantNotes fill:#fdd,stroke:#333,stroke-width:1px
-    style InheritanceRule fill:#ddf,stroke:#333,stroke-width:1px
 ```
 
 ## Manage users

--- a/content/guides/models/registry/configure_registry.md
+++ b/content/guides/models/registry/configure_registry.md
@@ -11,7 +11,11 @@ A registry admin can [configure registry roles]({{< relref "configure_registry.m
 
 ## Diagram
 
-This diagram illustrates the hierarchical permission structure in Weights & Biases (W&B), showing the relationships between Organization, Team, and Registry roles and how permissions are inherited. Users receive the highest permission level between their individual assignment and team membership, with Registry roles limited to three fixed types (Admin, Member, Viewer) that determine what actions users can perform.
+This diagram illustrates the hierarchical permission structure in Weights & Biases (W&B), showing the relationships between Organization, Team, and Registry roles and how permissions are inherited. Users receive the highest permission level between their individual assignment and team membership, with Registry roles limited to three fixed types (Admin, Member, Viewer) that determine what actions users can perform. 
+
+{{< alert >}}
+The permissions for teams and registries are separate. For example, being an admin on a team does not make a user an admin on a registry.
+{{< /alert >}}
 
 ```mermaid
 flowchart TD
@@ -38,20 +42,6 @@ flowchart TD
         RA["Registry Admin"]
         RM["Registry Member"]
         RV["Registry Viewer"]
-    end
-    
-    RegRoles --> ImportantNotes
-    
-    subgraph ImportantNotes["Important Notes"]
-        Note1["Team roles have NO impact<br>on Registry roles"]
-        Note2["Registry belongs to Organization,<br>not Teams"]
-        Note3["Only 3 fixed Registry roles:<br>Admin, Member, Viewer<br>(no custom roles)"]
-    end
-    
-    ImportantNotes --> InheritanceRule
-    
-    subgraph InheritanceRule["Inheritance Rule"]
-        Inherit["User gets highest permission level<br>between individual assignment<br>and team membership<br><br>Example: If user has Viewer role<br>but is in a team with Member role,<br>they get Member permissions"]
     end
     
     %% Default role assignment connections


### PR DESCRIPTION
Resolves DOCS-889

Adds diagram and caption giving an overview of the permissions structure for the various roles as they interact with Registry. 

Note: This was generated during bugbash and is likely to be very rough; the first cut of this is mainly to generate discussion about what DOCS-889 is asking for and how to address it. Feedback appreciated!

Direct link to the diagram: https://registry-diagram.docodile.pages.dev/guides/registry/configure_registry/