### PR TITLE
adding 5 youtube demos to different parts of the docs

### DIFF
--- a/content/guides/core/reports/cross-project-reports.md
+++ b/content/guides/core/reports/cross-project-reports.md
@@ -8,7 +8,7 @@ title: Compare runs across projects
 weight: 60
 ---
 {{% alert %}}
-Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=uD4if_nGrs4) (2 min)
+Watch a [video demonstrating comparing runs across projects](https://www.youtube.com/watch?v=uD4if_nGrs4) (2 min).
 {{% /alert %}}
 
 

--- a/content/guides/core/reports/cross-project-reports.md
+++ b/content/guides/core/reports/cross-project-reports.md
@@ -7,6 +7,10 @@ menu:
 title: Compare runs across projects
 weight: 60
 ---
+{{% alert %}}
+Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=uD4if_nGrs4) (2 min)
+{{% /alert %}}
+
 
 Compare runs from two different projects with cross-project reports. Use the project selector in the run set table to pick a project.
 

--- a/content/guides/hosting/data-security/secure-storage-connector.md
+++ b/content/guides/hosting/data-security/secure-storage-connector.md
@@ -319,6 +319,10 @@ W&B recommends that you use a Terraform module managed by W&B to provision a sto
 If you're connecting to a cloud-native storage bucket in another cloud or to an S3-compatible storage bucket like [MinIO](https://github.com/minio/minio) for team-level BYOB in your [Dedicated cloud]({{< relref "/guides/hosting/hosting-options/dedicated_cloud.md" >}}) or [Self-managed]({{< relref "/guides/hosting/hosting-options/self-managed.md" >}}) instance, refer to [Cross-cloud or S3-compatible storage for team-level BYOB]({{< relref "#cross-cloud-or-s3-compatible-storage-for-team-level-byob" >}}). In such cases, you must specify the storage bucket using the `GORILLA_SUPPORTED_FILE_STORES` environment variable for your W&B instance, before you configure it for a team using the instructions below.
 {{% /alert %}}
 
+{{% alert %}}
+Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=uda6jIx6n5o) (9 min)
+{{% /alert %}}
+
 To configure a storage bucket at the team level when you create a W&B Team:
 
 1. Provide a name for your team in the **Team Name** field. 

--- a/content/guides/hosting/data-security/secure-storage-connector.md
+++ b/content/guides/hosting/data-security/secure-storage-connector.md
@@ -320,7 +320,7 @@ If you're connecting to a cloud-native storage bucket in another cloud or to an 
 {{% /alert %}}
 
 {{% alert %}}
-Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=uda6jIx6n5o) (9 min)
+Watch a [video demonstrating the secure storage connector in action](https://www.youtube.com/watch?v=uda6jIx6n5o) (9 min).
 {{% /alert %}}
 
 To configure a storage bucket at the team level when you create a W&B Team:

--- a/content/guides/hosting/iam/scim.md
+++ b/content/guides/hosting/iam/scim.md
@@ -7,6 +7,10 @@ title: Manage users, groups, and roles with SCIM
 weight: 4
 ---
 
+{{% alert %}}
+Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=Nw3QBqV0I-o) (12 min)
+{{% /alert %}}
+
 The System for Cross-domain Identity Management (SCIM) API allows instance or organization admins to manage users, groups, and custom roles in their W&B organization. SCIM groups map to W&B teams. 
 
 The SCIM API is accessible at `<host-url>/scim/` and supports the `/Users` and `/Groups` endpoints with a subset of the fields found in the [RC7643 protocol](https://www.rfc-editor.org/rfc/rfc7643). It additionally includes the `/Roles` endpoints which are not part of the official SCIM schema. W&B adds the `/Roles` endpoints to support automated management of custom roles in W&B organizations.

--- a/content/guides/hosting/iam/scim.md
+++ b/content/guides/hosting/iam/scim.md
@@ -8,7 +8,7 @@ weight: 4
 ---
 
 {{% alert %}}
-Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=Nw3QBqV0I-o) (12 min)
+Watch a [video demonstrating SCIM in action](https://www.youtube.com/watch?v=Nw3QBqV0I-o) (12 min)
 {{% /alert %}}
 
 The System for Cross-domain Identity Management (SCIM) API allows instance or organization admins to manage users, groups, and custom roles in their W&B organization. SCIM groups map to W&B teams. 

--- a/content/guides/hosting/monitoring-usage/slack-alerts.md
+++ b/content/guides/hosting/monitoring-usage/slack-alerts.md
@@ -7,6 +7,9 @@ title: Configure Slack alerts
 ---
 
 Integrate W&B Server with [Slack](https://slack.com/).
+{{% alert %}}
+Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min)
+{{% /alert %}}
 
 ## Create the Slack application
 

--- a/content/guides/hosting/monitoring-usage/slack-alerts.md
+++ b/content/guides/hosting/monitoring-usage/slack-alerts.md
@@ -8,7 +8,7 @@ title: Configure Slack alerts
 
 Integrate W&B Server with [Slack](https://slack.com/).
 {{% alert %}}
-Watch a [video demonstrating setting up Slack alerts on W&B Dedicated Cloud deployment in action](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min).
+Watch a [video demonstrating setting up Slack alerts on W&B Dedicated Cloud deployment](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min).
 {{% /alert %}}
 
 ## Create the Slack application

--- a/content/guides/hosting/monitoring-usage/slack-alerts.md
+++ b/content/guides/hosting/monitoring-usage/slack-alerts.md
@@ -8,7 +8,7 @@ title: Configure Slack alerts
 
 Integrate W&B Server with [Slack](https://slack.com/).
 {{% alert %}}
-Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min)
+Watch a [video demonstrating setting up Slack alerts on W&B Dedicated Cloud deployment in action](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min).
 {{% /alert %}}
 
 ## Create the Slack application

--- a/content/guides/models/registry/link_version.md
+++ b/content/guides/models/registry/link_version.md
@@ -34,6 +34,10 @@ If an artifact version logs metrics (such as by using `run.log_artifact()`), you
 
 {{< tabpane text=true >}}
   {{% tab header="Python SDK" %}}
+{{% alert %}}
+Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=2i_n1ExgO0A) (8 min)
+{{% /alert %}}
+
 Programmatically link an artifact version to a collection with [`wandb.init.Run.link_artifact()`]({{< relref "/ref/python/run.md#link_artifact" >}}).
 
 {{% alert %}}

--- a/content/guides/models/registry/link_version.md
+++ b/content/guides/models/registry/link_version.md
@@ -35,7 +35,7 @@ If an artifact version logs metrics (such as by using `run.log_artifact()`), you
 {{< tabpane text=true >}}
   {{% tab header="Python SDK" %}}
 {{% alert %}}
-Prefer a video? Watch [this demo](https://www.youtube.com/watch?v=2i_n1ExgO0A) (8 min)
+Watch a [video demonstrating linking a version](https://www.youtube.com/watch?v=2i_n1ExgO0A) (8 min).
 {{% /alert %}}
 
 Programmatically link an artifact version to a collection with [`wandb.init.Run.link_artifact()`]({{< relref "/ref/python/run.md#link_artifact" >}}).


### PR DESCRIPTION
Adding youtube demo videos to these docs pages
1) Link an artifact version to a registry
https://docs.wandb.ai/guides/registry/link_version/
https://www.youtube.com/watch?v=2i_n1ExgO0A
2) Configure Slack alerts
https://docs.wandb.ai/guides/hosting/monitoring-usage/slack-alerts/
https://www.youtube.com/watch?v=JmvKb-7u-oU
3) Compare runs across projects
https://docs.wandb.ai/guides/reports/cross-project-reports/
https://www.youtube.com/watch?v=uD4if_nGrs4
4) Bring your own bucket (BYOB)
https://docs.wandb.ai/guides/hosting/data-security/secure-storage-connector/#configure-byob-in-wbv
https://www.youtube.com/watch?v=uda6jIx6n5o
5) Manage users, groups, and roles with SCIM
https://docs.wandb.ai/guides/hosting/iam/scim/
https://www.youtube.com/watch?v=Nw3QBqV0I-o