### PR TITLE
Runs: Add beta parameter and argument to code sample

### DIFF
--- a/content/guides/models/track/log/distributed-training.md
+++ b/content/guides/models/track/log/distributed-training.md
@@ -118,7 +118,7 @@ Within the primary node, initialize a W&B run with [`wandb.init`]({{< relref "/r
 1. The `mode` parameter set to `"shared"` to enable shared mode.
 2. A unique label for [`x_label`](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L638). You use the value you specify for `x_label` to identify which node the data is coming from in logs and system metrics in the W&B App UI. If left unspecified, W&B creates a label for you using the hostname and a random hash.
 3. Set the [`x_primary`](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L660) parameter to `True` to indicate that this is the primary node.
-4. Optionally provide a list of GPU indices ([0,1,2]) to `x_stats_gpu_device_ids` to specify which GPUs W&B tracks metrics for. If you do not provide a list, W&B tracks metrics for all GPUs on the machine.
+4. Optionally provide a list of GPU indexes ([0,1,2]) to `x_stats_gpu_device_ids` to specify which GPUs W&B tracks metrics for. If you do not provide a list, W&B tracks metrics for all GPUs on the machine.
 
 Make note of the run ID of the primary node. Each worker node needs the run ID of the primary node.
 

--- a/content/guides/models/track/log/distributed-training.md
+++ b/content/guides/models/track/log/distributed-training.md
@@ -113,11 +113,12 @@ To track multiple processes to a single run, you must have:
 
 In this approach you use a primary node and one or more worker nodes. Within the primary node you initialize a W&B run. For each worker node, initialize a run using the run ID used by the primary node. During training each worker node logs to the same run ID as the primary node. W&B aggregates metrics from all nodes and displays them in the W&B App UI.
 
-Within the primary node, initialize a W&B run with [`wandb.init`]({{< relref "/ref/python/init.md" >}}). Pass in a `wandb.Settings` object to the `settings` parameter (`wandb.init(settings=wandb.Settings()`) wit with the following:
+Within the primary node, initialize a W&B run with [`wandb.init`]({{< relref "/ref/python/init.md" >}}). Pass in a `wandb.Settings` object to the `settings` parameter (`wandb.init(settings=wandb.Settings()`) with the following:
 
 1. The `mode` parameter set to `"shared"` to enable shared mode.
 2. A unique label for [`x_label`](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L638). You use the value you specify for `x_label` to identify which node the data is coming from in logs and system metrics in the W&B App UI. If left unspecified, W&B creates a label for you using the hostname and a random hash.
 3. Set the [`x_primary`](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L660) parameter to `True` to indicate that this is the primary node.
+4. Optionally provide a list of GPU indices ([0,1,2]) to `x_stats_gpu_device_ids` to specify which GPUs W&B tracks metrics for. If you do not provide a list, W&B tracks metrics for all GPUs on the machine.
 
 Make note of the run ID of the primary node. Each worker node needs the run ID of the primary node.
 
@@ -146,7 +147,12 @@ import wandb
 run = wandb.init(
     entity="entity",
     project="project",
-	settings=wandb.Settings(x_label="rank_0", mode="shared", x_primary=True)
+	settings=wandb.Settings(
+        x_label="rank_0", 
+        mode="shared", 
+        x_primary=True,
+        x_stats_gpu_device_ids=[0, 1],  # (Optional) Only track metrics for GPU 0 and 1
+        )
 )
 
 # Note the run ID of the primary node.


### PR DESCRIPTION
Add newly added run setting available to make it easier to restrict which devices are collecting metrics. 

Note: Ideally we'd link to the Reference Docs. However, this feature is in beta and Settings Class is not currently available in public docs. For the latter, it'll get updated when we switch to lazydocs. 

Jira ticket: https://wandb.atlassian.net/browse/DOCS-1489