### PR TITLE
Update Weave info

### DIFF
--- a/content/guides/quickstart.md
+++ b/content/guides/quickstart.md
@@ -10,6 +10,10 @@ weight: 2
 ---
 Install W&B to track, visualize, and manage machine learning experiments of any size.
 
+{{% alert %}}
+Are you looking for information on W&B Weave? See the [Weave Python SDK quickstart](https://weave-docs.wandb.ai/quickstart) or [Weave TypeScript SDK quickstart](https://weave-docs.wandb.ai/reference/generated_typescript_docs/intro-notebook).
+{{% /alert %}}
+
 ## Sign up and create an API key
 
 To authenticate your machine with W&B, generate an API key from your user profile or at [wandb.ai/authorize](https://wandb.ai/authorize). Copy the API key and store it securely.
@@ -41,6 +45,7 @@ pip install wandb
 ```
 ```python
 import wandb
+
 wandb.login()
 ```
 
@@ -64,7 +69,7 @@ In your Python script or notebook, initialize a W&B run object with [`wandb.init
 ```python
 run = wandb.init(
     project="my-awesome-project",  # Specify your project
-    config={                        # Track hyperparameters and metadata
+    config={  # Track hyperparameters and metadata
         "learning_rate": 0.01,
         "epochs": 10,
     },
@@ -88,8 +93,8 @@ epochs = 10
 lr = 0.01
 
 run = wandb.init(
-    project="my-awesome-project",    # Specify your project
-    config={                         # Track hyperparameters and metadata
+    project="my-awesome-project",  # Specify your project
+    config={  # Track hyperparameters and metadata
         "learning_rate": lr,
         "epochs": epochs,
     },
@@ -122,3 +127,4 @@ Explore more features of the W&B ecosystem:
 4. Automate hyperparameter searches and optimize models with [W&B Sweeps]({{< relref "/guides/models/sweeps/" >}}).
 5. Analyze runs, visualize model predictions, and share insights on a [central dashboard]({{< relref "/guides/models/tables/" >}}).
 6. Visit [W&B AI Academy](https://wandb.ai/site/courses/) to learn about LLMs, MLOps, and W&B Models through hands-on courses.
+7. Visit the [official W&B Weave documentation](https://weave-docs.wandb.ai/) to learn how to track track, experiment with, evaluate, deploy, and improve your LLM-based applications using Weave. 

--- a/content/guides/quickstart.md
+++ b/content/guides/quickstart.md
@@ -69,7 +69,7 @@ In your Python script or notebook, initialize a W&B run object with [`wandb.init
 ```python
 run = wandb.init(
     project="my-awesome-project",  # Specify your project
-    config={  # Track hyperparameters and metadata
+    config={                        # Track hyperparameters and metadata
         "learning_rate": 0.01,
         "epochs": 10,
     },
@@ -93,8 +93,8 @@ epochs = 10
 lr = 0.01
 
 run = wandb.init(
-    project="my-awesome-project",  # Specify your project
-    config={  # Track hyperparameters and metadata
+    project="my-awesome-project",    # Specify your project
+    config={                         # Track hyperparameters and metadata
         "learning_rate": lr,
         "epochs": epochs,
     },

--- a/content/guides/weave/_index.md
+++ b/content/guides/weave/_index.md
@@ -6,8 +6,6 @@ title: W&B Weave
 weight: 4
 ---
 
-# W&B Weave
-
 {{% alert %}}
 Are you looking for the official Weave documentation? Head over to [https://weave-docs.wandb.ai/](https://weave-docs.wandb.ai/).
 {{% /alert %}}

--- a/content/guides/weave/_index.md
+++ b/content/guides/weave/_index.md
@@ -6,24 +6,31 @@ title: W&B Weave
 weight: 4
 ---
 
-{{< cta-button colabLink="http://wandb.me/weave_colab" >}}
-
-Weave is a lightweight toolkit for tracking and evaluating LLM applications. Use W&B Weave to visualize and inspect the execution flow of your LLMs, analyze the inputs and outputs of your LLMs, view the intermediate results and securely store and manage your prompts and LLM chain configurations.
-
-{{< img src="/images/weave/weave-hero.png" alt="" >}}
-
-With W&B Weave, you can:
-* Log and debug language model inputs, outputs, and traces
-* Build rigorous, apples-to-apples evaluations for language model use cases
-* Organize all the information generated across the LLM workflow, from experimentation to evaluations to production
+# W&B Weave
 
 {{% alert %}}
-Looking for Weave docs? See the [W&B Weave Docs](https://weave-docs.wandb.ai/).
+Are you looking for the official Weave documentation? Head over to [https://weave-docs.wandb.ai/](https://weave-docs.wandb.ai/).
 {{% /alert %}}
 
-## How to get started 
-Depending on your use case, explore the following resources to get started with W&B Weave:
+W&B Weave is a framework for tracking, experimenting with, evaluating, deploying, and improving LLM-based applications. Designed for flexibility and scalability, Weave supports every stage of your LLM application development workflow:
 
-* [Quickstart: Track inputs and outputs of LLM calls](https://wandb.github.io/weave/quickstart)
-* [Build an Evaluation pipeline tutorial](https://wandb.github.io/weave/tutorial-eval)
-* [Model-Based Evaluation of RAG applications tutorial](https://wandb.github.io/weave/tutorial-rag)
+- **Tracing & Monitoring**: Track LLM calls and application logic to debug and analyze production systems.
+- **Systematic Iteration**: Refine and iterate on prompts, datasets and models.
+- **Experimentation**: Experiment with different models and prompts in the LLM Playground. 
+- **Evaluation**: Use custom or pre-built scorers alongside our comparison tools to systematically assess and enhance application performance.
+- **Guardrails**: Protect your application with safeguards for content moderation, prompt safety, and more.
+
+## Get started with Weave
+
+Are you new to Weave? Set up and start using Weave with the [Python quickstart](https://weave-docs.wandb.ai/quickstart) or [TypeScript quickstart](https://weave-docs.wandb.ai/reference/generated_typescript_docs/intro-notebook).
+
+## Advanced guides
+
+Learn more about advanced topics:
+
+- [Integrations](https://weave-docs.wandb.ai/guides/integrations/): Use Weave with popular LLM providers, local models, frameworks, and third-party services.
+- [Cookbooks](https://weave-docs.wandb.ai/reference/gen_notebooks/intro_notebook): Build with Weave using Python and TypeScript. Tutorials are available as interactive notebooks.
+- [W&B AI Academy](https://www.wandb.courses/pages/w-b-courses): Build advanced RAG systems, improve LLM prompting, fine-tune LLMs, and more.
+- [Weave Python SDK](https://weave-docs.wandb.ai/reference/python-sdk/weave/)
+- [Weave TypeScript SDK](https://weave-docs.wandb.ai/reference/typescript-sdk/weave/)
+- [Weave Service API](https://weave-docs.wandb.ai/reference/service-api/call-start-call-start-post)


### PR DESCRIPTION
https://wandb.atlassian.net/browse/DOCS-1439

Context: Request from Weave PM to update W&B docs Weave info to help with Weave onboarding https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1744904793945169 

Changes
- Update https://docs.wandb.ai/guides/weave/ to match https://github.com/wandb/weave/blob/master/docs/docs/introduction.md with some slight modifications 
- Add callouts on Quickstart to direct folks to Weave docs if they are trying to do the Weave thing
