### PR TITLE
UI: Breadcrumb home icon + left-nav animation/spacings

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -560,7 +560,6 @@ ul.foldable, .card {
 
 // Table of Contents Component
 #TableOfContents {
-    font-family: $base-font;
     a{
         margin: 0px !important;
         padding: 8px !important;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -129,6 +129,10 @@ p, td, div, li, .lead
     }
 }
 
+#content-mobile {
+    max-height: 65px;
+}
+
 .td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
 {
     font-size: 14px; 
@@ -1361,6 +1365,80 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
                 padding-right: 3rem !important;
             }
         }
+    }
+}
+
+// Mobile spacing tweaks around the inline search bar at top of content
+@media (max-width: ($breakpoint-md - 1)) {
+    // Tighten the DocSearch trigger button spacing
+    .DocSearch-Button {
+        margin-top: 2px !important;
+        margin-bottom: 2px !important;
+    }
+
+    // Reduce spacing of the first content section that generally wraps the search
+    .container-fluid.td-default.td-outer > main > section:first-child,
+    .td-outer.td-default > main > section:first-child,
+    .td-outer > main > section:first-child {
+        padding-top: 4px !important;
+        padding-bottom: 4px !important;
+        margin-top: 0 !important;
+        margin-bottom: 4px !important;
+    }
+
+    // Also tighten the inner container of that first section
+    .container-fluid.td-default.td-outer > main > section:first-child > .container,
+    .container-fluid.td-default.td-outer > main > section:first-child > .container-fluid,
+    .td-outer > main > section:first-child > .container,
+    .td-outer > main > section:first-child > .container-fluid {
+        padding-top: 0 !important;
+        margin-top: 0 !important;
+    }
+
+    // Search wrapper and field
+    .td-search {
+        margin: 4px 0 !important;
+        padding: 0 !important;
+    }
+    .td-search__input, .td-search-input {
+        margin: 0 !important;
+    }
+
+    // Breadcrumb block directly under the search
+    nav[aria-label="breadcrumb"],
+    .breadcrumb {
+        margin-top: 4px !important;
+        margin-bottom: 6px !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+    }
+
+    // Ensure the mobile sidebar (hamburger menu) overlays breadcrumbs/content
+    // instead of visually overlapping with them.
+    .td-sidebar {
+        position: relative !important;
+        z-index: 1060 !important;
+    }
+
+    // Tighten the space before the main heading
+    .td-content h1 {
+        margin-top: 8px !important;
+    }
+
+    // Aggressively clamp large Bootstrap utility spacers within the first section
+    .td-outer > main > section:first-child {
+        .pt-5 { padding-top: 0.5rem !important; }
+        .pb-5 { padding-bottom: 0.5rem !important; }
+        .mt-5 { margin-top: 0.5rem !important; }
+        .mb-5 { margin-bottom: 0.5rem !important; }
+        .my-5 { margin-top: 0.5rem !important; margin-bottom: 0.5rem !important; }
+        .py-5 { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
+        .pt-4 { padding-top: 0.5rem !important; }
+        .pb-4 { padding-bottom: 0.5rem !important; }
+        .mt-4 { margin-top: 0.5rem !important; }
+        .mb-4 { margin-bottom: 0.5rem !important; }
+        .my-4 { margin-top: 0.5rem !important; margin-bottom: 0.5rem !important; }
+        .py-4 { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
     }
 }
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -6,6 +6,8 @@ Add styles or override variables from the theme here.
 
 @import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap');
 
+$base-font: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
 // First define the base color tokens
 // Moon (Grayscale)
 $moon-white: #ffffff;
@@ -106,7 +108,6 @@ $font-weight-bold: 700;
 // Typography Component
 // Base body styles
 body {
-    font-family: "Source Sans Pro", sans-serif;
     font-size: 16px;
     font-weight: $font-weight-regular;
     color: $text-primary;
@@ -117,34 +118,56 @@ body {
         background-color: $dark-bg-primary;
     }
 }
-p, td, div
-{
-    font-family: "Source Sans Pro", sans-serif;
-}
-.td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
-{
-    font-size: 14px;  // Reduced from 16px
-    font-weight: $font-weight-bold;
-}
 
-// Headings
-h1, h2, h3, h4, h5, h6 {
+p, td, div, li, .lead
+{
+    font-family: $base-font;
     font-weight: $font-weight-regular !important;
-    font-family: "Source Serif 4", sans-serif;
-    color: $text-primary;
-
+    font-size: 14px;
     [data-bs-theme=dark] & {
         color: $dark-text-primary;
     }
 }
 
+.td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
+{
+    font-size: 13px; 
+    font-weight: $font-weight-bold;
+}
+
+// Headings
+h1, h2, h3, h4, h5, h6 {
+    color: $text-primary;
+    [data-bs-theme=dark] & {
+        color: white !important;
+    }
+}
+
 // Heading sizes
-h1, .td-content h1 { font-size: 32px !important; }
-h2, .td-content h2 { font-size: 24px !important; }
-h3, .td-content h3 { font-size: 20px !important; }
-h4, .td-content h4 { font-size: 18px !important; }
-h5, .td-content h5 { font-size: 17px !important; }
-h6, .td-content h6 { font-size: 16px !important; }
+h1, .td-content h1 { 
+    font-size: 32px !important;
+    font-weight: $font-weight-bold !important;
+}
+h2, .td-content h2 { 
+    font-size: 24px !important;
+    font-weight: $font-weight-bold !important;
+}
+h3, .td-content h3 { 
+    font-size: 20px !important;
+    font-weight: $font-weight-bold !important;
+}
+h4, .td-content h4 { 
+    font-size: 16px !important;
+    font-weight: $font-weight-bold !important;
+}
+h5, .td-content h5 {
+    font-size: 14px !important;
+    font-weight: $font-weight-bold !important;
+}
+h6, .td-content h6 {
+    font-size: 12px !important;
+    font-weight: $font-weight-bold !important;
+}
 
 // Lead paragraph
 .td-content .lead {
@@ -459,7 +482,6 @@ $breakpoint-xl: 1200px;   // Large desktop
 // headings use WandB serif font
 h1, h2, h3, h4, h5, h6 {
     font-weight: $font-weight-regular !important;
-    font-family: "Source Serif 4", sans-serif;
     color: $text-primary;
 }
 
@@ -529,7 +551,6 @@ h1, h2, h3, h4, h5, h6 {
 #TableOfContents {
     
     font-size: 13px !important;
-    font-family: "Source Sans Pro", sans-serif;
     a{
         margin: 0px !important;
         padding: 8px !important;
@@ -1296,9 +1317,6 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
 .gsc-control-cse, .gsc-webResult.gsc-result, .gsc-cursor-page, .gsc-refinementHeader, .gs-no-results-result div {
     background-color: transparent !important;
     border: 0px !important;
-}
-.gs-title {
-    font-family: "Source Serif 4", sans-serif !important;
 }
 .gs-title b, .gs-title a, .gsc-cursor-page, .gsc-above-wrapper-area, .gcsc-find-more-on-google-query, .gcsc-find-more-on-google-magnifier {
     color: $link-primary !important;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1717,7 +1717,6 @@ body > div.container-fluid.td-default.td-outer > main > section > div > h2 {
         // Slightly increase main content width without overflowing
         main.col-xl-8 {
             flex: 0 0 auto;
-            width: 70% !important; // Modest increase from 66.67% 
         }
         
         // Slightly reduce right sidebar (TOC) width to compensate

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1274,11 +1274,11 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
       position: absolute;
       right: 4px; // move slightly left so the right edge isn't clipped
       top: 50%;
-      transform: translateY(-50%) rotate(0deg);
+      transform: translateY(-56%) rotate(0deg); // slight upward nudge for optical alignment
   }
 
   nav.foldable-nav .with-child > input:checked + label:after {
-      transform: translateY(-50%) rotate(90deg);
+      transform: translateY(-56%) rotate(90deg);
   }
   
   // Hover states

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -272,6 +272,7 @@ $breakpoint-xl: 1200px;   // Large desktop
                         &:hover {
                             text-decoration: none !important;
                             background-color: rgba($moon-300, 0.2) !important;
+                            transform: translateY(-2px);
                         }
 
                         &.active {
@@ -528,6 +529,16 @@ h1, h2, h3, h4, h5, h6 {
   [data-bs-theme=dark] & { 
     background-color: $dark-bg-secondary; 
   } 
+}
+
+/* Card hover transitions */
+ul.foldable, .card {
+    transition: all 0.2s ease-in-out !important;
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.1));
 }
 
 /* Hide breadcrumbs in cards */
@@ -1171,10 +1182,12 @@ div.td-page-meta__lastmod {
         color: $text-secondary !important;
         font-weight: $font-weight-regular;
         text-decoration: none !important;
+        transition: all 0.2s ease-in-out !important;
 
         &:hover {
             color: $link-primary !important;
             text-decoration: none !important;
+            transform: translateX(2px);
         }
     }
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1458,7 +1458,7 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
 
 #td-section-nav > div > div > a {
     padding-left: 25px !important;
-    margin-bottom: 10px !important;
+    margin-bottom: 14px !important;
 }
 
 .gs-title b, .gs-title a, .gsc-cursor-page, .gsc-above-wrapper-area, .gcsc-find-more-on-google-query, .gcsc-find-more-on-google-magnifier {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -146,27 +146,21 @@ h1, h2, h3, h4, h5, h6 {
 // Heading sizes
 h1, .td-content h1 { 
     font-size: 32px !important;
-    font-weight: $font-weight-bold !important;
 }
 h2, .td-content h2 { 
     font-size: 24px !important;
-    font-weight: $font-weight-bold !important;
 }
 h3, .td-content h3 { 
     font-size: 20px !important;
-    font-weight: $font-weight-bold !important;
 }
 h4, .td-content h4 { 
-    font-size: 16px !important;
-    font-weight: $font-weight-bold !important;
+    font-size: 18px !important;
 }
 h5, .td-content h5 {
-    font-size: 14px !important;
-    font-weight: $font-weight-bold !important;
+    font-size: 17px !important;
 }
 h6, .td-content h6 {
-    font-size: 12px !important;
-    font-weight: $font-weight-bold !important;
+    font-size: 16px !important;
 }
 
 // Lead paragraph
@@ -271,13 +265,13 @@ $breakpoint-xl: 1200px;   // Large desktop
 
                         &:hover {
                             text-decoration: none !important;
-                            background-color: rgba($moon-300, 0.2) !important;
+                            background-color: rgba($moon-300, 0.3) !important;
                             transform: translateY(-2px);
                         }
 
                         &.active {
                             color: $link-primary !important;
-                            background-color: rgba($moon-300, 0.2) !important;
+                            background-color: rgba($moon-300, 0.4) !important;
                             font-weight: $font-weight-regular !important;
                         }
                     }
@@ -439,10 +433,12 @@ $breakpoint-xl: 1200px;   // Large desktop
                         
                         &:hover {
                             color: $teal-500 !important;
+                            background-color: rgba($moon-700, 0.5) !important;
                         }
                         
                         &.active {
                             color: $teal-500 !important;
+                            background-color: $dark-bg-secondary !important;
                         }
                     }
                 }
@@ -482,8 +478,8 @@ $breakpoint-xl: 1200px;   // Large desktop
 
 // headings use WandB serif font
 h1, h2, h3, h4, h5, h6 {
-    font-weight: $font-weight-regular !important;
     color: $text-primary;
+    font-weight: $font-weight-bold !important;
 }
 
 .td-sidebar-nav-active-item {
@@ -517,7 +513,7 @@ h1, h2, h3, h4, h5, h6 {
 .breadcrumb-item.active::after { 
   content: ""; 
   position: absolute; 
-  background-color: $bg-tertiary; 
+  background-color: rgba($moon-300, 0.4); 
   border-radius: 15px;
   /* Much tighter positioning */
   top: 0em;
@@ -561,12 +557,11 @@ ul.foldable, .card {
 // Table of Contents Component
 #TableOfContents {
     font-family: $base-font;
-    font-size: 13px !important;
     a{
         margin: 0px !important;
         padding: 8px !important;
         font-weight: 500 !important;
-        font-size: 13px !important;
+        font-size: 12px !important;
     }
     // List styles
     ul { 
@@ -574,7 +569,6 @@ ul.foldable, .card {
         li {
             padding: 0px !important; 
             line-height: 14px;
-            font-size: 13px !important;
             a {
                 transition: all .2s ease-in;
             }
@@ -875,6 +869,18 @@ ul {
 // Add border radius to all images, code blocks and alerts
 img, pre, .highlight, .code-toolbar, .alert {
   border-radius: $border-radius-medium !important;
+}
+
+// Inline code styles
+code:not(pre code) {
+  background-color: rgba($moon-300, 0.4) !important;
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.875em;
+  
+  [data-bs-theme=dark] & {
+    background-color: $dark-bg-secondary !important;
+  }
 }
 
 // Style images and iframes consistently
@@ -1179,8 +1185,11 @@ div.td-page-meta__lastmod {
 
     // Base link styles
     a {
+        span {
+            font-weight: 500 !important;
+        }
         color: $text-secondary !important;
-        font-weight: $font-weight-regular;
+        
         text-decoration: none !important;
         transition: all 0.2s ease-in-out !important;
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1249,12 +1249,18 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
           width: 100%;
           position: relative;
           padding-right: 20px; // Space for chevron
+          // Ensure consistent spacing between a parent item and its child list
+          margin-bottom: 10px !important;
           
           // Remove default chevrons
           &:before {
               display: none !important;
           }
       }
+  }
+  // Apply the same spacing rule to all nested levels
+  nav.foldable-nav .with-child > label {
+      margin-bottom: 10px !important;
   }
   
   // Add chevrons to all expandable items

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -123,7 +123,7 @@ p, td, div
 }
 .td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
 {
-    font-size: 16px; 
+    font-size: 14px;  // Reduced from 16px
     font-weight: $font-weight-bold;
 }
 
@@ -467,11 +467,50 @@ h1, h2, h3, h4, h5, h6 {
     text-decoration: none;
 }
 
-ol.breadcrumb li {
-    font-size: 13px;
+// Breadcrumb improvements from css-improvements branch
+.breadcrumb-item { 
+  font-size: 12px; 
+} 
+
+/* Your existing breadcrumb separator */ 
+.breadcrumb-item:not(:first-child)::before { 
+  content: ">" !important; 
+  margin: 0 0.5em; 
+} 
+
+/* Simple pill styling for active breadcrumb */
+.breadcrumb-item.active { 
+  position: relative;
+  /* Set max width and handle overflow with ellipsis */
+  max-width: 500px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  padding-right: 6px;
 }
-ol.breadcrumb li:not(:first-child):before {
-    content: ">" !important;
+
+/* Create pill background using ::after */
+.breadcrumb-item.active::after { 
+  content: ""; 
+  position: absolute; 
+  background-color: $bg-tertiary; 
+  border-radius: 15px;
+  /* Much tighter positioning */
+  top: 0em;
+  bottom: 0em;
+  left: 2.5em; /* Much closer to separator */
+  right: 0em; /* Preserve border radius */
+  z-index: -1; 
+  
+  [data-bs-theme=dark] & { 
+    background-color: $dark-bg-secondary; 
+  } 
+}
+
+/* Hide breadcrumbs in cards */
+.card ol.breadcrumb {
+    display: none; 
 }
 
 .td-sidebar-nav__section-title, .td-sidebar-nav__section {
@@ -1085,6 +1124,7 @@ div.td-page-meta__lastmod {
 .td-sidebar-nav {
     font-family: "Source Sans Pro", sans-serif;
     padding-left: 15px !important;
+    font-size: 14px !important; // Reduced from default 16px
 
     // Base link styles
     a {
@@ -1489,5 +1529,46 @@ body > div.container-fluid.td-default.td-outer > main > section > div > h2 {
         .DocSearch-Modal {
             border-radius: $border-radius-large !important;
         }
+    }
+}
+
+// Increase main content area width to prevent squeezing tables and content
+// Use existing breakpoints and modest percentage adjustments
+@media (min-width: $breakpoint-xl) {
+    .td-main {
+        // Slightly increase main content width without overflowing
+        main.col-xl-8 {
+            flex: 0 0 auto;
+            width: 70% !important; // Modest increase from 66.67% 
+        }
+        
+        // Slightly reduce right sidebar (TOC) width to compensate
+        aside.td-sidebar-toc.col-xl-2 {
+            flex: 0 0 auto;
+            width: 14% !important; // Reduced from 16.67%
+        }
+        
+        // Keep left sidebar at standard width
+        aside.td-sidebar.col-xl-2 {
+            flex: 0 0 auto;
+            width: 16% !important; // Keep at 2/12 columns
+        }
+    }
+}
+
+// Ensure tables have enough space without removing all constraints
+.td-content {
+    table {
+        width: 100%;
+        overflow-x: auto;
+        display: block;
+        
+        // Add some margin to prevent edge-to-edge tables
+        margin-bottom: 1rem;
+    }
+    
+    // Allow content to use available width but maintain readability
+    > p, > ul, > ol {
+        max-width: 100%;
     }
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -123,7 +123,7 @@ p, td, div, li, .lead
 {
     font-family: $base-font;
     font-weight: $font-weight-regular !important;
-    font-size: 14px;
+    font-size: 16px;
     [data-bs-theme=dark] & {
         color: $dark-text-primary;
     }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -131,7 +131,7 @@ p, td, div, li, .lead
 
 .td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
 {
-    font-size: 13px; 
+    font-size: 14px; 
     font-weight: $font-weight-bold;
 }
 
@@ -1164,7 +1164,7 @@ div.td-page-meta__lastmod {
 .td-sidebar-nav {
     font-family: $base-font;
     padding-left: 15px !important;
-    font-size: 13px !important; // Match TableOfContents font size
+    font-size: 14px !important; // Slightly larger than right nav
 
     // Base link styles
     a {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -547,7 +547,7 @@ ul.foldable, .card {
 }
 
 .td-sidebar-nav__section-title, .td-sidebar-nav__section {
-  margin-bottom: 10px !important;
+  margin-bottom: 6px !important; // tighter and consistent spacing
   .nav-link.dropdown-toggle {
     margin-left: -5px !important;
   }
@@ -1248,9 +1248,9 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
           align-items: center;
           width: 100%;
           position: relative;
-          padding-right: 20px; // Space for chevron
-          // Ensure consistent spacing between a parent item and its child list
-          margin-bottom: 10px !important;
+          padding-right: 26px; // Space for chevron (extra to avoid clipping)
+  // Remove extra bottom margin so spacing matches peers
+  margin-bottom: 0 !important;
           
           // Remove default chevrons
           &:before {
@@ -1258,28 +1258,27 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
           }
       }
   }
-  // Apply the same spacing rule to all nested levels
+  // Ensure labels do not add extra spacing
   nav.foldable-nav .with-child > label {
-      margin-bottom: 10px !important;
+      margin-bottom: 0 !important;
   }
   
-  // Add chevrons to all expandable items
-  nav.foldable-nav .ul-1 .with-child > label:after {
-      content: "\f105" !important; // fa-angle-right (thinner chevron)
+  // Add chevrons to all expandable items and rotate on expand
+  nav.foldable-nav .with-child > label:after {
+      content: "\f105" !important; // fa-angle-right
       font-family: "Font Awesome 6 Free", "Font Awesome 5 Free";
       font-weight: 900;
       color: $moon-500;
-      transition: color 0.3s;
+      transition: color 0.3s, transform 0.2s ease;
       font-size: 14px;
       position: absolute;
-      right: 0px;
-      top: 35%;
-      transform: translateY(-50%);
+      right: 4px; // move slightly left so the right edge isn't clipped
+      top: 50%;
+      transform: translateY(-50%) rotate(0deg);
   }
-  
-  // Change chevron for expanded items
-  nav.foldable-nav .ul-1 .with-child > input:checked + label:after {
-      content: "\f107" !important; // fa-angle-down (thinner chevron)
+
+  nav.foldable-nav .with-child > input:checked + label:after {
+      transform: translateY(-50%) rotate(90deg);
   }
   
   // Hover states
@@ -1295,6 +1294,28 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
   // Dark mode hover state
   [data-bs-theme=dark] nav.foldable-nav .ul-1 .with-child > label:hover:after {
       color: $wandb-gold !important;
+  }
+
+  // Smooth expand/collapse for nested lists
+  nav.foldable-nav .foldable {
+      display: block !important;
+      overflow: hidden;
+      max-height: 0;
+      opacity: 0;
+      margin-top: 0;   // no gap when collapsed
+      margin-bottom: 0; // prevent extra gap after last child block
+      transition: max-height 220ms ease, opacity 180ms ease, margin-top 180ms ease;
+  }
+  
+  nav.foldable-nav .with-child > input:checked ~ .foldable {
+      max-height: 1200px; // sufficiently large to accommodate content
+      opacity: 1;
+      margin-top: 6px; // consistent space between parent label and first child
+  }
+
+  // Remove extra space after the last child item in a group
+  nav.foldable-nav .foldable > li:last-child { 
+      margin-bottom: 0 !important; 
   }
   
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -135,8 +135,8 @@ p, td, div, li, .lead
 
 .td-sidebar-nav__section-title, .td-sidebar-nav__section without-child 
 {
-    font-size: 14px; 
-    font-weight: $font-weight-bold;
+    font-size: 14px !important; 
+    font-weight: $font-weight-bold !important;
 }
 
 // Headings
@@ -1447,6 +1447,20 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
     background-color: transparent !important;
     border: 0px !important;
 }
+
+// Language selector dropdown: match left-hand navigation typography
+#td-section-nav > div > div > ul > li > a, #td-section-nav > div > div > a, #main_navbar > ul.navbar-nav.main-nav-right > li.nav-item.dropdown.d-none.d-lg-flex > div > a, #main_navbar > ul.navbar-nav.main-nav-right > li.nav-item.dropdown.d-none.d-lg-flex > div > ul > li > a {
+    font-family: $base-font !important;
+    font-size: 14px !important;
+    font-weight: 500 !important;
+
+}
+
+#td-section-nav > div > div > a {
+    padding-left: 25px !important;
+    margin-bottom: 10px !important;
+}
+
 .gs-title b, .gs-title a, .gsc-cursor-page, .gsc-above-wrapper-area, .gcsc-find-more-on-google-query, .gcsc-find-more-on-google-magnifier {
     color: $link-primary !important;
     text-decoration: none !important;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -555,6 +555,7 @@ h1, h2, h3, h4, h5, h6 {
         margin: 0px !important;
         padding: 8px !important;
         font-weight: 500 !important;
+        font-size: 13px !important;
     }
     // List styles
     ul { 
@@ -562,6 +563,7 @@ h1, h2, h3, h4, h5, h6 {
         li {
             padding: 0px !important; 
             line-height: 14px;
+            font-size: 13px !important;
             a {
                 transition: all .2s ease-in;
             }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1644,6 +1644,10 @@ body > div.container-fluid.td-default.td-outer > main > section > div > h2 {
 
 // Ensure tables have enough space without removing all constraints
 .td-content {
+    // Limit content width for optimal readability
+    max-width: 75ch;
+    margin: 0; // Left-align the content
+    
     table {
         width: 100%;
         overflow-x: auto;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -549,7 +549,7 @@ h1, h2, h3, h4, h5, h6 {
 
 // Table of Contents Component
 #TableOfContents {
-    
+    font-family: $base-font;
     font-size: 13px !important;
     a{
         margin: 0px !important;
@@ -1162,9 +1162,9 @@ div.td-page-meta__lastmod {
 
 // Update the sidebar navigation styles
 .td-sidebar-nav {
-    font-family: "Source Sans Pro", sans-serif;
+    font-family: $base-font;
     padding-left: 15px !important;
-    font-size: 14px !important; // Reduced from default 16px
+    font-size: 13px !important; // Match TableOfContents font size
 
     // Base link styles
     a {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -329,7 +329,7 @@ $breakpoint-xl: 1200px;   // Large desktop
 
 
     // Tablet styles (577px and up)
-    @media (min-width: $breakpoint-sm + 1) {
+    @media (min-width: ($breakpoint-sm + 1)) {
         .container-fluid {
             padding: 8px 12px !important;
         }
@@ -541,6 +541,16 @@ h1, h2, h3, h4, h5, h6 {
         li {
             padding: 0px !important; 
             line-height: 14px;
+            a {
+                transition: all .2s ease-in;
+            }
+            a.active {
+                border-left: 2px solid;
+                color: $link-primary !important;
+                [data-bs-theme=dark] & {
+                    color: $dark-link-primary !important;
+                }
+            }
         }
     }
 
@@ -566,6 +576,13 @@ h1, h2, h3, h4, h5, h6 {
     // Dark mode
     [data-bs-theme=dark] & {
         color: $dark-text-primary;
+    }
+}
+
+aside div.td-toc #TableOfContents ul {
+    border-left-color: $text-tertiary !important;
+    [data-bs-theme=dark] & {
+        border-left-color: $dark-text-secondary !important;
     }
 }
 

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,0 +1,23 @@
+{{/*
+  Custom breadcrumb partial overriding Docsy's default to prepend a Home icon.
+  This renders a Font Awesome house icon linking to the site root as the first breadcrumb item.
+*/}}
+{{ $isSingle := true -}}
+{{ with .Parent -}}
+  {{ $isSingle = .IsHome -}}
+{{ end -}}
+<nav aria-label="breadcrumb" class="td-breadcrumbs{{ if $isSingle }} td-breadcrumbs__single{{ end }}">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <a aria-label="Home page" href="{{ "/" | relLangURL }}">
+        <svg class="breadcrumb-home-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+        </svg>
+      </a>
+    </li>
+    {{- range .Ancestors.Reverse -}}
+      <li class="breadcrumb-item"><a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a></li>
+    {{- end -}}
+    <li class="breadcrumb-item active" aria-current="page">{{ .LinkTitle | default .Title }}</li>
+  </ol>
+  </nav>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -16,7 +16,9 @@
       </a>
     </li>
     {{- range .Ancestors.Reverse -}}
-      <li class="breadcrumb-item"><a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a></li>
+      {{- if not .IsHome -}}
+        <li class="breadcrumb-item"><a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a></li>
+      {{- end -}}
     {{- end -}}
     <li class="breadcrumb-item active" aria-current="page">{{ .LinkTitle | default .Title }}</li>
   </ol>

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -50,6 +50,164 @@
   if (breadcrumb) {
     breadcrumb.insertAdjacentHTML('afterbegin', homeBreadcrumbHTML);
   }
+
+  // right-nav scroll monitoring
+  // Table of Contents Scroll Synchronization
+class TOCScrollSync {
+  constructor() {
+    this.toc = document.getElementById('TableOfContents');
+    this.tocLinks = [];
+    this.headings = [];
+    this.activeLink = null;
+    this.isScrolling = false;
+    this.scrollTimeout = null;
+    
+    this.init();
+  }
+
+  init() {
+    if (!this.toc) {
+      console.warn('Table of Contents not found');
+      return;
+    }
+
+    // Collect all TOC links and their corresponding headings
+    this.collectLinksAndHeadings();
+    
+    if (this.headings.length === 0) {
+      console.warn('No headings found for TOC synchronization');
+      return;
+    }
+
+    // Set up scroll listener with throttling
+    this.setupScrollListener();
+    
+    // Initial check to set active link
+    this.updateActiveLink();
+  }
+
+  collectLinksAndHeadings() {
+    const links = this.toc.querySelectorAll('a[href^="#"]');
+    
+    links.forEach(link => {
+      const href = link.getAttribute('href');
+      const headingId = href.substring(1); // Remove the # symbol
+      const heading = document.getElementById(headingId);
+      
+      if (heading) {
+        this.tocLinks.push({
+          link: link,
+          heading: heading,
+          id: headingId
+        });
+        this.headings.push(heading);
+      }
+    });
+  }
+
+  setupScrollListener() {
+    // Throttled scroll handler for better performance
+    const throttledScrollHandler = this.throttle(() => {
+      this.updateActiveLink();
+    }, 16); // ~60fps
+
+    window.addEventListener('scroll', throttledScrollHandler, { passive: true });
+    
+    // Also listen for resize events in case content shifts
+    window.addEventListener('resize', this.throttle(() => {
+      this.updateActiveLink();
+    }, 100));
+  }
+
+  updateActiveLink() {
+    const scrollPosition = window.scrollY;
+    const windowHeight = window.innerHeight;
+    const documentHeight = document.documentElement.scrollHeight;
+    
+    // If we're at the bottom of the page, activate the last heading
+    if (scrollPosition + windowHeight >= documentHeight - 10) {
+      this.setActiveLink(this.tocLinks[this.tocLinks.length - 1]);
+      return;
+    }
+
+    // Find the current active heading
+    let activeHeading = null;
+    const offset = 300; // Offset from top to account for fixed headers, etc.
+
+    // Check headings from top to bottom
+    for (let i = 0; i < this.headings.length; i++) {
+      const heading = this.headings[i];
+      const headingTop = heading.offsetTop;
+      
+      // If this heading is above the scroll position + offset, it could be active
+      if (headingTop <= scrollPosition + offset) {
+        activeHeading = this.tocLinks[i];
+      } else {
+        // Once we find a heading that's below our scroll position, stop
+        break;
+      }
+    }
+
+    // If no heading is above our scroll position, check if we're near the top
+    if (!activeHeading && this.tocLinks.length > 0) {
+      const firstHeading = this.headings[0];
+      const firstHeadingTop = firstHeading.offsetTop;
+      
+      // If we're above the first heading or very close to it, activate the first link
+      if (scrollPosition + offset >= firstHeadingTop - 50) {
+        activeHeading = this.tocLinks[0];
+      }
+    }
+
+    this.setActiveLink(activeHeading);
+  }
+
+  setActiveLink(newActiveLink) {
+    // Remove active class from current active link
+    if (this.activeLink && this.activeLink !== newActiveLink) {
+      this.activeLink.link.classList.remove('active');
+    }
+
+    // Set new active link
+    if (newActiveLink && newActiveLink !== this.activeLink) {
+      newActiveLink.link.classList.add('active');
+      this.activeLink = newActiveLink;
+    } else if (!newActiveLink && this.activeLink) {
+      // Remove active class if no section is active
+      this.activeLink.link.classList.remove('active');
+      this.activeLink = null;
+    }
+  }
+
+  // Utility function to throttle scroll events
+  throttle(func, limit) {
+    let inThrottle;
+    return function() {
+      const args = arguments;
+      const context = this;
+      if (!inThrottle) {
+        func.apply(context, args);
+        inThrottle = true;
+        setTimeout(() => inThrottle = false, limit);
+      }
+    }
+  }
+
+  // Public method to destroy the instance
+  destroy() {
+    // Remove event listeners if needed
+    // (In a real implementation, you'd want to store references to remove them)
+    console.log('TOC Scroll Sync destroyed');
+  }
+}
+
+// Initialize the TOC scroll synchronization when the DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  const tocSync = new TOCScrollSync();
+  
+  // Make it globally accessible if needed
+  window.tocSync = tocSync;
+});
   
 </script>
 

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -34,6 +34,23 @@
       }
   });
   
+  // Define the HTML with Font Awesome home icon
+  const homeBreadcrumbHTML = `
+    <li class="breadcrumb-item">
+      <a aria-label="Home page" href="/">
+        <i class="fa-solid fa-house" style="margin-right: 4px; font-size: 10px"></i>
+      </a>
+    </li>
+  `;
+
+  // Find the <ol> element with class 'breadcrumb'
+  const breadcrumb = document.querySelector('ol.breadcrumb');
+
+  // Only proceed if breadcrumb exists
+  if (breadcrumb) {
+    breadcrumb.insertAdjacentHTML('afterbegin', homeBreadcrumbHTML);
+  }
+  
 </script>
 
 {{- $topLevelItem := "" -}}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -34,22 +34,7 @@
       }
   });
   
-  // Define the HTML with Font Awesome home icon
-  const homeBreadcrumbHTML = `
-    <li class="breadcrumb-item">
-      <a aria-label="Home page" href="/">
-        <i class="fa-solid fa-house" style="margin-right: 4px; font-size: 10px"></i>
-      </a>
-    </li>
-  `;
-
-  // Find the <ol> element with class 'breadcrumb'
-  const breadcrumb = document.querySelector('ol.breadcrumb');
-
-  // Only proceed if breadcrumb exists
-  if (breadcrumb) {
-    breadcrumb.insertAdjacentHTML('afterbegin', homeBreadcrumbHTML);
-  }
+  // Home icon is now rendered via the breadcrumb partial; remove JS injection
 
   // right-nav scroll monitoring
   // Table of Contents Scroll Synchronization


### PR DESCRIPTION
This PR adds a bunch of CSS tweaks and also a couple of features:

- Breadcrumb: render a Home icon as the first item via the Hugo partial (no JS injection). 
- Left nav: adds smooth expand/collapse animation, rotating caret, fixes caret clipping, and normalizes spacing before/after child groups.

Partially inspired by me wanting to try GPT-5 :)