### PR TITLE
Add WANDB_DATA_DIR to environment variables

### DIFF
--- a/content/guides/core/artifacts/manage-data/storage.md
+++ b/content/guides/core/artifacts/manage-data/storage.md
@@ -13,12 +13,15 @@ For sensitive files, we recommend you set up [Private Hosting]({{< relref "/guid
 
 During training, W&B locally saves logs, artifacts, and configuration files in the following local directories:
 
-| File      | Default location  | To change default location set:                                   |
-| --------- | ----------------- | ----------------------------------------------------------------- |
-| logs      | `./wandb`         | `dir` in `wandb.init` or set the `WANDB_DIR` environment variable |
-| artifacts | `~/.cache/wandb`  | the `WANDB_CACHE_DIR` environment variable                        |
-| configs   | `~/.config/wandb` | the `WANDB_CONFIG_DIR` environment variable                       |
+| File | Default location | To change default location set: |
+| ---- | ---------------- | ------------------------------- |
+| logs | `./wandb` | `dir` in `wandb.init` or set the `WANDB_DIR` environment variable |
+| artifacts | `~/.cache/wandb` | the `WANDB_CACHE_DIR` environment variable |
+| configs | `~/.config/wandb` | the `WANDB_CONFIG_DIR` environment variable |
+| staging artifacts for upload  | `~/.cache/wandb-data/` | the `WANDB_DATA_DIR` environment variable |
+| downloaded artifacts | `~/.cache/artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
 
+Set this to an absolute path to store all downloaded artifacts here instead of the _artifacts_ directory relative to your training script. Make sure this directory exists and the user your process runs as can write to it. Note that this does not affect the location of generated metadata files, which can instead be set using _WANDB_DIR_
 
 {{% alert color="secondary" %}}
 Depending on the machine on `wandb` is initialized on, these default folders may not be located in a writeable part of the file system. This might trigger an error.

--- a/content/guides/core/artifacts/manage-data/storage.md
+++ b/content/guides/core/artifacts/manage-data/storage.md
@@ -19,7 +19,7 @@ During training, W&B locally saves logs, artifacts, and configuration files in t
 | artifacts | `~/.cache/wandb` | the `WANDB_CACHE_DIR` environment variable |
 | configs | `~/.config/wandb` | the `WANDB_CONFIG_DIR` environment variable |
 | staging artifacts for upload  | `~/.cache/wandb-data/` | the `WANDB_DATA_DIR` environment variable |
-| downloaded artifacts | `~/.cache/artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
+| downloaded artifacts | `~./artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
 
 For a complete guide to using environment variables to configure W&B, see [the environment variables reference]({{< relref "/guides/models/track/environment-variables.md" >}}).
 

--- a/content/guides/core/artifacts/manage-data/storage.md
+++ b/content/guides/core/artifacts/manage-data/storage.md
@@ -19,7 +19,7 @@ During training, W&B locally saves logs, artifacts, and configuration files in t
 | artifacts | `~/.cache/wandb` | the `WANDB_CACHE_DIR` environment variable |
 | configs | `~/.config/wandb` | the `WANDB_CONFIG_DIR` environment variable |
 | staging artifacts for upload  | `~/.cache/wandb-data/` | the `WANDB_DATA_DIR` environment variable |
-| downloaded artifacts | `~./artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
+| downloaded artifacts | `./artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
 
 For a complete guide to using environment variables to configure W&B, see [the environment variables reference]({{< relref "/guides/models/track/environment-variables.md" >}}).
 

--- a/content/guides/core/artifacts/manage-data/storage.md
+++ b/content/guides/core/artifacts/manage-data/storage.md
@@ -21,7 +21,7 @@ During training, W&B locally saves logs, artifacts, and configuration files in t
 | staging artifacts for upload  | `~/.cache/wandb-data/` | the `WANDB_DATA_DIR` environment variable |
 | downloaded artifacts | `~/.cache/artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
 
-Set this to an absolute path to store all downloaded artifacts here instead of the _artifacts_ directory relative to your training script. Make sure this directory exists and the user your process runs as can write to it. Note that this does not affect the location of generated metadata files, which can instead be set using _WANDB_DIR_
+For a complete guide to using environment variables to configure W&B, see [the environment variables reference]({{< relref "/guides/models/track/environment-variables.md" >}}).
 
 {{% alert color="secondary" %}}
 Depending on the machine on `wandb` is initialized on, these default folders may not be located in a writeable part of the file system. This might trigger an error.

--- a/content/guides/core/artifacts/manage-data/storage.md
+++ b/content/guides/core/artifacts/manage-data/storage.md
@@ -21,7 +21,7 @@ During training, W&B locally saves logs, artifacts, and configuration files in t
 | staging artifacts for upload  | `~/.cache/wandb-data/` | the `WANDB_DATA_DIR` environment variable |
 | downloaded artifacts | `./artifacts` | the `WANDB_ARTIFACT_DIR` environment variable |
 
-For a complete guide to using environment variables to configure W&B, see [the environment variables reference]({{< relref "/guides/models/track/environment-variables.md" >}}).
+For a complete guide to using environment variables to configure W&B, see the [environment variables reference]({{< relref "/guides/models/track/environment-variables.md" >}}).
 
 {{% alert color="secondary" %}}
 Depending on the machine on `wandb` is initialized on, these default folders may not be located in a writeable part of the file system. This might trigger an error.

--- a/content/guides/models/track/environment-variables.md
+++ b/content/guides/models/track/environment-variables.md
@@ -78,4 +78,4 @@ If you're running containers in [Singularity](https://singularity.lbl.gov/index.
 
 ## Running on AWS
 
-If you're running batch jobs in AWS, it's easy to authenticate your machines with your W&B credentials. Get your API key from your [settings page](https://app.wandb.ai/settings), and set the WANDB_API_KEY environment variable in the [AWS batch job spec](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters).
+If you're running batch jobs in AWS, it's easy to authenticate your machines with your W&B credentials. Get your API key from your [settings page](https://app.wandb.ai/settings), and set the `WANDB_API_KEY` environment variable in the [AWS batch job spec](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters).

--- a/content/guides/models/track/environment-variables.md
+++ b/content/guides/models/track/environment-variables.md
@@ -36,40 +36,41 @@ os.environ["WANDB_SWEEP_ID"] = "b05fq58z"
 
 Use these optional environment variables to do things like set up authentication on remote machines.
 
-| Variable name               | Usage                                  |
+| Variable name | Usage |
 | --------------------------- | ---------- |
-| **WANDB_ANONYMOUS**        | Set this to `allow`, `never`, or `must` to let users create anonymous runs with secret urls.                                                    |
-| **WANDB_API_KEY**         | Sets the authentication key associated with your account. You can find your key on [your settings page](https://app.wandb.ai/settings).  This must be set if `wandb login` hasn't been run on the remote machine.               |
-| **WANDB_BASE_URL**        | If you're using [wandb/local]({{< relref "/guides/hosting/" >}}) you should set this environment variable to `http://YOUR_IP:YOUR_PORT`        |
-| **WANDB_CACHE_DIR**       | This defaults to \~/.cache/wandb, you can override this location with this environment variable                    |
-| **WANDB_CONFIG_DIR**      | This defaults to \~/.config/wandb, you can override this location with this environment variable                             |
-| **WANDB_CONFIG_PATHS**    | Comma separated list of yaml files to load into wandb.config. See [config]({{< relref "./config.md#file-based-configs" >}}).                                          |
-| **WANDB_CONSOLE**          | Set this to "off" to disable stdout / stderr logging. This defaults to "on" in environments that support it.                                          |
-| **WANDB_DIR**              | Set this to an absolute path to store all generated files here instead of the _wandb_ directory relative to your training script. _be sure this directory exists and the user your process runs as can write to it_. Note that this does not affect the location of downloaded artifacts, which can instead be set using _WANDB_ARTIFACT_DIR_                  |
-| **WANDB_ARTIFACT_DIR**              | Set this to an absolute path to store all downloaded artifacts here instead of the _artifacts_ directory relative to your training script. Make sure this directory exists and the user your process runs as can write to it. Note that this does not affect the location of generated metadata files, which can instead be set using _WANDB_DIR_                  |
-| **WANDB_DISABLE_GIT**     | Prevent wandb from probing for a git repository and capturing the latest commit / diff.      |
-| **WANDB_DISABLE_CODE**    | Set this to true to prevent wandb from saving notebooks or git diffs. We'll still save the current commit if we're in a git repo.                   |
-| **WANDB_DOCKER**           | Set this to a docker image digest to enable restoring of runs. This is set automatically with the wandb docker command. You can obtain an image digest by running `wandb docker my/image/name:tag --digest` |
-| **WANDB_ENTITY**           | The entity associated with your run. If you have run `wandb init` in the directory of your training script, it will create a directory named _wandb_ and will save a default entity which can be checked into source control. If you don't want to create that file or want to override the file you can use the environmental variable. |
-| **WANDB_ERROR_REPORTING** | Set this to false to prevent wandb from logging fatal errors to its error tracking system.                             |
-| **WANDB_HOST**             | Set this to the hostname you want to see in the wandb interface if you don't want to use the system provided hostname                                |
-| **WANDB_IGNORE_GLOBS**    | Set this to a comma separated list of file globs to ignore. These files will not be synced to the cloud.                              |
-| **WANDB_JOB_NAME**        | Specify a name for any jobs created by `wandb`. |
-| **WANDB_JOB_TYPE**        | Specify the job type, like "training" or "evaluation" to indicate different types of runs. See [grouping]({{< relref "/guides/models/track/runs/grouping.md" >}}) for more info.               |
-| **WANDB_MODE**             | If you set this to "offline" wandb will save your run metadata locally and not sync to the server. If you set this to `disabled` wandb will turn off completely.                  |
-| **WANDB_NAME**             | The human-readable name of your run. If not set it will be randomly generated for you                       |
-| **WANDB_NOTEBOOK_NAME**   | If you're running in jupyter you can set the name of the notebook with this variable. We attempt to auto detect this.                    |
-| **WANDB_NOTES**            | Longer notes about your run. Markdown is allowed and you can edit this later in the UI.                                    |
-| **WANDB_PROJECT**          | The project associated with your run. This can also be set with `wandb init`, but the environmental variable will override the value.                               |
-| **WANDB_RESUME**           | By default this is set to _never_. If set to _auto_ wandb will automatically resume failed runs. If set to _must_ forces the run to exist on startup. If you want to always generate your own unique ids, set this to _allow_ and always set **WANDB_RUN_ID**.      |
-| **WANDB_RUN_GROUP**       | Specify the experiment name to automatically group runs together. See [grouping]({{< relref "/guides/models/track/runs/grouping.md" >}}) for more info.                                 |
-| **WANDB_RUN_ID**          | Set this to a globally unique string (per project) corresponding to a single run of your script. It must be no longer than 64 characters. All non-word characters will be converted to dashes. This can be used to resume an existing run in cases of failure.      |
-| **WANDB_SILENT**           | Set this to **true** to silence wandb log statements. If this is set all logs will be written to **WANDB_DIR**/debug.log               |
-| **WANDB_SHOW_RUN**        | Set this to **true** to automatically open a browser with the run url if your operating system supports it.        |
-| **WANDB_SWEEP_ID**        | Add sweep ID tracking to `Run` objects and related classes, and display in the UI.           |
-| **WANDB_TAGS**             | A comma separated list of tags to be applied to the run.                 |
-| **WANDB_USERNAME**         | The username of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team.               |
-| **WANDB_USER_EMAIL**      | The email of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team.            |
+| **WANDB_ANONYMOUS** | Set this to `allow`, `never`, or `must` to let users create anonymous runs with secret urls. |
+| **WANDB_API_KEY** | Sets the authentication key associated with your account. You can find your key on [your settings page](https://app.wandb.ai/settings).  This must be set if `wandb login` hasn't been run on the remote machine.               |
+| **WANDB_BASE_URL** | If you're using [wandb/local]({{< relref "/guides/hosting/" >}}) you should set this environment variable to `http://YOUR_IP:YOUR_PORT` |
+| **WANDB_CACHE_DIR** | This defaults to \~/.cache/wandb, you can override this location with this environment variable |
+| **WANDB_CONFIG_DIR** | This defaults to \~/.config/wandb, you can override this location with this environment variable |
+| **WANDB_CONFIG_PATHS** | Comma separated list of yaml files to load into wandb.config. See [config]({{< relref "./config.md#file-based-configs" >}}). |
+| **WANDB_CONSOLE** | Set this to "off" to disable stdout / stderr logging. This defaults to "on" in environments that support it. |
+| **WANDB_DATA_DIR** | This location is used for staging artifacts during upload. The default depends on your platform, as it uses `user_data_dir` from `platformdirs` python package |
+| **WANDB_DIR** | Set this to an absolute path to store all generated files here instead of the _wandb_ directory relative to your training script. _be sure this directory exists and the user your process runs as can write to it_. Note that this does not affect the location of downloaded artifacts, which can instead be set using _WANDB_ARTIFACT_DIR_ |
+| **WANDB_ARTIFACT_DIR** | Set this to an absolute path to store all downloaded artifacts here instead of the _artifacts_ directory relative to your training script. Make sure this directory exists and the user your process runs as can write to it. Note that this does not affect the location of generated metadata files, which can instead be set using _WANDB_DIR_ |
+| **WANDB_DISABLE_GIT** | Prevent wandb from probing for a git repository and capturing the latest commit / diff. |
+| **WANDB_DISABLE_CODE** | Set this to true to prevent wandb from saving notebooks or git diffs. We'll still save the current commit if we're in a git repo. |
+| **WANDB_DOCKER** | Set this to a docker image digest to enable restoring of runs. This is set automatically with the wandb docker command. You can obtain an image digest by running `wandb docker my/image/name:tag --digest` |
+| **WANDB_ENTITY** | The entity associated with your run. If you have run `wandb init` in the directory of your training script, it will create a directory named _wandb_ and will save a default entity which can be checked into source control. If you don't want to create that file or want to override the file you can use the environmental variable. |
+| **WANDB_ERROR_REPORTING** | Set this to false to prevent wandb from logging fatal errors to its error tracking system. |
+| **WANDB_HOST** | Set this to the hostname you want to see in the wandb interface if you don't want to use the system provided hostname |
+| **WANDB_IGNORE_GLOBS** | Set this to a comma separated list of file globs to ignore. These files will not be synced to the cloud. |
+| **WANDB_JOB_NAME** | Specify a name for any jobs created by `wandb`. |
+| **WANDB_JOB_TYPE** | Specify the job type, like "training" or "evaluation" to indicate different types of runs. See [grouping]({{< relref "/guides/models/track/runs/grouping.md" >}}) for more info. |
+| **WANDB_MODE** | If you set this to "offline" wandb will save your run metadata locally and not sync to the server. If you set this to `disabled` wandb will turn off completely. |
+| **WANDB_NAME** | The human-readable name of your run. If not set it will be randomly generated for you |
+| **WANDB_NOTEBOOK_NAME** | If you're running in jupyter you can set the name of the notebook with this variable. We attempt to auto detect this. |
+| **WANDB_NOTES** | Longer notes about your run. Markdown is allowed and you can edit this later in the UI. |
+| **WANDB_PROJECT** | The project associated with your run. This can also be set with `wandb init`, but the environmental variable will override the value. |
+| **WANDB_RESUME** | By default this is set to _never_. If set to _auto_ wandb will automatically resume failed runs. If set to _must_ forces the run to exist on startup. If you want to always generate your own unique ids, set this to _allow_ and always set **WANDB_RUN_ID**. |
+| **WANDB_RUN_GROUP** | Specify the experiment name to automatically group runs together. See [grouping]({{< relref "/guides/models/track/runs/grouping.md" >}}) for more info. |
+| **WANDB_RUN_ID** | Set this to a globally unique string (per project) corresponding to a single run of your script. It must be no longer than 64 characters. All non-word characters will be converted to dashes. This can be used to resume an existing run in cases of failure. |
+| **WANDB_SILENT** | Set this to **true** to silence wandb log statements. If this is set all logs will be written to **WANDB_DIR**/debug.log |
+| **WANDB_SHOW_RUN** | Set this to **true** to automatically open a browser with the run url if your operating system supports it. |
+| **WANDB_SWEEP_ID** | Add sweep ID tracking to `Run` objects and related classes, and display in the UI. |
+| **WANDB_TAGS** | A comma separated list of tags to be applied to the run. |
+| **WANDB_USERNAME** | The username of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team. |
+| **WANDB_USER_EMAIL** | The email of a member of your team associated with the run. This can be used along with a service account API key to enable attribution of automated runs to members of your team. |
 
 ## Singularity environments
 

--- a/content/guides/models/track/environment-variables.md
+++ b/content/guides/models/track/environment-variables.md
@@ -45,7 +45,7 @@ Use these optional environment variables to do things like set up authentication
 | **WANDB_CONFIG_DIR** | This defaults to \~/.config/wandb, you can override this location with this environment variable |
 | **WANDB_CONFIG_PATHS** | Comma separated list of yaml files to load into wandb.config. See [config]({{< relref "./config.md#file-based-configs" >}}). |
 | **WANDB_CONSOLE** | Set this to "off" to disable stdout / stderr logging. This defaults to "on" in environments that support it. |
-| **WANDB_DATA_DIR** | This location is used for staging artifacts during upload. The default depends on your platform, as it uses `user_data_dir` from `platformdirs` python package |
+| **WANDB_DATA_DIR** | The location where staging artifacts are uploaded. The default location depends on your platform, because it uses the value of `user_data_dir` from the `platformdirs` Python package. |
 | **WANDB_DIR** | Set this to an absolute path to store all generated files here instead of the _wandb_ directory relative to your training script. _be sure this directory exists and the user your process runs as can write to it_. Note that this does not affect the location of downloaded artifacts, which can instead be set using _WANDB_ARTIFACT_DIR_ |
 | **WANDB_ARTIFACT_DIR** | Set this to an absolute path to store all downloaded artifacts here instead of the _artifacts_ directory relative to your training script. Make sure this directory exists and the user your process runs as can write to it. Note that this does not affect the location of generated metadata files, which can instead be set using _WANDB_DIR_ |
 | **WANDB_DISABLE_GIT** | Prevent wandb from probing for a git repository and capturing the latest commit / diff. |

--- a/content/support/how_can_i_define_the_local_folder_where_to_save_the_wandb_files.md
+++ b/content/support/how_can_i_define_the_local_folder_where_to_save_the_wandb_files.md
@@ -8,7 +8,7 @@ tags:
 ---
 
 - `WANDB_DIR=<path>` or `wandb.init(dir=<path>)`: Controls the location of the `wandb` folder created for your training script. Defaults to `./wandb`. This folder stores Run's data and logs
-- `WANDB_ARTIFACT_DIR=<path>` or `wandb.Artifact().download(root="<path>")`: Controls the location where artifacts are downloaded. Defaults to `artifacts/`
+- `WANDB_ARTIFACT_DIR=<path>` or `wandb.Artifact().download(root="<path>")`: Controls the location where artifacts are downloaded. Defaults to `./artifacts`
 - `WANDB_CACHE_DIR=<path>`: This is the location where artifacts are created and stored when you call `wandb.Artifact`. Defaults to `~/.cache/wandb`
 - `WANDB_CONFIG_DIR=<path>`: Where config files are stored. Defaults to `~/.config/wandb`
-- `WANDB_DATA_DIR=<PATH>`: This location is used for staging artifacts during upload. The default depends on your platform, as it uses `user_data_dir` from `platformdirs` python package
+- `WANDB_DATA_DIR=<PATH>`: This location is used for staging artifacts during upload. Defaults to `~/.cache/wandb-data/`.

--- a/content/support/how_can_i_define_the_local_folder_where_to_save_the_wandb_files.md
+++ b/content/support/how_can_i_define_the_local_folder_where_to_save_the_wandb_files.md
@@ -11,4 +11,4 @@ tags:
 - `WANDB_ARTIFACT_DIR=<path>` or `wandb.Artifact().download(root="<path>")`: Controls the location where artifacts are downloaded. Defaults to `./artifacts`
 - `WANDB_CACHE_DIR=<path>`: This is the location where artifacts are created and stored when you call `wandb.Artifact`. Defaults to `~/.cache/wandb`
 - `WANDB_CONFIG_DIR=<path>`: Where config files are stored. Defaults to `~/.config/wandb`
-- `WANDB_DATA_DIR=<PATH>`: This location is used for staging artifacts during upload. Defaults to `~/.cache/wandb-data/`.
+- `WANDB_DATA_DIR=<PATH>`: Controls the location used for staging artifacts during upload. Defaults to `~/.cache/wandb-data/`.


### PR DESCRIPTION
Resolves DOCS-975

- Adds WANDB_DATA_DIR to list of environment variables.
- Based on searching through GH org code, presumes that the user-folder is accessible via `~` so we can give better instructions in the support article that covers this env var
- Updates storage docs to refer to WANDB_DATA_DIR and WANDB_ARTIFACT_DIR and links to full reference, as suggested in the Jira