### PR TITLE
Use best practices for wandb.init() and the Run object

### DIFF
--- a/content/guides/integrations/add-wandb-to-any-library.md
+++ b/content/guides/integrations/add-wandb-to-any-library.md
@@ -31,7 +31,7 @@ Below we cover best tips and best practices when the codebase you are working on
 
 Before you get started, decide whether or not to require W&B in your library’s dependencies:
 
-#### Require W&B On Installation
+#### Require W&B on installation
 
 Add the W&B Python library (`wandb`) to your dependencies file, for example, in your `requirements.txt` file:
 
@@ -41,7 +41,7 @@ torch==1.8.0
 wandb==0.13.*
 ```
 
-#### Make W&B optional On Installation
+#### Make W&B optional on installation
 
 There are two ways to make the W&B SDK (`wandb`) optional:
 
@@ -74,7 +74,7 @@ dev = [
 ]
 ```
 
-### User Login
+### User login
 
 #### Create an API key
 
@@ -166,11 +166,11 @@ with wandb.init() as run:
 ```
 
 
-#### Where To Place `wandb.init`?
+#### When to call `wandb.init`?
 
 Your library should create W&B Run as early as possible because any output in your console, including error messages, is logged as part of the W&B Run. This makes debugging easier.
 
-#### Run The Library With `wandb` As Optional
+#### Use `wandb` as an optional dependency
 
 If you want to make `wandb` optional when your users use your library, you can either:
 

--- a/content/guides/integrations/add-wandb-to-any-library.md
+++ b/content/guides/integrations/add-wandb-to-any-library.md
@@ -146,14 +146,25 @@ A W&B Run is a unit of computation logged by W&B. Typically, you associate a sin
 Initialize W&B and start a Run within your code with:
 
 ```python
-wandb.init()
+run = wandb.init()
 ```
 
 Optionally, you can provide a name for their project, or let the user set it themselves with parameters such as `wandb_project` in your code along with the username or team name, such as `wandb_entity`, for the entity parameter:
 
 ```python
-wandb.init(project=wandb_project, entity=wandb_entity)
+run = wandb.init(project=wandb_project, entity=wandb_entity)
 ```
+
+It is important to eventually call `run.finish()` on the run. If this works with your integartion's design, the most convenient way to do this is by using the run as a context manager:
+
+```python
+# When this block exits, it calls run.finish() automatically.
+# If it exits due to an exception, it uses run.finish(exit_code=1) which
+# marks the run as failed.
+with wandb.init() as run:
+    ...
+```
+
 
 #### Where To Place `wandb.init`?
 
@@ -254,19 +265,19 @@ wandb.init(..., config=config)
 ```
 
 #### Update the run config
-Use `wandb.config.update` to update the config. Updating your configuration dictionary is useful when parameters are obtained after the dictionary was defined. For example, you might want to add a model’s parameters after the model is instantiated.
+Use `run.config.update` to update the config. Updating your configuration dictionary is useful when parameters are obtained after the dictionary was defined. For example, you might want to add a model’s parameters after the model is instantiated.
 
 ```python
-wandb.config.update({"model_parameters": 3500})
+run.config.update({"model_parameters": 3500})
 ```
 
-For more information on how to define a config file, see [Configure Experiments with wandb.config]({{< relref "/guides/models/track/config" >}}).
+For more information on how to define a config file, see [Configure experiments]({{< relref "/guides/models/track/config" >}}).
 
 ### Log to W&B
 
 #### Log metrics
 
-Create a dictionary where the key value is the name of the metric. Pass this dictionary object to [`wandb.log`]({{< relref "/guides/models/track/log" >}}):
+Create a dictionary where the key value is the name of the metric. Pass this dictionary object to [`run.log`]({{< relref "/guides/models/track/log" >}}):
 
 ```python
 for epoch in range(NUM_EPOCHS):
@@ -274,7 +285,7 @@ for epoch in range(NUM_EPOCHS):
         prediction = model(input) 
         loss = loss_fn(prediction, ground_truth) 
         metrics = { "loss": loss } 
-        wandb.log(metrics)
+        run.log(metrics)
 ```
 
 If you have a lot of metrics, you can have them automatically grouped in the UI by using prefixes in the metric name, such as `train/...` and `val/...`. This will create separate sections in your W&B Workspace for your training and validation metrics, or other metric types you'd like to separate:
@@ -286,37 +297,37 @@ metrics = {
     "val/loss": 0.5, 
     "val/accuracy": 0.7
 }
-wandb.log(metrics)
+run.log(metrics)
 ```
 
 {{< img src="/images/integrations/integrations_add_any_lib_log.png" alt="A W&B Workspace with 2 separate sections" >}}
 
-For more on `wandb.log`, see [Log Data with wandb.log]({{< relref "/guides/models/track/log" >}}).
+For more on `run.log`, see [here]({{< relref "/guides/models/track/log" >}}).
 
 #### Prevent x-axis misalignments
 
-Sometimes you might need to perform multiple calls to `wandb.log` for the same training step. The wandb SDK has its own internal step counter that is incremented every time a `wandb.log` call is made. This means that there is a possibility that the wandb log counter is not aligned with the training step in your training loop.
+Sometimes you might need to perform multiple calls to `run.log` for the same training step. The wandb SDK has its own internal step counter that is incremented every time a `run.log` call is made. This means that there is a possibility that the wandb log counter is not aligned with the training step in your training loop.
 
-To avoid this, we recommend that you specifically define your x-axis step. You can define the x-axis with `wandb.define_metric` and you only need to do this once, after `wandb.init` is called:
+To avoid this, we recommend that you specifically define your x-axis step. You can define the x-axis with `run.define_metric` and you only need to do this once, after `wandb.init` is called:
 
 ```python
-wandb.init(...)
-wandb.define_metric("*", step_metric="global_step")
+with wandb.init(...) as run:
+    run.define_metric("*", step_metric="global_step")
 ```
 
 The glob pattern, `*`, means that every metric will use `global_step` as the x-axis in your charts. If you only want certain metrics to be logged against `global_step`, you can specify them instead:
 
 ```python
-wandb.define_metric("train/loss", step_metric="global_step")
+run.define_metric("train/loss", step_metric="global_step")
 ```
 
-Now that you've called `wandb.define_metric`, you just need to log your metrics as well as your `step_metric`, `global_step`, every time you call `wandb.log`:
+Now that you've called `run.define_metric`, you just need to log your metrics as well as your `step_metric`, `global_step`, every time you call `run.log`:
 
 ```python
 for step, (input, ground_truth) in enumerate(data):
     ...
-    wandb.log({"global_step": step, "train/loss": 0.1})
-    wandb.log({"global_step": step, "eval/loss": 0.2})
+    run.log({"global_step": step, "train/loss": 0.1})
+    run.log({"global_step": step, "eval/loss": 0.2})
 ```
 
 If you do not have access to the independent step variable, for example "global_step" is not available during your validation loop, the previously logged value for "global_step" is automatically used by wandb. In this case, ensure you log an initial value for the metric so it has been defined when it’s needed.
@@ -332,7 +343,7 @@ Some considerations when logging data include:
   * For images, you can log sample predictions, segmentation masks, etc., to see the evolution over time.
   * For text, you can log tables of sample predictions for later exploration.
 
-Refer to [Log Data with wandb.log]({{< relref "/guides/models/track/log" >}}) for a full guide on logging media, objects, plots, and more.
+Refer [here]({{< relref "/guides/models/track/log" >}}) for a full guide on logging media, objects, plots, and more.
 
 ### Distributed training
 
@@ -363,14 +374,14 @@ You can log Model Checkpoints to W&B. It is useful to leverage the unique `wandb
 metadata = {"eval/accuracy": 0.8, "train/steps": 800} 
 
 artifact = wandb.Artifact(
-                name=f"model-{wandb.run.id}", 
+                name=f"model-{run.id}", 
                 metadata=metadata, 
                 type="model"
                 ) 
 artifact.add_dir("output_model") # local directory where the model weights are stored
 
 aliases = ["best", "epoch_10"] 
-wandb.log_artifact(artifact, aliases=aliases)
+run.log_artifact(artifact, aliases=aliases)
 ```
 
 For information on how to create a custom alias, see [Create a Custom Alias]({{< relref "/guides/core/artifacts/create-a-custom-alias/" >}}).
@@ -384,7 +395,7 @@ You can log artifacts that are used as inputs to your training such as pre-train
 ```python
 artifact_input_data = wandb.Artifact(name="flowers", type="dataset")
 artifact_input_data.add_file("flowers.npy")
-wandb.use_artifact(artifact_input_data)
+run.use_artifact(artifact_input_data)
 ```
 
 #### Download an artifact
@@ -392,7 +403,7 @@ wandb.use_artifact(artifact_input_data)
 You re-use an Artifact (dataset, model, etc.) and `wandb` will download a copy locally (and cache it):
 
 ```python
-artifact = wandb.run.use_artifact("user/project/artifact:latest")
+artifact = run.use_artifact("user/project/artifact:latest")
 local_path = artifact.download("./tmp")
 ```
 

--- a/content/guides/integrations/add-wandb-to-any-library.md
+++ b/content/guides/integrations/add-wandb-to-any-library.md
@@ -155,7 +155,7 @@ Optionally, you can provide a name for their project, or let the user set it the
 run = wandb.init(project=wandb_project, entity=wandb_entity)
 ```
 
-It is important to eventually call `run.finish()` on the run. If this works with your integartion's design, the most convenient way to do this is by using the run as a context manager:
+You must call `run.finish()` to finish the run. If this works with your integration's design,  use the run as a context manager:
 
 ```python
 # When this block exits, it calls run.finish() automatically.
@@ -302,13 +302,13 @@ run.log(metrics)
 
 {{< img src="/images/integrations/integrations_add_any_lib_log.png" alt="A W&B Workspace with 2 separate sections" >}}
 
-For more on `run.log`, see [here]({{< relref "/guides/models/track/log" >}}).
+[Learn more about `run.log`]({{< relref "/guides/models/track/log" >}}).
 
 #### Prevent x-axis misalignments
 
-Sometimes you might need to perform multiple calls to `run.log` for the same training step. The wandb SDK has its own internal step counter that is incremented every time a `run.log` call is made. This means that there is a possibility that the wandb log counter is not aligned with the training step in your training loop.
+If you perform multiple calls to `run.log` for the same training step, the wandb SDK increments an internal step counter for each call to `run.log`. This counter may not align with the training step in your training loop.
 
-To avoid this, we recommend that you specifically define your x-axis step. You can define the x-axis with `run.define_metric` and you only need to do this once, after `wandb.init` is called:
+To avoid this situation, define your x-axis step explicitly with `run.define_metric`, one time, immediately after you call `wandb.init`:
 
 ```python
 with wandb.init(...) as run:
@@ -321,7 +321,7 @@ The glob pattern, `*`, means that every metric will use `global_step` as the x-a
 run.define_metric("train/loss", step_metric="global_step")
 ```
 
-Now that you've called `run.define_metric`, you just need to log your metrics as well as your `step_metric`, `global_step`, every time you call `run.log`:
+Now, log your metrics, your `step` metric, and your `global_step` each time you call `run.log`:
 
 ```python
 for step, (input, ground_truth) in enumerate(data):
@@ -343,7 +343,7 @@ Some considerations when logging data include:
   * For images, you can log sample predictions, segmentation masks, etc., to see the evolution over time.
   * For text, you can log tables of sample predictions for later exploration.
 
-Refer [here]({{< relref "/guides/models/track/log" >}}) for a full guide on logging media, objects, plots, and more.
+[Learn more about logging]({{< relref "/guides/models/track/log" >}}) media, objects, plots, and more.
 
 ### Distributed training
 

--- a/content/guides/models/track/_index.md
+++ b/content/guides/models/track/_index.md
@@ -24,29 +24,32 @@ The image above shows an example dashboard where you can view and compare metric
 
 Track a machine learning experiment with a few lines of code:
 1. Create a [W&B run]({{< relref "/guides/models/track/runs/" >}}).
-2. Store a dictionary of hyperparameters, such as learning rate or model type, into your configuration ([`wandb.config`]({{< relref "./config.md" >}})).
-3. Log metrics ([`wandb.log()`]({{< relref "./log/" >}})) over time in a training loop, such as accuracy and loss.
+2. Store a dictionary of hyperparameters, such as learning rate or model type, into your configuration ([`run.config`]({{< relref "./config.md" >}})).
+3. Log metrics ([`run.log()`]({{< relref "./log/" >}})) over time in a training loop, such as accuracy and loss.
 4. Save outputs of a run, like the model weights or a table of predictions.
 
-The proceeding pseudocode demonstrates a common W&B Experiment tracking workflow:
+The following code demonstrates a common W&B Experiment tracking workflow:
 
 ```python showLineNumbers
 # 1. Start a W&B Run
-wandb.init(entity="", project="my-project-name")
+#
+# When this block exits, it waits for logged data to finish uploading.
+# If an exception is raised, the run is marked failed.
+with wandb.init(entity="", project="my-project-name") as run:
 
-# 2. Save mode inputs and hyperparameters
-wandb.config.learning_rate = 0.01
+  # 2. Save mode inputs and hyperparameters
+  run.config.learning_rate = 0.01
 
-# Import model and data
-model, dataloader = get_model(), get_data()
+  # Import model and data
+  model, dataloader = get_model(), get_data()
 
-# Model training code goes here
+  # Model training code goes here
 
-# 3. Log metrics over time to visualize performance
-wandb.log({"loss": loss})
+  # 3. Log metrics over time to visualize performance
+  run.log({"loss": loss})
 
-# 4. Log an artifact to W&B
-wandb.log_artifact(model)
+  # 4. Log an artifact to W&B
+  run.log_artifact(model)
 ```
 
 ## How to get started

--- a/content/guides/models/track/_index.md
+++ b/content/guides/models/track/_index.md
@@ -52,7 +52,7 @@ with wandb.init(entity="", project="my-project-name") as run:
   run.log_artifact(model)
 ```
 
-## How to get started
+## Get started
 
 Depending on your use case, explore the following resources to get started with W&B Experiments:
 

--- a/content/guides/models/track/_index.md
+++ b/content/guides/models/track/_index.md
@@ -28,7 +28,7 @@ Track a machine learning experiment with a few lines of code:
 3. Log metrics ([`run.log()`]({{< relref "./log/" >}})) over time in a training loop, such as accuracy and loss.
 4. Save outputs of a run, like the model weights or a table of predictions.
 
-The following code demonstrates a common W&B Experiment tracking workflow:
+The following code demonstrates a common W&B experiment tracking workflow:
 
 ```python
 # Start a run.

--- a/content/guides/models/track/_index.md
+++ b/content/guides/models/track/_index.md
@@ -30,25 +30,23 @@ Track a machine learning experiment with a few lines of code:
 
 The following code demonstrates a common W&B Experiment tracking workflow:
 
-```python showLineNumbers
-# 1. Start a W&B Run
+```python
+# Start a run.
 #
 # When this block exits, it waits for logged data to finish uploading.
 # If an exception is raised, the run is marked failed.
 with wandb.init(entity="", project="my-project-name") as run:
-
-  # 2. Save mode inputs and hyperparameters
+  # Save mode inputs and hyperparameters.
   run.config.learning_rate = 0.01
 
-  # Import model and data
-  model, dataloader = get_model(), get_data()
+  # Run your experiment code.
+  for epoch in range(num_epochs):
+    # Do some training...
 
-  # Model training code goes here
+    # Log metrics over time to visualize model performance.
+    run.log({"loss": loss})
 
-  # 3. Log metrics over time to visualize performance
-  run.log({"loss": loss})
-
-  # 4. Log an artifact to W&B
+  # Upload model outputs as artifacts.
   run.log_artifact(model)
 ```
 

--- a/content/guides/models/track/config.md
+++ b/content/guides/models/track/config.md
@@ -177,19 +177,19 @@ run.config.update({"lr": 0.1, "channels": 16})
 ### Set the configuration after your Run has finished
 Use the [W&B Public API]({{< relref "/ref/python/public-api/" >}}) to update a completed run's config. 
 
-You will need to provide your entity, project name and the run's ID, which you can get from the Run object or find in the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
+You must provide the API with your entity, project name and the run's ID. You can find these details in the Run object or in the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
 
 ```python
 with wandb.init() as run:
     ...
 
-# You can access attributes from the run object directly if you are in the same
-# script or notebook, or you can get them from the app.
+# Find the following values from the Run object if it was initiated from the
+# current script or notebook, or you can copy them from the W&B App UI.
 username = run.entity
 project = run.project
 run_id = run.id
 
-# NOTE: api.run returns a different type of object than wandb.init().
+# Note that api.run() returns a different type of object than wandb.init().
 api = wandb.Api()
 api_run = api.run(f"{username}/{project}/{run_id}")
 api_run.config["bar"] = 32

--- a/content/guides/models/track/config.md
+++ b/content/guides/models/track/config.md
@@ -9,7 +9,7 @@ title: Configure experiments
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Configs_in_W%26B.ipynb" >}}
 
-Use the `config` property of a Run to save your training configuration such as: 
+Use the `config` property of a run to save your training configuration: 
 - hyperparameter
 - input settings such as the dataset name or model type
 - any other independent variables for your experiments. 
@@ -17,7 +17,7 @@ Use the `config` property of a Run to save your training configuration such as:
 The `run.config` property makes it easy to analyze your experiments and reproduce your work in the future. You can group by configuration values in the W&B App, compare the settings of different W&B Runs and view how different training configurations affect the output. A Run's `config` property is a dictionary-like object, and it can be built from lots of dictionary-like objects.
 
 {{% alert %}}
-Dependent variables (like loss and accuracy) or output metrics should be saved with `run.log` instead.
+To save output metrics or dependent variables like loss and accuracy, use `run.log` instead of `run.config`.
 {{% /alert %}}
 
 

--- a/content/guides/models/track/config.md
+++ b/content/guides/models/track/config.md
@@ -25,10 +25,9 @@ To save output metrics or dependent variables like loss and accuracy, use `run.l
 ## Set up an experiment configuration
 Configurations are typically defined in the beginning of a training script. Machine learning workflows may vary, however, so you are not required to define a configuration at the beginning of your training script.
 
-{{% alert color="secondary" %}}
-We recommend that you avoid using dots in your config variable names. Instead, use a dash or underscore instead. Use the dictionary access syntax `["key"]["foo"]` instead of the attribute access syntax `config.key.foo` if your script accesses `run.config` keys below the root.
-{{% /alert %}}
-
+Use dashes (`-`) or underscores (`_`) instead of periods (`.`) in your config variable names.
+	
+Use the dictionary access syntax `["key"]["value"]` instead of the attribute access syntax `config.key.value` if your script accesses `run.config` keys below the root.
 
 The following sections outline different common scenarios of how to define your experiments configuration.
 
@@ -55,9 +54,7 @@ with wandb.init(project="config_example", config=config) as run:
     ...
 ```
 
-{{% alert %}}
-You can pass a nested dictionary as the `config`. W&B will flatten the names using dots.
-{{% /alert %}}
+If you pass a nested dictionary as the `config`, W&B flattens the names using dots.
 
 Access the values from the dictionary similarly to how you access other dictionaries in Python:
 

--- a/content/guides/models/track/config.md
+++ b/content/guides/models/track/config.md
@@ -9,15 +9,15 @@ title: Configure experiments
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Configs_in_W%26B.ipynb" >}}
 
-Use the `wandb.config` object to save your training configuration such as: 
+Use the `config` property of a Run to save your training configuration such as: 
 - hyperparameter
 - input settings such as the dataset name or model type
 - any other independent variables for your experiments. 
 
-The `wandb.config` attribute makes it easy to analyze your experiments and reproduce your work in the future. You can group by configuration values in the W&B App, compare the settings of different W&B Runs and view how different training configurations affect the output. A Run's `config` attribute is a dictionary-like object, and it can be built from lots of dictionary-like objects.
+The `run.config` property makes it easy to analyze your experiments and reproduce your work in the future. You can group by configuration values in the W&B App, compare the settings of different W&B Runs and view how different training configurations affect the output. A Run's `config` property is a dictionary-like object, and it can be built from lots of dictionary-like objects.
 
 {{% alert %}}
-Dependent variables (like loss and accuracy) or output metrics should be saved with `wandb.log`instead.
+Dependent variables (like loss and accuracy) or output metrics should be saved with `run.log` instead.
 {{% /alert %}}
 
 
@@ -26,7 +26,7 @@ Dependent variables (like loss and accuracy) or output metrics should be saved w
 Configurations are typically defined in the beginning of a training script. Machine learning workflows may vary, however, so you are not required to define a configuration at the beginning of your training script.
 
 {{% alert color="secondary" %}}
-We recommend that you avoid using dots in your config variable names. Instead, use a dash or underscore instead. Use the dictionary access syntax `["key"]["foo"]` instead of the attribute access syntax `config.key.foo` if your script accesses `wandb.config` keys below the root.
+We recommend that you avoid using dots in your config variable names. Instead, use a dash or underscore instead. Use the dictionary access syntax `["key"]["foo"]` instead of the attribute access syntax `config.key.foo` if your script accesses `run.config` keys below the root.
 {{% /alert %}}
 
 
@@ -51,25 +51,26 @@ config = {
 }
 
 # Pass the config dictionary when you initialize W&B
-run = wandb.init(project="config_example", config=config)
+with wandb.init(project="config_example", config=config) as run:
+    ...
 ```
 
 {{% alert %}}
-You can pass a nested dictionary to `wandb.config()`. W&B will flatten the names using dots in the W&B backend.
+You can pass a nested dictionary as the `config`. W&B will flatten the names using dots.
 {{% /alert %}}
 
 Access the values from the dictionary similarly to how you access other dictionaries in Python:
 
 ```python
 # Access values with the key as the index value
-hidden_layer_sizes = wandb.config["hidden_layer_sizes"]
-kernel_sizes = wandb.config["kernel_sizes"]
-activation = wandb.config["activation"]
+hidden_layer_sizes = run.config["hidden_layer_sizes"]
+kernel_sizes = run.config["kernel_sizes"]
+activation = run.config["activation"]
 
 # Python dictionary get() method
-hidden_layer_sizes = wandb.config.get("hidden_layer_sizes")
-kernel_sizes = wandb.config.get("kernel_sizes")
-activation = wandb.config.get("activation")
+hidden_layer_sizes = run.config.get("hidden_layer_sizes")
+kernel_sizes = run.config.get("kernel_sizes")
+activation = run.config.get("activation")
 ```
 
 {{% alert %}}
@@ -85,10 +86,11 @@ The proceeding Python script demonstrates how to define a parser object to defin
 
 ```python
 # config_experiment.py
-import wandb
 import argparse
-import numpy as np
 import random
+
+import numpy as np
+import wandb
 
 
 # Training and evaluation demo code
@@ -106,28 +108,27 @@ def evaluate_one_epoch(epoch):
 
 def main(args):
     # Start a W&B Run
-    run = wandb.init(project="config_example", config=args)
+    with wandb.init(project="config_example", config=args) as run:
+        # Access values from config dictionary and store them
+        # into variables for readability
+        lr = run.config["learning_rate"]
+        bs = run.config["batch_size"]
+        epochs = run.config["epochs"]
 
-    # Access values from config dictionary and store them
-    # into variables for readability
-    lr = wandb.config["learning_rate"]
-    bs = wandb.config["batch_size"]
-    epochs = wandb.config["epochs"]
+        # Simulate training and logging values to W&B
+        for epoch in np.arange(1, epochs):
+            train_acc, train_loss = train_one_epoch(epoch, lr, bs)
+            val_acc, val_loss = evaluate_one_epoch(epoch)
 
-    # Simulate training and logging values to W&B
-    for epoch in np.arange(1, epochs):
-        train_acc, train_loss = train_one_epoch(epoch, lr, bs)
-        val_acc, val_loss = evaluate_one_epoch(epoch)
-
-        wandb.log(
-            {
-                "epoch": epoch,
-                "train_acc": train_acc,
-                "train_loss": train_loss,
-                "val_acc": val_acc,
-                "val_loss": val_loss,
-            }
-        )
+            run.log(
+                {
+                    "epoch": epoch,
+                    "train_acc": train_acc,
+                    "train_loss": train_loss,
+                    "val_acc": val_acc,
+                    "val_loss": val_loss,
+                }
+            )
 
 
 if __name__ == "__main__":
@@ -163,38 +164,37 @@ config = {
 }
 
 # Pass the config dictionary when you initialize W&B
-run = wandb.init(project="config_example", config=config)
-
-# Update config after you initialize W&B
-wandb.config["dropout"] = 0.2
-wandb.config.epochs = 4
-wandb.config["batch_size"] = 32
+with wandb.init(project="config_example", config=config) as run:
+    # Update config after you initialize W&B
+    run.config["dropout"] = 0.2
+    run.config.epochs = 4
+    run.config["batch_size"] = 32
 ```
+
 You can update multiple values at a time:
 
 ```python
-wandb.init(config={"epochs": 4, "batch_size": 32})
-# later
-wandb.config.update({"lr": 0.1, "channels": 16})
+run.config.update({"lr": 0.1, "channels": 16})
 ```
 
 ### Set the configuration after your Run has finished
 Use the [W&B Public API]({{< relref "/ref/python/public-api/" >}}) to update your config (or anything else about from a complete Run) after your Run. This is particularly useful if you forgot to log a value during a Run. 
 
-Provide your `entity`, `project name`, and the `Run ID` to update your configuration after a Run has finished. Find these values directly from the Run object itself `wandb.run` or from the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
+Provide your `entity`, `project name`, and the `Run ID` to update your configuration after a Run has finished. Find these values directly from the Run object itself or from the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
 
 ```python
-api = wandb.Api()
+with wandb.init() as run:
+    api = wandb.Api()
 
-# Access attributes directly from the run object
-# or from the W&B App
-username = wandb.run.entity
-project = wandb.run.project
-run_id = wandb.run.id
+    # You can access attributes on the run object directly.
+    username = run.entity
+    project = run.project
+    run_id = run.id
 
-run = api.run(f"{username}/{project}/{run_id}")
-run.config["bar"] = 32
-run.update()
+    # NOTE: api.run returns a different type of object than wandb.init().
+    api_run = api.run(f"{username}/{project}/{run_id}")
+    api_run.config["bar"] = 32
+    api_run.update()
 ```
 
 
@@ -208,11 +208,11 @@ You can also pass in [`absl` flags](https://abseil.io/docs/python/guides/flags).
 ```python
 flags.DEFINE_string("model", None, "model to run")  # name, default, help
 
-wandb.config.update(flags.FLAGS)  # adds absl flags to config
+run.config.update(flags.FLAGS)  # adds absl flags to config
 ```
 
 ## File-Based Configs
-If you place a file named `config-defaults.yaml` in the same directory as your run script, the run automatically picks up the key-value pairs defined in the file and passes them to `wandb.config`. 
+If you place a file named `config-defaults.yaml` in the same directory as your run script, the run automatically picks up the key-value pairs defined in the file and passes them to `run.config`. 
 
 The following code snippet shows a sample `config-defaults.yaml` YAML file:
 
@@ -226,8 +226,10 @@ You can override the default values automatically loaded from `config-defaults.y
 
 ```python
 import wandb
+
 # Override config-defaults.yaml by passing custom values
-wandb.init(config={"epochs": 200, "batch_size": 64})
+with wandb.init(config={"epochs": 200, "batch_size": 64}) as run:
+    ...
 ```
 
 To load a configuration file other than `config-defaults.yaml`, use the `--configs command-line` argument and specify the path to the file:
@@ -251,7 +253,8 @@ config_dictionary = dict(
     params=hyperparameter_defaults,
 )
 
-wandb.init(config=config_dictionary)
+with wandb.init(config=config_dictionary) as run:
+    ...
 ```
 
 ## TensorFlow v1 flags
@@ -259,35 +262,11 @@ wandb.init(config=config_dictionary)
 You can pass TensorFlow flags into the `wandb.config` object directly.
 
 ```python
-wandb.init()
-wandb.config.epochs = 4
+with wandb.init() as run:
+    run.config.epochs = 4
 
-flags = tf.app.flags
-flags.DEFINE_string("data_dir", "/tmp/data")
-flags.DEFINE_integer("batch_size", 128, "Batch size.")
-wandb.config.update(flags.FLAGS)  # add tensorflow flags as config
+    flags = tf.app.flags
+    flags.DEFINE_string("data_dir", "/tmp/data")
+    flags.DEFINE_integer("batch_size", 128, "Batch size.")
+    run.config.update(flags.FLAGS)  # add tensorflow flags as config
 ```
-
-<!-- ## Dataset Identifier
-
-You can add a unique identifier (like a hash or other identifier) in your run's configuration for your dataset by tracking it as input to your experiment using `wandb.config`
-
-```yaml
-wandb.config.update({"dataset": "ab131"})
-``` -->
-
-<!-- ## Update Config Files
-
-You can use the public API to add values your `config` file, even after the run has finished.
-
-```python
-import wandb
-api = wandb.Api()
-run = api.run("username/project/run_id")
-run.config["foo"] = 32
-run.update()
-``` -->
-
-<!-- ## Key-Value Pairs
-
-You can log any key-value pairs into `wandb.config`. They can be different for every type of model you are training, e.g.`wandb.config.update({"my_param": 10, "learning_rate": 0.3, "model_architecture": "B"})`. -->

--- a/content/guides/models/track/config.md
+++ b/content/guides/models/track/config.md
@@ -14,7 +14,7 @@ Use the `config` property of a run to save your training configuration:
 - input settings such as the dataset name or model type
 - any other independent variables for your experiments. 
 
-The `run.config` property makes it easy to analyze your experiments and reproduce your work in the future. You can group by configuration values in the W&B App, compare the settings of different W&B Runs and view how different training configurations affect the output. A Run's `config` property is a dictionary-like object, and it can be built from lots of dictionary-like objects.
+The `run.config` property makes it easy to analyze your experiments and reproduce your work in the future. You can group by configuration values in the W&B App, compare the configurations of different W&B runs, and evaluate how each training configuration affects the output. The `config` property is a dictionary-like object that can be composed from multiple dictionary-like objects.
 
 {{% alert %}}
 To save output metrics or dependent variables like loss and accuracy, use `run.log` instead of `run.config`.
@@ -175,23 +175,25 @@ run.config.update({"lr": 0.1, "channels": 16})
 ```
 
 ### Set the configuration after your Run has finished
-Use the [W&B Public API]({{< relref "/ref/python/public-api/" >}}) to update your config (or anything else about from a complete Run) after your Run. This is particularly useful if you forgot to log a value during a Run. 
+Use the [W&B Public API]({{< relref "/ref/python/public-api/" >}}) to update a completed run's config. 
 
-Provide your `entity`, `project name`, and the `Run ID` to update your configuration after a Run has finished. Find these values directly from the Run object itself or from the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
+You will need to provide your entity, project name and the run's ID, which you can get from the Run object or find in the [W&B App UI]({{< relref "/guides/models/track/workspaces.md" >}}):
 
 ```python
 with wandb.init() as run:
-    api = wandb.Api()
+    ...
 
-    # You can access attributes on the run object directly.
-    username = run.entity
-    project = run.project
-    run_id = run.id
+# You can access attributes from the run object directly if you are in the same
+# script or notebook, or you can get them from the app.
+username = run.entity
+project = run.project
+run_id = run.id
 
-    # NOTE: api.run returns a different type of object than wandb.init().
-    api_run = api.run(f"{username}/{project}/{run_id}")
-    api_run.config["bar"] = 32
-    api_run.update()
+# NOTE: api.run returns a different type of object than wandb.init().
+api = wandb.Api()
+api_run = api.run(f"{username}/{project}/{run_id}")
+api_run.config["bar"] = 32
+api_run.update()
 ```
 
 

--- a/content/guides/models/track/launch.md
+++ b/content/guides/models/track/launch.md
@@ -54,25 +54,17 @@ run.config = {"epochs": 100, "learning_rate": 0.001, "batch_size": 128}
 For more information on how to configure an experiment, see [Configure Experiments]({{< relref "./config.md" >}}).
 
 ### Log metrics inside your training loop
-Log metrics during each `for` loop (epoch), the accuracy and loss values are computed and logged to W&B with [`run.log()`]({{< relref "/ref/python/log.md" >}}). By default, when you call `run.log()` it appends a new step to the history object and updates the summary object.
-
-The following code example shows how to log metrics with `run.log`.
-
-{{% alert %}}
-Details of how to set up your mode and retrieve data are omitted. 
-{{% /alert %}}
+Call [`run.log()`]({{< relref "/ref/python/log.md" >}}) to log metrics about each training step such as accuracy and loss.
 
 ```python
-# Set up model and data
 model, dataloader = get_model(), get_data()
 
 for epoch in range(run.config.epochs):
     for batch in dataloader:
         loss, accuracy = model.training_step()
-        #  3. Log metrics inside your training loop to visualize
-        # model performance
         run.log({"accuracy": accuracy, "loss": loss})
 ```
+
 For more information on different data types you can log with W&B, see [Log Data During Experiments]({{< relref "./log/" >}}).
 
 ### Log an artifact to W&B 

--- a/content/guides/models/track/launch.md
+++ b/content/guides/models/track/launch.md
@@ -22,7 +22,7 @@ Create a W&B Experiment in four steps:
 4. [Log an artifact to W&B]({{< relref "#log-an-artifact-to-wb" >}})
 
 ### Initialize a W&B run
-At the beginning of your script call, the [`wandb.init()`]({{< relref "/ref/python/init.md" >}}) API to generate a background process to sync and log data as a W&B Run. 
+Use [`wandb.init()`]({{< relref "/ref/python/init.md" >}}) to create a W&B Run.
 
 The proceeding code snippet demonstrates how to create a new W&B project named `“cat-classification”`. A note `“My first experiment”` was added to help identify this run. Tags `“baseline”` and `“paper1”` are included to remind us that this run is a baseline experiment intended for a future paper publication.
 
@@ -31,11 +31,12 @@ The proceeding code snippet demonstrates how to create a new W&B project named `
 import wandb
 
 # 1. Start a W&B Run
-run = wandb.init(
+with wandb.init(
     project="cat-classification",
     notes="My first experiment",
     tags=["baseline", "paper1"],
-)
+) as run:
+    ...  # Experiment code goes here
 ```
 A [Run]({{< relref "/ref/python/run.md" >}}) object is returned when you initialize W&B with `wandb.init()`. Additionally, W&B creates a local directory where all logs and files are saved and streamed asynchronously to a W&B server.
 
@@ -48,14 +49,14 @@ Save a dictionary of hyperparameters such as learning rate or model type. The mo
 
 ```python
 #  2. Capture a dictionary of hyperparameters
-wandb.config = {"epochs": 100, "learning_rate": 0.001, "batch_size": 128}
+run.config = {"epochs": 100, "learning_rate": 0.001, "batch_size": 128}
 ```
 For more information on how to configure an experiment, see [Configure Experiments]({{< relref "./config.md" >}}).
 
 ### Log metrics inside your training loop
-Log metrics during each `for` loop (epoch), the accuracy and loss values are computed and logged to W&B with [`wandb.log()`]({{< relref "/ref/python/log.md" >}}). By default, when you call wandb.log it appends a new step to the history object and updates the summary object.
+Log metrics during each `for` loop (epoch), the accuracy and loss values are computed and logged to W&B with [`run.log()`]({{< relref "/ref/python/log.md" >}}). By default, when you call `run.log()` it appends a new step to the history object and updates the summary object.
 
-The following code example shows how to log metrics with `wandb.log`.
+The following code example shows how to log metrics with `run.log`.
 
 {{% alert %}}
 Details of how to set up your mode and retrieve data are omitted. 
@@ -65,19 +66,19 @@ Details of how to set up your mode and retrieve data are omitted.
 # Set up model and data
 model, dataloader = get_model(), get_data()
 
-for epoch in range(wandb.config.epochs):
+for epoch in range(run.config.epochs):
     for batch in dataloader:
         loss, accuracy = model.training_step()
         #  3. Log metrics inside your training loop to visualize
         # model performance
-        wandb.log({"accuracy": accuracy, "loss": loss})
+        run.log({"accuracy": accuracy, "loss": loss})
 ```
 For more information on different data types you can log with W&B, see [Log Data During Experiments]({{< relref "./log/" >}}).
 
 ### Log an artifact to W&B 
 Optionally log a W&B Artifact. Artifacts make it easy to version datasets and models. 
 ```python
-wandb.log_artifact(model)
+run.log_artifact(model)
 ```
 For more information about Artifacts, see the [Artifacts Chapter]({{< relref "/guides/core/artifacts/" >}}). For more information about versioning models, see [Model Management]({{< relref "/guides/core/registry/model_registry/" >}}).
 
@@ -89,27 +90,30 @@ The full script with the preceding code snippets is found below:
 import wandb
 
 # 1. Start a W&B Run
-run = wandb.init(project="cat-classification", notes="", tags=["baseline", "paper1"])
+with wandb.init(
+    project="cat-classification",
+    notes="",
+    tags=["baseline", "paper1"],
+) as run:
+    # 2. Capture a dictionary of hyperparameters
+    run.config = {"epochs": 100, "learning_rate": 0.001, "batch_size": 128}
 
-#  2. Capture a dictionary of hyperparameters
-wandb.config = {"epochs": 100, "learning_rate": 0.001, "batch_size": 128}
+    # Set up model and data
+    model, dataloader = get_model(), get_data()
 
-# Set up model and data
-model, dataloader = get_model(), get_data()
+    for epoch in range(run.config.epochs):
+        for batch in dataloader:
+            loss, accuracy = model.training_step()
+            #  3. Log metrics inside your training loop to visualize
+            # model performance
+            run.log({"accuracy": accuracy, "loss": loss})
 
-for epoch in range(wandb.config.epochs):
-    for batch in dataloader:
-        loss, accuracy = model.training_step()
-        #  3. Log metrics inside your training loop to visualize
-        # model performance
-        wandb.log({"accuracy": accuracy, "loss": loss})
+    # 4. Log an artifact to W&B
+    run.log_artifact(model)
 
-# 4. Log an artifact to W&B
-wandb.log_artifact(model)
-
-# Optional: save model at the end
-model.to_onnx()
-wandb.save("model.onnx")
+    # Optional: save model at the end
+    model.to_onnx()
+    run.save("model.onnx")
 ```
 
 ## Next steps: Visualize your experiment 
@@ -123,11 +127,21 @@ For more information on how to view experiments and specific runs, see [Visualiz
 ## Best practices
 The following are some suggested guidelines to consider when you create experiments:
 
-1. **Config**: Track hyperparameters, architecture, dataset, and anything else you'd like to use to reproduce your model. These will show up in columns— use config columns to group, sort, and filter runs dynamically in the app.
-2. **Project**: A project is a set of experiments you can compare together. Each project gets a dedicated dashboard page, and you can easily turn on and off different groups of runs to compare different model versions.
-3. **Notes**: Set a quick commit message directly from your script. Edit and access notes in the Overview section of a run in the W&B App.
-4. **Tags**: Identify baseline runs and favorite runs. You can filter runs using tags. You can edit tags at a later time on the Overview section of your project's dashboard on the W&B App.
-5. **Create multiple run sets to compare experiments**: When comparing experiments, create multiple run sets to make metrics easy to compare. You can toggle run sets on or off on the same chart or group of charts.
+1. **Finish your runs**: Use `wandb.init()` in a `with` statement to automatically mark the run as finished when the code completes or raises an exception.
+    * In Jupyter notebooks, it may be more convenient to manage the Run object yourself. In this case, you can explicitly call `finish()` on the Run object to mark it complete:
+
+        ```python
+        # In a notebook cell:
+        run = wandb.init()
+
+        # In a different cell:
+        run.finish()
+        ```
+2. **Config**: Track hyperparameters, architecture, dataset, and anything else you'd like to use to reproduce your model. These will show up in columns— use config columns to group, sort, and filter runs dynamically in the app.
+3. **Project**: A project is a set of experiments you can compare together. Each project gets a dedicated dashboard page, and you can easily turn on and off different groups of runs to compare different model versions.
+4. **Notes**: Set a quick commit message directly from your script. Edit and access notes in the Overview section of a run in the W&B App.
+5. **Tags**: Identify baseline runs and favorite runs. You can filter runs using tags. You can edit tags at a later time on the Overview section of your project's dashboard on the W&B App.
+6. **Create multiple run sets to compare experiments**: When comparing experiments, create multiple run sets to make metrics easy to compare. You can toggle run sets on or off on the same chart or group of charts.
 
 The following code snippet demonstrates how to define a W&B Experiment using the best practices listed above:
 
@@ -135,15 +149,19 @@ The following code snippet demonstrates how to define a W&B Experiment using the
 import wandb
 
 config = dict(
-    learning_rate=0.01, momentum=0.2, architecture="CNN", dataset_id="cats-0192"
+    learning_rate=0.01,
+    momentum=0.2,
+    architecture="CNN",
+    dataset_id="cats-0192",
 )
 
-wandb.init(
+with wandb.init(
     project="detect-cats",
     notes="tweak baseline",
     tags=["baseline", "paper1"],
     config=config,
-)
+) as run:
+    ...
 ```
 
 For more information about available parameters when defining a W&B Experiment, see the [`wandb.init`]({{< relref "/ref/python/init.md" >}}) API docs in the [API Reference Guide]({{< relref "/ref/python/" >}}).

--- a/content/ref/python/log.md
+++ b/content/ref/python/log.md
@@ -120,8 +120,8 @@ For more and more detailed examples, see
 ```python
 import wandb
 
-run = wandb.init()
-run.log({"accuracy": 0.9, "epoch": 5})
+with wandb.init() as run:
+    run.log({"accuracy": 0.9, "epoch": 5})
 ```
 
 ### Incremental logging
@@ -129,10 +129,10 @@ run.log({"accuracy": 0.9, "epoch": 5})
 ```python
 import wandb
 
-run = wandb.init()
-run.log({"loss": 0.2}, commit=False)
-# Somewhere else when I'm ready to report this step:
-run.log({"accuracy": 0.8})
+with wandb.init() as run:
+    run.log({"loss": 0.2}, commit=False)
+    # Somewhere else when I'm ready to report this step:
+    run.log({"accuracy": 0.8})
 ```
 
 ### Histogram
@@ -143,8 +143,8 @@ import wandb
 
 # sample gradients at random from normal distribution
 gradients = np.random.randn(100, 100)
-run = wandb.init()
-run.log({"gradients": wandb.Histogram(gradients)})
+with wandb.init() as run:
+    run.log({"gradients": wandb.Histogram(gradients)})
 ```
 
 ### Image from numpy
@@ -153,13 +153,13 @@ run.log({"gradients": wandb.Histogram(gradients)})
 import numpy as np
 import wandb
 
-run = wandb.init()
-examples = []
-for i in range(3):
-    pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
-    image = wandb.Image(pixels, caption=f"random field {i}")
-    examples.append(image)
-run.log({"examples": examples})
+with wandb.init() as run:
+    examples = []
+    for i in range(3):
+        pixels = np.random.randint(low=0, high=256, size=(100, 100, 3))
+        image = wandb.Image(pixels, caption=f"random field {i}")
+        examples.append(image)
+    run.log({"examples": examples})
 ```
 
 ### Image from PIL
@@ -169,19 +169,19 @@ import numpy as np
 from PIL import Image as PILImage
 import wandb
 
-run = wandb.init()
-examples = []
-for i in range(3):
-    pixels = np.random.randint(
-        low=0,
-        high=256,
-        size=(100, 100, 3),
-        dtype=np.uint8,
-    )
-    pil_image = PILImage.fromarray(pixels, mode="RGB")
-    image = wandb.Image(pil_image, caption=f"random field {i}")
-    examples.append(image)
-run.log({"examples": examples})
+with wandb.init() as run:
+    examples = []
+    for i in range(3):
+        pixels = np.random.randint(
+            low=0,
+            high=256,
+            size=(100, 100, 3),
+            dtype=np.uint8,
+        )
+        pil_image = PILImage.fromarray(pixels, mode="RGB")
+        image = wandb.Image(pil_image, caption=f"random field {i}")
+        examples.append(image)
+    run.log({"examples": examples})
 ```
 
 ### Video from numpy
@@ -190,15 +190,15 @@ run.log({"examples": examples})
 import numpy as np
 import wandb
 
-run = wandb.init()
-# axes are (time, channel, height, width)
-frames = np.random.randint(
-    low=0,
-    high=256,
-    size=(10, 3, 100, 100),
-    dtype=np.uint8,
-)
-run.log({"video": wandb.Video(frames, fps=4)})
+with wandb.init() as run:
+    # axes are (time, channel, height, width)
+    frames = np.random.randint(
+        low=0,
+        high=256,
+        size=(10, 3, 100, 100),
+        dtype=np.uint8,
+    )
+    run.log({"video": wandb.Video(frames, fps=4)})
 ```
 
 ### Matplotlib Plot
@@ -208,12 +208,12 @@ from matplotlib import pyplot as plt
 import numpy as np
 import wandb
 
-run = wandb.init()
-fig, ax = plt.subplots()
-x = np.linspace(0, 10)
-y = x * x
-ax.plot(x, y)  # plot y = x^2
-run.log({"chart": fig})
+with wandb.init() as run:
+    fig, ax = plt.subplots()
+    x = np.linspace(0, 10)
+    y = x * x
+    ax.plot(x, y)  # plot y = x^2
+    run.log({"chart": fig})
 ```
 
 ### PR Curve
@@ -221,8 +221,8 @@ run.log({"chart": fig})
 ```python
 import wandb
 
-run = wandb.init()
-run.log({"pr": wandb.plot.pr_curve(y_test, y_probas, labels)})
+with wandb.init() as run:
+    run.log({"pr": wandb.plot.pr_curve(y_test, y_probas, labels)})
 ```
 
 ### 3D Object
@@ -230,16 +230,16 @@ run.log({"pr": wandb.plot.pr_curve(y_test, y_probas, labels)})
 ```python
 import wandb
 
-run = wandb.init()
-run.log(
-    {
-        "generated_samples": [
-            wandb.Object3D(open("sample.obj")),
-            wandb.Object3D(open("sample.gltf")),
-            wandb.Object3D(open("sample.glb")),
-        ]
-    }
-)
+with wandb.init() as run:
+    run.log(
+        {
+            "generated_samples": [
+                wandb.Object3D(open("sample.obj")),
+                wandb.Object3D(open("sample.gltf")),
+                wandb.Object3D(open("sample.glb")),
+            ]
+        }
+    )
 ```
 
 | Raises |  |


### PR DESCRIPTION
* Updates some documentation that uses the global run explicitly (`wandb.run`) or implicitly (`wandb.config`, `wandb.log`, etc.) to use a Run object directly instead.
* Updates some documentation to use `wandb.init()` as a context manager by default. This is a best practice from the SDK's perspective because it avoids dangling runs: when the `with` block exits, the run is marked complete (on normal exit) or failed (on exception) and the process waits for its data to finish uploading.

This regex finds most places that need to be updated (with some false positives):

```
run = wandb\.init\(|wandb\.(run|finish|config|log\(|summary|save|use|link|watch|unwatch|define|alert|mark)
```

Unfortunately, there are quite a few places left to update---523 by my count! This PR just updates some top-level guides for users and integrations, which I think are the most important places to start with.