### PR TITLE
[DOCS-1646] Release notes for v0.70.1

### DIFF
--- a/content/en/ref/release-notes/releases/0.70.md
+++ b/content/en/ref/release-notes/releases/0.70.md
@@ -1,9 +1,7 @@
 ---
 title: "0.70.x"
-date: 2025-07-07
+date: 2025-07-09
 description: "July 7, 2025"
-
-
 ---
 
 W&B Server v0.70 includes features, enhancements, and performance improvements to help you gain and share insights more efficiently. For example:
@@ -13,9 +11,9 @@ W&B Server v0.70 includes features, enhancements, and performance improvements t
 - Rapidly prototype workspaces and visualizations to gain and share insights with workspace templates and additional bulk line plot and media panel settings at the workspace and section level.
 - Monitor long-running running experiments before they finish with incremental table logging.
 
-The latest patch is **v0.70.0**.
+The latest patch is **v0.70.1**. Refer to [Patches]({{< relref "#patches" >}}).
+
 <!--more-->
-<!-- Refer to [Patches]({{< relref "#patches" >}}). -->
 
 ## Support and end of life
 <ul>
@@ -75,8 +73,15 @@ The latest patch is **v0.70.0**.
 - Clarified text in project-level automation setup to refer to "artifacts" instead of the Registry terminology "collections".
 - The artifact browser now searches all artifacts when searching the artifact browser by name, rather than the previous limit of the first 500 artifacts.
 
-<!--
 ## Patches
 ### 0.70.1
 **July 9, 2025**
--->
+
+<!-- wandb/core 50fd85a61a7c39db4c97d48c989fe2472f3840eb to d37a5c07a2f6712ad8e1a65edb48a51894e35759 -->
+
+- Fixed a bug where the status of crashed runs was not updated to **Crashed** after an upgrade.
+- Fixed a bug where the **State** column was missing from the **Sweeps** Runs table.
+- Fixed a Weave bug where the browser for a Registry collection could display files from an incorrect version because the cached path for an artifact manifest file depended only on the artifact's version index.
+- Fixed a Weave bug that could prevent JSON with valid syntax from being parsed correctly.
+
+These bugs were introduced in v0.70.0.


### PR DESCRIPTION
[DOCS-1646] Release notes for v0.70.1

- Confirmed the crashed runs note with @jessicaxiang 
- Confirmed the Weave caching note with @ibindlish 
- The other two were obvious from the upstream PRs

Preview: https://server-0-70-1-rn.docodile.pages.dev/ref/release-notes/0.70/#0701

Ready for review, for publication on 7/9.


[DOCS-1646]: https://wandb.atlassian.net/browse/DOCS-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ