### PR TITLE
Revert "Link to commit in last modified date, remove hash"

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -175,6 +175,16 @@ a {
 // hide "create child" and "create project issue" links
 .td-page-meta__child, .td-page-meta__project-issue { display: none !important; }
 
+// shrink the right nav a bit
+.td-page-meta {
+    display: none !important;
+    font-size: 16px !important;
+    a {
+        padding-bottom: 15px;
+        line-height: 22px;
+    }
+}
+
 // hide taxonomy cloud on right and top
 .taxonomy-terms-cloud, .taxonomy-terms-article { display: none; }
 
@@ -1007,13 +1017,20 @@ img, iframe {
 }
 
 // Last modified date with feedback links - mobile styles
-div.td-page-meta {
+div.td-page-meta__lastmod {
     display: flex !important;
     flex-direction: column !important; // Stack elements vertically on mobile
     gap: 8px !important;
     color: $text-secondary !important;
     font-size: 14px !important;
     margin-top: 0 !important;
+
+    // Container for last modified text and commit link
+    &:first-child {
+        display: flex !important;
+        align-items: center !important;
+        gap: 4px !important;
+    }
 
     // Style the commit link
     a {

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,11 +1,12 @@
 {{ if and .GitInfo .Site.Params.github_repo -}}
-<div class="td-page-meta">
-  <div>
-    {{- T "post_last_mod" }}
-    <a data-proofer-ignore href="{{ .Site.Params.github_repo }}/commit/{{ .GitInfo.Hash }}">
-      {{- .Lastmod.Format .Site.Params.time_format_default -}}
+<div class="td-page-meta__lastmod">
+  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+  {{ with .GitInfo }}: {{/* Trim WS */ -}}
+    <a data-proofer-ignore href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+      {{ .AbbreviatedHash }} {{- /* Trim WS */ -}}
     </a>
-  </div>
+  {{- end }}
+
   <div class="feedback--links">
     {{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
     {{ $gh_repo := $.Param "github_repo" -}}


### PR DESCRIPTION
Reverts wandb/docs#1161, which breaks the page-edit and bug-reporting links in the page footer and breaks the right-hand nav. A followup PR will revert this and allow us to fix the CSS and reapply the change.