### PR TITLE
Add redirect for a URL used in a marketing page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -113,6 +113,7 @@
 /guides/comparing-runs/ /guides/runs/ 301
 /guides/config/ /guides/sweeps/define-sweep-configuration/ 301
 /guides/configurations/ /guides/track/config/ 301
+/guides/core/registry/model_registry/model-registry-automations/ /guides/core/automations/ 301
 /guides/data-and-model-versioning/dataset-versioning/ /guides/artifacts/ 301
 /guides/data-and-model-versioning/intro/ / 301
 /guides/data-and-model-versioning/model-versioning/ /guides/core/registry/ 301


### PR DESCRIPTION
From /guides/core/registry/model_registry/model-registry-automations to /guides/core/automations/ Ref: https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1749825032634899

Ready for review