### PR TITLE
Enable breadcrumbs

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -496,10 +496,11 @@ h6, .td-content h6 {
   }
 }
 
-ol.breadcrumb:before {
-    content: "🏠︎" !important;
-    color: grey; filter: grayscale(100%);
-    margin-right: 10px;
+ol.breadcrumb li {
+    font-size: 13px;
+}
+ol.breadcrumb li:not(:first-child):before {
+    content: ">" !important;
 }
 
 .td-sidebar-nav__section.nav-item.dropdown {

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -230,8 +230,8 @@ params:
   # User interface configuration
   ui:
     # Set to true to disable breadcrumb navigation.
-    breadcrumb_disable: true
-    taxonomy_breadcrumb_disable: true
+    breadcrumb_disable: false
+    taxonomy_breadcrumb_disable: false
     # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top navbar
     navbar_logo: true
     # Set to true if you don't want the top navbar to be translucent when over a `block/cover`, like on the homepage.


### PR DESCRIPTION
Breadcrumbs: A useful navigational tool!

Some minor CSS customizations bring this more inline with what, say, Docusaurus produces. 

Some previews (added by Matt):
https://breadcrumbs.docodile.pages.dev/guides/runs/tags/
https://breadcrumbs.docodile.pages.dev/guides/track/
https://breadcrumbs.docodile.pages.dev/guides/models/app/settings-page/team-settings/
https://breadcrumbs.docodile.pages.dev/guides/reports/
https://breadcrumbs.docodile.pages.dev/tutorials/huggingface/
https://breadcrumbs.docodile.pages.dev/ref/release-notes/0.69.0/
https://breadcrumbs.docodile.pages.dev/ref/release-notes/release-policies/
https://breadcrumbs.docodile.pages.dev/ref/python/automations/newautomation/
https://breadcrumbs.docodile.pages.dev/support/environment-variables/
https://breadcrumbs.docodile.pages.dev/support/environment_variables_overwrite_parameters/
