### PR TITLE
Experiments: Removed `wandb.init.Run.history` from dev guide

### DIFF
--- a/content/guides/models/track/public-api-guide.md
+++ b/content/guides/models/track/public-api-guide.md
@@ -225,17 +225,6 @@ these are the different outputs for the above run object attributes
 {"n_epochs": 5}
 ```
 
-#### `run.history()`
-
-```shell
-   _step  val   loss  _runtime  _timestamp
-0      0  500  0.244         4  1644345412
-1      1   45  0.521         4  1644345412
-2      2  240  0.785         4  1644345412
-3      3   31  0.305         4  1644345412
-4      4  525  0.041         4  1644345412
-```
-
 #### `run.summary`
 
 ```python


### PR DESCRIPTION
SDK Team removed this method. This PR removes mention of it.

Note: This is not to be confused with the run.history method from the Public API. These are different Classes.

Jira ticket: https://wandb.atlassian.net/browse/DOCS-1393