### PR TITLE
fix: update cli link in ref index

### DIFF
--- a/content/ref/_index.md
+++ b/content/ref/_index.md
@@ -23,7 +23,7 @@ no_list: true
     <p className="card-content">Train, fine-tune, and manage models from experimentation to production.</p>
   {{< /card >}}
   {{< card >}}
-    <a href="./query-panel/">
+    <a href="./cli/">
       <h2 className="card-title">Command Line Interface</h2>
     </a>
     <p className="card-content">Log in, run jobs, execute sweeps, and more using shell commands.</p>


### PR DESCRIPTION
A quickfix to update the link for the cli page in the references page. Currently this links to query panels, the fix updates the href to link to cli instead.
