### PR TITLE
Add Core and Platform areas to homepage; highlight inference under Weave

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -15,14 +15,15 @@ Choose the product for which you need documentation.
 </div>
 <h2>W&B Weave</h2>
 
-##### Use AI models in your app
+### Use AI models in your app
 
-Use [W&B Weave](https://weave-docs.wandb.ai/) to manage AI models in your code. Features include tracing, output evaluation, cost estimates, and a playground for comparing different large language models (LLMs) and settings.
+Use [W&B Weave](https://weave-docs.wandb.ai/) to manage AI models in your code. Features include tracing, output evaluation, cost estimates, and a hosted inference service and playground for comparing different large language models (LLMs) and settings.
 
 - [Introduction](https://weave-docs.wandb.ai/)
 - [Quickstart](https://weave-docs.wandb.ai/quickstart)
 - [YouTube Demo](https://www.youtube.com/watch?v=IQcGGNLN3zo)
 - [Try the Playground](https://weave-docs.wandb.ai/guides/tools/playground/)
+- [Try W&B Inference](https://weave-docs.wandb.ai/guides/integrations/inference)
 
 </div>{{% /card %}}
 {{% card %}}<div onclick="window.location.href='/guides'" style="cursor: pointer;">
@@ -32,7 +33,7 @@ Use [W&B Weave](https://weave-docs.wandb.ai/) to manage AI models in your code. 
 </div>
 <h2>W&B Models</h2>
 
-##### Develop AI models
+### Develop AI models
 
 Use [W&B Models]({{< relref "/guides/" >}}) to manage AI model development. Features include training, fine-tuning, reporting, automating hyperparameter sweeps, and utilizing the model registry for versioning and reproducibility.
 
@@ -43,6 +44,37 @@ Use [W&B Models]({{< relref "/guides/" >}}) to manage AI model development. Feat
 
 </div>{{% /card %}}
 {{< /cardpane >}}
+
+{{< cardpane >}}
+{{% card %}}<div onclick="window.location.href='/guides/core/'" style="cursor: pointer; padding-left: 20px">
+<h2>Core Components</h2>
+
+Both W&B Weave and W&B Models share common components that enable and accelerate your AI/ML engineering work. 
+
+- [Registry]({{< relref "/guides/core/registry/" >}})
+- [Artifacts]({{< relref "/guides/core/artifacts/" >}})
+- [Reports]({{< relref "/guides/core/reports/" >}})
+- [Automations]({{< relref "/guides/core/automations/" >}})
+- [Secrets]({{< relref "/guides/core/secrets.md" >}})
+
+</div>{{% /card %}}
+{{% card %}}<div onclick="window.location.href='/guides/hosting'" style="cursor: pointer;padding-left:20px;">
+
+<h2>Platform</h2>
+
+The Weights & Biases platform can be accessed through our SaaS offering or deployed on-premise, and it provides IAM, security, monitoring, and privacy features.
+
+- [Deployment Options]({{< relref "/guides/hosting/hosting-options/" >}})
+- [Identity and access management (IAM)]({{< relref "/guides/hosting/iam/" >}})
+- [Data Security]({{< relref "/guides/hosting/data-security/" >}})
+- [Privacy settings]({{< relref "/guides/hosting/privacy-settings/" >}})
+- [Monitoring and Usage]({{< relref "/guides/hosting/monitoring-usage/" >}})
+
+</div>{{% /card %}}
+{{< /cardpane >}}
+
+
+
 
 <!-- End max-width constraing -->
 </div>


### PR DESCRIPTION
In this PR the homepage becomes a more robust portal to the content of the site, highlighting various product aspects. Per the P0 discussions around positioning these elements.