### PR TITLE
[DOCS-1683] Update Activity Dashboard documentation for Multi-tenant Cloud

### DIFF
--- a/content/en/guides/hosting/monitoring-usage/org_dashboard.md
+++ b/content/en/guides/hosting/monitoring-usage/org_dashboard.md
@@ -54,7 +54,7 @@ From the **Users** tab, you can export details about how your organization uses 
 {{% /tab %}}
 
 {{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
-This feature is not available for Multi-tenant Cloud.
+Exporting users is not available for Multi-tenant Cloud.
 {{% /tab %}}
 {{< /tabpane >}}
 

--- a/content/en/guides/hosting/monitoring-usage/org_dashboard.md
+++ b/content/en/guides/hosting/monitoring-usage/org_dashboard.md
@@ -52,6 +52,10 @@ From the **Users** tab, you can export details about how your organization uses 
 1. Click the action `...` menu next to the **Invite new user user** button.
 1. Click **Export as CSV**. The downloaded CSV file lists details about each user of an organization, such as their user name and email address, the time they were last active, their roles, and more.
 {{% /tab %}}
+
+{{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
+This feature is not available for Multi-tenant Cloud.
+{{% /tab %}}
 {{< /tabpane >}}
 
 ## View activity over time

--- a/content/en/guides/hosting/monitoring-usage/org_dashboard.md
+++ b/content/en/guides/hosting/monitoring-usage/org_dashboard.md
@@ -29,7 +29,7 @@ This page shows various ways to view activity within your W&B organization.
     - interact with the W&B Server in any way.
 {{% /tab %}}
 
-{{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
+{{% tab header="Multi-tenant Cloud" value="saas" %}}
 1. Navigate to the [**Members** page](https://wandb.ai/account-settings/wandb/members/). This page lists all users, along with data about each user.
 1. To sort the list by user status, click the **Last Active** column label. Each user's status is one of the following:
 
@@ -53,7 +53,7 @@ From the **Users** tab, you can export details about how your organization uses 
 1. Click **Export as CSV**. The downloaded CSV file lists details about each user of an organization, such as their user name and email address, the time they were last active, their roles, and more.
 {{% /tab %}}
 
-{{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
+{{% tab header="Multi-tenant Cloud" value="saas" %}}
 Exporting users is not available for Multi-tenant Cloud.
 {{% /tab %}}
 {{< /tabpane >}}
@@ -79,7 +79,7 @@ To change the period of time for a plot, use the drop-down. You can select:
 - All time
 
 {{% /tab %}}
-{{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
+{{% tab header="Multi-tenant Cloud" value="saas" %}}
 
 Use the plots in the **Activity Dashboard** to get an aggregate view of activity over time:
 

--- a/content/en/guides/hosting/monitoring-usage/org_dashboard.md
+++ b/content/en/guides/hosting/monitoring-usage/org_dashboard.md
@@ -37,7 +37,7 @@ This page shows various ways to view activity within your W&B organization.
     * **Active**: User has accepted the invite and created an account.
     * `-`: A hyphen indicates that the user has not yet been active within the organization.
 
-    A user is _active_ if they perform any auditable action scoped to the organization. For a full list, refer to [Actions]({{< relref "/guides/hosting/monitoring-usage/audit-logging.md#actions" >}}) in the Audit Logging page.
+    A user is _active_ if they perform any auditable action scoped to the organization _after May 8, 2025_. For a full list, refer to [Actions]({{< relref "/guides/hosting/monitoring-usage/audit-logging.md#actions" >}}) in the Audit Logging page.
 
 {{% /tab %}}
 {{< /tabpane >}}

--- a/content/en/guides/hosting/monitoring-usage/org_dashboard.md
+++ b/content/en/guides/hosting/monitoring-usage/org_dashboard.md
@@ -35,9 +35,7 @@ This page shows various ways to view activity within your W&B organization.
 
     * **Invite pending**: Admin has sent invite but user has not accepted invitation. 
     * **Active**: User has accepted the invite and created an account.
-    * `-`: A hyphen indicates that the user was previously active but has not been active in the last 6 months.
-    * **Deactivated**: Admin has revoked access of the user.
-1. To see details about a user's last activity, hover your mouse over the **Last Active** field for the user.  A tooltip appears that shows when the user was added and how many total days the user has been active.
+    * `-`: A hyphen indicates that the user has not yet been active within the organization.
 
     A user is _active_ if they perform any auditable action scoped to the organization. For a full list, refer to [Actions]({{< relref "/guides/hosting/monitoring-usage/audit-logging.md#actions" >}}) in the Audit Logging page.
 
@@ -54,17 +52,10 @@ From the **Users** tab, you can export details about how your organization uses 
 1. Click the action `...` menu next to the **Invite new user user** button.
 1. Click **Export as CSV**. The downloaded CSV file lists details about each user of an organization, such as their user name and email address, the time they were last active, their roles, and more.
 {{% /tab %}}
-
-
-{{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
-1. Navigate to the [Members page](https://wandb.ai/account-settings/wandb/members/).
-1. Click the action `...` menu next to the search field.
-1. Click **Export as CSV**. The downloaded CSV file downloads lists details about each user of an organization, such as their user name and email address, the time they were last active, their roles, and more.
-{{% /tab %}}
 {{< /tabpane >}}
 
-## View active users over time
-This section shows how to get an aggregate view of how many users have been active over time.
+## View activity over time
+This section shows how to get an aggregate view of activity over time.
 
 {{< tabpane text=true >}}
 {{% tab header="Dedicated or Self-managed" value="dedicated" %}}
@@ -86,14 +77,14 @@ To change the period of time for a plot, use the drop-down. You can select:
 {{% /tab %}}
 {{% tab header="Multi-tenant SaaS Cloud" value="saas" %}}
 
-Use the plots in the **Activity Dashboard** to get an aggregate view of how many users have been active over time:
+Use the plots in the **Activity Dashboard** to get an aggregate view of activity over time:
 
 1. Click the user profile icon at the top right.
 1. Under **Account**, click **Users**.
 1. View the Activity Panel above the list of users. It shows:
 
   - The **Active user count** badge shows how many unique users have been active in a period of time (defaults to 3 months). A user is _active_ if they perform any auditable action scoped to the organization. For a full list, refer to [Actions]({{< relref "/guides/hosting/monitoring-usage/audit-logging.md#actions" >}}) in the Audit Logging page.
-  - The **Weekly active users** plot charts how many users have been active over the period of time.
+  - The **Weekly active users** plot shows the number of users active per week.
   - The **Most active user** leaderboard ranks the top ten most active users by how many days they were active over the period of time, as well as when they were most recently active.
 
 1. To adjust the span of time the plots show, click the date picker in the top right. You can choose 7, 30, or 90 days. The default date range is 30 days. All of the plots share the same time range and update automatically.


### PR DESCRIPTION
## Summary

This PR addresses feedback from DOCS-1683 to update the Activity Dashboard documentation for multi-tenant SaaS Cloud following the initial implementation in DOCS-1609.

Ready for final technical review (Cassie) and peer review (Noah).
Preview: https://docs-activity-dashboard-feed.docodile.pages.dev/guides/hosting/monitoring-usage/org_dashboard/

## Changes Made

### 1. User Status and Activity Section (Multi-tenant SaaS Cloud tab)
- **Updated hyphen status**: Changed from "user was previously active but has not been active in the last 6 months" to "user has not yet been active within the organization"
- **Removed**: "Deactivated" status (not applicable for SaaS)
- **Removed**: Instructions to hover for details and tooltip description

### 2. Export User Details Section
- **Removed**: Multi-tenant SaaS Cloud tab entirely (feature not available for SaaS)

### 3. View Activity Over Time Section
- **Title change**: "View active users over time" → "View activity over time"
- **Updated description**: References "aggregate view of activity" instead of "users"
- **Clarified**: "Weekly active users" description now states it "shows the number of users active per week"

## Related Issues
- DOCS-1683: Fast follow feedback for Activity Dashboard for multi-tenant
- DOCS-1609: Draft and Publish documentation for SaaS Activity Dashboard (original implementation)

## Testing
- [ ] Verified all changes reflect current SaaS functionality
- [ ] Checked that removed features are indeed not available in SaaS
- [ ] Confirmed terminology updates align with the new Activity Dashboard

## Notes for Reviewers
This is ready for initial review. After addressing any feedback, we'll send it to an SME for final verification.