### PR TITLE
Fix version typo in 0.68.2 release notes

### DIFF
--- a/content/ref/release-notes/releases/0.68.0.md
+++ b/content/ref/release-notes/releases/0.68.0.md
@@ -67,7 +67,7 @@ Private preview features are available by invitation only. To request enrollment
 ### 0.68.2
 **May 7, 2025**
 
-- Fixed a bug introduced in v0.68.0 that could cause background jobs to crash or run inconsistently. After upgrading to v0.68.1, affected background jobs will recover automatically. If you experience issues with background jobs after upgrading, contact [Support](mailto:support@wandb.com).
+- Fixed a bug introduced in v0.68.0 that could cause background jobs to crash or run inconsistently. After upgrading to v0.68.2, affected background jobs will recover automatically. If you experience issues with background jobs after upgrading, contact [Support](mailto:support@wandb.com).
 - Fixed a long-standing UI bug where typing an invalid regular expression into the W&B App search field could crash the app. Now if you type an invalid regular expression, it is treated as a simple search string, and you can update the search field and try again.
 - Fixed a bug where the SMTP port is set to 25 instead of the port specified in `GORILLA_EMAIL_SINK`.
 - Fixed a bug where inviting a user to a team could fail with the misleading error `You have no available seats`.


### PR DESCRIPTION
Fix version typo in 0.68.2 release notes

Not updating `date` so it doesn't notify the RSS feed