### PR TITLE
[DOCS-1475] 2 of 2: Document fix for media panel bug

### DIFF
--- a/content/ref/release-notes/release-policies.md
+++ b/content/ref/release-notes/release-policies.md
@@ -6,7 +6,7 @@ menu:
     parent: w-b-platform
 title: Release policies and processes
 weight: 10
-lastmod: 2025-05-01
+date: 2025-05-01
 ---
 This page gives details about W&B Server releases and W&B's release policies. This page relates to [W&B Dedicated Cloud]({{< relref "/guides/hosting/hosting-options/dedicated_cloud/" >}}) and [Self-Managed]({{< relref "/guides/hosting/hosting-options/self-managed/" >}}) deployments. To learn more about an individual W&B Server release, refer to [W&B release notes]({{< relref "/ref/release-notes/" >}}).
 

--- a/content/ref/release-notes/release-policies.md
+++ b/content/ref/release-notes/release-policies.md
@@ -5,7 +5,8 @@ menu:
     identifier: server-release-process
     parent: w-b-platform
 title: Release policies and processes
-weight: -1
+weight: 10
+lastmod: 2025-05-01
 ---
 This page gives details about W&B Server releases and W&B's release policies. This page relates to [W&B Dedicated Cloud]({{< relref "/guides/hosting/hosting-options/dedicated_cloud/" >}}) and [Self-Managed]({{< relref "/guides/hosting/hosting-options/self-managed/" >}}) deployments. To learn more about an individual W&B Server release, refer to [W&B release notes]({{< relref "/ref/release-notes/" >}}).
 

--- a/content/ref/release-notes/releases/0.63.0.md
+++ b/content/ref/release-notes/releases/0.63.0.md
@@ -1,5 +1,5 @@
 ---
-title: "0.63.0"
+title: "0.63.x"
 date: 2024-12-10
 description: "December 10, 2024"
 ---

--- a/content/ref/release-notes/releases/0.65.0.md
+++ b/content/ref/release-notes/releases/0.65.0.md
@@ -1,5 +1,5 @@
 ---
-title: "0.65.0"
+title: "0.65.x"
 date: 2025-01-30
 description: "January 30, 2025"
 ---

--- a/content/ref/release-notes/releases/0.66.0.md
+++ b/content/ref/release-notes/releases/0.66.0.md
@@ -1,5 +1,5 @@
 ---
-title: "0.66.0"
+title: "0.66.x"
 date: 2025-03-06
 description: "March 06, 2025"
 ---

--- a/content/ref/release-notes/releases/0.67.0.md
+++ b/content/ref/release-notes/releases/0.67.0.md
@@ -1,5 +1,5 @@
 ---
-title: "0.67.0"
+title: "0.67.x"
 date: 2025-03-28
 description: "March 28, 2025"
 ---

--- a/content/ref/release-notes/releases/0.68.0.md
+++ b/content/ref/release-notes/releases/0.68.0.md
@@ -1,13 +1,16 @@
 ---
-title: "0.68.0"
+title: "0.68.x"
 date: 2025-04-29
+lastmod: 2025-05-02
 description: "April 29, 2025"
 ---
 
 W&B Server v0.68 includes enhancements to various types of panels and visualizations, security improvements for Registry, Weave, and service accounts, performance improvements when forking and rewinding runs, and more. 
 
-{{% alert title="Known issue" color="warning" %}}
-This version introduced a bug that could prevent media from loading in media panels. If this could cause issues in your deployment, consider waiting for the fix, which will be announced separately, before upgrading. If you are impacted by this bug, contact [support](mailto:support@wandb.com).
+The latest patch is [v0.68.1]({{< relref "#0_68_1" >}}). Refer to [Patches]({{< relref "#patches" >}}). 
+
+{{% alert title="Known issue" %}}
+v0.68.0 introduced a bug, fixed in [v0.68.1]({{< relref "#0_68_1" >}}), that could prevent media from loading in media panels. To avoid this bug, install or upgrade to a patch that contains the fix. If you need assistance, contact [support](mailto:support@wandb.com).
 {{% /alert %}}
 
 ## Features
@@ -35,11 +38,9 @@ Private preview features are available by invitation only. To request enrollment
 - Build labeled datasets directly from traces, with your annotations automatically converted into dataset columns. [Learn more](https://weave-docs.wandb.ai/guides/core-types/datasets/#create-edit-and-delete-a-dataset-in-the-ui).
 
 ## Security
-
 - Registry admins can now designate a [service account]({{< relref "/guides/hosting/iam/authentication/service-accounts.md" >}}) in a registry as either a Registry Admin or a Member. Previously, the service account’s role was always Registry Admin. [Learn more]({{< relref "/guides/core/registry/configure_registry.md" >}}).
 
 ## Performance
-
 - Improved the performance of many workspace interactions, particularly in large workspaces. For example, expanding sections and using the run selector are significantly more responsive.
 - Improved Fork and Rewind Performance. 
 
@@ -48,7 +49,6 @@ Private preview features are available by invitation only. To request enrollment
     In projects with many nested forks, forking new runs is now much more efficient due to improvements in caching.
 
 ## Fixes
-
 - Fixed a bug that could prevent an organization service account from being added to new teams.
 - Fixed a bug that could cause hover marks to be missing for grouped lines.
 - Fixed a bug that could include invalid project names in the **Import** dropdown of a Report panel.
@@ -58,3 +58,9 @@ Private preview features are available by invitation only. To request enrollment
 - Fixed a bug that could prevent image captions from appearing when they are logged to a Table.
 - Fixed a bug that could prevent sparse metrics from showing up in panels.
 - In **Run Overview** pages, the **Description** field is now named **Notes**.
+
+## Patches
+### 0.68.1
+**May 2, 2025**
+
+- Fixed a bug introduced in v0.68.0 that could prevent media from loading in media panels.

--- a/content/ref/release-notes/releases/0.68.0.md
+++ b/content/ref/release-notes/releases/0.68.0.md
@@ -1,6 +1,6 @@
 ---
 title: "0.68.x"
-date: 2025-05-02T13:45:00-07:00
+date: 2025-05-02T14:00:00-07:00
 description: "April 29, 2025"
 ---
 
@@ -8,7 +8,7 @@ W&B Server v0.68 includes enhancements to various types of panels and visualizat
 
 The latest patch is [v0.68.1]({{< relref "#0_68_1" >}}). Refer to [Patches]({{< relref "#patches" >}}). 
 
-{{% alert title="Known issue" %}}
+{{% alert %}}
 v0.68.0 introduced a bug, fixed in [v0.68.1]({{< relref "#0_68_1" >}}), that could prevent media from loading in media panels. To avoid this bug, install or upgrade to a patch that contains the fix. If you need assistance, contact [support](mailto:support@wandb.com).
 {{% /alert %}}
 

--- a/content/ref/release-notes/releases/0.68.0.md
+++ b/content/ref/release-notes/releases/0.68.0.md
@@ -1,7 +1,6 @@
 ---
 title: "0.68.x"
-date: 2025-04-29
-lastmod: 2025-05-02
+date: 2025-05-02T13:45:00-07:00
 description: "April 29, 2025"
 ---
 

--- a/content/ref/release-notes/releases/archived/_index.md
+++ b/content/ref/release-notes/releases/archived/_index.md
@@ -6,11 +6,24 @@ cascade:
 - url: /ref/release-notes/archived/:filename/
 - type: docs
 - weight: 1
-menu:
-  default:
-    parent: release-notes
-    identifier: archived-release-notes
-    weight: 99
+parent: release-notes
+identifier: archived-release-notes
+weight: 9
+outputFormats:
+  rss:
+    baseName: index
+    isHTML: false
+    isPlainText: false
+    mediaType: application/rss+xml
+    noUgly: true
+    notAlternative: false
+    path: ""
+    permalinkable: false
+    protocol: ""
+    rel: alternate
+    root: false
+    ugly: false
+    weight: 0
 ---
 Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/ref/release-notes/).
 

--- a/content/ref/release-notes/releases/archived/_index.md
+++ b/content/ref/release-notes/releases/archived/_index.md
@@ -9,21 +9,6 @@ cascade:
 parent: release-notes
 identifier: archived-release-notes
 weight: 9
-outputFormats:
-  rss:
-    baseName: index
-    isHTML: false
-    isPlainText: false
-    mediaType: application/rss+xml
-    noUgly: true
-    notAlternative: false
-    path: ""
-    permalinkable: false
-    protocol: ""
-    rel: alternate
-    root: false
-    ugly: false
-    weight: 0
 ---
 Archived releases have reached end of life and are no longer supported. A major release and its patches are supported for six months from the initial release date. Release notes for archived releases are provided for historical purposes. For supported releases, refer to [Releases](/ref/release-notes/).
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,6 +16,27 @@ enableRobotsTXT: true
 # Will give values to .Lastmod etc.
 enableGitInfo: true
 
+# Override default date priority to give more
+# control over RSS feeds.
+# - If you set `date` it overrides the page's generic date.
+# - `publishdate` is for hiding future-dated pages, but W&B
+#    is configured to publish future-dated pages, so it is
+#    less useful.
+# - If you set `lastmod` it overrides the default, which comes
+#   from Git. To update `lastmod` twice in one day, use a fully
+#   qualified date with offset from GMT, like 2025-05-02T09:45:00-07:00
+frontmatter:
+  date:
+  - date
+  - lastmod
+  - publishdate
+  - :git
+  lastmod:
+  - lastmod
+  - date
+  - publishdate
+  - :git
+
 taxonomies:
     support: support
 
@@ -134,6 +155,8 @@ outputs:
 services:
   googleAnalytics:
     id: GTM-5BL5RTH
+  RSS:
+    Limit: 20
 
 params:
   #search:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -18,21 +18,12 @@ enableGitInfo: true
 
 # Override default date priority to give more
 # control over RSS feeds.
-# - If you set `date` it overrides the page's generic date.
-# - `publishdate` is for hiding future-dated pages, but W&B
-#    is configured to publish future-dated pages, so it is
-#    less useful.
-# - If you set `lastmod` it overrides the default, which comes
-#   from Git. To update `lastmod` twice in one day, use a fully
+# - If you set `date` it overrides the item's date as gleaned from Git info
+# - Otherwise, Git info is used.
+# To update `date` for a given page twice in one day, use a fully
 #   qualified date with offset from GMT, like 2025-05-02T09:45:00-07:00
 frontmatter:
   date:
-  - date
-  - lastmod
-  - publishdate
-  - :git
-  lastmod:
-  - lastmod
   - date
   - publishdate
   - :git

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -33,9 +33,9 @@
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ .Title }} on {{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
-    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <description>Recent content {{ if eq .Title .Site.Title }}on {{ .Site.Title }}{{ else }}in {{ .Title }} on {{ .Site.Title }}{{ end }}</description>
     <generator>Hugo</generator>
     <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
     <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
@@ -52,7 +52,7 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Content | safeHTML | transform.XMLEscape }}</description>
+      <description>{{ printf "<![CDATA[" | safeHTML }}{{- printf "%s" .Content | safeHTML }}{{- printf "]]>" | safeHTML }}</description>
     </item>
     {{- end }}
   </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,59 @@
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | safeHTML | transform.XMLEscape }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
[DOCS-1475] 2 of 2: Document fix for media panel bug

- Also update the RSS feed and the site to better handle updated release notes
- Also move Release Policies to after the archive and set an explicit `date` on it so that it updates only if we intend to

Previews:
Index: https://0-68-1.docodile.pages.dev/ref/release-notes/
Feed: https://0-68-1.docodile.pages.dev/ref/release-notes/index.xml
0.68.x notes: https://0-68-1.docodile.pages.dev/ref/release-notes/0.68.0/


[DOCS-1475]: https://wandb.atlassian.net/browse/DOCS-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ