### PR TITLE
update sdk version requirement for shared mode

### DIFF
--- a/content/guides/models/track/log/distributed-training.md
+++ b/content/guides/models/track/log/distributed-training.md
@@ -105,7 +105,7 @@ Parameters prefixed by `x_` (such as `x_label`) are in public preview. Create a 
 {{% /alert %}}
 
 {{% alert %}}
-To track multiple processes to a single run, you must have W&B Python SDK version `v0.19.5` or newer.
+To track multiple processes to a single run, you must have W&B Python SDK version `v0.19.9` or newer.
 {{% /alert  %}}
 
 In this approach you use a primary node and one or more worker nodes. Within the primary node you initialize a W&B run. For each worker node, initialize a run using the run ID used by the primary node. During training each worker node logs to the same run ID as the primary node. W&B aggregates metrics from all nodes and displays them in the W&B App UI.


### PR DESCRIPTION
https://weightsandbiases.slack.com/archives/C081QT67T35/p1745355489885389?thread_ts=1745273793.368359&cid=C081QT67T35

Update the required version of sdk in docs for folks using shared mode for multi-processing to include changes for structured log format. 

This is the PR that introduced structured log format on the sdk side https://github.com/wandb/wandb/pull/9573