### PR TITLE
Try again to prevent launch-library/ links from showing up in the nav with broken links

### DIFF
--- a/content/en/guides/integrations/yolov5.md
+++ b/content/en/guides/integrations/yolov5.md
@@ -9,7 +9,7 @@ weight: 470
 
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/yolo/Train_and_Debug_YOLOv5_Models_with_Weights_%26_Biases_.ipynb" >}}
 
-[Ultralytics' YOLOv5](https://ultralytics.com/yolov5) ("You Only Look Once") model family enables real-time object detection with convolutional neural networks without all the agonizing pain.
+[Ultralytics' YOLOv5](https://ultralytics.com/yolo) ("You Only Look Once") model family enables real-time object detection with convolutional neural networks without all the agonizing pain.
 
 [Weights & Biases](http://wandb.com) is directly integrated into YOLOv5, providing experiment metric tracking, model and dataset versioning, rich model prediction visualization, and more. **It's as easy as running a single `pip install` before you run your YOLO experiments.**
 

--- a/content/en/launch-library/_index.md
+++ b/content/en/launch-library/_index.md
@@ -4,8 +4,10 @@ menu:
   launch:
     identifier: launch-library
 type: docs
+hidden: true
 cascade:
   type: docs
+  hidden: true
   menu:
     launch-library:
       parent: launch-library

--- a/content/en/ref/python/data-types/table.md
+++ b/content/en/ref/python/data-types/table.md
@@ -25,7 +25,7 @@ This means you can embed `Images`, `Video`, `Audio`, and other sorts of rich, an
 directly in Tables, alongside other traditional scalar values.
 
 This class is the primary class used to generate the Table Visualizer
-in the UI: https://docs.wandb.ai/guides/data-vis/tables.
+in the UI: https://docs.wandb.ai/guides/models/tables/.
 
 | Args |  |
 | :--- | :--- |

--- a/content/ja/guides/integrations/yolov5.md
+++ b/content/ja/guides/integrations/yolov5.md
@@ -9,7 +9,7 @@ weight: 470
 
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/yolo/Train_and_Debug_YOLOv5_Models_with_Weights_%26_Biases_.ipynb" >}}
 
-[Ultralytics' YOLOv5](https://ultralytics.com/yolov5) ("You Only Look Once") モデルファミリーは、畳み込みニューラルネットワークを使用したリアルタイムのオブジェクト検出を、苦痛なく実現します。
+[Ultralytics' YOLOv5](https://ultralytics.com/yolo) ("You Only Look Once") モデルファミリーは、畳み込みニューラルネットワークを使用したリアルタイムのオブジェクト検出を、苦痛なく実現します。
 
 [Weights & Biases](http://wandb.com) は YOLOv5 に直接インテグレーションされており、実験のメトリクス追跡、モデルとデータセットのバージョン管理、リッチなモデル予測の可視化などを提供します。**YOLO の実験を実行する前に `pip install` 一行を実行するだけで始められます。**
 

--- a/content/ko/guides/integrations/yolov5.md
+++ b/content/ko/guides/integrations/yolov5.md
@@ -9,7 +9,7 @@ weight: 470
 
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/yolo/Train_and_Debug_YOLOv5_Models_with_Weights_%26_Biases_.ipynb" >}}
 
-[Ultralytics' YOLOv5](https://ultralytics.com/yolov5) ("You Only Look Once") 모델 제품군은 고통스러운 과정 없이 컨볼루션 신경망을 통해 실시간 오브젝트 검출을 가능하게 합니다.
+[Ultralytics' YOLOv5](https://ultralytics.com/yolo) ("You Only Look Once") 모델 제품군은 고통스러운 과정 없이 컨볼루션 신경망을 통해 실시간 오브젝트 검출을 가능하게 합니다.
 
 [Weights & Biases](http://wandb.com)는 YOLOv5에 직접 통합되어 실험 메트릭 추적, 모델 및 데이터셋 버전 관리, 풍부한 모델 예측 시각화 등을 제공합니다. **YOLO 실험을 실행하기 전에 간단히 `pip install` 한 번만 실행하면 됩니다.**
 

--- a/content/ko/ref/python/data-types/table.md
+++ b/content/ko/ref/python/data-types/table.md
@@ -19,7 +19,7 @@ Table(
 기존 스프레드시트와 달리 Tables는 다양한 유형의 데이터를 지원합니다. 스칼라 값, 문자열, numpy 배열 및 `wandb.data_types.Media`의 대부분의 서브클래스가 해당됩니다.
 즉, 다른 기존 스칼라 값과 함께 `Images`, `Video`, `Audio` 및 기타 종류의 풍부하고 주석이 달린 미디어를 Tables에 직접 포함할 수 있습니다.
 
-이 클래스는 UI에서 Table Visualizer를 생성하는 데 사용되는 기본 클래스입니다. https://docs.wandb.ai/guides/data-vis/tables/ 를 참조하세요.
+이 클래스는 UI에서 Table Visualizer를 생성하는 데 사용되는 기본 클래스입니다. https://docs.wandb.ai/guides/models/tables/ 를 참조하세요.
 
 | 인수 |  |
 | :--- | :--- |


### PR DESCRIPTION
After #1397 the same `launch-library/` links are still failing. I believe it is actually links within the left nav that are breaking. To prevent a page from showing in the nav you set `hidden: true`. This sets it on the index and its children.

- Also fixes outbound link to https://www.ultralytics.com/yolo
- Also manually fixes links in Python reference to go to /guides/models/tables instead of /guides/data-vis/tables/ until the upstream reference link is fixed.

Test: https://github.com/wandb/docs/actions/runs/15745284135 (0 errors)