### PR TITLE
Fix table of contents, consolidate fonts

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -794,6 +794,14 @@ img, iframe {
   display: block;
 }
 
+.section-index {
+    max-width: 80%;
+}
+
+.section-index .entry p {
+    margin-top: 5px;
+}
+
 @media (min-width: $breakpoint-lg) {
     img, iframe {
         max-width: 80% !important;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -117,6 +117,15 @@ body {
         background-color: $dark-bg-primary;
     }
 }
+p, td, div
+{
+    font-family: "Source Sans Pro", sans-serif;
+}
+.td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
+{
+    font-size: 16px; 
+    font-weight: $font-weight-bold;
+}
 
 // Headings
 h1, h2, h3, h4, h5, h6 {
@@ -542,27 +551,20 @@ ol.breadcrumb li:not(:first-child):before {
 }
 
 // Table of Contents Component
-#TableOfContents { 
-    margin-top: 15px;
-    font-size: 16px !important;
+#TableOfContents {
+    font-size: 13px !important;
     padding-left: 10px !important;
-
-    // Add "On this page" header
-    &:before { 
-        content: "On this page";
-        color: $text-primary;
-
-        [data-bs-theme=dark] & {
-            color: $dark-text-primary;
-        }
+    font-family: "Source Sans Pro", sans-serif;
+    a{
+        margin: 0px !important;
+        padding: 8px !important;
     }
-
     // List styles
     ul { 
-        padding-top: 10px !important;
+        padding: 0px !important;
         li {
-            padding-bottom: 10px;
-            line-height: 22px;
+            padding: 0px !important; 
+            line-height: 14px;
         }
     }
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -490,7 +490,6 @@ ol.breadcrumb li:not(:first-child):before {
 #TableOfContents {
     
     font-size: 13px !important;
-    padding-left: 10px !important;
     font-family: "Source Sans Pro", sans-serif;
     a{
         margin: 0px !important;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -462,47 +462,9 @@ h1, h2, h3, h4, h5, h6 {
     font-family: "Source Serif 4", sans-serif;
     color: $text-primary;
 }
-h1, .td-content h1 {
-    font-size: 32px !important;
-}
-h2, .td-content h2 {
-    font-size: 24px !important;
-}
-h3, .td-content h3 {
-    font-size: 20px !important;
-}
-h4, .td-content h4 {
-    font-size: 16px !important;
-}
-h5, .td-content h5 {
-    font-size: 14px !important;
-}
-h6, .td-content h6 {
-    font-size: 12px !important;
-}
+
 .td-sidebar-nav-active-item {
     text-decoration: none;
-}
-
-#m-guideshostingiamorg_team_struct-li
-
-.td-sidebar-nav, .td-navbar .nav-link  {
-  font-family: "Source Sans Pro", sans-serif;
-  a {
-    color: $text-secondary !important;
-    font-weight: $font-weight-regular;
-    text-decoration: none !important;
-    &:hover {
-      color: $link-primary !important;
-      text-decoration: none !important;
-    }
-
-    .td-sidebar-nav-active-item {
-      color: $link-primary !important;
-      text-decoration: none !important;
-      font-weight: $font-weight-medium !important;
-    }
-  }
 }
 
 ol.breadcrumb li {
@@ -512,37 +474,11 @@ ol.breadcrumb li:not(:first-child):before {
     content: ">" !important;
 }
 
-.td-sidebar-nav__section.nav-item.dropdown {
-    font-size: 14px !important;
-    color: $text-secondary !important;
-}
-
 .td-sidebar-nav__section-title, .td-sidebar-nav__section {
   margin-bottom: 10px !important;
-  margin-top: 5px !important;
-
   .nav-link.dropdown-toggle {
-    margin-left: 10px !important;
-    font-size: 14px !important;
-
-    &::after {
-      display: none !important;
-    }
+    margin-left: -5px !important;
   }
-}
-
-.td-sidebar-nav__section-title {
-    display: block;
-    font-weight: $font-weight-regular !important;
-    line-height: 19px;
-    .active {
-        font-weight: $font-weight-regular !important;
-    }
-    
-    a {
-        color: var(--bs-secondary-color);
-        font-weight: $font-weight-regular !important;
-    }
 }
 
 .td-content .lead {
@@ -552,12 +488,14 @@ ol.breadcrumb li:not(:first-child):before {
 
 // Table of Contents Component
 #TableOfContents {
+    
     font-size: 13px !important;
     padding-left: 10px !important;
     font-family: "Source Sans Pro", sans-serif;
     a{
         margin: 0px !important;
         padding: 8px !important;
+        font-weight: 500 !important;
     }
     // List styles
     ul { 
@@ -879,7 +817,7 @@ img, iframe {
     // Update sidebar nav colors for dark mode
     .td-sidebar-nav {
         a {
-            color: $dark-text-secondary !important;
+            color: $dark-text-primary !important;
             &:hover {
                 color: $dark-link-primary !important;
             }


### PR DESCRIPTION
1. The Table of Contents has uneven spacing and is very oversized; CoreWeave sets their TOC `font-size` to a bit below 13px; it's set to 13px here.
2. There is a lot of surface area where the default Docsy font, Open Sans, pokes through -- even in the main text. Source Sans Pro is used in other places -- in fact, every time we make an active choice. We shouldn't whipsaw between two reading fonts, in any case, and Source Sans Pro seems to be the preference (and, to my eyes, looks more modern/readable). So, consolidating the reading surfaces to Source Sans Pro, here.
3. The CoreWeave docs don't need an "On This Page" header above the Table of Contents and neither do we.

Pay special attention to the TOC on the right in these comparisons, but also note the more modern-looking font in the main text body: 

Before: https://docs.wandb.ai/guides/artifacts/construct-an-artifact/
After: https://styles.docodile.pages.dev/guides/artifacts/construct-an-artifact/
