### PR TITLE
[DOCS-1576] Clarify that you can pin columns only from the Runs tab

### DIFF
--- a/content/en/guides/models/track/project-page.md
+++ b/content/en/guides/models/track/project-page.md
@@ -116,6 +116,10 @@ The proceeding tabs demonstrate some common actions you can take in the Runs tab
    {{% tab header="Customize columns" %}}
 The Runs tab shows details about runs in the project. It shows a large number of columns by default.
 
+{{% alert %}}
+When you customize the Runs tab, the customization is also reflected in the **Runs** selector of the [Workspace tab]({{< relref "#workspace-tab" >}}).
+{{% /alert %}}
+
 - To view all visible columns, scroll the page horizontally.
 - To change the order of the columns, drag a column to the left or right.
 - To pin a column, hover over the column name, click the action menu `...`. that appears, then click **Pin column**. Pinned columns appear near the left of the page, after the **Name** column. To unpin a pinned column, choose **Unpin column**
@@ -125,7 +129,6 @@ The Runs tab shows details about runs in the project. It shows a large number of
   - Click the name of a visible column to hide it.
   - Click the pin icon next to a visible column to pin it.
 
-When you customize the Runs tab, the customization is also reflected in the **Runs** selector of the [Workspace tab]({{< relref "#workspace-tab" >}}).
    {{% /tab %}}
 
    {{% tab header="Sort" %}}

--- a/content/en/guides/models/track/runs/_index.md
+++ b/content/en/guides/models/track/runs/_index.md
@@ -341,7 +341,7 @@ https://wandb.ai/<team-name>/<project-name>/runs/<run-id>
 Where values enclosed in angle brackets (`< >`) are placeholders for the actual values of the team name, project name, and run ID.
 
 ### Customize how runs are displayed
-You can customize how runs are displayed in your project from the **Workspace** or **Runs** tabs. Both tabs use the same display configuration.
+This section shows how to customize how runs are displayed in your project's **Workspace** and **Runs** tab, which share the same display configuration.
 
 {{% alert %}}
 A workspace is limited to displaying a maximum of 1000 runs, regardless of its configuration.
@@ -349,6 +349,7 @@ A workspace is limited to displaying a maximum of 1000 runs, regardless of its c
 
 
 To customize which columns are visible:
+1. In the project sidebar, navigate to the **Runs** tab.
 1. Above the list of runs, click **Columns**.
 1. Click the name of a hidden column to show it. Click the name of a visible column to hide it.
   
@@ -360,9 +361,16 @@ To sort the list of runs by any visible column:
 1. Hover over the column name, then click its action `...` menu.
 1. Click **Sort ascending** or **Sort descending**.
 
-Pinned columns are shown on the right-hand side. To pin or unpin a column:
+Pinned columns are shown on the right-hand side. Unpinned columns are shown on the left-hand side of the **Runs** tab and are not shown on the **Workspace** tab.
+
+To pin a column:
+1. In the project sidebar, navigate to the **Runs** tab.
+1. Click **Pin column**.
+
+To unpin a column:
+1. In the project sidebar, navigate to the **Workspace** or **Runs** tab.
 1. Hover over the column name, then click its action `...` menu.
-1. Click **Pin column** or **Unpin column**.
+1. Click **Unpin column**.
 
 By default, long run names are truncated in the middle for readability. To customize the truncation of run names:
 


### PR DESCRIPTION
[DOCS-1576] Clarify that you can pin columns only from the Runs tab

Ready for peer review

Preview:
- https://docs-1516.docodile.pages.dev/guides/runs/#customize-how-runs-are-displayed
- https://docs-1516.docodile.pages.dev/guides/track/project-page/#runs-tab

[DOCS-1576]: https://wandb.atlassian.net/browse/DOCS-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ