### PR TITLE
[DOCS-1543] Workspace templates are now GA

### DIFF
--- a/content/en/_includes/workspace-templates-private-preview-feature.md
+++ b/content/en/_includes/workspace-templates-private-preview-feature.md
@@ -1,1 +1,0 @@
-This feature requires an [Enterprise](https://wandb.ai/site/pricing/) license. For **Dedicated Cloud** and **Self-Hosted**, this feature is in **private preview**, available by invitation only. To request enrollment, contact [support](mailto:support@wandb.com) or your AISE.

--- a/content/en/guides/models/app/features/cascade-settings.md
+++ b/content/en/guides/models/app/features/cascade-settings.md
@@ -21,7 +21,7 @@ To edit settings that apply to the overall structure of this workspace:
 {{< img src="/images/app_ui/workspace_settings.png" alt="" >}}
 
 {{% alert %}}
-After customizing your workspace, you can use _workspace templates_ to quickly create new workspaces with the same settings. Refer to [Workspace templates]({{< relref "content/en/guides/models/track/workspaces.md#workspace-templates" >}}).
+After customizing your workspace, you can use _workspace templates_ to quickly create new workspaces with the same settings. Refer to [Workspace templates]({{< relref "/guides/models/track/workspaces.md#workspace-templates" >}}).
 {{% /alert %}}
 
 ### Workspace layout options

--- a/content/en/guides/models/app/features/cascade-settings.md
+++ b/content/en/guides/models/app/features/cascade-settings.md
@@ -9,9 +9,6 @@ url: guides/app/features/cascade-settings
 
 Within a given workspace page there are three different setting levels: workspaces, sections, and panels. [Workspace settings]({{< relref "#workspace-settings" >}}) apply to the entire workspace. [Section settings]({{< relref "#section-settings" >}}) apply to all panels within a section. [Panel settings]({{< relref "#panel-settings" >}}) apply to individual panels. 
 
-
-
-
 ## Workspace settings
 
 Workspace settings apply to all sections and all panels within those sections. You can edit two types of workspace settings: [**Workspace layout**]({{< relref "#workspace-layout-options" >}}) and [**Line plots**]({{< relref "#line-plots-options" >}}). **Workspace layouts** determine the structure of the workspace, while **Line plots** settings control the default settings for line plots in the workspace.
@@ -22,6 +19,10 @@ To edit settings that apply to the overall structure of this workspace:
 2. Click the gear icon next to the **New report** button to view the workspace settings.
 3. Choose **Workspace layout** to change the workspace's layout, or choose **Line plots** to configure default settings for line plots in the workspace.
 {{< img src="/images/app_ui/workspace_settings.png" alt="" >}}
+
+{{% alert %}}
+After customizing your workspace, you can use _workspace templates_ to quickly create new workspaces with the same settings. Refer to [Workspace templates]({{< relref "content/en/guides/models/track/workspaces.md#workspace-templates" >}}).
+{{% /alert %}}
 
 ### Workspace layout options
 

--- a/content/en/guides/models/track/workspaces.md
+++ b/content/en/guides/models/track/workspaces.md
@@ -63,11 +63,6 @@ Share your customized workspace with your team by sharing the workspace URL dire
 
 ## Workspace templates
 
-<!-- Tracked in https://wandb.atlassian.net/browse/DOCS-1543 -->
-{{% alert %}}
-{{< readfile file="/_includes/workspace-templates-private-preview-feature.md" >}}
-{{% /alert %}}
-
 Use _workspace templates_ to quickly create workspaces using the same settings as an existing workspace instead of the [default settings for new workspaces]({{< relref "#default-workspace-settings" >}}). Currently, a workspace template can define custom [line plot settings]({{< relref "/guides/models/app/features/panels/line-plot/#all-line-plots-in-a-workspace" >}}).
 
 ### Default workspace settings

--- a/content/en/guides/models/track/workspaces.md
+++ b/content/en/guides/models/track/workspaces.md
@@ -62,6 +62,7 @@ Remove saved views that are no longer needed.
 Share your customized workspace with your team by sharing the workspace URL directly. All users with access to the workspace project can see the saved Views of that workspace.
 
 ## Workspace templates
+{{% alert %}}This feature requires an [Enterprise](https://wandb.ai/site/pricing/) license.{{% /alert %}}
 
 Use _workspace templates_ to quickly create workspaces using the same settings as an existing workspace instead of the [default settings for new workspaces]({{< relref "#default-workspace-settings" >}}). Currently, a workspace template can define custom [line plot settings]({{< relref "/guides/models/app/features/panels/line-plot/#all-line-plots-in-a-workspace" >}}).
 


### PR DESCRIPTION
[DOCS-1543] Workspace templates are now GA

Preview:
https://docs-1422.docodile.pages.dev/guides/track/workspaces/#workspace-templates
https://docs-1422.docodile.pages.dev/guides/app/features/cascade-settings/#workspace-settings (minor)

Ready for peer review

[DOCS-1543]: https://wandb.atlassian.net/browse/DOCS-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ