### PR TITLE
[WIP POC] Try outputting Markdown and plaintext

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -146,6 +146,11 @@ outputs:
     - HTML
     - llms
     - llms-full
+  page:
+    - HTML
+    - markdown
+    - plain
+    - print
 
 outputFormats:
   llms:
@@ -156,6 +161,18 @@ outputFormats:
     mediaType: "text/plain"
     baseName: "llms-full"
     isPlainText: true
+  markdown:
+    path: "_markdown"
+    isPlainText: true
+    mediaType: text/markdown
+    suffixes:
+      - md
+  plain:
+    path: "_plain"
+    isPlainText: true
+    mediaType: text/plain
+    suffixes:
+      - txt
 
 services:
   googleAnalytics:

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,2 +1,2 @@
 # {{ .Title }}
-{{ .RawContent  }}
+{{ .RawContent }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,0 +1,2 @@
+# {{ .Title }}
+{{ .RawContent  }}

--- a/layouts/_default/single.txt
+++ b/layouts/_default/single.txt
@@ -1,4 +1,4 @@
-# {{ .Title }}
+# {{ .Title | transform.HTMLUnescape | safeHTML }}
 
-{{ .Plain | replaceRE "(.*img src=.*)" "" | replaceRE "(\n)" "\n\n" }}
+{{ .Plain | transform.HTMLUnescape | safeHTML }}
 

--- a/layouts/_default/single.txt
+++ b/layouts/_default/single.txt
@@ -1,0 +1,4 @@
+# {{ .Title }}
+
+{{ .Plain | replaceRE "(.*img src=.*)" "" | replaceRE "(\n)" "\n\n" }}
+


### PR DESCRIPTION
Requested by Morgan to mimic functionality on OpenAI's site. Very much WIP.

- Enable Markdown output for pages, to `public/_markdown`
- Enable plaintext output for pages, to `public/_plain`
- Add Markdown template, working well
- Add Plain template, nearly there.

I'm hoping someone else can take this the last mile as I'm at the edge of my capabilities on this one.

TODO:
- Plain: Insert blank lines between paras, have not quite figured out the `regexRE` invocation
- Markdown:Transform the relrefs into plain Markdown links
- Add page footer links and HTML meta tags

To test:
- Review https://try-markdown-and-text-output.docodile.pages.dev/_plain/guides/app/features/cascade-settings/index.txt (and/or other pages)
- Review https://try-markdown-and-text-output.docodile.pages.dev/_markdown/guides/app/features/cascade-settings/index.md (and/or other pages)
- Check out the branch and run `hugo serve` locally and poke around in `public/_plain/` and `public/_markdown/`.