### PR TITLE
Remove stale timelines from legacy model registry

### DIFF
--- a/content/guides/core/registry/model_registry/_index.md
+++ b/content/guides/core/registry/model_registry/_index.md
@@ -12,7 +12,7 @@ cascade:
 ---
 
 {{% alert %}}
-W&B will eventually stop supporting the W&B Model Registry. Users are encouraged to instead use [W&B Registry]({{< relref "/guides/core/registry/" >}}) for linking and sharing their model artifacts versions. W&B Registry broadens the capabilities of the legacy W&B Model Registry. For more information about W&B Registry, see the [Registry docs]({{< relref "/guides/core/registry/" >}}).
+W&B will eventually stop supporting W&B Model Registry. Users are encouraged to instead use [W&B Registry]({{< relref "/guides/core/registry/" >}}) for linking and sharing their model artifacts versions. W&B Registry broadens the capabilities of the legacy W&B Model Registry. For more information about W&B Registry, see the [Registry docs]({{< relref "/guides/core/registry/" >}}).
 
 
 W&B will migrate existing model artifacts linked to the legacy Model Registry to the new W&B Registry in the near future. See [Migrating from legacy Model Registry]({{< relref "/guides/core/registry/model_registry_eol.md" >}}) for information about the migration process.

--- a/content/guides/core/registry/model_registry/_index.md
+++ b/content/guides/core/registry/model_registry/_index.md
@@ -12,10 +12,10 @@ cascade:
 ---
 
 {{% alert %}}
-W&B will no longer support W&B Model Registry after 2024. Users are encouraged to instead use [W&B Registry]({{< relref "/guides/core/registry/" >}}) for linking and sharing their model artifacts versions. W&B Registry broadens the capabilities of the legacy W&B Model Registry. For more information about W&B Registry, see the [Registry docs]({{< relref "/guides/core/registry/" >}}).
+W&B will eventually stop supporting the W&B Model Registry. Users are encouraged to instead use [W&B Registry]({{< relref "/guides/core/registry/" >}}) for linking and sharing their model artifacts versions. W&B Registry broadens the capabilities of the legacy W&B Model Registry. For more information about W&B Registry, see the [Registry docs]({{< relref "/guides/core/registry/" >}}).
 
 
-W&B will migrate existing model artifacts linked to the legacy Model Registry to the new W&B Registry in the Fall or early Winter of 2024. See [Migrating from legacy Model Registry]({{< relref "/guides/core/registry/model_registry_eol.md" >}}) for information about the migration process.
+W&B will migrate existing model artifacts linked to the legacy Model Registry to the new W&B Registry in the near future. See [Migrating from legacy Model Registry]({{< relref "/guides/core/registry/model_registry_eol.md" >}}) for information about the migration process.
 {{% /alert %}}
 
 The W&B Model Registry houses a team's trained models where ML Practitioners can publish candidates for production to be consumed by downstream teams and stakeholders. It is used to house staged/candidate models and manage workflows associated with staging.


### PR DESCRIPTION
Remove stale 2024 timelines from Registry documentation. 

- JIRA - [WB-24158](https://wandb.atlassian.net/browse/WB-24158)


[WB-24158]: https://wandb.atlassian.net/browse/WB-24158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ