### PR TITLE
[DOCS-1582] Document using scientific notation in a sweep config

### DIFF
--- a/content/en/guides/models/sweeps/define-sweep-configuration/_index.md
+++ b/content/en/guides/models/sweeps/define-sweep-configuration/_index.md
@@ -166,6 +166,8 @@ command:
 - ${Command macro}      
 ```
 
+To express a numeric value using scientific notation, add the YAML `!!float` operator, which casts the value to a floating point number. For example, `min: !!float 1e-5`. See [Command example]({{< relref "#command-example" >}}).
+
 ## Sweep configuration examples
 
 {{< tabpane text=true >}}
@@ -287,6 +289,10 @@ early_terminate:
 
 
 ### Command example
+
+{{% alert %}}
+This example defines `parameters.optimizer.config.learning_rate` using scientific notation, and uses the `!!float ` operator to convert it to a floating point number. 
+{{% /alert %}}
 
 ```yaml
 program: main.py


### PR DESCRIPTION
[DOCS-1582] Document using scientific notation in a sweep config

Ready for review

[DOCS-1582]: https://wandb.atlassian.net/browse/DOCS-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ