### PR TITLE
[DOCS-1323] Improvements for reporting an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,6 +1,6 @@
 ---
-name: general_issue
-about: Default issue template
+name: feedback
+about: Template for providing feedback about unhelpful content
 title: Feedback or issue summary
 labels: ''
 assignees: ''
@@ -9,4 +9,4 @@ assignees: ''
 
 W&B employees: Please file a doc JIRA instead, using this template: https://wandb.atlassian.net/secure/CreateIssueDetails!init.jspa?priority=3&pid=10026&issuetype=10047
 
-Describe the issue or feedback, providing links, screenshots, or additional details as appropriate.
+We're sorry you did not find this content helpful. Please give us suggestions for improvement. If relevant, include links, screenshots, or additional details.

--- a/.github/ISSUE_TEMPLATE/praise.md
+++ b/.github/ISSUE_TEMPLATE/praise.md
@@ -1,7 +1,7 @@
 ---
-name: general_issue
-about: Default issue template
-title: Feedback or issue summary
+name: praise
+about: Template for providing feedback about helpful content
+title: Feedback
 labels: ''
 assignees: ''
 
@@ -9,4 +9,4 @@ assignees: ''
 
 W&B employees: Please file a doc JIRA instead, using this template: https://wandb.atlassian.net/secure/CreateIssueDetails!init.jspa?priority=3&pid=10026&issuetype=10047
 
-Describe the issue or feedback, providing links, screenshots, or additional details as appropriate.
+We're glad you found this content helpful. If you have additional info, please let us know.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -166,9 +166,9 @@ params:
       enable: true
       # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
       'yes': >-
-        Glad to hear it! Please <a href="https://github.com/wandb/docs/issues/new">tell us how we can improve</a>.
+        Glad to hear it! If you have further feedback, please <a href="https://github.com/wandb/docs/issues/new?template=praise.md">let us knowe</a>.
       'no': >-
-        Sorry to hear that. Please <a href="https://github.com/wandb/docs/issues/new">tell us how we can improve</a>.
+        Sorry to hear that. Please <a href="https://github.com/wandb/docs/issues/new?template=feedback.md">tell us how we can improve</a>.
     # Adds a reading time to the top of each doc.
     # If you want this feature, but occasionally need to remove the Reading time from a single page,
     # add "hide_readingtime: true" to the page's front matter


### PR DESCRIPTION
[DOCS-1323] Improvements for reporting an issue

- Add praise template
- Add feedback template
- Update Hugo config to use the new templates when the user clicks Yes/No for 'Was this page helpful?' question (this is hard to test before we merge)
- Don't use the template in the Report an issue link in page-meta-lastmod partial

This change is hard to test before we merge because the templates are not available to use.


[DOCS-1323]: https://wandb.atlassian.net/browse/DOCS-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ