### PR TITLE
[DOCS-1573] Document Azure pre-signed URL requesting username field

### DIFF
--- a/content/en/guides/hosting/data-security/presigned-urls.md
+++ b/content/en/guides/hosting/data-security/presigned-urls.md
@@ -50,4 +50,10 @@ Pre-signed URLs are the only supported blob storage access mechanism in W&B. W&B
 {{% /alert %}}
 
 ### Determine the user that requested a pre-signed URL
-When W&B returns a pre-signed URL for AWS or GCP blob storage, the `X-User` header contains the requester's username. The header is not set for Azure blob storage.
+When W&B returns a pre-signed URL, the response includes the requester's username:
+
+| Storage provider   | Response field  |
+|--------------------|-----------------|
+| AWS bucket         | `X-User` header |
+| GCP bucket         | `X-User` header |
+| Azure blob storage | `scid` query parameter |

--- a/content/en/guides/hosting/data-security/presigned-urls.md
+++ b/content/en/guides/hosting/data-security/presigned-urls.md
@@ -50,10 +50,11 @@ Pre-signed URLs are the only supported blob storage access mechanism in W&B. W&B
 {{% /alert %}}
 
 ### Determine the user that requested a pre-signed URL
-When W&B returns a pre-signed URL, the response includes the requester's username:
+### Determine the user that requested a pre-signed URL
+When W&B returns a pre-signed URL, a query parameter in the URL contains the requester's username:
 
-| Storage provider   | Response field  |
+| Storage provider   | Signed URL query parameter  |
 |--------------------|-----------------|
-| AWS bucket         | `X-User` header |
-| GCP bucket         | `X-User` header |
-| Azure blob storage | `scid` query parameter |
+| AWS S3  storage           | `X-User`  |
+| Google Cloud storage   | `X-User` |
+| Azure  blob storage       | `scid`      |

--- a/content/en/guides/hosting/data-security/presigned-urls.md
+++ b/content/en/guides/hosting/data-security/presigned-urls.md
@@ -50,7 +50,6 @@ Pre-signed URLs are the only supported blob storage access mechanism in W&B. W&B
 {{% /alert %}}
 
 ### Determine the user that requested a pre-signed URL
-### Determine the user that requested a pre-signed URL
 When W&B returns a pre-signed URL, a query parameter in the URL contains the requester's username:
 
 | Storage provider   | Signed URL query parameter  |


### PR DESCRIPTION
[DOCS-1573] Document Azure pre-signed URL requesting username field

Preview: https://docs-1573.docodile.pages.dev/guides/hosting/data-security/presigned-urls/#determine-the-user-that-requested-a-pre-signed-url

Ready for peer review


[DOCS-1573]: https://wandb.atlassian.net/browse/DOCS-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ