### PR TITLE
Link to commit in last modified date, remove hash

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -175,16 +175,6 @@ a {
 // hide "create child" and "create project issue" links
 .td-page-meta__child, .td-page-meta__project-issue { display: none !important; }
 
-// shrink the right nav a bit
-.td-page-meta {
-    display: none !important;
-    font-size: 16px !important;
-    a {
-        padding-bottom: 15px;
-        line-height: 22px;
-    }
-}
-
 // hide taxonomy cloud on right and top
 .taxonomy-terms-cloud, .taxonomy-terms-article { display: none; }
 
@@ -1017,20 +1007,13 @@ img, iframe {
 }
 
 // Last modified date with feedback links - mobile styles
-div.td-page-meta__lastmod {
+div.td-page-meta {
     display: flex !important;
     flex-direction: column !important; // Stack elements vertically on mobile
     gap: 8px !important;
     color: $text-secondary !important;
     font-size: 14px !important;
     margin-top: 0 !important;
-
-    // Container for last modified text and commit link
-    &:first-child {
-        display: flex !important;
-        align-items: center !important;
-        gap: 4px !important;
-    }
 
     // Style the commit link
     a {

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,12 +1,11 @@
 {{ if and .GitInfo .Site.Params.github_repo -}}
-<div class="td-page-meta__lastmod">
-  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
-  {{ with .GitInfo }}: {{/* Trim WS */ -}}
-    <a data-proofer-ignore href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
-      {{ .AbbreviatedHash }} {{- /* Trim WS */ -}}
+<div class="td-page-meta">
+  <div>
+    {{- T "post_last_mod" }}
+    <a data-proofer-ignore href="{{ .Site.Params.github_repo }}/commit/{{ .GitInfo.Hash }}">
+      {{- .Lastmod.Format .Site.Params.time_format_default -}}
     </a>
-  {{- end }}
-
+  </div>
   <div class="feedback--links">
     {{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
     {{ $gh_repo := $.Param "github_repo" -}}


### PR DESCRIPTION
Fixes DOCS-1324.

Removes the commit hash from the "Last modified" footer and makes the date link to it instead.

I also removed the `td-page-meta` CSS class because it was unused and repurposed it as the new name for `td-page-meta__lastmod` (which was misleading, as the div is responsible for more than just the last modified date).