### PR TITLE
Release notes fast follows

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -34,6 +34,10 @@ W&B consists of three major components: [Models]({{< relref "/guides/models.md" 
 - [Tables]({{< relref "/guides/models/tables/" >}}): Visualize and query tabular data
 - [Reports]({{< relref "/guides/core/reports/" >}}): Document and collaborate on your discoveries
 
+{{% alert %}}
+Learn about recent releases in the [W&B release notes]({{< relref "/ref/release-notes/" >}}).
+{{% /alert %}}
+
 ## How does W&B work?
 
 Read the following sections in this order if you are a first-time user of W&B and you are interested in training, tracking, and visualizing machine learning models and experiments:

--- a/content/ref/_index.md
+++ b/content/ref/_index.md
@@ -15,7 +15,7 @@ no_list: true
 
 {{< cardpane >}}
   {{< card >}}
-    <a href="./release-notes/releases/">
+    <a href="./release-notes/">
       <h2 className="card-title">Release notes</h2>
     </a>
     <p className="card-content">Learn about W&B releases, including new features, performance improvements, and bug fixes.</p>

--- a/content/ref/release-notes/_index.md
+++ b/content/ref/release-notes/_index.md
@@ -6,8 +6,6 @@ cascade:
 - url: /ref/release-notes/:filename/
 - type: docs
 - weight: 1
-aliases:
-- /ref/release-notes/releases/
 menu:
   default:
     parent: reference
@@ -17,5 +15,4 @@ menu:
 
 This section includes release notes for supported W&B Server releases. For releases that are no longer supported, refer to [Archived releases]({{< relref "archived/" >}}).
 
-<a href="/ref/release-notes/releases/index.xml"><button class="btn btn-primary mb-4 feedback--answer"><i class="fa-sharp fa-regular fa-square-rss" alt="RSS icon"></i>&nbsp;RSS feed</button></a>
-
+<a href="/ref/release-notes/index.xml"><button class="btn btn-primary mb-4 feedback--answer"><i class="fa-sharp fa-regular fa-square-rss" alt="RSS icon"></i>&nbsp;RSS feed</button></a>

--- a/content/ref/release-notes/releases/0.68.0.md
+++ b/content/ref/release-notes/releases/0.68.0.md
@@ -7,7 +7,7 @@ description: "April 29, 2025"
 W&B Server v0.68 includes enhancements to various types of panels and visualizations, security improvements for Registry, Weave, and service accounts, performance improvements when forking and rewinding runs, and more. 
 
 ## Features
-- Release notes for W&B Server are now published [in the W&B documentation](/ref/release-notes/releases/) in addition to on GitHub. [Subscribe using RSS]({/ref/release-notes/releases/index.xml).
+- Release notes for W&B Server are now published [in the W&B documentation](/ref/release-notes/) in addition to on GitHub. [Subscribe using RSS]({/ref/release-notes/index.xml).
 - Registry admins can define and assign [*protected aliases*]({{< relref "/guides/core/registry/model_registry/access_controls.md#add-protected-aliases" >}}) to represent key stages of your development pipeline. A protected alias can be assigned only by a registry admin. W&B blocks other users from adding or removing protected aliases from versions in a registry using the API or UI.
 - You can now filter console logs based on a run's `x_label` value. During [distributed training]({{< relref "/guides/models/track/log/distributed-training.md#track-all-processes-to-a-single-run" >}}), this optional parameter tracks the node that logged the run.
 - You can now move runs between `Groups`, one by one or in bulk. Also, you can now create new `Groups` after the initial logging time.

--- a/content/ref/release-notes/releases/archived/_index.md
+++ b/content/ref/release-notes/releases/archived/_index.md
@@ -3,7 +3,7 @@ title: Archived Releases
 type: docs
 url: /ref/release-notes/archived/
 cascade:
-- url: /ref/release-notes/archived/:title/
+- url: /ref/release-notes/archived/:filename/
 - type: docs
 - weight: 1
 menu:

--- a/content/ref/release-notes/releases/archived/_index.md
+++ b/content/ref/release-notes/releases/archived/_index.md
@@ -12,7 +12,7 @@ menu:
     identifier: archived-release-notes
     weight: 99
 ---
-Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/release-notes/).
+Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/ref/release-notes/).
 
 {{% alert color="warning" %}}
 Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/releases-notes/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).

--- a/content/ref/release-notes/releases/archived/_index.md
+++ b/content/ref/release-notes/releases/archived/_index.md
@@ -3,7 +3,7 @@ title: Archived Releases
 type: docs
 url: /ref/release-notes/archived/
 cascade:
-- url: /ref/release-notes/releases/archived/:title/
+- url: /ref/release-notes/archived/:title/
 - type: docs
 - weight: 1
 menu:
@@ -12,11 +12,8 @@ menu:
     identifier: archived-release-notes
     weight: 99
 ---
-Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/release-notes/releases/).
+Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/release-notes/).
 
 {{% alert color="warning" %}}
 Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/releases-notes/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).
 {{% /alert %}}
-
-
-

--- a/content/ref/release-notes/releases/archived/unsupported.md
+++ b/content/ref/release-notes/releases/archived/unsupported.md
@@ -1,3 +1,3 @@
 This release is no longer supported. A major release and its patches are supported for six months from the initial release date.
 
-Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/ref/releases-notes/releases/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).
+Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/ref/releases-notes/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).

--- a/content/ref/release-notes/releases/archived/unsupported.md
+++ b/content/ref/release-notes/releases/archived/unsupported.md
@@ -1,3 +1,3 @@
 This release is no longer supported. A major release and its patches are supported for six months from the initial release date.
 
-Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/ref/releases-notes/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).
+Customers using [Self-managed](/guides/hosting/hosting-options/self-managed/) are responsible to upgrade to a [supported release](/ref/releases-notes/releases/) in time to maintain support. For assistance or questions, contact [support](mailto:support@wandb.com).

--- a/static/_redirects
+++ b/static/_redirects
@@ -361,6 +361,8 @@
 /ref/python/README /ref/python 301
 /ref/python/wandb.ai/settings /ref/python 301
 /ref/README /ref 301
+/ref/release-notes/releases/index.xml /ref/release-notes/index.xml 301
+/ref/release-notes/releases/ /ref/release-notes/ 301
 /ref/run/summary /ref/python/run 301
 /ref/sweep/configurations /guides/sweeps/define-sweep-configuration 301
 /ref/weave/README /ref/weave 301
@@ -426,6 +428,8 @@
 /integrations/* /guides/integrations/:splat 301
 /library/frameworks/* /guides/integrations/:splat 301
 /library/integrations/* /guides/integrations/:splat 301
+/ref/release-notes/releases/* /ref/releases/:splat 301
+/ref/release-notes/releases/archived/* /ref/releases/archived/:splat 301
 
 
 


### PR DESCRIPTION
- Fixes links after updating the release notes and archived release notes index URLs
- Add redirects from old page locations even though they were only live for a few minutes
- Remove the alias entry from the release note index which was added as a stop-gap
- Adds a link from the guides index to the release notes
Ready for review.

Previews:
https://fix-unsupported-admonition.docodile.pages.dev/ref/release-notes/
https://fix-unsupported-admonition.docodile.pages.dev/ref/release-notes/index.xml
https://fix-unsupported-admonition.docodile.pages.dev/ref/release-notes/archived/
https://fix-unsupported-admonition.docodile.pages.dev/guides/#what-is-wb (bottom of the section)
