### PR TITLE
Document new reinit='allow' setting

### DIFF
--- a/content/support/kb-articles/launch_multiple_runs_one_script.md
+++ b/content/support/kb-articles/launch_multiple_runs_one_script.md
@@ -6,29 +6,60 @@ type: docs
 support:
    - experiments
 ---
-Use `wandb.init` and `run.finish()` to log multiple runs within a single script:
+Finish previous runs before starting new runs to log multiple runs within
+a single script.
 
-1. Use `run = wandb.init(reinit=True)` to allow reinitialization of runs.
-2. Call `run.finish()` at the end of each run to complete logging.
-
-```python
-import wandb
-
-for x in range(10):
-    run = wandb.init(reinit=True)
-    for y in range(100):
-        wandb.log({"metric": x + y})
-    run.finish()
-```
-
-Alternatively, utilize a Python context manager to automatically finish logging:
+The recommended way to do this is by using `wandb.init()` as a context manager
+because this finishes the run and marks it as failed if your script raises an
+exception:
 
 ```python
 import wandb
 
 for x in range(10):
-    run = wandb.init(reinit=True)
-    with run:
+    with wandb.init() as run:
         for y in range(100):
             run.log({"metric": x + y})
 ```
+
+You can also call `run.finish()` explicitly:
+
+```python
+import wandb
+
+for x in range(10):
+    run = wandb.init()
+
+    try:
+        for y in range(100):
+            run.log({"metric": x + y})
+
+    except Exception:
+        run.finish(exit_code=1)
+        raise
+
+    finally:
+        run.finish()
+```
+
+## Multiple active runs
+
+Starting with wandb 0.19.10, you can set the `reinit` setting to `"create_new"`
+to create multiple simultaneously active runs.
+
+
+```python
+import wandb
+
+with wandb.init(reinit="create_new") as tracking_run:
+    for x in range(10):
+        with wandb.init(reinit="create_new") as run:
+            for y in range(100):
+                run.log({"x_plus_y": x + y})
+
+            tracking_run.log({"x": x})
+```
+
+See [here]({{< relref "guides/models/track/runs/multiple-runs-per-process.md" >}})
+for more information about `reinit="create_new"`, including caveats about W&B
+integrations.


### PR DESCRIPTION
Updates documentation for https://github.com/wandb/wandb/pull/9562.

NOTE: This original example on this page was wrong: `reinit` was not necessary because the example already called `run.finish()`. Setting `reinit=True` simply calls `run.finish()` automatically for the user. I removed mention of `reinit=True` as we would like to deprecate this setting completely.