### PR TITLE
Remove project parameter from OpenAI client configuration in inference quickstart

### DIFF
--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -24,7 +24,7 @@ client = openai.OpenAI(
     base_url='https://api.inference.wandb.ai/v1',
     
     # Get your API key from https://wandb.ai/authorize
-    api_key="<your-api-key>",
+    api_key="<your-api-key>"
 )
 
 response = client.chat.completions.create(

--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -25,9 +25,6 @@ client = openai.OpenAI(
     
     # Get your API key from https://wandb.ai/authorize
     api_key="<your-api-key>",
-    
-    # Team and project are required for usage tracking
-    project="<your-team>/<your-project>",
 )
 
 response = client.chat.completions.create(

--- a/content/en/guides/inference/api-reference.md
+++ b/content/en/guides/inference/api-reference.md
@@ -72,10 +72,7 @@ client = openai.OpenAI(
 
     # Get your API key from https://wandb.ai/authorize
     # Consider setting it in the environment as OPENAI_API_KEY instead for safety
-    api_key="<your-api-key>",
-
-    # Team and project are required for usage tracking
-    project="<your-team>/<your-project>",
+    api_key="<your-api-key>"
 )
 
 # Replace <model-id> with any model ID from the available models list
@@ -115,8 +112,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="https://api.inference.wandb.ai/v1",
-    api_key="<your-api-key>",
-    project="<your-team>/<your-project>"
+    api_key="<your-api-key>"
 )
 
 response = client.models.list()

--- a/content/en/guides/inference/examples.md
+++ b/content/en/guides/inference/examples.md
@@ -98,7 +98,7 @@ class WBInferenceModel(weave.Model):
             # Get your API key from https://wandb.ai/authorize
             api_key="<your-api-key>",
             # Optional: Customizes the logs destination
-            project="<your-team>/<your-project>",
+            project="<your-team>/<your-project>"
         )
         resp = client.chat.completions.create(
             model=self.model,

--- a/content/en/guides/inference/examples.md
+++ b/content/en/guides/inference/examples.md
@@ -36,9 +36,6 @@ client = openai.OpenAI(
 
     # Get your API key from https://wandb.ai/authorize
     api_key="<your-api-key>",
-
-    # Required for W&B inference usage tracking
-    project="wandb/inference-demo",
 )
 
 # Trace the model call in Weave
@@ -97,8 +94,6 @@ class WBInferenceModel(weave.Model):
             base_url="https://api.inference.wandb.ai/v1",
             # Get your API key from https://wandb.ai/authorize
             api_key="<your-api-key>",
-            # Required for W&B inference usage tracking
-            project="<your-team>/<your-project>",
         )
         resp = client.chat.completions.create(
             model=self.model,

--- a/content/en/guides/inference/examples.md
+++ b/content/en/guides/inference/examples.md
@@ -61,9 +61,12 @@ After running the code, view the trace in Weave by:
 
 ## Advanced example: Use Weave Evaluations and Leaderboards
 
-Besides tracing model calls, you can also evaluate performance and publish leaderboards. This example compares two models on a question-answer dataset.
+Besides tracing model calls, you can also evaluate performance and publish leaderboards. 
+This example compares two models on a question-answer dataset, and sets a custom project
+name in the client initialization, specifying where to send logs. 
 
 Before running this example, complete the [prerequisites]({{< relref "prerequisites" >}}).
+
 
 ```python
 import os
@@ -94,6 +97,8 @@ class WBInferenceModel(weave.Model):
             base_url="https://api.inference.wandb.ai/v1",
             # Get your API key from https://wandb.ai/authorize
             api_key="<your-api-key>",
+            # Optional: Customizes the logs destination
+            project="<your-team>/<your-project>",
         )
         resp = client.chat.completions.create(
             model=self.model,

--- a/content/en/guides/inference/usage-limits.md
+++ b/content/en/guides/inference/usage-limits.md
@@ -40,7 +40,7 @@ W&B applies rate limits per W&B project. For example, if you have 3 projects in 
 ## Personal entities unsupported
 
 {{< alert title="Note" >}}
-Personal entities were deprecated in May 2024, so this only applies to legacy accounts.
+W&B deprecated personal entities in May 2024, so this only applies to legacy accounts.
 {{< /alert >}}
 
 Personal accounts (personal entities) don't support W&B Inference. To access W&B Inference, switch to a non-personal account by creating a Team.


### PR DESCRIPTION
What it says on the tin. The option to specify a project during client initialization is not what we want to show in the quickstart. Instead, we call out the option under the "advanced" example.