### PR TITLE
CAIOS Reference Artifacts Docs

### DIFF
--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -8,21 +8,21 @@ title: Track external files
 weight: 7
 ---
 
-Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon Simple Storage Service (S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
+Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon Simple Storage Service (Amazon S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
 
-W&B logs metadata about the externally stored object, such as its ETag, size, and version ID if object versioning is enabled on the bucket. Reference artifact metadata does not leave your system.
+W&B logs metadata about the the object, such as the object's ETag and size. If object versioning is enabled on the bucket, the version ID is also logged.
 
 {{% alert %}}
-W&B saves an artifact's files to W&B servers when you log an artifact that does not track external files. This is the default behavior when you log artifacts with the W&B Python SDK.
+If you log an artifact that does not track external files, W&B saves the artifact's files to W&B servers. This is the default behavior when you log artifacts with the W&B Python SDK.
 
-See the [Artifacts start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
+See the [Artifacts quickstart]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
 {{% /alert %}}
 
 The following describes how to construct reference artifacts.
 
 ## Track an artifact in an external bucket
 
-Use the W&B Python SDK to track references to files in your CoreWeave AI Object Storage/S3/GCS/Azure bucket. 
+Use the W&B Python SDK to track references to files stored outside of W&B.
 
 1. Initialize a run with `wandb.init()`.
 2. Create an artifact object with `wandb.Artifact()`.
@@ -143,7 +143,7 @@ W&B uses the default mechanism to look for credentials based on the cloud provid
 
 | Cloud provider | Credentials Documentation |
 | -------------- | ------------------------- |
-| CoreWeave AI Object Storage (CoreWeave AI Object Storage)| [CoreWeave AI Object Storage documentation](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/manage-access-keys/cloud-console-tokens) |
+| CoreWeave AI Object Storage | [CoreWeave AI Object Storage documentation](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/manage-access-keys/cloud-console-tokens) |
 | AWS            | [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) |
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |
@@ -153,7 +153,7 @@ For AWS, if the bucket is not located in the configured user's default region, y
 {{% alert color="secondary" %}}
 Rich media such as images, audio, video, and point clouds may fail to render in the App UI depending on the CORS configuration of your bucket. Allow listing **app.wandb.ai** in your bucket's CORS settings will allow the App UI to properly render such rich media.
 
-If rich media such as images, audio, video, and point clouds does not render in the App UI, you may need to allowlist `app.wandb.ai` in your bucket's CORS policy.
+If rich media such as images, audio, video, and point clouds does not render in the App UI, ensure that `app.wandb.ai` is allowlisted in your bucket's CORS policy.
 {{% /alert %}}
 
 ## Track an artifact in a filesystem
@@ -184,7 +184,7 @@ run.log_artifact(artifact)
 By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
 {{% /alert %}}
 
-Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second begins the path to the dataset, `/mount/datasets/mnist/`.
+Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second component begins the path to the dataset, `/mount/datasets/mnist/`.
 
 The resulting artifact `mnist:latest` looks and acts like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
 
@@ -200,7 +200,7 @@ artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
 artifact_dir = artifact.download()
 ```
 
-For a filesystem reference, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` is copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
+For a filesystem reference, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` are copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
 
 Putting it all together, you can use the following code to track a dataset under a mounted filesystem that feeds into a training job:
 

--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -8,21 +8,21 @@ title: Track external files
 weight: 7
 ---
 
-Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage (CAIOS), an Amazon Simple Storage Service (S3) bucket, GCS bucket, Azure blob, HTTP file server, or an NFS share.
+Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon Simple Storage Service (S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
 
-W&B logs metadata about the CAIOS/S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket). Reference artifact metadata does not leave your system. 
+W&B logs metadata about the externally stored object, such as its ETag, size, and version ID if object versioning is enabled on the bucket. Reference artifact metadata does not leave your system.
 
 {{% alert %}}
-Non reference artifacts save artifacts (such as the model and metadata associated for that model) to W&B Servers, and are the default behavior when you log artifacts with the W&B Python SDK.
+W&B saves an artifact's files to W&B servers when you log an artifact that does not track external files. This is the default behavior when you log artifacts with the W&B Python SDK.
 
-See the [Quick start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
+See the [Artifacts start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
 {{% /alert %}}
 
-The following describes how to construct reference artifacts and how to incorporate them into your workflows.
+The following describes how to construct reference artifacts.
 
 ## Track an artifact in an external bucket
 
-Use the W&B Python SDK to track references to files in your CAIOS/S3/GCS/Azure bucket. 
+Use the W&B Python SDK to track references to files in your CoreWeave AI Object Storage/S3/GCS/Azure bucket. 
 
 1. Initialize a run with `wandb.init()`.
 2. Create an artifact object with `wandb.Artifact()`.
@@ -46,9 +46,9 @@ run.log_artifact(artifact)
 run.finish()
 ```
 
-Suppose you have a bucket with the following directory structure in your Amazon S3 bucket:
+Suppose your bucket has the following directory structure:
 
-```bash
+```text
 s3://my-bucket
 
 |datasets/
@@ -57,7 +57,7 @@ s3://my-bucket
   |---- cnn/
 ```
 
-Within `mnist/` is a collection of images. Track the your images dataset with `wandb.Artifact.add_reference()`:
+The `datasets/mnist/` directory contains a collection of images. Track the directory as a dataset with `wandb.Artifact.add_reference()`. The following code sample creates a reference artifact `mnist:latest` using the artifact object's `add_reference()` method.
 
 ```python
 import wandb
@@ -69,7 +69,7 @@ run.log_artifact(artifact)
 run.finish()
 ```
 
-The previous code sample creates a reference artifact `mnist:latest`. Within the W&B App, you can look through the contents of the reference artifact using the file browser, [explore the full dependency graph]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph" >}}), and scan through the versioned history of your artifact. The W&B App does not render rich media such as images, audio, and so forth because the data itself is not contained within the artifact.
+Within the W&B App, you can look through the contents of the reference artifact using the file browser, [explore the full dependency graph]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph" >}}), and scan through the versioned history of your artifact. The W&B App does not render rich media such as images, audio, and so forth because the data itself is not contained within the artifact.
 
 {{% alert %}}
 W&B Artifacts support any Amazon S3 compatible interface, including MinIO. The scripts described below work as-is with MinIO, when you set the `AWS_S3_ENDPOINT_URL` environment variable to point at your MinIO server.
@@ -81,9 +81,9 @@ By default, W&B imposes a 10,000 object limit when adding an object prefix. You 
 
 ## Download an artifact from an external bucket
 
-W&B uses the metadata recorded when the artifact was logged to retrieve the files from the underlying bucket when it downloads a reference artifact. If your bucket has object versioning enabled, W&B will retrieve the object version corresponding to the state of the file at the time an artifact was logged. This means that as you evolve the contents of your bucket, you can still point to the exact iteration of your data a given model was trained on since the artifact serves as a snapshot of your bucket at the time of training.
+W&B  retrieves the files from the underlying bucket when it downloads a reference artifact using the metadata recorded when the artifact is logged. If your bucket has object versioning enabled, W&B retrieves the object version that corresponds to the state of the file at the time an artifact was logged. As you evolve the contents of your bucket, you can always point to the exact version of your data a given model was trained on,  because the artifact serves as a snapshot of your bucket during the training run.
 
-The following code sample shows how to download a reference artifact. Note that the the APIs for downloading artifacts are the same for both reference and non-reference artifacts:
+The following code sample shows how to download a reference artifact. The the APIs for downloading artifacts are the same for both reference and non-reference artifacts:
 
 ```python
 import wandb
@@ -101,7 +101,7 @@ Based on your use case, read the instructions to enable object versioning: [AWS]
 
 ### Add and download an external reference example
 
-The following code snippet shows how to upload a dataset to an Amazon S3 bucket, track it with a reference artifact, and how to download the artifact:
+The following code sample uploads a dataset to an Amazon S3 bucket, tracks it with a reference artifact, then downloads it:
 
 ```python
 import boto3
@@ -133,7 +133,7 @@ datadir = artifact.download()
 {{% alert %}}
 See the following reports for an end-to-end walkthrough on how to track artifacts by reference for GCP or Azure:
 
-* [Guide to Tracking Artifacts by Reference](https://wandb.ai/stacey/artifacts/reports/Tracking-Artifacts-by-Reference--Vmlldzo1NDMwOTE)
+* [Guide to Tracking Artifacts by Reference with GCP](https://wandb.ai/stacey/artifacts/reports/Tracking-Artifacts-by-Reference--Vmlldzo1NDMwOTE)
 * [Working with Reference Artifacts in Microsoft Azure](https://wandb.ai/andrea0/azure-2023/reports/Efficiently-Harnessing-Microsoft-Azure-Blob-Storage-with-Weights-Biases--Vmlldzo0NDA2NDgw)
 {{% /alert %}}
 
@@ -143,7 +143,7 @@ W&B uses the default mechanism to look for credentials based on the cloud provid
 
 | Cloud provider | Credentials Documentation |
 | -------------- | ------------------------- |
-| CoreWeave AI Object Storage (CAIOS)| [CAIOS documentation](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/manage-access-keys) |
+| CoreWeave AI Object Storage (CoreWeave AI Object Storage)| [CoreWeave AI Object Storage documentation](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/manage-access-keys/cloud-console-tokens) |
 | AWS            | [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) |
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |
@@ -153,7 +153,7 @@ For AWS, if the bucket is not located in the configured user's default region, y
 {{% alert color="secondary" %}}
 Rich media such as images, audio, video, and point clouds may fail to render in the App UI depending on the CORS configuration of your bucket. Allow listing **app.wandb.ai** in your bucket's CORS settings will allow the App UI to properly render such rich media.
 
-Panels might fail to render in the App UI for private buckets. If your company has a VPN, you could update your bucket's access policy to whitelist IPs within your VPN.
+If rich media such as images, audio, video, and point clouds does not render in the App UI, you may need to allowlist `app.wandb.ai` in your bucket's CORS policy.
 {{% /alert %}}
 
 ## Track an artifact in a filesystem
@@ -184,11 +184,11 @@ run.log_artifact(artifact)
 By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
 {{% /alert %}}
 
-Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second is the path to the dataset, `/mount/datasets/mnist/`.
+Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second begins the path to the dataset, `/mount/datasets/mnist/`.
 
 The resulting artifact `mnist:latest` looks and acts like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
 
-You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI will not be able to render rich media such as images, audio, etc. as the data itself is not contained within the artifact.
+You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI cannot render rich media such as images, audio, because the data itself is not contained within the artifact.
 
 Downloading a reference artifact:
 
@@ -200,7 +200,7 @@ artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
 artifact_dir = artifact.download()
 ```
 
-For filesystem references, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` is copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error as the artifact can no longer be reconstructed.
+For a filesystem reference, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` is copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
 
 Putting it all together, you can use the following code to track a dataset under a mounted filesystem that feeds into a training job:
 
@@ -223,7 +223,7 @@ artifact_dir = artifact.download()
 # Perform training here...
 ```
 
-To track models, log the model artifact after the training script writes the model files to the mount point:
+To track a model, log the model artifact after the training script writes the model files to the mount point:
 
 ```python
 import wandb

--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -1,6 +1,5 @@
 ---
-description: Track files saved outside the W&B such as in an CoreWeave AI Object Storage, Amazon S3 bucket, GCS
-  bucket, HTTP file server, or even an NFS share.
+description: Track files saved in an external bucket, HTTP file server, or an NFS share.
 menu:
   default:
     identifier: track-external-files
@@ -9,53 +8,124 @@ title: Track external files
 weight: 7
 ---
 
-Use **reference artifacts** to track files saved outside the W&B server, for example in CoreWeave AI Object Storage, an Amazon S3 bucket, GCS bucket, Azure blob, HTTP file server, or even an NFS share. Reference artifacts store metadata about the files, such as URLs, size, and checksums locally on your machine. Reference artifact metadata does not leaves your system. 
+Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon S3 bucket, GCS bucket, Azure blob, HTTP file server, or an NFS share.
+
+W&B logs metadata about the CAIOS/S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket). Reference artifact metadata does not leave your system. 
+
+{{% alert %}}
+Non reference artifacts save artifacts (such as the model and metadata associated for that model) to W&B Servers, and are the default behavior when you log artifacts with the W&B Python SDK.
 
 See the [Quick start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
+{{% /alert %}}
 
 The following describes how to construct reference artifacts and how to incorporate them into your workflows.
 
-## CAOIS/ Amazon S3 / GCS / Azure Blob Storage References
+## Track an artifact in an external bucket
 
-Use [W&B Artifacts]({{< relref "/guides/core/artifacts/_index" >}}) for dataset and model versioning to track references in cloud storage buckets. With artifact references, seamlessly layer tracking on top of your buckets with no modifications to your existing storage layout.
-
-Artifacts abstract away the underlying cloud storage vendor (such CoreWeave, AWS, GCP or Azure). Information described in the following sections apply uniformly to CoreWeave AI Object Storage (CAIOS), Amazon S3, Google Cloud Storage and Azure Blob Storage.
-
-{{% alert %}}
-W&B Artifacts support any Amazon S3 compatible interface, including MinIO. The scripts below work as-is, when you set the `AWS_S3_ENDPOINT_URL` environment variable to point at your MinIO server.
-{{% /alert %}}
-
-Suppose you have a bucket with the following structure in your S3 bucket:
-
-```bash
-s3://my-bucket
-
-| datasets/
-  |-- mnist/
-| models/
-  |-- cnn/
-```
-
-Within `mnist/` is a collection of images. You can track the your images dataset with an artifact with the W&B Python SDK:
+Use the W&B Python SDK to track references to files in your CAIOS/S3/GCS/Azure bucket. First, initialize a run, next create an artifact object, add a reference to the bucket path with `wandb.Artifact.add_reference()`. Finally, log the artifact with `run.log_artifact()`.
 
 ```python
 import wandb
 
 run = wandb.init()
-artifact = wandb.Artifact("mnist", type="dataset")
-artifact.add_reference("s3://my-bucket/datasets/mnist")
+artifact = wandb.Artifact(name="name", type="type")
+artifact.add_reference(uri = "uri/to/your/bucket/path")
 run.log_artifact(artifact)
 run.finish()
 ```
-{{% alert color="secondary" %}}
-By default, W&B imposes a 10,000 object limit when adding an object prefix. You can adjust this limit by specifying `max_objects=` in calls to `add_reference`.
+
+Suppose you have a bucket with the following directory structure in your Amazon S3 bucket:
+
+```bash
+s3://my-bucket
+
+|datasets/
+  |---- mnist/
+|models/
+  |---- cnn/
+```
+
+Within `mnist/` is a collection of images. Track the your images dataset with `wandb.Artifact.add_reference()`:
+
+```python
+import wandb
+
+run = wandb.init()
+artifact = wandb.Artifact(name="mnist", type="dataset")
+artifact.add_reference(uri="s3://my-bucket/datasets/mnist")
+run.log_artifact(artifact)
+run.finish()
+```
+
+The previous code sample creates a reference artifact `mnist:latest`. Within the W&B App, you can look through the contents of the reference artifact using the file browser, [explore the full dependency graph]({{< relref "/guides/core/artifacts/explore-and-traverse-an-artifact-graph" >}}), and scan through the versioned history of your artifact. The W&B App does not render rich media such as images, audio, and so forth because the data itself is not contained within the artifact.
+
+{{% alert %}}
+W&B Artifacts support any Amazon S3 compatible interface, including MinIO. The scripts described below work as-is with MinIO, when you set the `AWS_S3_ENDPOINT_URL` environment variable to point at your MinIO server.
 {{% /alert %}}
 
-This creates a reference artifact `mnist:latest` that looks and behaves similarly to a regular artifact. Unlike a regular artifact, the reference artifacts only log metadata about the CW/S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket).
+{{% alert color="secondary" %}}
+By default, W&B imposes a 10,000 object limit when adding an object prefix. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
+{{% /alert %}}
 
-Interact with this artifact similarly to a normal artifact. In the App UI, you can look through the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact.
+## Download an artifact from an external bucket
 
-## Storage credentials
+W&B uses the metadata recorded when the artifact was logged to retrieve the files from the underlying bucket when it downloads a reference artifact. If your bucket has object versioning enabled, W&B will retrieve the object version corresponding to the state of the file at the time an artifact was logged. This means that as you evolve the contents of your bucket, you can still point to the exact iteration of your data a given model was trained on since the artifact serves as a snapshot of your bucket at the time of training.
+
+The following code sample shows how to download a reference artifact. Note that the the APIs for downloading artifacts are the same for both reference and non-reference artifacts:
+
+```python
+import wandb
+
+run = wandb.init()
+artifact = run.use_artifact("mnist:latest", type="dataset")
+artifact_dir = artifact.download()
+```
+
+{{% alert %}}
+W&B recommends that you enable 'Object Versioning' on your storage buckets if you overwrite files as part of your workflow. With versioning enabled on your buckets, artifacts with references to files that have been overwritten will still be intact because the older object versions are retained. 
+
+Based on your use case, read the instructions to enable object versioning: [AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html), [GCP](https://cloud.google.com/storage/docs/using-object-versioning#set), [Azure](https://learn.microsoft.com/azure/storage/blobs/versioning-enable).
+{{% /alert %}}
+
+### Add and download an external reference example
+
+The following code snippet shows how to upload a dataset to an Amazon S3 bucket, track it with a reference artifact, and how to download the artifact:
+
+```python
+import boto3
+import wandb
+
+run = wandb.init()
+
+# Training here...
+
+s3_client = boto3.client("s3")
+s3_client.upload_file(file_name="my_model.h5", bucket="my-bucket", object_name="models/cnn/my_model.h5")
+
+# Log the model artifact
+model_artifact = wandb.Artifact("cnn", type="model")
+model_artifact.add_reference("s3://my-bucket/models/cnn/")
+run.log_artifact(model_artifact)
+```
+
+At a later point, you can download the model artifact. Specify the name of the artifact and its type:
+
+```python
+import wandb
+
+run = wandb.init()
+artifact = run.use_artifact(artifact_or_name = "cnn", type="model")
+datadir = artifact.download()
+```
+
+{{% alert %}}
+See the following reports for an end-to-end walkthrough on how to track artifacts by reference for GCP or Azure:
+
+* [Guide to Tracking Artifacts by Reference](https://wandb.ai/stacey/artifacts/reports/Tracking-Artifacts-by-Reference--Vmlldzo1NDMwOTE)
+* [Working with Reference Artifacts in Microsoft Azure](https://wandb.ai/andrea0/azure-2023/reports/Efficiently-Harnessing-Microsoft-Azure-Blob-Storage-with-Weights-Biases--Vmlldzo0NDA2NDgw)
+{{% /alert %}}
+
+## Cloud storage credentials
 
 W&B uses the default mechanism to look for credentials based on the cloud provider you use. Read the documentation from your cloud provider to learn more about the credentials used:
 
@@ -74,72 +144,7 @@ Rich media such as images, audio, video, and point clouds may fail to render in 
 Panels might fail to render in the App UI for private buckets. If your company has a VPN, you could update your bucket's access policy to whitelist IPs within your VPN.
 {{% /alert %}}
 
-## Download a reference artifact
-
-```python
-import wandb
-
-run = wandb.init()
-artifact = run.use_artifact("mnist:latest", type="dataset")
-artifact_dir = artifact.download()
-```
-
-W&B uses the metadata recorded when the artifact was logged to retrieve the files from the underlying bucket when it downloads a reference artifact. If your bucket has object versioning enabled, W&B will retrieve the object version corresponding to the state of the file at the time an artifact was logged. This means that as you evolve the contents of your bucket, you can still point to the exact iteration of your data a given model was trained on since the artifact serves as a snapshot of your bucket at the time of training.
-
-{{% alert %}}
-W&B recommends that you enable 'Object Versioning' on your storage buckets if you overwrite files as part of your workflow. With versioning enabled on your buckets, artifacts with references to files that have been overwritten will still be intact because the older object versions are retained. 
-
-Based on your use case, read the instructions to enable object versioning: [AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html), [GCP](https://cloud.google.com/storage/docs/using-object-versioning#set), [Azure](https://learn.microsoft.com/azure/storage/blobs/versioning-enable).
-{{% /alert %}}
-
-## Tying it together
-
-The following code snippet shows how to track a dataset in an S3 bucket that is used in a training job:
-
-```python
-import wandb
-
-run = wandb.init()
-
-artifact = wandb.Artifact("mnist", type="dataset")
-artifact.add_reference("s3://my-bucket/datasets/mnist")
-
-# Track the artifact and mark it as an input to
-# this run in one swoop. A new artifact version
-# is only logged if the files in the bucket changed.
-run.use_artifact(artifact)
-
-artifact_dir = artifact.download()
-
-# Perform training here...
-```
-
-To track models, log the model artifact after the training script uploads the model files to the bucket:
-
-```python
-import boto3
-import wandb
-
-run = wandb.init()
-
-# Training here...
-
-s3_client = boto3.client("s3")
-s3_client.upload_file("my_model.h5", "my-bucket", "models/cnn/my_model.h5")
-
-model_artifact = wandb.Artifact("cnn", type="model")
-model_artifact.add_reference("s3://my-bucket/models/cnn/")
-run.log_artifact(model_artifact)
-```
-
-{{% alert %}}
-See the following reports for an end-to-end walkthrough on how to track artifacts by reference for GCP or Azure:
-
-* [Guide to Tracking Artifacts by Reference](https://wandb.ai/stacey/artifacts/reports/Tracking-Artifacts-by-Reference--Vmlldzo1NDMwOTE)
-* [Working with Reference Artifacts in Microsoft Azure](https://wandb.ai/andrea0/azure-2023/reports/Efficiently-Harnessing-Microsoft-Azure-Blob-Storage-with-Weights-Biases--Vmlldzo0NDA2NDgw)
-{{% /alert %}}
-
-## Filesystem references
+## Track an artifact in a filesystem
 
 Another common pattern for fast access to datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an even simpler solution than a cloud storage bucket because from the perspective of the training script, the files look just like they are sitting on your local filesystem. Luckily, that ease of use extends into using Artifacts to track references to file systems, whether they are mounted or not.
 
@@ -147,10 +152,10 @@ Suppose you have a filesystem mounted at `/mount` with the following structure:
 
 ```bash
 mount
-+-- datasets/
-|		+-- mnist/
-+-- models/
-		+-- cnn/
+|datasets/
+		|-- mnist/
+|models/
+		|-- cnn/
 ```
 
 Within `mnist/` is a dataset, a collection of images. You can track it with an artifact:
@@ -164,12 +169,12 @@ artifact.add_reference("file:///mount/datasets/mnist/")
 run.log_artifact(artifact)
 ```
 {{% alert color="secondary" %}}
-By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` in calls to `add_reference`.
+By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
 {{% /alert %}}
 
 Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second is the path to the dataset, `/mount/datasets/mnist/`.
 
-The resulting artifact `mnist:latest` looks and acts just like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
+The resulting artifact `mnist:latest` looks and acts like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
 
 You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI will not be able to render rich media such as images, audio, etc. as the data itself is not contained within the artifact.
 

--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -131,7 +131,7 @@ W&B uses the default mechanism to look for credentials based on the cloud provid
 
 | Cloud provider | Credentials Documentation |
 | -------------- | ------------------------- |
-| CoreWeave AI Object Storage (CAIOS)| [CAIOS documentation](https://docs.coreweave.com/docs/products/storage/object-storage/concepts/policies) |
+| CoreWeave AI Object Storage (CAIOS)| [CAIOS documentation](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/manage-access-keys) |
 | AWS            | [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) |
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |

--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -1,5 +1,5 @@
 ---
-description: Track files saved outside the W&B such as in an Amazon S3 bucket, GCS
+description: Track files saved outside the W&B such as in an CoreWeave AI Object Storage, Amazon S3 bucket, GCS
   bucket, HTTP file server, or even an NFS share.
 menu:
   default:
@@ -9,38 +9,23 @@ title: Track external files
 weight: 7
 ---
 
-Use **reference artifacts** to track files saved outside the W&B system, for example in an Amazon S3 bucket, GCS bucket, Azure blob, HTTP file server, or even an NFS share. Log artifacts outside of a [W&B Run]({{< relref "/ref/python/run" >}}) with the W&B [CLI]({{< relref "/ref/cli" >}}).
+Use **reference artifacts** to track files saved outside the W&B server, for example in CoreWeave AI Object Storage, an Amazon S3 bucket, GCS bucket, Azure blob, HTTP file server, or even an NFS share. Reference artifacts store metadata about the files, such as URLs, size, and checksums locally on your machine. Reference artifact metadata does not leaves your system. 
 
-### Log artifacts outside of runs
+See the [Quick start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
 
-W&B creates a run when you log an artifact outside of a run. Each artifact belongs to a run, which in turn belongs to a project. An artifact (version) also belongs to a collection, and has a type.
+The following describes how to construct reference artifacts and how to incorporate them into your workflows.
 
-Use the [`wandb artifact put`]({{< relref "/ref/cli/wandb-artifact/wandb-artifact-put" >}}) command to upload an artifact to the W&B server outside of a W&B run. Provide the name of the project you want the artifact to belong to along with the name of the artifact (`project/artifact_name`).Optionally provide the type (`TYPE`). Replace `PATH` in the code snippet below with the file path of the artifact you want to upload.
+## CAOIS/ Amazon S3 / GCS / Azure Blob Storage References
 
-```bash
-$ wandb artifact put --name project/artifact_name --type TYPE PATH
-```
+Use [W&B Artifacts]({{< relref "/guides/core/artifacts/_index" >}}) for dataset and model versioning to track references in cloud storage buckets. With artifact references, seamlessly layer tracking on top of your buckets with no modifications to your existing storage layout.
 
-W&B will create a new project if a the project you specify does not exist. For information on how to download an artifact, see [Download and use artifacts]({{< relref "/guides/core/artifacts/download-and-use-an-artifact" >}}).
-
-## Track artifacts outside of W&B
-
-Use W&B Artifacts for dataset versioning and model lineage, and use **reference artifacts** to track files saved outside the W&B server. In this mode an artifact only stores metadata about the files, such as URLs, size, and checksums. The underlying data never leaves your system. See the [Quick start]({{< relref "/guides/core/artifacts/artifacts-walkthrough" >}}) for information on how to save files and directories to W&B servers instead.
-
-The following describes how to construct reference artifacts and how to best incorporate them into your workflows.
-
-### Amazon S3 / GCS / Azure Blob Storage References
-
-Use W&B Artifacts for dataset and model versioning to track references in cloud storage buckets. With artifact references, seamlessly layer tracking on top of your buckets with no modifications to your existing storage layout.
-
-
-Artifacts abstract away the underlying cloud storage vendor (such AWS, GCP or Azure). Information described in the proceeding section apply uniformly to Amazon S3, Google Cloud Storage and Azure Blob Storage.
+Artifacts abstract away the underlying cloud storage vendor (such CoreWeave, AWS, GCP or Azure). Information described in the following sections apply uniformly to CoreWeave AI Object Storage (CAIOS), Amazon S3, Google Cloud Storage and Azure Blob Storage.
 
 {{% alert %}}
 W&B Artifacts support any Amazon S3 compatible interface, including MinIO. The scripts below work as-is, when you set the `AWS_S3_ENDPOINT_URL` environment variable to point at your MinIO server.
 {{% /alert %}}
 
-Assume we have a bucket with the following structure:
+Suppose you have a bucket with the following structure:
 
 ```bash
 s3://my-bucket
@@ -50,7 +35,7 @@ s3://my-bucket
 		+-- cnn/
 ```
 
-Under `mnist/` we have our dataset, a collection of images. Lets track it with an artifact:
+Within `mnist/` is a collection of images. You can track the dataset with an artifact:
 
 ```python
 import wandb
@@ -59,17 +44,21 @@ run = wandb.init()
 artifact = wandb.Artifact("mnist", type="dataset")
 artifact.add_reference("s3://my-bucket/datasets/mnist")
 run.log_artifact(artifact)
+run.finish()
 ```
 {{% alert color="secondary" %}}
 By default, W&B imposes a 10,000 object limit when adding an object prefix. You can adjust this limit by specifying `max_objects=` in calls to `add_reference`.
 {{% /alert %}}
 
-Our new reference artifact `mnist:latest` looks and behaves similarly to a regular artifact. The only difference is that the artifact only consists of metadata about the S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket).
+This creates a reference artifact `mnist:latest` that looks and behaves similarly to a regular artifact. The only difference is that the artifact only consists of metadata about the CW/S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket).
 
-W&B will use the default mechanism to look for credentials based on the cloud provider you use. Read the documentation from your cloud provider to learn more about the credentials used:
+## Storage credentials
+
+W&B uses the default mechanism to look for credentials based on the cloud provider you use. Read the documentation from your cloud provider to learn more about the credentials used:
 
 | Cloud provider | Credentials Documentation |
 | -------------- | ------------------------- |
+| CoreWeave AI Object Storage (CAIOS)| [CAIOS documentation](https://docs.coreweave.com/docs/products/storage/object-storage/concepts/policies) |
 | AWS            | [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) |
 | GCP            | [Google Cloud documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc) |
 | Azure          | [Azure documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) |
@@ -84,7 +73,7 @@ Rich media such as images, audio, video, and point clouds may fail to render in 
 Panels might fail to render in the App UI for private buckets. If your company has a VPN, you could update your bucket's access policy to whitelist IPs within your VPN.
 {{% /alert %}}
 
-### Download a reference artifact
+## Download a reference artifact
 
 ```python
 import wandb
@@ -102,7 +91,7 @@ W&B recommends that you enable 'Object Versioning' on your storage buckets if yo
 Based on your use case, read the instructions to enable object versioning: [AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html), [GCP](https://cloud.google.com/storage/docs/using-object-versioning#set), [Azure](https://learn.microsoft.com/azure/storage/blobs/versioning-enable).
 {{% /alert %}}
 
-### Tying it together
+## Tying it together
 
 The following code example demonstrates a simple workflow you can use to track a dataset in Amazon S3, GCS, or Azure that feeds into a training job:
 
@@ -124,7 +113,7 @@ artifact_dir = artifact.download()
 # Perform training here...
 ```
 
-To track models, we can log the model artifact after the training script uploads the model files to the bucket:
+To track models, log the model artifact after the training script uploads the model files to the bucket:
 
 ```python
 import boto3
@@ -149,11 +138,11 @@ Read through the following reports for an end-to-end walkthrough of how to track
 * [Working with Reference Artifacts in Microsoft Azure](https://wandb.ai/andrea0/azure-2023/reports/Efficiently-Harnessing-Microsoft-Azure-Blob-Storage-with-Weights-Biases--Vmlldzo0NDA2NDgw)
 {{% /alert %}}
 
-### Filesystem References
+## Filesystem references
 
 Another common pattern for fast access to datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an even simpler solution than a cloud storage bucket because from the perspective of the training script, the files look just like they are sitting on your local filesystem. Luckily, that ease of use extends into using Artifacts to track references to file systems, whether they are mounted or not.
 
-Assume we have a filesystem mounted at `/mount` with the following structure:
+Suppose you have a filesystem mounted at `/mount` with the following structure:
 
 ```bash
 mount
@@ -163,7 +152,7 @@ mount
 		+-- cnn/
 ```
 
-Under `mnist/` we have our dataset, a collection of images. Let's track it with an artifact:
+Within `mnist/` is a dataset, a collection of images. Let's track it with an artifact:
 
 ```python
 import wandb
@@ -176,13 +165,13 @@ run.log_artifact(artifact)
 
 By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` in calls to `add_reference`.
 
-Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second is the path to our dataset, `/mount/datasets/mnist/`.
+Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second is the path to the dataset, `/mount/datasets/mnist/`.
 
 The resulting artifact `mnist:latest` looks and acts just like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
 
 You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI will not be able to render rich media such as images, audio, etc. as the data itself is not contained within the artifact.
 
-Downloading a reference artifact is simple:
+Downloading a reference artifact:
 
 ```python
 import wandb
@@ -192,9 +181,9 @@ artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
 artifact_dir = artifact.download()
 ```
 
-For filesystem references, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` will be copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error as the artifact can no longer be reconstructed.
+For filesystem references, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` is copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error as the artifact can no longer be reconstructed.
 
-Putting everything together, here's a simple workflow you can use to track a dataset under a mounted filesystem that feeds into a training job:
+Putting it all together, you can use the following code to track a dataset under a mounted filesystem that feeds into a training job:
 
 ```python
 import wandb
@@ -215,7 +204,7 @@ artifact_dir = artifact.download()
 # Perform training here...
 ```
 
-To track models, we can log the model artifact after the training script writes the model files to the mount point:
+To track models, log the model artifact after the training script writes the model files to the mount point:
 
 ```python
 import wandb
@@ -230,3 +219,18 @@ model_artifact = wandb.Artifact("cnn", type="model")
 model_artifact.add_reference("file:///mount/cnn/my_model.h5")
 run.log_artifact(model_artifact)
 ```
+
+
+<!-- Log artifacts outside of a [W&B Run]({{< relref "/ref/python/run" >}}) with the W&B [CLI]({{< relref "/ref/cli" >}}). -->
+
+<!-- ### Log artifacts outside of runs
+
+W&B creates a run when you log an artifact outside of a run. Each artifact belongs to a run, which in turn belongs to a project. An artifact (version) also belongs to a collection, and has a type.
+
+Use the [`wandb artifact put`]({{< relref "/ref/cli/wandb-artifact/wandb-artifact-put" >}}) command to upload an artifact to the W&B server outside of a W&B run. Provide the name of the project you want the artifact to belong to along with the name of the artifact (`project/artifact_name`).Optionally provide the type (`TYPE`). Replace `PATH` in the code snippet below with the file path of the artifact you want to upload.
+
+```bash
+$ wandb artifact put --name project/artifact_name --type TYPE PATH
+```
+
+W&B will create a new project if a the project you specify does not exist. For information on how to download an artifact, see [Download and use artifacts]({{< relref "/guides/core/artifacts/download-and-use-an-artifact" >}}). -->

--- a/content/en/guides/core/artifacts/track-external-files.md
+++ b/content/en/guides/core/artifacts/track-external-files.md
@@ -8,7 +8,7 @@ title: Track external files
 weight: 7
 ---
 
-Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon S3 bucket, GCS bucket, Azure blob, HTTP file server, or an NFS share.
+Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage (CAIOS), an Amazon Simple Storage Service (S3) bucket, GCS bucket, Azure blob, HTTP file server, or an NFS share.
 
 W&B logs metadata about the CAIOS/S3/GCS/Azure object such as its ETag, size, and version ID (if object versioning is enabled on the bucket). Reference artifact metadata does not leave your system. 
 
@@ -22,14 +22,26 @@ The following describes how to construct reference artifacts and how to incorpor
 
 ## Track an artifact in an external bucket
 
-Use the W&B Python SDK to track references to files in your CAIOS/S3/GCS/Azure bucket. First, initialize a run, next create an artifact object, add a reference to the bucket path with `wandb.Artifact.add_reference()`. Finally, log the artifact with `run.log_artifact()`.
+Use the W&B Python SDK to track references to files in your CAIOS/S3/GCS/Azure bucket. 
+
+1. Initialize a run with `wandb.init()`.
+2. Create an artifact object with `wandb.Artifact()`.
+3. Specify the reference to the bucket path with the artifact object's `add_reference()` method.
+4. Log the artifact's metadata with `run.log_artifact()`.
 
 ```python
 import wandb
 
+# Initialize a W&B run
 run = wandb.init()
+
+# Create an artifact object
 artifact = wandb.Artifact(name="name", type="type")
+
+# Add a reference to the bucket path
 artifact.add_reference(uri = "uri/to/your/bucket/path")
+
+# Log the artifact's metadata
 run.log_artifact(artifact)
 run.finish()
 ```


### PR DESCRIPTION
Tentative release date: next SDK release ~(7/1)

Mostly updates existing docs on tracking, downloading external artifacts (reference artifacts).  

Docs preview: https://caois-reference-artifacts.docodile.pages.dev/guides/artifacts/track-external-files/

PR: https://wandb.atlassian.net/browse/DOCS-1622

@anmolmann: I tagged you in the two locations where CAIOS is relevant.
@mdlinville: Most of the edits here is aimed to make the doc less confusing, redundant. There is more work to be done here like (maybe) combining info on buckets and filesystems into one section. But that's for a later PR.