### PR TITLE
Hugo version improvements for Cloudflare and local build environments 

### DIFF
--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -26,7 +26,7 @@ if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
         hugo -b $CF_PAGES_URL
     fi
 else
-    echo "Building locally with Hugo" $(cat .hugo-version)
+    echo "Building locally with Hugo" $(cat ".hugo-version")
     hugo
 fi
 

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -1,5 +1,8 @@
 # Run this from root by calling sh ./scripts/production.sh
 
+# Get the Hugo version for Cloudflare to use
+export HUGO_VERSION=$(cat ".hugo-version")
+
 # Build the English docs from this branch
 
 # Update Hugo if necessary
@@ -10,6 +13,7 @@ rm -rf public
 # Detect whether we are in Cloudflare
 if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
     echo "Building in Cloudflare with these variables:"
+    echo "  HUGO_VERSION: $HUGO_VERSION"
     echo "  CF_PAGES: $CF_PAGES"
     echo "  CF_PAGES_URL: $CF_PAGES_URL"
     echo "  CF_PAGES_COMMIT_SHA: $CF_PAGES_COMMIT_SHA"
@@ -22,7 +26,7 @@ if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
         hugo -b $CF_PAGES_URL
     fi
 else
-    echo "Building locally"
+    echo "Building locally with Hugo" $(cat .hugo-version)
     hugo
 fi
 

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -1,9 +1,23 @@
 # Run this from root by calling sh ./scripts/production.sh
 
-# Get the Hugo version for Cloudflare to use
-export HUGO_VERSION=$(cat ".hugo-version")
-
 # Build the English docs from this branch
+
+# Verify the Hugo version in Cloudflare and Hugo match:
+# - Cloudflare builds read wrangler.toml
+# - Local builds read .hugo-version
+
+CLOUDFLARE_HUGO_VERSION="$(grep 'HUGO_VERSION' wrangler.toml | awk -F '\"' {'print $2'})"
+LOCAL_HUGO_VERSION=$(cat ".hugo-version")
+if [ "$CLOUDFLARE_HUGO_VERSION" = "$LOCAL_HUGO_VERSION" ]; then
+    echo "Cloudflare and local Hugo versions match: $CLOUDFLARE_HUGO_VERSION. Continuing."
+else
+    echo "Cloudflare and local Hugo versions disagree:"
+    echo "    CLOUDFLARE_HUGO_VERSION from wrangler.toml: $CLOUDFLARE_HUGO_VERSION"
+    echo "    LOCAL_HUGO_VERSION from .hugo-version: $LOCAL_HUGO_VERSION"
+    echo "Giving up."
+    exit 1
+fi
+
 
 # Update Hugo if necessary
 hugo mod get -u
@@ -13,7 +27,7 @@ rm -rf public
 # Detect whether we are in Cloudflare
 if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
     echo "Building in Cloudflare with these variables:"
-    echo "  HUGO_VERSION: $HUGO_VERSION"
+    echo "  HUGO_VERSION from wrangler.toml: $CLOUDFLARE_HUGO_VERSION"
     echo "  CF_PAGES: $CF_PAGES"
     echo "  CF_PAGES_URL: $CF_PAGES_URL"
     echo "  CF_PAGES_COMMIT_SHA: $CF_PAGES_COMMIT_SHA"
@@ -26,7 +40,8 @@ if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
         hugo -b $CF_PAGES_URL
     fi
 else
-    echo "Building locally with Hugo" $(cat ".hugo-version")
+    echo "Building locally with Hugo"
+    echo "Hugo version from .hugo-version: $LOCAL_HUGO_VERSION"
     hugo
 fi
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,2 @@
+[vars]
+HUGO_VERSION=0.147.5


### PR DESCRIPTION
- Add a wrangler.toml to set the Hugo version for Cloudflare
- Check that wrangler.toml and .hugo-version files agree on the version, fail the build if not
- Add debug messages to the build log

Now, upgrading Hugo will mean updating both the .hugo-version for local builds and the wrangler.toml for Cloudflare.

Ready for review!