### PR TITLE
Revise PyTorch integration tutorial for improved readability and style

### DIFF
--- a/content/en/tutorials/integration-tutorials/pytorch.md
+++ b/content/en/tutorials/integration-tutorials/pytorch.md
@@ -20,7 +20,7 @@ This notebook shows you how to integrate Weights & Biases (W&B) with your PyTorc
 ## Background
 [PyTorch](https://pytorch.org/) is an open-source machine learning framework built for Python that provides high performance and scalability for production deployment, making it  popular for research and rapid prototyping. When you use W&B with your PyTorch projects, you can track your experiments, visualize results, and collaborate with your team in real time. Log metrics, hyperparameters, and model checkpoints to W&B as you train. Then view your results on the W&B Dashboard at [wandb.ai](http://wandb.ai).
 
-W&B helps you track everything for your PyTorch projects - model architectures, datasets, and results. With W&B, you can share discoveries with your team and stay organized when testing different models and fine tuning hyperparameters.
+W&B helps you track everything for your PyTorch projects - model architectures, datasets, and results. With W&B, you can share discoveries with your team and stay organized when you test different models and fine tune hyperparameters.
 
 ## TL;DR
 
@@ -140,7 +140,7 @@ wandb.login()
 
 3. When prompted, choose to log in with an existing account or create a new account for free. Follow the instructions to log in or complete your registration and obtain your API key.  W&B saves your credentials locally so you won't need to log in again on the same machine.
 
-If you have trouble authenticating, see the support article [How can I resolve login issues with my account?](https://docs.wandb.ai/support/resolve_login_issues_with_account/)
+If you have trouble with the authentication step, see the support article [How can I resolve login issues with my account?](https://docs.wandb.ai/support/resolve_login_issues_with_account/)
 
 ## Define your experiment and pipeline
 As a best practice, structure your machine learning experiments into clear, trackable pipelines. The experiment pipeline that we recommend comprises two phases:
@@ -148,7 +148,7 @@ As a best practice, structure your machine learning experiments into clear, trac
 1. [Set up hyperparameters and metadata](#set-up-hyperparameters-and-metadata)  
 2. [Implement the model pipeline](#implement-the-model-pipeline)
 
-This structured approach helps you maintain reproducible experiments, compare different versions and iterations of your models, and efficiently scale and debug your training workflows. You can also benefit by standardizing the experimentation process across your team, making it easier to understand what works and what doesn't in your model development process.
+This structured approach helps you maintain reproducible experiments, compare different versions and iterations of your models, and efficiently scale and debug your training workflows. You can also standardize the experimentation process across your team so it's easier to understand what works and what doesn't in your model development process.
 
 ### Set up hyperparameters and metadata
 Hyperparameters and metadata help you organize and filter your experiments later, especially when you work with different architectures or datasets within the same project. Define the hyperparameters and metadata that describe your model. You can store these settings in a configuration dictionary that you'll access throughout your training process. 
@@ -183,14 +183,14 @@ def model_pipeline(hyperparameters):
     return model
 ```
 
-When you start the experiment, W&B creates and shares the link to your new project so you can start watching the magic right away.
+When you start the experiment, W&B creates and shares the link to your new project so you can watch the magic right away.
  
 ```
 wandb: ⭐️ View project at https://wandb.ai/joemama/pytorch-demo
 wandb: 🚀 View run at https://wandb.ai/joemama/pytorch-demo/runs/abc123yz
 ```
 
-For accurate logging, get your parameters from `wandb.config`. Your model pipeline already uses `wandb.config` as `config`, so you're ready to implement this function to create your components.
+For the most accurate logging, get your parameters from `wandb.config`. Your model pipeline already uses `wandb.config` as `config`, so you're ready to implement this function to create your components.
 
 ```python
 def make(config):
@@ -209,7 +209,7 @@ def make(config):
     return model, train_loader, test_loader, criterion, optimizer
 ```
 
-The `make()` function handles several key setup tasks. It prepares the training and test datasets using `get_data()` and `make_loader()`. It also initializes the PyTorch ConvNet model and moves it to the appropriate device, and sets up the loss function (Cross-Entropy Loss) and optimizer (Adam) for model training.
+The `make()` function handles several key setup tasks. It prepares the training and test datasets with `get_data()` and `make_loader()`. It also initializes the PyTorch ConvNet model and moves it to the appropriate device, and sets up the loss function (Cross-Entropy Loss) and optimizer (Adam) for model training.
 
 **Note:** For increased resilience, W&B runs your tracking code in separate processes. If you ever lose connection, use the `wandb sync` command once you're back online to upload any missing data.
 
@@ -341,8 +341,8 @@ def train_batch(images, labels, model, optimizer, criterion):
 To log your training metrics, use `wandb.log`. The main difference between this option and and standard training loops is that, when you use `wandb.log`, you log metrics to W&B for visualization and analysis instead of printing them to your terminal. 
 
 With `wandb.log`:
-* The **keys** are strings that identify what you're logging  
-* The **values** are the metrics you want to track  
+* The **keys** are strings that identify what you want to log  
+* The **values** are the metrics that you want to track  
 * The optional **`step` parameter** logs your training progression
 
 The logging call in the following example creates visualizations in the W&B Dashboard that show the relationship between training progress and the epoch number and loss values.  
@@ -358,9 +358,9 @@ With `example_ct` (example count) as the step value, the call uses the number of
 ## Save and test your model
 Once you've trained your model, test it to find out how well it performs on data it hasn't seen before. Run your model against a fresh validation dataset or test it with examples that match your production scenarios.
 
-After testing, save your model's architecture and final parameters. To ensure compatibility across different platforms, export your model in the ONNX format. When you store your model on the W&B servers with `wandb.save()`, you can track which model files correspond to specific training runs. 
+Then save your model's architecture and final parameters. To ensure compatibility across different platforms, export your model in the ONNX format. When you store your model on the W&B servers with `wandb.save()`, you can track which model files correspond to specific training runs. 
 
-Here's how to implement testing and save your model:
+Here's how to test and save your model:
 
 ```python
 def test(model, test_loader):
@@ -400,8 +400,8 @@ model = model_pipeline(config)
 
 When you make the call:
 
-* W&B starts a new experiment, logging hyperparameters and metadata through `wandb.init()`.
-* Your model begins training, and `wandb.log()` captures metrics like loss and accuracy in real time.  
+* W&B starts a new experiment and logs hyperparameters and metadata through `wandb.init()`.
+* Your model begins to train, and `wandb.log()` captures metrics like loss and accuracy in real time.  
 * Throughout training, `wandb.watch()` tracks gradients and parameters (see the live data on the [W&B Dashboard](https://wandb.ai/)). 
 * When training completes, your model exports to ONNX format and saves to W&B.  
 * W&B then displays a summary of your experiment results.
@@ -412,7 +412,7 @@ Navigate to [wandb.ai](http://wandb.ai) to analyze the results for your model co
 Now that you've integrated Weights & Biases into your PyTorch model training pipeline, explore these additional W&B resources to further optimize your machine learning projects.
 
 ### Optimize your model with Sweeps
-While running a single experiment is useful, you'll want to try different hyperparameter combinations. [W&B Sweeps](https://docs.wandb.ai/guides/sweeps/) is a lightweight tuning tool that automates the exploration of different hyperparameter configurations. Sweeps can systematically explore various model configurations and track the results in your W&B Dashboard. This makes it easy to find the optimal hyperparameters for your PyTorch model. To learn more about running a hyperparameter sweep with Weights & Biases, see the [Organizing Hyperparameter Sweeps in PyTorch with W&B](http://wandb.me/sweeps-colab) Colab notebook.
+Now that you've run a single experiment, you'll want to try different hyperparameter combinations. [W&B Sweeps](https://docs.wandb.ai/guides/sweeps/) is a lightweight tuning tool that automates the exploration of different hyperparameter configurations. Sweeps can systematically explore various model configurations and track the results in your W&B Dashboard. This makes it easy to find the optimal hyperparameters for your PyTorch model. To learn more about how to run a hyperparameter sweep with Weights & Biases, see the [Organizing Hyperparameter Sweeps in PyTorch with W&B](http://wandb.me/sweeps-colab) Colab notebook.
 
 ### Explore advanced W&B configurations
 Weights & Biases offers advanced setup options to fit specific needs:
@@ -425,4 +425,4 @@ Explore these and other advanced features in the [W&B platform documentation](ht
 ### Browse example reports and related content
 For examples of how teams use W&B to track and visualize their machine learning projects, search the [Fully Connected blog](https://www.wandb.com/blog) for posts that showcase different W&B visualizations and use cases. 
 
-For a look at how to leverage W&B with PyTorch for debugging your models through gradient tracking and visualizations, check out the [Debugging Neural Networks with PyTorch and W&B Using Gradients and Visualizations](https://wandb.ai/wandb_fc/articles/reports/Debugging-Neural-Networks-with-PyTorch-and-W-B-Using-Gradients-and-Visualizations--Vmlldzo1NDQxNTA5?galleryTag=reinforcement-learning) article.
+For a look at how to leverage W&B with PyTorch to debug your models through gradient tracking and visualizations, check out the [Debugging Neural Networks with PyTorch and W&B Using Gradients and Visualizations](https://wandb.ai/wandb_fc/articles/reports/Debugging-Neural-Networks-with-PyTorch-and-W-B-Using-Gradients-and-Visualizations--Vmlldzo1NDQxNTA5?galleryTag=reinforcement-learning) article.

--- a/content/en/tutorials/integration-tutorials/pytorch.md
+++ b/content/en/tutorials/integration-tutorials/pytorch.md
@@ -69,7 +69,7 @@ torch.onnx.export(model, demo_input, "model.onnx")
 wandb.save("model.onnx")
 ```
 
-All metrics, gradients, and parameters that `wandb.log()` and `wandb.watch()` log appear in real-time on your [W&B dashboard](http://wandb.ai).
+All metrics, gradients, and parameters that `wandb.log()` and `wandb.watch()` log appear in real-time on your [W&B Dashboard](http://wandb.ai).
 
 # Detailed integration steps
 Read on for comprehensive steps to integrate W&B with your PyTorch code. Follow along with the [video tutorial](http://wandb.me/pytorch-video) too.
@@ -290,7 +290,7 @@ class ConvNet(nn.Module):
         return out
 ```
 
-Experiment with different architectures, layer configurations, and activation functions. You can compare the performance of each variation at [wandb.ai](https://wandb.ai) once you integrate W&B into your pipline.
+Experiment with different architectures, layer configurations, and activation functions. You can compare the performance of each variation at [wandb.ai](https://wandb.ai) once you integrate W&B into your pipeline.
 
 ## Integrate W&B into your pipeline
 To integrate W&B into your training pipeline, you'll use two key functions: 
@@ -345,7 +345,7 @@ With `wandb.log`:
 * The **values** are the metrics you want to track  
 * The optional **`step` parameter** logs your training progression
 
-The logging call in the following example creates visualizations in the W&B dashboard that show the relationship between training progress and the epoch number and loss values.  
+The logging call in the following example creates visualizations in the W&B Dashboard that show the relationship between training progress and the epoch number and loss values.  
 
 ```python
 def train_log(loss, example_ct, epoch):
@@ -402,7 +402,7 @@ When you make the call:
 
 * W&B starts a new experiment, logging hyperparameters and metadata through `wandb.init()`.
 * Your model begins training, and `wandb.log()` captures metrics like loss and accuracy in real time.  
-* Throughout training, `wandb.watch()` tracks gradients and parameters (see the live data on the W&B Dashboard). 
+* Throughout training, `wandb.watch()` tracks gradients and parameters (see the live data on the [W&B Dashboard](https://wandb.ai/)). 
 * When training completes, your model exports to ONNX format and saves to W&B.  
 * W&B then displays a summary of your experiment results.
 

--- a/content/en/tutorials/integration-tutorials/pytorch.md
+++ b/content/en/tutorials/integration-tutorials/pytorch.md
@@ -3,58 +3,85 @@ menu:
   tutorials:
     identifier: pytorch
     parent: integration-tutorials
-title: PyTorch
+title: Add Weights & Biases experiment tracking to your PyTorch projects
 weight: 1
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/pytorch/Simple_PyTorch_Integration.ipynb" >}}
 
-Use [Weights & Biases](https://wandb.com) for machine learning experiment tracking, dataset versioning, and project collaboration.
+Use [Weights & Biases](https://wandb.com) with PyTorch for machine learning experiment tracking, dataset versioning, and project collaboration.
 
-{{< img src="/images/tutorials/huggingface-why.png" alt="" >}}
+{{< img src="/images/tutorials/huggingface-why.png" alt="Feature icons for W&B tools: Experiments, Reports, Artifacts, Tables, Sweeps, Launch, and Models." >}}
 
 ## What this notebook covers
+This notebook shows you how to integrate Weights & Biases (W&B) with your PyTorch code to add experiment tracking to your machine learning pipeline.
 
-We show you how to integrate Weights & Biases with your PyTorch code to add experiment tracking to your pipeline.
+{{< img src="/images/tutorials/pytorch.png" alt="Weights & Biases dashboard showing gradient visualization graphs that track model training progress." >}}
 
-{{< img src="/images/tutorials/pytorch.png" alt="" >}}
+## Background
+[PyTorch](https://pytorch.org/) is an open-source machine learning framework built for Python that provides high performance and scalability for production deployment, making it  popular for research and rapid prototyping. When you use W&B with your PyTorch projects, you can track your experiments, visualize results, and collaborate with your team in real time. Log metrics, hyperparameters, and model checkpoints to W&B as you train. Then view your results on the W&B Dashboard at [wandb.ai](http://wandb.ai).
+
+W&B helps you track everything for your PyTorch projects - model architectures, datasets, and results. With W&B, you can share discoveries with your team and stay organized when testing different models and fine tuning hyperparameters.
+
+## TL;DR
+
+In the following sections, you'll [set up your PyTorch environment](#set-up-your-environment) for W&B integration and [log in to the W&B library](#install-wb-and-log-in). Then, you'll define your experiment, [set up your data loading and model architecture](#configure-dataloaders-and-define-your-architecture), and [integrate W&B into the pipeline](#integrate-wb-into-your-pipeline) to track gradients and log metrics.
+
+In a nutshell, the end-to-end process looks like this:
 
 ```python
-# import the library
+# Import the library
 import wandb
 
-# start a new experiment
-wandb.init(project="new-sota-model")
+# Start a new experiment
+wandb.init(project="pytorch-demo")
 
-# capture a dictionary of hyperparameters with config
-wandb.config = {"learning_rate": 0.001, "epochs": 100, "batch_size": 128}
+# Capture a dictionary of hyperparameters
+wandb.config = {
+  "learning_rate": 0.001,
+  "epochs": 100,
+  "batch_size": 128
+}
 
-# set up model and data
-model, dataloader = get_model(), get_data()
+# Set up model and data
+model = get_model()
+dataloader = get_data()
 
-# optional: track gradients
-wandb.watch(model)
+# Track gradients and parameters during training
+wandb.watch(model, log="all", log_freq=10)
 
-for batch in dataloader:
-  metrics = model.training_step()
-  # log metrics inside your training loop to visualize model performance
-  wandb.log(metrics)
+# Training loop
+for epoch in range(wandb.config.epochs):
+    for batch in dataloader:
+        # Forward pass, loss calculation, backward pass, etc.
+        loss = train_batch(batch)
+        accuracy = calculate_accuracy(batch)
+        
+        # Log metrics to visualize model performance in real-time
+        wandb.log({
+            "loss": loss.item(),
+            "accuracy": accuracy,
+            "epoch": epoch
+        })
 
-# optional: save model at the end
-model.to_onnx()
+# Save the model in ONNX format
+demo_input = torch.randn(1, 1, 28, 28, device=device)
+torch.onnx.export(model, demo_input, "model.onnx")
 wandb.save("model.onnx")
 ```
 
-Follow along with a [video tutorial](http://wandb.me/pytorch-video).
+All metrics, gradients, and parameters that `wandb.log()` and `wandb.watch()` log appear in real-time on your [W&B dashboard](http://wandb.ai).
 
-**Note**: Sections starting with _Step_ are all you need to integrate W&B in an existing pipeline. The rest just loads data and defines a model.
+# Detailed integration steps
+Read on for comprehensive steps to integrate W&B with your PyTorch code. Follow along with the [video tutorial](http://wandb.me/pytorch-video) too.
 
-## Install, import, and log in
+## Set up your environment
+Before you begin, you should already have [PyTorch and TorchVision](https://pytorch.org/get-started/) installed in your environment. The following script sets up your Python environment and PyTorch model with the configurations that you need to install W&B. If you've already configured your training pipeline, you can skip ahead to the [Installation](#install-wb-and-log-in) section. 
 
+Copy the following setup script into a new file `wandb-setup.py`:
 
 ```python
 import os
 import random
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -72,56 +99,61 @@ torch.cuda.manual_seed_all(hash("so runs are repeatable") % 2**32 - 1)
 # Device configuration
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
-# remove slow mirror from list of MNIST mirrors
-torchvision.datasets.MNIST.mirrors = [mirror for mirror in torchvision.datasets.MNIST.mirrors
-                                      if not mirror.startswith("http://yann.lecun.com")]
+# Remove slow mirror from list of MNIST mirrors
+torchvision.datasets.MNIST.mirrors = [
+    mirror
+    for mirror in torchvision.datasets.MNIST.mirrors
+    if not mirror.startswith("http://yann.lecun.com")
+]
 ```
 
-### Step 0: Install W&B
+Execute the `wandb-setup.py` file in your environment:
 
-To get started, we'll need to get the library.
-`wandb` is easily installed using `pip`.
+```bash
+python path/to/wandb-setup.py
+```
 
+The script completes the setup tasks silently. Your environment is now ready for you to install the Weights & Biases tracking code. 
+
+## Install W&B and log in
+Use `pip` to install the W&B library. We recommend that you also install ONNX if you haven't already. ONNX lets you export your model to the [Open Neural Network eXchange](https://onnx.ai/) standard format so you can deploy it across different platforms and frameworks. 
+
+Use the following command to quietly (`-q`) install or upgrade (`-U`) both packages:
+
+```bash
+pip install wandb onnx -Uq
+```
+
+Next, authenticate with Weights & Biases so that you can log data to the W&B service. 
+
+1. Import the `wandb` package:
+   
+```python
+import wandb
+```
+
+2. Then run the login command:
 
 ```python
-!pip install wandb onnx -Uq
-```
-
-### Step 1: Import W&B and Login
-
-In order to log data to our web service,
-you'll need to log in.
-
-If this is your first time using W&B,
-you'll need to sign up for a free account at the link that appears.
-
-
-```
-import wandb
-
 wandb.login()
 ```
 
-## Define the Experiment and Pipeline
+3. When prompted, choose to log in with an existing account or create a new account for free. Follow the instructions to log in or complete your registration and obtain your API key.  W&B saves your credentials locally so you won't need to log in again on the same machine.
 
-### Track metadata and hyperparameters with `wandb.init`
+If you have trouble authenticating, see the support article [How can I resolve login issues with my account?](https://docs.wandb.ai/support/resolve_login_issues_with_account/)
 
-Programmatically, the first thing we do is define our experiment:
-what are the hyperparameters? what metadata is associated with this run?
+## Define your experiment and pipeline
+As a best practice, structure your machine learning experiments into clear, trackable pipelines. The experiment pipeline that we recommend comprises two phases:
 
-It's a pretty common workflow to store this information in a `config` dictionary
-(or similar object)
-and then access it as needed.
+1. [Set up hyperparameters and metadata](#set-up-hyperparameters-and-metadata)  
+2. [Implement the model pipeline](#implement-the-model-pipeline)
 
-For this example, we're only letting a few hyperparameters vary
-and hand-coding the rest.
-But any part of your model can be part of the `config`.
+This structured approach helps you maintain reproducible experiments, compare different versions and iterations of your models, and efficiently scale and debug your training workflows. You can also benefit by standardizing the experimentation process across your team, making it easier to understand what works and what doesn't in your model development process.
 
-We also include some metadata: we're using the MNIST dataset and a convolutional
-architecture. If we later work with, say,
-fully connected architectures on CIFAR in the same project,
-this will help us separate our runs.
+### Set up hyperparameters and metadata
+Hyperparameters and metadata help you organize and filter your experiments later, especially when you work with different architectures or datasets within the same project. Define the hyperparameters and metadata that describe your model. You can store these settings in a configuration dictionary that you'll access throughout your training process. 
 
+Here's a basic configuration that you can pass into your project:
 
 ```python
 config = dict(
@@ -131,120 +163,99 @@ config = dict(
     batch_size=128,
     learning_rate=0.005,
     dataset="MNIST",
-    architecture="CNN")
+    architecture="CNN"
+)
 ```
 
-Now, let's define the overall pipeline,
-which is pretty typical for model-training:
+While this example shows just a few parameters, you can include any aspect of your model in the configuration. This flexibility allows you to track and compare different model variations as your experiments evolve.
 
-1. we first `make` a model, plus associated data and optimizer, then
-2. we `train` the model accordingly and finally
-3. `test` it to see how training went.
-
-We'll implement these functions below.
-
+### Implement the model pipeline
+Once you've defined the metadata, create a function to initialize W&B tracking, set up your model components, and execute the training and testing phases. Use the `wandb.init()` context to establish communication between your code and the W&B servers. The function passes your configuration dictionary to `wandb.init()` and W&B logs your hyperparameter values. 
 
 ```python
 def model_pipeline(hyperparameters):
-
-    # tell wandb to get started
     with wandb.init(project="pytorch-demo", config=hyperparameters):
-      # access all HPs through wandb.config, so logging matches execution.
-      config = wandb.config
-
-      # make the model, data, and optimization problem
-      model, train_loader, test_loader, criterion, optimizer = make(config)
-      print(model)
-
-      # and use them to train the model
-      train(model, train_loader, criterion, optimizer, config)
-
-      # and test its final performance
-      test(model, test_loader)
-
+        config = wandb.config
+        model, train_loader, test_loader, criterion, optimizer = make(config)
+        print(model)
+        train(model, train_loader, criterion, optimizer, config)
+        test(model, test_loader)
     return model
 ```
 
-The only difference here from a standard pipeline
-is that it all occurs inside the context of `wandb.init`.
-Calling this function sets up a line of communication
-between your code and our servers.
+When you start the experiment, W&B creates and shares the link to your new project so you can start watching the magic right away.
+ 
+```
+wandb: ⭐️ View project at https://wandb.ai/joemama/pytorch-demo
+wandb: 🚀 View run at https://wandb.ai/joemama/pytorch-demo/runs/abc123yz
+```
 
-Passing the `config` dictionary to `wandb.init`
-immediately logs all that information to us,
-so you'll always know what hyperparameter values
-you set your experiment to use.
-
-To ensure the values you chose and logged are always the ones that get used
-in your model, we recommend using the `wandb.config` copy of your object.
-Check the definition of `make` below to see some examples.
-
-> *Side Note*: We take care to run our code in separate processes,
-so that any issues on our end
-(such as if a giant sea monster attacks our data centers)
-don't crash your code.
-Once the issue is resolved, such as when the Kraken returns to the deep,
-you can log the data with `wandb sync`.
-
+For accurate logging, get your parameters from `wandb.config`. Your model pipeline already uses `wandb.config` as `config`, so you're ready to implement this function to create your components.
 
 ```python
 def make(config):
-    # Make the data
+    # Prepare your data
     train, test = get_data(train=True), get_data(train=False)
     train_loader = make_loader(train, batch_size=config.batch_size)
     test_loader = make_loader(test, batch_size=config.batch_size)
 
-    # Make the model
+    # Make your model
     model = ConvNet(config.kernels, config.classes).to(device)
 
-    # Make the loss and optimizer
+    # Set up loss function and optimizer
     criterion = nn.CrossEntropyLoss()
-    optimizer = torch.optim.Adam(
-        model.parameters(), lr=config.learning_rate)
-    
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+
     return model, train_loader, test_loader, criterion, optimizer
 ```
 
-### Define the Data Loading and Model
+The `make()` function handles several key setup tasks. It prepares the training and test datasets using `get_data()` and `make_loader()`. It also initializes the PyTorch ConvNet model and moves it to the appropriate device, and sets up the loss function (Cross-Entropy Loss) and optimizer (Adam) for model training.
 
-Now, we need to specify how the data is loaded and what the model looks like.
+**Note:** For increased resilience, W&B runs your tracking code in separate processes. If you ever lose connection, use the `wandb sync` command once you're back online to upload any missing data.
 
-This part is very important, but it's
-no different from what it would be without `wandb`,
-so we won't dwell on it.
+## Configure DataLoaders and define your architecture
+While W&B helps you track your experiments, your core PyTorch components remain unchanged. The following sections show an example of how you might set up your data loading and model architecture. If you've already prepared your data and architecture for PyTorch model training, you can skip ahead to [Integrate W&B into your pipeline](#integrate-wb-into-your-pipeline).
 
+### Prepare your data for PyTorch model training
+Before you start training, use the `get_data()` and `make_loader()` PyTorch functions to load your datasets and set up your PyTorch DataLoaders.
+
+The `get_data()` function prepares the training and test datasets.
 
 ```python
 def get_data(slice=5, train=True):
-    full_dataset = torchvision.datasets.MNIST(root=".",
-                                              train=train, 
-                                              transform=transforms.ToTensor(),
-                                              download=True)
-    #  equiv to slicing with [::slice] 
+    # Load and preprocess MNIST dataset
+    full_dataset = torchvision.datasets.MNIST(
+        root=".", 
+        train=train, 
+        transform=transforms.ToTensor(), 
+        download=True
+    )
+    # Create subset of data with specified slice
     sub_dataset = torch.utils.data.Subset(
-      full_dataset, indices=range(0, len(full_dataset), slice))
-    
+        full_dataset, 
+        indices=range(0, len(full_dataset), 
+        slice)
+    )
     return sub_dataset
+```
 
+The `make_loader()` function sets up the PyTorch DataLoaders.
 
+```python
 def make_loader(dataset, batch_size):
-    loader = torch.utils.data.DataLoader(dataset=dataset,
-                                         batch_size=batch_size, 
-                                         shuffle=True,
-                                         pin_memory=True, num_workers=2)
+    # Configure DataLoader with specified batch size
+    loader = torch.utils.data.DataLoader(
+        dataset=dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        pin_memory=True,
+        num_workers=2,
+    )
     return loader
 ```
 
-Defining the model is normally the fun part.
-
-But nothing changes with `wandb`,
-so we're gonna stick with a standard ConvNet architecture.
-
-Don't be afraid to mess around with this and try some experiments --
-all your results will be logged on [wandb.ai](https://wandb.ai).
-
-
-
+### Define the model architecture
+Next, define your model architecture. This example uses a standard ConvNet, but you can modify the architecture to experiment with different approaches. 
 
 ```python
 # Conventional and convolutional neural network
@@ -252,130 +263,110 @@ all your results will be logged on [wandb.ai](https://wandb.ai).
 class ConvNet(nn.Module):
     def __init__(self, kernels, classes=10):
         super(ConvNet, self).__init__()
-        
+
+        # First convolutional layer
         self.layer1 = nn.Sequential(
             nn.Conv2d(1, kernels[0], kernel_size=5, stride=1, padding=2),
             nn.ReLU(),
-            nn.MaxPool2d(kernel_size=2, stride=2))
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        # Second convolutional layer
         self.layer2 = nn.Sequential(
             nn.Conv2d(16, kernels[1], kernel_size=5, stride=1, padding=2),
             nn.ReLU(),
-            nn.MaxPool2d(kernel_size=2, stride=2))
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        # Fully connected output layer
         self.fc = nn.Linear(7 * 7 * kernels[-1], classes)
-        
+
     def forward(self, x):
         out = self.layer1(x)
         out = self.layer2(out)
         out = out.reshape(out.size(0), -1)
         out = self.fc(out)
+
         return out
 ```
 
-### Define Training Logic
+Experiment with different architectures, layer configurations, and activation functions. You can compare the performance of each variation at [wandb.ai](https://wandb.ai) once you integrate W&B into your pipline.
 
-Moving on in our `model_pipeline`, it's time to specify how we `train`.
+## Integrate W&B into your pipeline
+To integrate W&B into your training pipeline, you'll use two key functions: 
+* **[wandb.watch()](#track-gradients-and-parameters-with-wandbwatch)** to track model gradients and parameters  
+* **[wandb.log()](#log-metrics-with-wandblog)** to track everything else
 
-Two `wandb` functions come into play here: `watch` and `log`.
-
-## Track gradients with `wandb.watch` and everything else with `wandb.log`
-
-`wandb.watch` will log the gradients and the parameters of your model,
-every `log_freq` steps of training.
-
-All you need to do is call it before you start training.
-
-The rest of the training code remains the same:
-we iterate over epochs and batches,
-running forward and backward passes
-and applying our `optimizer`.
-
+### Track gradients and parameters with `wandb.watch()`
+To keep track of the gradients and parameters for your model, call `wandb.watch()` before you start training. The `log_freq` parameter controls how often W&B logs these metrics. Once you've set up tracking, your training loop runs just like normal - iterating through epochs and batches, computing forward and backward passes, and updating weights with your optimizer.
 
 ```python
 def train(model, loader, criterion, optimizer, config):
-    # Tell wandb to watch what the model gets up to: gradients, weights, and more.
+    # Track model gradients and parameters
     wandb.watch(model, criterion, log="all", log_freq=10)
 
-    # Run training and track with wandb
+    # Initialize tracking variables
     total_batches = len(loader) * config.epochs
-    example_ct = 0  # number of examples seen
+    example_ct = 0  # number of examples processed
     batch_ct = 0
+
     for epoch in tqdm(range(config.epochs)):
         for _, (images, labels) in enumerate(loader):
-
             loss = train_batch(images, labels, model, optimizer, criterion)
-            example_ct +=  len(images)
+            example_ct += len(images)
             batch_ct += 1
 
-            # Report metrics every 25th batch
+            # Log metrics every 25 batches
             if ((batch_ct + 1) % 25) == 0:
                 train_log(loss, example_ct, epoch)
 
-
 def train_batch(images, labels, model, optimizer, criterion):
     images, labels = images.to(device), labels.to(device)
-    
-    # Forward pass ➡
+
+    # Forward pass
     outputs = model(images)
     loss = criterion(outputs, labels)
-    
-    # Backward pass ⬅
+
+    # Backward pass
     optimizer.zero_grad()
     loss.backward()
 
-    # Step with optimizer
+    # Update weights
     optimizer.step()
 
     return loss
 ```
 
-The only difference is in the logging code:
-where previously you might have reported metrics by printing to the terminal,
-now you pass the same information to `wandb.log`.
+### Log metrics with `wandb.log()`
+To log your training metrics, use `wandb.log`. The main difference between this option and and standard training loops is that, when you use `wandb.log`, you log metrics to W&B for visualization and analysis instead of printing them to your terminal. 
 
-`wandb.log` expects a dictionary with strings as keys.
-These strings identify the objects being logged, which make up the values.
-You can also optionally log which `step` of training you're on.
+With `wandb.log`:
+* The **keys** are strings that identify what you're logging  
+* The **values** are the metrics you want to track  
+* The optional **`step` parameter** logs your training progression
 
-> *Side Note*: I like to use the number of examples the model has seen,
-since this makes for easier comparison across batch sizes,
-but you can use raw steps or batch count. For longer training runs, it can also make sense to log by `epoch`.
-
+The logging call in the following example creates visualizations in the W&B dashboard that show the relationship between training progress and the epoch number and loss values.  
 
 ```python
 def train_log(loss, example_ct, epoch):
-    # Where the magic happens
     wandb.log({"epoch": epoch, "loss": loss}, step=example_ct)
     print(f"Loss after {str(example_ct).zfill(5)} examples: {loss:.3f}")
 ```
 
-### Define Testing Logic
+With `example_ct` (example count) as the step value, the call uses the number of processed examples as the step count. This is useful to compare across different batch sizes. You can also use batch count or epochs. For longer training runs, it might be more appropriate to log by epoch.
 
-Once the model is done training, we want to test it:
-run it against some fresh data from production, perhaps,
-or apply it to some hand-curated examples.
+## Save and test your model
+Once you've trained your model, test it to find out how well it performs on data it hasn't seen before. Run your model against a fresh validation dataset or test it with examples that match your production scenarios.
 
+After testing, save your model's architecture and final parameters. To ensure compatibility across different platforms, export your model in the ONNX format. When you store your model on the W&B servers with `wandb.save()`, you can track which model files correspond to specific training runs. 
 
-
-## (Optional) Call `wandb.save`
-
-This is also a great time to save the model's architecture
-and final parameters to disk.
-For maximum compatibility, we'll `export` our model in the
-[Open Neural Network eXchange (ONNX) format](https://onnx.ai/).
-
-Passing that filename to `wandb.save` ensures that the model parameters
-are saved to W&B's servers: no more losing track of which `.h5` or `.pb`
-corresponds to which training runs.
-
-For more advanced `wandb` features for storing, versioning, and distributing
-models, check out our [Artifacts tools](https://www.wandb.com/artifacts).
-
+Here's how to implement testing and save your model:
 
 ```python
 def test(model, test_loader):
     model.eval()
 
-    # Run the model on some test examples
+    # Test your model's performance
     with torch.no_grad():
         correct, total = 0, 0
         for images, labels in test_loader:
@@ -385,74 +376,53 @@ def test(model, test_loader):
             total += labels.size(0)
             correct += (predicted == labels).sum().item()
 
-        print(f"Accuracy of the model on the {total} " +
-              f"test images: {correct / total:%}")
-        
+        print(
+            f"Accuracy of the model on the {total} "
+            + f"test images: {correct / total:%}"
+        )
+
         wandb.log({"test_accuracy": correct / total})
 
-    # Save the model in the exchangeable ONNX format
+    # Save your model in ONNX format
     torch.onnx.export(model, images, "model.onnx")
     wandb.save("model.onnx")
 ```
 
-### Run training and watch your metrics live on wandb.ai
+To download the saved ONNX model, navigate to the **Files** tab on your [W&B Dashboard](https://wandb.ai/). For advanced model management options for your machine learning assets (including model storage, versioning, and distribution), explore the [W&B Artifacts](https://www.wandb.com/artifacts) tools.
 
-Now that we've defined the whole pipeline and slipped in
-those few lines of W&B code,
-we're ready to run our fully tracked experiment.
-
-We'll report a few links to you:
-our documentation,
-the Project page, which organizes all the runs in a project, and
-the Run page, where this run's results will be stored.
-
-Navigate to the Run page and check out these tabs:
-
-1. **Charts**, where the model gradients, parameter values, and loss are logged throughout training
-2. **System**, which contains a variety of system metrics, including Disk I/O utilization, CPU and GPU metrics (watch that temperature soar), and more
-3. **Logs**, which has a copy of anything pushed to standard out during training
-4. **Files**, where, once training is complete, you can click on the `model.onnx` to view our network with the [Netron model viewer](https://github.com/lutzroeder/netron).
-
-Once the run in finished, when the `with wandb.init` block exits,
-we'll also print a summary of the results in the cell output.
-
+## Run your experiment and analyze the results
+Now that you've built your PyTorch model pipeline and added W&B tracking, call `model_pipeline(config)` to run your experiment with full instrumentation.
 
 ```python
-# Build, train and analyze the model with the pipeline
+# Build, train, and analyze the model with the pipeline
 model = model_pipeline(config)
 ```
 
-### Test Hyperparameters with Sweeps
+When you make the call:
 
-We only looked at a single set of hyperparameters in this example.
-But an important part of most ML workflows is iterating over
-a number of hyperparameters.
+* W&B starts a new experiment, logging hyperparameters and metadata through `wandb.init()`.
+* Your model begins training, and `wandb.log()` captures metrics like loss and accuracy in real time.  
+* Throughout training, `wandb.watch()` tracks gradients and parameters (see the live data on the W&B Dashboard). 
+* When training completes, your model exports to ONNX format and saves to W&B.  
+* W&B then displays a summary of your experiment results.
 
-You can use Weights & Biases Sweeps to automate hyperparameter testing and explore the space of possible models and optimization strategies.
+Navigate to [wandb.ai](http://wandb.ai) to analyze the results for your model configuration on the W&B Dashboard. For more information on navigating your project in the W&B Dashboard, see the [Projects](https://docs.wandb.ai/guides/track/project-page/) documentation.
 
-## [Check out Hyperparameter Optimization in PyTorch using W&B Sweeps](http://wandb.me/sweeps-colab)
+## Next steps
+Now that you've integrated Weights & Biases into your PyTorch model training pipeline, explore these additional W&B resources to further optimize your machine learning projects.
 
-Running a hyperparameter sweep with Weights & Biases is very easy. There are just 3 simple steps:
+### Optimize your model with Sweeps
+While running a single experiment is useful, you'll want to try different hyperparameter combinations. [W&B Sweeps](https://docs.wandb.ai/guides/sweeps/) is a lightweight tuning tool that automates the exploration of different hyperparameter configurations. Sweeps can systematically explore various model configurations and track the results in your W&B Dashboard. This makes it easy to find the optimal hyperparameters for your PyTorch model. To learn more about running a hyperparameter sweep with Weights & Biases, see the [Organizing Hyperparameter Sweeps in PyTorch with W&B](http://wandb.me/sweeps-colab) Colab notebook.
 
-1. **Define the sweep:** We do this by creating a dictionary or a [YAML file]({{< relref "/guides/models/sweeps/define-sweep-configuration" >}}) that specifies the parameters to search through, the search strategy, the optimization metric et all.
+### Explore advanced W&B configurations
+Weights & Biases offers advanced setup options to fit specific needs:
+* **[Environment variables](https://docs.wandb.ai/guides/hosting/env-vars/):** Set your W&B API keys in environment variables to run training on a managed cluster or CI/CD pipeline.  
+* **[Offline mode](https://docs.wandb.ai/support/run_wandb_offline/):** Use the "dryrun" mode to train your models offline, then sync the results to W&B later when you're connected.  
+* **[On-prem installations](https://docs.wandb.ai/guides/hosting/hosting-options/self-managed/):** For enterprise users or those with strict data governance requirements, install W&B in your own private cloud or air-gapped infrastructure.
 
-2. **Initialize the sweep:** 
-`sweep_id = wandb.sweep(sweep_config)`
+Explore these and other advanced features in the [W&B platform documentation](https://docs.wandb.ai/guides/hosting).
 
-3. **Run the sweep agent:** 
-`wandb.agent(sweep_id, function=train)`
+### Browse example reports and related content
+For examples of how teams use W&B to track and visualize their machine learning projects, search the [Fully Connected blog](https://www.wandb.com/blog) for posts that showcase different W&B visualizations and use cases. 
 
-That's all there is to running a hyperparameter sweep.
-
-{{< img src="/images/tutorials/pytorch-2.png" alt="" >}}
-
-
-## Example Gallery
-
-See examples of projects tracked and visualized with W&B in our [Gallery →](https://app.wandb.ai/gallery)
-
-## Advanced Setup
-1. [Environment variables]({{< relref "/guides/hosting/env-vars/" >}}): Set API keys in environment variables so you can run training on a managed cluster.
-2. [Offline mode]({{< relref "/support/kb-articles/run_wandb_offline.md" >}}): Use `dryrun` mode to train offline and sync results later.
-3. [On-prem]({{< relref "/guides/hosting/hosting-options/self-managed" >}}): Install W&B in a private cloud or air-gapped servers in your own infrastructure. We have local installations for everyone from academics to enterprise teams.
-4. [Sweeps]({{< relref "/guides/models/sweeps/" >}}): Set up hyperparameter search quickly with our lightweight tool for tuning.
+For a look at how to leverage W&B with PyTorch for debugging your models through gradient tracking and visualizations, check out the [Debugging Neural Networks with PyTorch and W&B Using Gradients and Visualizations](https://wandb.ai/wandb_fc/articles/reports/Debugging-Neural-Networks-with-PyTorch-and-W-B-Using-Gradients-and-Visualizations--Vmlldzo1NDQxNTA5?galleryTag=reinforcement-learning) article.


### PR DESCRIPTION
This commit introduces a significant revision to the PyTorch integration with W&B tutorial.

- Revised the title to be task-based and descriptive
- Added alt text for images
- Added a bit more context to "What this notebook covers"
- Added a "Background" section 
- Added context to the random block of code that previews the E2E process
- Reorganized content flow for a more logical progression
- Called out prerequisites and linked to PyTorch installation instructions
- Added troubleshooting link for authentication issues
- Clarified that the PyTorch-side setup was just a recommended approach
- Defeated the Kraken (it put up a fight!)
- Improved code samples with better comments and language tags
- Edited the example project name to be more intuitive (pytorch-demo)
- Highlighted that W&B conveniently provides dashboard URLs on init
- Changed "Define Training Logic" section to an H2 "Integrate W&B into your pipeline"  
- Shifted focus to the main W&B integration points watch/log
- Aligned terminology with PyTorch conventions (eg, "DataLoader")
- Deleted not-evergreen descriptions of the dashboard and linked to the Projects docs instead
- Created a What's next? section for advanced topics
- Checked and removed all the dead links a the end and added links to related content
- Edited for Google Dev Style 

Technical Qs flagged for dev review:

1. In the ConvNet class definition, there's a hardcoded value of `16` that might cause an error if the first kernel size is anything other than 16. Should it perhaps be:  nn.Conv2d(kernels[0], kernels[1], kernel_size=5, stride=1, padding=2),

2. In the test function, the ONNX export might not be ideal. Several review tools recommended to create a dedicated input tensor for ONNX export rather than using the last batch.