### PR TITLE
add documention for support pathlib.Path objects in media objects

### DIFF
--- a/content/ref/python/data-types/html.md
+++ b/content/ref/python/data-types/html.md
@@ -8,14 +8,14 @@ Wandb class for arbitrary html.
 
 ```python
 Html(
-    data: Union[str, 'TextIO'],
+    data: Union[pathlib.Path, str, 'TextIO'],
     inject: bool = (True)
 ) -> None
 ```
 
 | Args |  |
 | :--- | :--- |
-|  `data` |  (string or io object) HTML to display in wandb |
+|  `data` |  (pathlib.Path, string, or io object) The path to an HTML file, or the literal HTML to display in wandb |
 |  `inject` |  (boolean) Add a stylesheet to the HTML object. If set to False the HTML will pass through unchanged. |
 
 ## Methods

--- a/content/ref/python/data-types/image.md
+++ b/content/ref/python/data-types/image.md
@@ -21,7 +21,7 @@ Image(
 
 | Args |  |
 | :--- | :--- |
-|  `data_or_path` |  (numpy array, string, io) Accepts numpy array of image data, or a PIL image. The class attempts to infer the data format and converts it. |
+|  `data_or_path` |  (numpy array, string, pathlib.Path, io) Accepts numpy array of image data, a PIL image, or a path to an image file. The class attempts to infer the data format and converts it. |
 |  `mode` |  (string) The PIL mode for an image. Most common are "L", "RGB", "RGBA". Full explanation at https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes |
 |  `caption` |  (string) Label for display of image. |
 

--- a/content/ref/python/data-types/molecule.md
+++ b/content/ref/python/data-types/molecule.md
@@ -8,7 +8,7 @@ Wandb class for 3D Molecular data.
 
 ```python
 Molecule(
-    data_or_path: Union[str, 'TextIO'],
+    data_or_path: Union[pathlib.Path, str, 'TextIO'],
     caption: Optional[str] = None,
     **kwargs
 ) -> None
@@ -16,7 +16,7 @@ Molecule(
 
 | Args |  |
 | :--- | :--- |
-|  `data_or_path` |  (string, io) Molecule can be initialized from a file name or an io object. |
+|  `data_or_path` |  (pathlib.Path, string, io) Molecule can be initialized from a file path or an io object. |
 |  `caption` |  (string) Caption associated with the molecule for display. |
 
 ## Methods

--- a/content/ref/python/data-types/object3d.md
+++ b/content/ref/python/data-types/object3d.md
@@ -8,7 +8,7 @@ Wandb class for 3D point clouds.
 
 ```python
 Object3D(
-    data_or_path: Union['np.ndarray', str, 'TextIO', dict],
+    data_or_path: Union['np.ndarray', pathlib.Path, str, 'TextIO', dict],
     caption: Optional[str] = None,
     **kwargs
 ) -> None
@@ -16,7 +16,7 @@ Object3D(
 
 | Args |  |
 | :--- | :--- |
-|  `data_or_path` |  (numpy array, string, io) Object3D can be initialized from a file or a numpy array. You can pass a path to a file or an io object and a file_type which must be one of SUPPORTED_TYPES |
+|  `data_or_path` |  (numpy array, pathlib.Path, string, io) Object3D can be initialized from a file path or a numpy array. You can pass a path to a file or an io object and a file_type which must be one of SUPPORTED_TYPES |
 
 The shape of the numpy array must be one of either:
 

--- a/content/ref/python/data-types/video.md
+++ b/content/ref/python/data-types/video.md
@@ -8,7 +8,7 @@ Format a video for logging to W&B.
 
 ```python
 Video(
-    data_or_path: Union['np.ndarray', str, 'TextIO', 'BytesIO'],
+    data_or_path: Union['np.ndarray', str, pathlib.Path, 'TextIO', 'BytesIO'],
     caption: Optional[str] = None,
     fps: Optional[int] = None,
     format: Optional[str] = None
@@ -17,7 +17,7 @@ Video(
 
 | Args |  |
 | :--- | :--- |
-|  `data_or_path` |  (numpy array, string, io) Video can be initialized with a path to a file or an io object. The format must be "gif", "mp4", "webm" or "ogg". The format must be specified with the format argument. Video can be initialized with a numpy tensor. The numpy tensor must be either 4 dimensional or 5 dimensional. Channels should be (time, channel, height, width) or (batch, time, channel, height width) |
+|  `data_or_path` |  (numpy array, pathlib.Path, string, io) Video can be initialized with a path to a file or an io object. The format must be "gif", "mp4", "webm" or "ogg". The format must be specified with the format argument. Video can be initialized with a numpy tensor. The numpy tensor must be either 4 dimensional or 5 dimensional. Channels should be (time, channel, height, width) or (batch, time, channel, height width) |
 |  `caption` |  (string) caption associated with the video for display |
 |  `fps` |  (int) The frame rate to use when encoding raw video frames. Default value is 4. This parameter has no effect when data_or_path is a string, or bytes. |
 |  `format` |  (string) format of video, necessary if initializing with path or io object. |


### PR DESCRIPTION
The W&B SDK has added support for initializing media objects using pythons [pathlib.Path object](https://docs.python.org/3/library/pathlib.html#pathlib.Path). This change adds documentation for those objects.
