### PR TITLE
Undo CSS change that breaks right nav

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -176,7 +176,8 @@ a {
 .td-page-meta__child, .td-page-meta__project-issue { display: none !important; }
 
 // shrink the right nav a bit
-.td-page-meta {
+.td-page-meta,
+.td-page-meta__lastmod {
     display: none !important;
     font-size: 16px !important;
     a {
@@ -1017,6 +1018,7 @@ img, iframe {
 }
 
 // Last modified date with feedback links - mobile styles
+div.td-page-meta,
 div.td-page-meta__lastmod {
     display: flex !important;
     flex-direction: column !important; // Stack elements vertically on mobile

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -175,6 +175,16 @@ a {
 // hide "create child" and "create project issue" links
 .td-page-meta__child, .td-page-meta__project-issue { display: none !important; }
 
+// shrink the right nav a bit
+.td-page-meta {
+    display: none !important;
+    font-size: 16px !important;
+    a {
+        padding-bottom: 15px;
+        line-height: 22px;
+    }
+}
+
 // hide taxonomy cloud on right and top
 .taxonomy-terms-cloud, .taxonomy-terms-article { display: none; }
 
@@ -1007,13 +1017,20 @@ img, iframe {
 }
 
 // Last modified date with feedback links - mobile styles
-div.td-page-meta {
+div.td-page-meta__lastmod {
     display: flex !important;
     flex-direction: column !important; // Stack elements vertically on mobile
     gap: 8px !important;
     color: $text-secondary !important;
     font-size: 14px !important;
     margin-top: 0 !important;
+
+    // Container for last modified text and commit link
+    &:first-child {
+        display: flex !important;
+        align-items: center !important;
+        gap: 4px !important;
+    }
 
     // Style the commit link
     a {


### PR DESCRIPTION
The CSS changes in `12059305c78ad4c5af36f0410d913b11e1845c92` break the right-hand navigation on docs pages
```
$ git checkout 12059305c78ad4c5af36f0410d913b11e1845c92^ -- assets/scss/_variables_project.scss
$ git commit -m "Undo CSS change that breaks right nav" -a
[fix_css cf94ec74] Undo CSS change that breaks right nav
```