### PR TITLE
Update "redirects" section in the registry migration documentation

### DIFF
--- a/content/en/guides/core/registry/model_registry_eol.md
+++ b/content/en/guides/core/registry/model_registry_eol.md
@@ -112,6 +112,7 @@ W&B will automatically redirect these paths to the new W&B Registry format, whic
 f"{org-name}/wandb-registry-{team-name}/{collection-name}:{version}"
 ```
 
+
 {{% alert title="Python SDK warnings" %}}
 
 A warning error may appear if you continue to use legacy Model Registry paths in your code. The warning will not break your code, but it indicates that you should update your paths to the new W&B Registry format. 

--- a/content/en/guides/core/registry/model_registry_eol.md
+++ b/content/en/guides/core/registry/model_registry_eol.md
@@ -95,11 +95,23 @@ Existing API calls in your code that refer to the legacy Model Registry will aut
 
 W&B will automatically redirect legacy Model Registry paths to the new W&B Registry format. This means you can continue using your existing code without needing to refactor paths immediately. Note that automatic redirection only applies to collections that were created in the legacy Model Registry before migration.
 
+For example:
+- If the legacy Model Registry had collection "my-model" already present, the link action will redirect successfully
+- If the legacy Model Registry did not have collection "my-model", it will not redirect and will lead to an error
+
+```python
+# This will redirect successfully if "my-model" existed in legacy Model Registry
+run.link_artifact(artifact, "team-name/model-registry/my-model")
+
+# This will fail if "new-model" did not exist in legacy Model Registry
+run.link_artifact(artifact, "team-name/model-registry/new-model")
+```
+
 <!-- - Existing training and deployment workflows remain intact.
 - CI/CD pipelines built on model promotion or artifact linking will not break.
 - Teams can adopt the new W&B Registry gradually, without needing to refactor old codebases immediately. -->
 
-In the legacy Model Registry, paths consisted of a team name, a `"model-registry"` string, collection name, and version:
+To fetch versions from the legacy Model Registry, paths consisted of a team name, a `"model-registry"` string, collection name, and version:
 
 ```python
 f"{team-name}/model-registry/{collection-name}:{version}"

--- a/content/en/guides/core/registry/model_registry_eol.md
+++ b/content/en/guides/core/registry/model_registry_eol.md
@@ -96,8 +96,8 @@ Existing API calls in your code that refer to the legacy Model Registry will aut
 W&B will automatically redirect legacy Model Registry paths to the new W&B Registry format. This means you can continue using your existing code without needing to refactor paths immediately. Note that automatic redirection only applies to collections that were created in the legacy Model Registry before migration.
 
 For example:
-- If the legacy Model Registry had collection "my-model" already present, the link action will redirect successfully
-- If the legacy Model Registry did not have collection "my-model", it will not redirect and will lead to an error
+- If the legacy Model Registry had collection `"my-model"` already present, the link action will redirect successfully
+- If the legacy Model Registry did not have collection `"my-model"`, it will not redirect and will lead to an error
 
 ```python
 # This will redirect successfully if "my-model" existed in legacy Model Registry

--- a/content/en/guides/core/registry/model_registry_eol.md
+++ b/content/en/guides/core/registry/model_registry_eol.md
@@ -93,7 +93,7 @@ Existing API calls in your code that refer to the legacy Model Registry will aut
 
 ### Legacy paths will redirect to new W&B Registry paths
 
-W&B will automatically redirect legacy Model Registry paths to the new W&B Registry format. This means you can continue using your existing code without needing to refactor paths immediately.
+W&B will automatically redirect legacy Model Registry paths to the new W&B Registry format. This means you can continue using your existing code without needing to refactor paths immediately. Note that automatic redirection only applies to collections that were created in the legacy Model Registry before migration.
 
 <!-- - Existing training and deployment workflows remain intact.
 - CI/CD pipelines built on model promotion or artifact linking will not break.
@@ -111,7 +111,6 @@ W&B will automatically redirect these paths to the new W&B Registry format, whic
 # Redirects to new path
 f"{org-name}/wandb-registry-{team-name}/{collection-name}:{version}"
 ```
-
 
 {{% alert title="Python SDK warnings" %}}
 


### PR DESCRIPTION
Based on customer feedback, this PR updates the Registry migration documentation to clarify that SDK redirects only apply to collections that were already present in the Model Registry prior to the migration.

Before:
<img width="953" height="467" alt="image" src="https://github.com/user-attachments/assets/16f2f944-70a8-4e83-81b7-1497972095c3" />

After:
<img width="991" height="692" alt="image" src="https://github.com/user-attachments/assets/1d71d232-764d-4a87-9e09-841dfe4d0c54" />

