### PR TITLE
Update link to example artifact tab

### DIFF
--- a/content/guides/models/track/runs/_index.md
+++ b/content/guides/models/track/runs/_index.md
@@ -505,8 +505,7 @@ The **Artifacts** tab lists the input and output [artifacts]({{< relref "/guides
 
 {{< img src="/images/app_ui/artifacts_tab.png" alt="" >}}
 
-View an example artifacts tab [here](https://wandb.ai/stacey/artifact_july_demo/runs/2cslp2rt/artifacts).
-
+View [Example artifact graphs]({{< relref "/guides/artifacts/explore-and-traverse-an-artifact-graph.md" >}}).
 
 ## Delete runs
 

--- a/content/guides/models/track/runs/_index.md
+++ b/content/guides/models/track/runs/_index.md
@@ -505,7 +505,7 @@ The **Artifacts** tab lists the input and output [artifacts]({{< relref "/guides
 
 {{< img src="/images/app_ui/artifacts_tab.png" alt="" >}}
 
-View [Example artifact graphs]({{< relref "/guides/artifacts/explore-and-traverse-an-artifact-graph.md" >}}).
+View [Example artifact graphs]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph.md" >}}).
 
 ## Delete runs
 

--- a/content/guides/models/track/runs/_index.md
+++ b/content/guides/models/track/runs/_index.md
@@ -505,7 +505,7 @@ The **Artifacts** tab lists the input and output [artifacts]({{< relref "/guides
 
 {{< img src="/images/app_ui/artifacts_tab.png" alt="" >}}
 
-View [Example artifact graphs]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph.md" >}}).
+View [example artifact graphs]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph.md" >}}).
 
 ## Delete runs
 


### PR DESCRIPTION
Fixes #1186
The existing link is a 404 and no longer exists. It was in support of a blog post.
