### PR TITLE
Revert PR#1498: Re-add project parameter to OpenAI client configuration

### DIFF
--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -24,7 +24,10 @@ client = openai.OpenAI(
     base_url='https://api.inference.wandb.ai/v1',
     
     # Get your API key from https://wandb.ai/authorize
-    api_key="<your-api-key>"
+    api_key="<your-api-key>",
+    
+    # Team and project are required for usage tracking
+    project="<your-team>/<your-project>",
 )
 
 response = client.chat.completions.create(

--- a/content/en/guides/inference/api-reference.md
+++ b/content/en/guides/inference/api-reference.md
@@ -72,7 +72,10 @@ client = openai.OpenAI(
 
     # Get your API key from https://wandb.ai/authorize
     # Consider setting it in the environment as OPENAI_API_KEY instead for safety
-    api_key="<your-api-key>"
+    api_key="<your-api-key>",
+
+    # Team and project are required for usage tracking
+    project="<your-team>/<your-project>",
 )
 
 # Replace <model-id> with any model ID from the available models list
@@ -112,7 +115,8 @@ import openai
 
 client = openai.OpenAI(
     base_url="https://api.inference.wandb.ai/v1",
-    api_key="<your-api-key>"
+    api_key="<your-api-key>",
+    project="<your-team>/<your-project>"
 )
 
 response = client.models.list()

--- a/content/en/guides/inference/examples.md
+++ b/content/en/guides/inference/examples.md
@@ -36,6 +36,9 @@ client = openai.OpenAI(
 
     # Get your API key from https://wandb.ai/authorize
     api_key="<your-api-key>",
+
+    # Required for W&B inference usage tracking
+    project="wandb/inference-demo",
 )
 
 # Trace the model call in Weave
@@ -61,12 +64,9 @@ After running the code, view the trace in Weave by:
 
 ## Advanced example: Use Weave Evaluations and Leaderboards
 
-Besides tracing model calls, you can also evaluate performance and publish leaderboards. 
-This example compares two models on a question-answer dataset, and sets a custom project
-name in the client initialization, specifying where to send logs. 
+Besides tracing model calls, you can also evaluate performance and publish leaderboards. This example compares two models on a question-answer dataset.
 
 Before running this example, complete the [prerequisites]({{< relref "prerequisites" >}}).
-
 
 ```python
 import os
@@ -97,8 +97,8 @@ class WBInferenceModel(weave.Model):
             base_url="https://api.inference.wandb.ai/v1",
             # Get your API key from https://wandb.ai/authorize
             api_key="<your-api-key>",
-            # Optional: Customizes the logs destination
-            project="<your-team>/<your-project>"
+            # Required for W&B inference usage tracking
+            project="<your-team>/<your-project>",
         )
         resp = client.chat.completions.create(
             model=self.model,

--- a/content/en/guides/inference/usage-limits.md
+++ b/content/en/guides/inference/usage-limits.md
@@ -40,7 +40,7 @@ W&B applies rate limits per W&B project. For example, if you have 3 projects in 
 ## Personal entities unsupported
 
 {{< alert title="Note" >}}
-W&B deprecated personal entities in May 2024, so this only applies to legacy accounts.
+Personal entities were deprecated in May 2024, so this only applies to legacy accounts.
 {{< /alert >}}
 
 Personal accounts (personal entities) don't support W&B Inference. To access W&B Inference, switch to a non-personal account by creating a Team.


### PR DESCRIPTION
This PR reverts the changes made in [PR #1498](https://github.com/wandb/docs/pull/1498) which removed the project parameter from the OpenAI client configuration in the inference quickstart documentation.

## What was reverted:

### `content/en/guides/inference/_index.md`
- Re-added the `project` parameter with comment "Team and project are required for usage tracking"

### `content/en/guides/inference/api-reference.md`
- Re-added the `project` parameter in two OpenAI client initialization examples

### `content/en/guides/inference/examples.md`
- Re-added the `project` parameter to the first example
- Changed the comment back from "Optional: Customizes the logs destination" to "Required for W&B inference usage tracking" in the advanced example
- Removed the additional explanatory text about setting a custom project name

### `content/en/guides/inference/usage-limits.md`
- Reverted wording from "W&B deprecated personal entities" back to "Personal entities were deprecated"

## Reason for revert:
The project parameter appears to be required for proper usage tracking in W&B Inference, and its removal from the quickstart documentation could cause confusion or issues for users.