### PR TITLE
Python SDK: SDK Release 0.21.1

### DIFF
--- a/content/en/ref/cli/wandb-sync.md
+++ b/content/en/ref/cli/wandb-sync.md
@@ -33,6 +33,7 @@ Upload an offline training directory to W&B
 | `--show` | Number of runs to show |
 | `--append` | Append run |
 | `--skip-console` | Skip console logs |
+| `--replace-tags` | Replace tags in the format   'old_tag1=new_tag1,old_tag2=new_tag2' |
 
 
 

--- a/content/en/ref/python/_index.md
+++ b/content/en/ref/python/_index.md
@@ -1,12 +1,11 @@
 ---
-title: Python Library v(0.21.0)
+title: Python Library v(0.21.1)
 ---
 {{< cardpane >}}
     {{< card >}}
             <a href="/ref/python/python_api_walkthrough">
             <h2 className="card-title">API Walkthrough</h2></a>
             <p className="card-content">Learn when and how to use different W&B APIs in your machine learning workflows.</p>
-        
         {{< /card >}}
     {{< card >}}
             <a href="/ref/python/public-api">

--- a/content/en/ref/python/sdk/classes/Run.md
+++ b/content/en/ref/python/sdk/classes/Run.md
@@ -242,8 +242,8 @@ Customize metrics logged with `wandb.Run.log()`.
  - `step_metric`:  The name of another metric to serve as the X-axis  for this metric in automatically generated charts. 
  - `step_sync`:  Automatically insert the last value of step_metric into  `wandb.Run.log()` if it is not provided explicitly. Defaults to True  if step_metric is specified. 
  - `hidden`:  Hide this metric from automatic plots. 
- - `summary`:  Specify aggregate metrics added to summary.  Supported aggregations include "min", "max", "mean", "last",  "best", "copy" and "none". "best" is used together with the  goal parameter. "none" prevents a summary from being generated.  "copy" is deprecated and should not be used. 
- - `goal`:  Specify how to interpret the "best" summary type.  Supported options are "minimize" and "maximize". 
+ - `summary`:  Specify aggregate metrics added to summary.  Supported aggregations include "min", "max", "mean", "last",  "first", "best", "copy" and "none". "none" prevents a summary  from being generated. "best" is used together with the goal  parameter, "best" is deprecated and should not be used, use  "min" or "max" instead. "copy" is deprecated and should not be  used. 
+ - `goal`:  Specify how to interpret the "best" summary type.  Supported options are "minimize" and "maximize". "goal" is  deprecated and should not be used, use "min" or "max" instead. 
  - `overwrite`:  If false, then this call is merged with previous  `define_metric` calls for the same metric by using their  values for any unspecified parameters. If true, then  unspecified parameters overwrite values specified by  previous calls. 
 
 
@@ -680,8 +680,8 @@ Declare an artifact as an output of a run.
 log_code(
     root: 'str | None' = '.',
     name: 'str | None' = None,
-    include_fn: 'Callable[[str, str], bool] | Callable[[str], bool]' = <function _is_py_requirements_or_dockerfile at 0x102da5f30>,
-    exclude_fn: 'Callable[[str, str], bool] | Callable[[str], bool]' = <function exclude_wandb_fn at 0x103b4c5e0>
+    include_fn: 'Callable[[str, str], bool] | Callable[[str], bool]' = <function _is_py_requirements_or_dockerfile at 0x102e65f30>,
+    exclude_fn: 'Callable[[str, str], bool] | Callable[[str], bool]' = <function exclude_wandb_fn at 0x103c0c5e0>
 ) → Artifact | None
 ```
 

--- a/content/en/ref/python/sdk/classes/Settings.md
+++ b/content/en/ref/python/sdk/classes/Settings.md
@@ -154,68 +154,29 @@ Attributes:
 - sync_tensorboard (Optional): Whether to synchronize TensorBoard logs with W&B.
 - table_raise_on_max_row_limit_exceeded (bool): Whether to raise an exception when table row limits are exceeded.
 - username (Optional): Username.
-
-
 - x_disable_meta (bool): Flag to disable the collection of system metadata.
 - x_disable_stats (bool): Flag to disable the collection of system metrics.
-
-
 - x_extra_http_headers (Optional): Additional headers to add to all outgoing HTTP requests.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 - x_label (Optional): Label to assign to system metrics and console logs collected for the run.
     This is used to group data by on the frontend and can be used to distinguish data
     from different processes in a distributed training job.
-
-
-
-
 - x_primary (bool): Determines whether to save internal wandb files and metadata.
     In a distributed setting, this is useful for avoiding file overwrites
     from secondary processes when only system metrics and logs are needed,
     as the primary process handles the main logging.
-
-
 - x_save_requirements (bool): Flag to save the requirements file.
 - x_server_side_derived_summary (bool): Flag to delegate automatic computation of summary from history to the server.
     This does not disable user-provided summary updates.
-
-
 - x_service_wait (float): Time in seconds to wait for the wandb-core internal service to start.
 - x_skip_transaction_log (bool): Whether to skip saving the run events to the transaction log.
     This is only relevant for online runs. Can be used to reduce the amount of
     data written to disk.
     Should be used with caution, as it removes the gurantees about
     recoverability.
-
-
-
-
 - x_stats_cpu_count (Optional): System CPU count.
     If set, overrides the auto-detected value in the run metadata.
 - x_stats_cpu_logical_count (Optional): Logical CPU count.
     If set, overrides the auto-detected value in the run metadata.
-
 - x_stats_disk_paths (Optional): System paths to monitor for disk usage.
 - x_stats_gpu_count (Optional): GPU device count.
     If set, overrides the auto-detected value in the run metadata.
@@ -224,19 +185,16 @@ Attributes:
     Assumes 0-based indexing matching CUDA/ROCm device enumeration.
 - x_stats_gpu_type (Optional): GPU device type.
     If set, overrides the auto-detected value in the run metadata.
-
 - x_stats_open_metrics_endpoints (Optional): OpenMetrics `/metrics` endpoints to monitor for system metrics.
 - x_stats_open_metrics_filters (Union): Filter to apply to metrics collected from OpenMetrics `/metrics` endpoints.
     Supports two formats:
     - {"metric regex pattern, including endpoint name as prefix": {"label": "label value regex pattern"}}
     - ("metric regex pattern 1", "metric regex pattern 2", ...)
 - x_stats_open_metrics_http_headers (Optional): HTTP headers to add to OpenMetrics requests.
-
 - x_stats_sampling_interval (float): Sampling interval for the system monitor in seconds.
 - x_stats_track_process_tree (bool): Monitor the entire process tree for resource usage, starting from `x_stats_pid`.
     When `True`, the system monitor aggregates the RSS, CPU%, and thread count
     from the process with PID `x_stats_pid` and all of its descendants.
     This can have a performance overhead and is disabled by default.
-
 - x_update_finish_state (bool): Flag to indicate whether this process can update the run's final state on the server.
     Set to False in distributed training when only the main process should determine the final state.

--- a/content/en/ref/python/sdk/classes/Settings.md
+++ b/content/en/ref/python/sdk/classes/Settings.md
@@ -156,6 +156,11 @@ Attributes:
 - username (Optional): Username.
 
 
+- x_disable_meta (bool): Flag to disable the collection of system metadata.
+- x_disable_stats (bool): Flag to disable the collection of system metrics.
+
+
+- x_extra_http_headers (Optional): Additional headers to add to all outgoing HTTP requests.
 
 
 
@@ -178,24 +183,25 @@ Attributes:
 
 
 
+- x_label (Optional): Label to assign to system metrics and console logs collected for the run.
+    This is used to group data by on the frontend and can be used to distinguish data
+    from different processes in a distributed training job.
 
 
 
 
+- x_primary (bool): Determines whether to save internal wandb files and metadata.
+    In a distributed setting, this is useful for avoiding file overwrites
+    from secondary processes when only system metrics and logs are needed,
+    as the primary process handles the main logging.
 
 
+- x_save_requirements (bool): Flag to save the requirements file.
+- x_server_side_derived_summary (bool): Flag to delegate automatic computation of summary from history to the server.
+    This does not disable user-provided summary updates.
 
 
-
-
-
-
-
-
-
-
-
-
+- x_service_wait (float): Time in seconds to wait for the wandb-core internal service to start.
 - x_skip_transaction_log (bool): Whether to skip saving the run events to the transaction log.
     This is only relevant for online runs. Can be used to reduce the amount of
     data written to disk.
@@ -205,21 +211,32 @@ Attributes:
 
 
 
+- x_stats_cpu_count (Optional): System CPU count.
+    If set, overrides the auto-detected value in the run metadata.
+- x_stats_cpu_logical_count (Optional): Logical CPU count.
+    If set, overrides the auto-detected value in the run metadata.
 
-
-
-
-
-
-
+- x_stats_disk_paths (Optional): System paths to monitor for disk usage.
+- x_stats_gpu_count (Optional): GPU device count.
+    If set, overrides the auto-detected value in the run metadata.
+- x_stats_gpu_device_ids (Optional): GPU device indices to monitor.
+    If not set, the system monitor captures metrics for all GPUs.
+    Assumes 0-based indexing matching CUDA/ROCm device enumeration.
+- x_stats_gpu_type (Optional): GPU device type.
+    If set, overrides the auto-detected value in the run metadata.
 
 - x_stats_open_metrics_endpoints (Optional): OpenMetrics `/metrics` endpoints to monitor for system metrics.
 - x_stats_open_metrics_filters (Union): Filter to apply to metrics collected from OpenMetrics `/metrics` endpoints.
     Supports two formats:
     - {"metric regex pattern, including endpoint name as prefix": {"label": "label value regex pattern"}}
     - ("metric regex pattern 1", "metric regex pattern 2", ...)
+- x_stats_open_metrics_http_headers (Optional): HTTP headers to add to OpenMetrics requests.
 
+- x_stats_sampling_interval (float): Sampling interval for the system monitor in seconds.
+- x_stats_track_process_tree (bool): Monitor the entire process tree for resource usage, starting from `x_stats_pid`.
+    When `True`, the system monitor aggregates the RSS, CPU%, and thread count
+    from the process with PID `x_stats_pid` and all of its descendants.
+    This can have a performance overhead and is disabled by default.
 
-
-
-
+- x_update_finish_state (bool): Flag to indicate whether this process can update the run's final state on the server.
+    Set to False in distributed training when only the main process should determine the final state.

--- a/content/en/ref/python/sdk/functions/init.md
+++ b/content/en/ref/python/sdk/functions/init.md
@@ -45,7 +45,7 @@ Start a new run to track and log to W&B.
 
 In an ML training pipeline, you could add `wandb.init()` to the beginning of your training script as well as your evaluation script, and each piece would be tracked as a run in W&B. 
 
-`wandb.init()` spawns a new background process to log data to a run, and it also syncs data to https://wandb.ai by default, so you can see your results in real-time. When you're done logging data, call `wandb.finish()` to end the run. If you don't call `run.finish()`, the run will end when your script exits. 
+`wandb.init()` spawns a new background process to log data to a run, and it also syncs data to https://wandb.ai by default, so you can see your results in real-time. When you're done logging data, call `wandb.Run.finish()` to end the run. If you don't call `run.finish()`, the run will end when your script exits. 
 
 Run IDs must not contain any of the following special characters `/ \ # ? % :` 
 
@@ -94,6 +94,11 @@ Run IDs must not contain any of the following special characters `/ \ # ? % :`
 
 
 
+**Returns:**
+ A `Run` object. 
+
+
+
 **Raises:**
  
  - `Error`:  If some unknown or internal error happened during the run  initialization. 
@@ -101,13 +106,6 @@ Run IDs must not contain any of the following special characters `/ \ # ? % :`
  - `CommError`:  If there was a problem communicating with the WandB server. 
  - `UsageError`:  If the user provided invalid arguments. 
  - `KeyboardInterrupt`:  If user interrupts the run. 
-
-
-
-**Returns:**
- A `Run` object. 
-
-
 
 
 

--- a/content/en/ref/python/sdk/functions/login.md
+++ b/content/en/ref/python/sdk/functions/login.md
@@ -32,7 +32,7 @@ By default, this will only store credentials locally without verifying them with
 
 **Args:**
  
- - `anonymous`:  Set to "must", "allow", or "never".  If set to "must", always log a user in anonymously. If set to  "allow", only create an anonymous user if the user  isn't already logged in. If set to "never", never log a  user anonymously. Default set to "never". 
+ - `anonymous`:  Set to "must", "allow", or "never".  If set to "must", always log a user in anonymously. If set to  "allow", only create an anonymous user if the user  isn't already logged in. If set to "never", never log a  user anonymously. Default set to "never". Defaults to `None`. 
  - `key`:  The API key to use. 
  - `relogin`:  If true, will re-prompt for API key. 
  - `host`:  The host to connect to. 

--- a/content/en/ref/python/sdk/functions/sweep.md
+++ b/content/en/ref/python/sdk/functions/sweep.md
@@ -41,4 +41,4 @@ See [Sweep configuration structure](https://docs.wandb.ai/guides/sweeps/define-s
 
 **Returns:**
  
- - `sweep_id`:  (str) A unique identifier for the sweep. 
+ - `str`:  A unique identifier for the sweep. 


### PR DESCRIPTION
Manual updates SDK Docs for Release 0.21.1.  

Here's the docugen version that was not used (since no using lazydocs): https://github.com/wandb/docs/pull/1501