### PR TITLE
[DOCS-1262] ci: Action to leave a PR comment with page-level Cloudflare preview links for added/modified/deleted pages and visual assets

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -364,7 +364,7 @@ jobs:
                   const currentBody = pr.data.body || '';
                   const commentUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}#issuecomment-${existing.id}`;
                   const linkMarker = '<!-- preview-links-comment -->';
-                  const linkText = `\n\n${linkMarker}\n📄 **[View preview links for changed pages](${commentUrl})**`;
+                  const linkText = `\n\n${linkMarker}\n\n📄 **[View preview links for changed content](${commentUrl})**`;
                   
                   // Only add if not already present
                   if (!currentBody.includes(linkMarker)) {

--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -1,0 +1,392 @@
+name: PR Preview Links - Update on Cloudflare Comment
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  update-preview-links:
+    # Only run on PR comments from Cloudflare bot
+    if: |
+      github.event.issue.pull_request && 
+      contains(github.event.comment.user.login, 'cloudflare') &&
+      contains(github.event.comment.body, 'Branch Preview URL')
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('base_sha', pr.data.base.sha);
+            
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Get Hugo version and setup
+        run: |
+          set -euo pipefail
+          ver=$(grep 'HUGO_VERSION' wrangler.toml | awk -F '"' '{print $2}')
+          wget "https://github.com/gohugoio/hugo/releases/download/v${ver}/hugo_extended_${ver}_linux-amd64.deb" -O hugo.deb
+          sudo apt-get update
+          sudo apt-get install -y ./hugo.deb
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Setup deps for build
+        run: |
+          set -euo pipefail
+          npm install
+          go mod download
+          hugo mod get -u
+
+      - name: Get changed files
+        id: changed
+        uses: tj-actions/changed-files@v44
+        with:
+          base_sha: ${{ steps.pr.outputs.base_sha }}
+          sha: ${{ steps.pr.outputs.head_sha }}
+          files: |
+            content/**
+            static/**
+            assets/**
+            layouts/**
+            i18n/**
+            configs/**
+
+      - name: Build Hugo (generate pageurls)
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          hugo --minify
+          test -f public/pageurls.json && echo "Found pageurls.json" || (echo "Missing pageurls.json" && ls -la public || true)
+
+      - name: Extract Branch Preview URL
+        id: extract-url
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function sanitizeUrl(u) {
+              if (!u) return '';
+              u = u.trim().replace(/^['"<]+/, '').replace(/[>'"]+$/, '');
+              u = u.split(/[\s<>'"\]\)]/)[0];
+              try { u = decodeURI(u); } catch (e) {}
+              return u.replace(/\/$/, '');
+            }
+            
+            function extractBranchPreviewUrl(body) {
+              const patterns = [
+                // Table format with anchor tag (what Cloudflare actually uses)
+                /Branch\s+Preview\s+URL:<\/strong><\/td><td>[\s\S]*?<a[^>]+href=['"]([^'"<>]+pages\.dev[^'"<>]*)['"]/i,
+                // Try anchor tag format on same line
+                /Branch\s+Preview\s+URL:\s*<a[^>]+href=['"]([^'"<>]+pages\.dev[^'"<>]*)['"]/i,
+                // Try plain URL format
+                /Branch\s+Preview\s+URL:\s*<?(?:https?:\/\/)?([^\s<>]+pages\.dev[^\s<>]*)/i
+              ];
+              
+              for (const pattern of patterns) {
+                const m = (body || '').match(pattern);
+                if (m && m[1]) {
+                  const url = m[1];
+                  if (!url.startsWith('http')) {
+                    return sanitizeUrl('https://' + url);
+                  }
+                  return sanitizeUrl(url);
+                }
+              }
+              return '';
+            }
+            
+            const branchUrl = extractBranchPreviewUrl(context.payload.comment.body);
+            core.info(`Extracted Branch Preview URL: ${branchUrl}`);
+            core.setOutput('branch_url', branchUrl);
+
+      - name: Update PR comment with preview links
+        if: steps.changed.outputs.any_changed == 'true' && steps.extract-url.outputs.branch_url
+        uses: actions/github-script@v7
+        env:
+          ADDED: ${{ steps.changed.outputs.added_files }}
+          MODIFIED: ${{ steps.changed.outputs.modified_files }}
+          DELETED: ${{ steps.changed.outputs.deleted_files }}
+          PREVIEW_BASE: ${{ steps.extract-url.outputs.branch_url }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            function splitList(s) {
+              if (!s) return [];
+              return s
+                .split(/\r?\n|,|\s+/)
+                .map(x => x.trim())
+                .filter(Boolean);
+            }
+
+            const added = splitList(process.env.ADDED);
+            const modified = splitList(process.env.MODIFIED);
+            const deleted = splitList(process.env.DELETED);
+
+            const allChanged = [...added, ...modified, ...deleted];
+            const anyEligible = allChanged.some(p => /^(content|static|assets)\//.test(p));
+            
+            // Handle case where there are no content changes
+            if (!anyEligible) {
+              core.info('No relevant content changes. Updating comment to reflect this.');
+              
+              const previewBase = (process.env.PREVIEW_BASE || '').replace(/\/$/, '');
+              const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + previewBase + ' -->\n**PR Preview: Changed content**';
+              const body = header + '\n\nNo documentation content changes in this PR.';
+              
+              // Find and update our existing comment
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              
+              const existing = comments.find(c => /<!-- docs-preview-links -->/.test(c.body || ''));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                core.info('Updated existing preview links comment to show no content changes');
+              }
+              
+              return;
+            }
+
+            let pageMap = [];
+            try {
+              const raw = fs.readFileSync('public/pageurls.json', 'utf8');
+              pageMap = JSON.parse(raw);
+            } catch (e) {
+              core.warning('Could not read public/pageurls.json. Proceeding with unlinked entries. ' + e.message);
+              pageMap = [];
+            }
+
+            // Build lookup: support keys with and without language prefix
+            const byPath = new Map();
+            for (const p of pageMap) {
+              const lang = p.lang || '';
+              const rel = (p.path || '').replace(/^\/+/, '').replace(/\\/g, '/');
+              const withLang = lang && !rel.startsWith(lang + '/') ? `${lang}/${rel}` : rel;
+              const withoutLang = lang && rel.startsWith(lang + '/') ? rel.slice(lang.length + 1) : rel;
+              const keys = new Set([
+                rel,
+                withLang,
+                withoutLang,
+                path.posix.join('content', withLang),
+                path.posix.join('content', withoutLang),
+              ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
+              for (const k of keys) byPath.set(k, p);
+            }
+
+            const previewBase = (process.env.PREVIEW_BASE || '').replace(/\/$/, '');
+            core.info(`Using Branch Preview URL: ${previewBase}`);
+
+            function mapEntry(filePath) {
+              const norm = filePath.replace(/\\/g, '/');
+              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+              if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
+              const rel = item.relPermalink || '';
+              const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
+              const title = item.title || titleFromPath(norm);
+              return { title, rel, href, path: norm };
+            }
+
+            function titleFromPath(p) {
+              const stem = p.replace(/^content\//, '').replace(/\.(md|markdown)$/, '');
+              const parts = stem.split('/');
+              const last = parts[parts.length - 1];
+              const base = last === 'index' ? (parts[parts.length - 2] || 'index') : last;
+              return base.replace(/[\-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            }
+
+            // Function to check if a file is an include
+            function isIncludeFile(filePath) {
+              return /^content\/[^\/]+\/_includes\//.test(filePath);
+            }
+            
+            // Function to find pages that use a specific include
+            function findPagesUsingInclude(includePath) {
+              const includeFileName = includePath.split('/').pop();
+              const includeRef = `/_includes/${includeFileName}`;
+              const pagesUsingInclude = [];
+              
+              // Search through all pages in pageMap
+              for (const page of pageMap) {
+                if (page.path && page.path.endsWith('.md')) {
+                  try {
+                    // Construct the correct file path: content/<lang>/<page.path>
+                    const contentPath = path.join('content', page.lang || 'en', page.path);
+                    if (fs.existsSync(contentPath)) {
+                      const content = fs.readFileSync(contentPath, 'utf8');
+                      // Check for both readfile syntaxes
+                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+["']${includeRef}["']\\s*%\\}\\}`, 'i');
+                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["']${includeRef}["']\\s*>\\}\\}`, 'i');
+                      
+                      if (pattern1.test(content) || pattern2.test(content)) {
+                        pagesUsingInclude.push(page);
+                      }
+                    }
+                  } catch (e) {
+                    // Skip if file can't be read
+                  }
+                }
+              }
+              
+              return pagesUsingInclude;
+            }
+
+            function buildRows(files) {
+              const rows = [];
+              
+              for (const fp of files) {
+                if (fp.startsWith('content/')) {
+                  // Check if this is an include file
+                  if (isIncludeFile(fp)) {
+                    // Use just the filename for includes
+                    const filename = fp.split('/').pop();
+                    
+                    // Find pages that use this include
+                    const dependentPages = findPagesUsingInclude(fp);
+                    
+                    // Build the title cell with filename and dependent pages
+                    let titleCell = `\`${filename}\``;
+                    if (dependentPages.length > 0) {
+                      // Add dependent pages as a nested list
+                      const pageLinks = dependentPages.map(page => {
+                        const href = previewBase ? (previewBase + page.relPermalink) : '';
+                        const linkText = page.title || titleFromPath(page.path);
+                        return href ? `[${linkText}](${href})` : linkText;
+                      });
+                      
+                      const dependentList = pageLinks.map(link => `<br>↳ ${link}`).join('');
+                      titleCell += `:${dependentList}`;
+                    }
+                    
+                    rows.push(`| ${titleCell} | \`${fp}\` |`);
+                  } else {
+                    // Regular content file
+                    const e = mapEntry(fp);
+                    const titleCell = e.href ? `[${e.title}](${e.href})` : e.title;
+                    const pathCell = '`' + e.path + '`';
+                    rows.push(`| ${titleCell} | ${pathCell} |`);
+                  }
+                } else {
+                  // Static/assets: create direct preview links if base is known
+                  // Only link common web assets; skip JSON, map files, etc.
+                  const isLinkableAsset = /\.(png|jpe?g|gif|webp|svg|css|js|ico|txt|pdf|mp4|webm)$/i.test(fp);
+                  const rel = fp.replace(/^static\//, '/').replace(/^assets\//, '/assets/');
+                  const href = (previewBase && isLinkableAsset) ? (previewBase + rel) : '';
+                  const title = titleFromPath(fp);
+                  const titleCell = href ? `[${title}](${href})` : title;
+                  const pathCell = '`' + fp + '`';
+                  rows.push(`| ${titleCell} | ${pathCell} |`);
+                }
+              }
+              
+              return rows;
+            }
+
+            const addedRows = buildRows(added);
+            const modifiedRows = buildRows(modified);
+            const deletedRows = buildRows(deleted);
+
+            const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + previewBase + ' -->\n**PR Preview: Changed content**\n\nBase preview: ' + previewBase;
+            
+            function section(title, rows) {
+              if (rows.length === 0) return '';
+              return `\n\n### ${title}\n\n| Title | Path |\n| --- | --- |\n${rows.join('\n')}`;
+            }
+
+            const body = [
+              header,
+              section('Added', addedRows),
+              section('Modified', modifiedRows),
+              section('Deleted', deletedRows),
+            ].join('');
+
+            // Find and update our existing comment
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            
+            const existing = comments.find(c => /<!-- docs-preview-links -->/.test(c.body || ''));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info('Updated existing preview links comment');
+              
+              // Add link to PR description if we have preview links
+              if (added.length + modified.length > 0) {
+                try {
+                  const pr = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.issue.number,
+                  });
+                  
+                  const currentBody = pr.data.body || '';
+                  const commentUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}#issuecomment-${existing.id}`;
+                  const linkMarker = '<!-- preview-links-comment -->';
+                  const linkText = `\n\n${linkMarker}\n📄 **[View preview links for changed pages](${commentUrl})**`;
+                  
+                  // Only add if not already present
+                  if (!currentBody.includes(linkMarker)) {
+                    await github.rest.pulls.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: context.issue.number,
+                      body: currentBody + linkText,
+                    });
+                    core.info('Added preview link to PR description');
+                  }
+                } catch (e) {
+                  core.warning(`Could not update PR description: ${e.message}`);
+                }
+              }
+            } else {
+              // This shouldn't happen since main workflow creates comment first
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Created new preview links comment');
+            }

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -1,0 +1,506 @@
+name: PR Preview Links
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  preview-links:
+    runs-on: ubuntu-latest
+    env:
+      CF_PAGES_SUFFIX: docodile.pages.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Get Hugo version and setup
+        run: |
+          set -euo pipefail
+          ver=$(grep 'HUGO_VERSION' wrangler.toml | awk -F '"' '{print $2}')
+          wget "https://github.com/gohugoio/hugo/releases/download/v${ver}/hugo_extended_${ver}_linux-amd64.deb" -O hugo.deb
+          sudo apt-get update
+          sudo apt-get install -y ./hugo.deb
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Setup deps for build
+        run: |
+          set -euo pipefail
+          npm install
+          go mod download
+          hugo mod get -u
+
+      - name: Get changed files
+        id: changed
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            content/**
+            static/**
+            assets/**
+            layouts/**
+            i18n/**
+            configs/**
+
+      - name: Build Hugo (generate pageurls)
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          hugo --minify
+          test -f public/pageurls.json && echo "Found pageurls.json" || (echo "Missing pageurls.json" && ls -la public || true)
+
+      - name: Create or find preview comment
+        if: steps.changed.outputs.any_changed == 'true'
+        id: find-comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // First, check if our comment already exists
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            
+            const existingComment = comments.find(c => /<!-- docs-preview-links -->/.test(c.body || ''));
+            if (existingComment) {
+              core.info(`Found existing preview comment: ${existingComment.id}`);
+              core.setOutput('comment_id', existingComment.id);
+              core.setOutput('comment_exists', 'true');
+            } else {
+              // Create placeholder comment immediately
+              const placeholderBody = `<!-- docs-preview-links -->\n<!-- preview-base:  -->\n**PR Preview: Changed content**\n\n⏳ *Generating preview links...*\n\n<sub>This comment will be automatically updated when file changes are detected and Cloudflare Pages finishes deploying.</sub>`;
+              
+              const newComment = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: placeholderBody,
+              });
+              
+              core.info(`Created placeholder preview comment: ${newComment.data.id}`);
+              core.setOutput('comment_id', newComment.data.id);
+              core.setOutput('comment_exists', 'false');
+            }
+            
+      - name: Find Cloudflare Branch Preview URL
+        if: steps.changed.outputs.any_changed == 'true'
+        id: find-preview
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function htmlDecode(s) {
+              return (s || '')
+                .replace(/&amp;/g, '&')
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>')
+                .replace(/&quot;/g, '"')
+                .replace(/&#39;/g, "'");
+            }
+            function sanitizeUrl(u) {
+              if (!u) return '';
+              u = htmlDecode(u.trim());
+              u = u.replace(/^['"<]+/, '').replace(/[>'"]+$/, '');
+              u = u.split(/[\s<>'"\]\)]/)[0];
+              try { u = decodeURI(u); } catch (e) {}
+              return u.replace(/\/$/, '');
+            }
+            function extractBranchPreviewUrl(body) {
+              // Look for "Branch Preview URL:" followed by a URL
+              // In Cloudflare's table format, it's split across table cells
+              const patterns = [
+                // Table format with anchor tag (what Cloudflare actually uses)
+                // Matches across multiple lines in a table cell
+                /Branch\s+Preview\s+URL:<\/strong><\/td><td>[\s\S]*?<a[^>]+href=['"]([^'"<>]+pages\.dev[^'"<>]*)['"]/i,
+                // Try anchor tag format on same line
+                /Branch\s+Preview\s+URL:\s*<a[^>]+href=['"]([^'"<>]+pages\.dev[^'"<>]*)['"]/i,
+                // Try markdown link format
+                /Branch\s+Preview\s+URL:\s*\[.*?\]\(([^)]+pages\.dev[^)]*)\)/i,
+                // Try plain URL format (with or without angle brackets)
+                /Branch\s+Preview\s+URL:\s*<?(?:https?:\/\/)?([^\s<>]+pages\.dev[^\s<>]*)/i
+              ];
+              
+              for (const pattern of patterns) {
+                const m = (body || '').match(pattern);
+                if (m && m[1]) {
+                  const url = m[1];
+                  // Make sure we have the full URL including https://
+                  if (!url.startsWith('http')) {
+                    return sanitizeUrl('https://' + url);
+                  }
+                  return sanitizeUrl(url);
+                }
+              }
+              return '';
+            }
+            async function fromOurExistingComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              const ours = comments.find(c => /<!-- docs-preview-links -->/i.test(c.body || ''));
+              if (!ours) return '';
+              const body = ours.body || '';
+              const hidden = body.match(/<!--\s*preview-base:\s*([^>]+?)\s*-->/i);
+              if (hidden && hidden[1]) return sanitizeUrl(hidden[1]);
+              return '';
+            }
+            async function waitForCloudflareBranchUrl(maxWaitMs = 120000) { // Max 2 minutes
+              const startTime = Date.now();
+              let delayMs = 5000; // Start with 5 seconds
+              let attempt = 0;
+              
+              while (Date.now() - startTime < maxWaitMs) {
+                attempt++;
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  per_page: 100,
+                });
+                
+                for (const c of comments) {
+                  // Check if this is a Cloudflare comment
+                  if (c.user && c.user.login && c.user.login.includes('cloudflare') && c.body && c.body.includes('pages.dev')) {
+                    core.info(`Found Cloudflare comment from ${c.user.login}`);
+                    const url = extractBranchPreviewUrl(c.body || '');
+                    if (url) {
+                      core.info(`Successfully extracted Branch Preview URL: ${url}`);
+                      return url;
+                    } else if (c.body.includes('Branch Preview URL')) {
+                      core.info('Branch Preview URL field found but URL not yet populated');
+                    }
+                  }
+                }
+                
+                const elapsed = Math.round((Date.now() - startTime) / 1000);
+                const remaining = Math.round((maxWaitMs - (Date.now() - startTime)) / 1000);
+                
+                if (Date.now() - startTime + delayMs < maxWaitMs) {
+                  core.info(`Attempt ${attempt}: Branch Preview URL not found yet (${elapsed}s elapsed, ${remaining}s remaining)`);
+                  await new Promise(r => setTimeout(r, delayMs));
+                  // Exponential backoff: increase delay but cap at 20 seconds
+                  delayMs = Math.min(delayMs * 1.5, 20000);
+                }
+              }
+              
+              core.warning('Branch Preview URL not found within 2 minutes. Links will be added when Cloudflare comment triggers update workflow.');
+              return '';
+            }
+            let base = await waitForCloudflareBranchUrl();
+            if (!base) base = await fromOurExistingComment();
+            core.info(`Branch Preview URL found: ${base || '(not yet)'}`);
+            core.setOutput('base', base);
+
+      - name: Update PR comment with preview links
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          ADDED: ${{ steps.changed.outputs.added_files }}
+          MODIFIED: ${{ steps.changed.outputs.modified_files }}
+          DELETED: ${{ steps.changed.outputs.deleted_files }}
+          PREVIEW_BASE: ${{ steps.find-preview.outputs.base }}
+          COMMENT_ID: ${{ steps.find-comment.outputs.comment_id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            function splitList(s) {
+              if (!s) return [];
+              // Support newline, comma, or space separated outputs
+              return s
+                .split(/\r?\n|,|\s+/)
+                .map(x => x.trim())
+                .filter(Boolean);
+            }
+
+            const added = splitList(process.env.ADDED);
+            const modified = splitList(process.env.MODIFIED);
+            const deleted = splitList(process.env.DELETED);
+
+            const allChanged = [...added, ...modified, ...deleted];
+            const anyEligible = allChanged.some(p => /^(content|static|assets)\//.test(p));
+            if (!anyEligible) {
+              core.info('No relevant content changes. Updating comment to reflect this.');
+              
+              // Update the comment to show no content changes
+              const commentId = process.env.COMMENT_ID;
+              if (!commentId) {
+                core.error('No comment ID found');
+                return;
+              }
+              
+              const previewBase = (process.env.PREVIEW_BASE || '').replace(/\/$/, '');
+              const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + (previewBase || '') + ' -->\n**PR Preview: Changed content**';
+              const body = header + '\n\nNo documentation content changes in this PR.';
+              
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(commentId),
+                body,
+              });
+              
+              core.info('Updated preview comment to show no content changes');
+              return;
+            }
+
+            let pageMap = [];
+            try {
+              const raw = fs.readFileSync('public/pageurls.json', 'utf8');
+              pageMap = JSON.parse(raw);
+            } catch (e) {
+              core.warning('Could not read public/pageurls.json. Proceeding with unlinked entries. ' + e.message);
+              pageMap = [];
+            }
+
+            // Build lookup: support keys with and without language prefix
+            const byPath = new Map();
+            for (const p of pageMap) {
+              const lang = p.lang || '';
+              const rel = (p.path || '').replace(/^\/+/, '').replace(/\\/g, '/');
+              const withLang = lang && !rel.startsWith(lang + '/') ? `${lang}/${rel}` : rel;
+              const withoutLang = lang && rel.startsWith(lang + '/') ? rel.slice(lang.length + 1) : rel;
+              const keys = new Set([
+                rel,
+                withLang,
+                withoutLang,
+                path.posix.join('content', withLang),
+                path.posix.join('content', withoutLang),
+              ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
+              for (const k of keys) byPath.set(k, p);
+            }
+
+            // Find Cloudflare preview base URL from existing PR comments
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            // Helpers to extract and sanitize pages.dev URLs
+            function htmlDecode(s) {
+              return s
+                .replace(/&amp;/g, '&')
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>')
+                .replace(/&quot;/g, '"')
+                .replace(/&#39;/g, "'");
+            }
+            function sanitizeUrl(u) {
+              if (!u) return '';
+              u = htmlDecode(u.trim());
+              // trim surrounding quotes or angle brackets
+              u = u.replace(/^['"<]+/, '').replace(/[>'"]+$/, '');
+              // cut at first disallowed delimiter if present
+              u = u.split(/[\s<>'"\]\)]/)[0];
+              try { u = decodeURI(u); } catch (e) {}
+              // remove trailing slash
+              return u.replace(/\/$/, '');
+            }
+            function extractUrls(body) {
+              const urls = [];
+              const regex = /https?:\/\/[^\s'"<>]+pages\.dev[^\s'"<>]*/ig;
+              const matches = (body || '').match(regex) || [];
+              for (let m of matches) {
+                const clean = sanitizeUrl(m);
+                if (clean && !urls.includes(clean)) urls.push(clean);
+              }
+              return urls;
+            }
+
+            // Use Branch Preview URL extracted from Cloudflare comment
+            const previewBase = (process.env.PREVIEW_BASE || '').replace(/\/$/, '');
+            if (!previewBase) {
+              core.warning('No Branch Preview URL found yet; leaving links unlinked rather than using commit URL.');
+            }
+            core.info(`Preview base: ${previewBase || '(not found yet)'}`);
+
+            function mapEntry(filePath) {
+              const norm = filePath.replace(/\\/g, '/');
+              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+              if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
+              const rel = item.relPermalink || '';
+              const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
+              const title = item.title || titleFromPath(norm);
+              return { title, rel, href, path: norm };
+            }
+
+            function titleFromPath(p) {
+              const stem = p.replace(/^content\//, '').replace(/\.(md|markdown)$/, '');
+              const parts = stem.split('/');
+              const last = parts[parts.length - 1];
+              const base = last === 'index' ? (parts[parts.length - 2] || 'index') : last;
+              return base.replace(/[\-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            }
+
+            // Function to check if a file is an include
+            function isIncludeFile(filePath) {
+              return /^content\/[^\/]+\/_includes\//.test(filePath);
+            }
+            
+            // Function to find pages that use a specific include
+            function findPagesUsingInclude(includePath) {
+              const includeFileName = includePath.split('/').pop();
+              const includeRef = `/_includes/${includeFileName}`;
+              const pagesUsingInclude = [];
+              
+              // Search through all pages in pageMap
+              for (const page of pageMap) {
+                if (page.path && page.path.endsWith('.md')) {
+                  try {
+                    // Construct the correct file path: content/<lang>/<page.path>
+                    const contentPath = path.join('content', page.lang || 'en', page.path);
+                    if (fs.existsSync(contentPath)) {
+                      const content = fs.readFileSync(contentPath, 'utf8');
+                      // Check for both readfile syntaxes
+                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+["']${includeRef}["']\\s*%\\}\\}`, 'i');
+                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["']${includeRef}["']\\s*>\\}\\}`, 'i');
+                      
+                      if (pattern1.test(content) || pattern2.test(content)) {
+                        pagesUsingInclude.push(page);
+                      }
+                    }
+                  } catch (e) {
+                    // Skip if file can't be read
+                  }
+                }
+              }
+              
+              return pagesUsingInclude;
+            }
+
+            function buildRows(files) {
+              const rows = [];
+              
+              for (const fp of files) {
+                if (fp.startsWith('content/')) {
+                  // Check if this is an include file
+                  if (isIncludeFile(fp)) {
+                    // Use just the filename for includes
+                    const filename = fp.split('/').pop();
+                    
+                    // Find pages that use this include
+                    const dependentPages = findPagesUsingInclude(fp);
+                    
+                    // Build the title cell with filename and dependent pages
+                    let titleCell = `\`${filename}\``;
+                    if (dependentPages.length > 0) {
+                      // Add dependent pages as a nested list
+                      const pageLinks = dependentPages.map(page => {
+                        const href = previewBase ? (previewBase + page.relPermalink) : '';
+                        const linkText = page.title || titleFromPath(page.path);
+                        return href ? `[${linkText}](${href})` : linkText;
+                      });
+                      
+                      const dependentList = pageLinks.map(link => `<br>↳ ${link}`).join('');
+                      titleCell += `:${dependentList}`;
+                    }
+                    
+                    rows.push(`| ${titleCell} | \`${fp}\` |`);
+                  } else {
+                    // Regular content file
+                    const e = mapEntry(fp);
+                    const titleCell = e.href ? `[${e.title}](${e.href})` : e.title;
+                    const pathCell = '`' + e.path + '`';
+                    rows.push(`| ${titleCell} | ${pathCell} |`);
+                  }
+                } else {
+                  // Static/assets: create direct preview links if base is known
+                  // Only link common web assets; skip JSON, map files, etc.
+                  const isLinkableAsset = /\.(png|jpe?g|gif|webp|svg|css|js|ico|txt|pdf|mp4|webm)$/i.test(fp);
+                  const rel = fp.replace(/^static\//, '/').replace(/^assets\//, '/assets/');
+                  const href = (previewBase && isLinkableAsset) ? (previewBase + rel) : '';
+                  const title = titleFromPath(fp);
+                  const titleCell = href ? `[${title}](${href})` : title;
+                  const pathCell = '`' + fp + '`';
+                  rows.push(`| ${titleCell} | ${pathCell} |`);
+                }
+              }
+              
+              return rows;
+            }
+
+            const addedRows = buildRows(added);
+            const modifiedRows = buildRows(modified);
+            const deletedRows = buildRows(deleted);
+
+            const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + (previewBase || '') + ' -->\n**PR Preview: Changed content**' + (previewBase ? `\n\nBase preview: ${previewBase}` : '\n\n⏳ *Links will be added automatically when Cloudflare Pages finishes deploying (typically 2-5 minutes)*');
+            if (!previewBase) {
+              core.info('Preview base URL not available yet. Comment will be automatically updated when Cloudflare posts the Branch Preview URL.');
+            }
+            function section(title, rows) {
+              if (rows.length === 0) return '';
+              return `\n\n### ${title}\n\n| Title | Path |\n| --- | --- |\n${rows.join('\n')}`;
+            }
+
+            const body = [
+              header,
+              section('Added', addedRows),
+              section('Modified', modifiedRows),
+              section('Deleted', deletedRows),
+            ].join('');
+
+            // Update the existing comment
+            const commentId = process.env.COMMENT_ID;
+            if (!commentId) {
+              core.error('No comment ID found');
+              return;
+            }
+            
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: parseInt(commentId),
+              body,
+            });
+            
+            core.info(`Updated preview comment ${commentId} with ${added.length + modified.length + deleted.length} changed files`);
+            
+            // Add link to PR description if we have preview links and this is the first time
+            if (previewBase && added.length + modified.length > 0) {
+              try {
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                });
+                
+                const currentBody = pr.data.body || '';
+                const commentUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}#issuecomment-${commentId}`;
+                const linkMarker = '<!-- preview-links-comment -->';
+                const linkText = `\n\n${linkMarker}\n📄 **[View preview links for changed pages](${commentUrl})**`;
+                
+                // Only add if not already present
+                if (!currentBody.includes(linkMarker)) {
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.issue.number,
+                    body: currentBody + linkText,
+                  });
+                  core.info('Added preview link to PR description');
+                }
+              } catch (e) {
+                core.warning(`Could not update PR description: ${e.message}`);
+              }
+            }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -146,6 +146,7 @@ outputs:
     - HTML
     - llms
     - llms-full
+    - pageurls
 
 outputFormats:
   llms:
@@ -156,6 +157,11 @@ outputFormats:
     mediaType: "text/plain"
     baseName: "llms-full"
     isPlainText: true
+  pageurls:
+    mediaType: "application/json"
+    baseName: "pageurls"
+    isPlainText: true
+    suffix: "json"
 
 services:
   googleAnalytics:

--- a/layouts/_default/home.pageurls.json
+++ b/layouts/_default/home.pageurls.json
@@ -1,0 +1,9 @@
+{{- $items := slice -}}
+{{- range .Site.Pages -}}
+  {{- if or (eq .Kind "page") (eq .Kind "section") -}}
+    {{- if .File -}}
+      {{- $items = $items | append (dict "path" .File.Path "lang" .Lang "kind" .Kind "isPage" .IsPage "isSection" .IsSection "bundleType" .BundleType "title" .Title "relPermalink" .RelPermalink "permalink" .Permalink) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $items | jsonify -}}

--- a/layouts/index.pageurls.json
+++ b/layouts/index.pageurls.json
@@ -1,0 +1,9 @@
+{{- $items := slice -}}
+{{- range .Site.Pages -}}
+  {{- if or (eq .Kind "page") (eq .Kind "section") -}}
+    {{- if .File -}}
+      {{- $items = $items | append (dict "path" .File.Path "lang" .Lang "kind" .Kind "isPage" .IsPage "isSection" .IsSection "bundleType" .BundleType "title" .Title "relPermalink" .RelPermalink "permalink" .Permalink) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $items | jsonify -}}

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
   "prettier": {
     "proseWrap": "always",
     "singleQuote": true
-  },
-  "dependencies": {
-    "prod": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Description
[DOCS-1262] Adds an automated PR comment that lists changed docs and related files, with direct preview links.

- Added: Lists each file a PR adds. Newly added pages, images, etc, have HTML preview links.
- Modified: Lists each file a PR modifies. Modified pages, images, etc, have HTML preview links.
- Deleted: Lists each file a PR deletes, without HTML preview links.

## How it works

Uses tj-actions/changed-files to detect changes under:
- `content/**` (Hugo pages)
- `static/**`, `assets/**` (linked when preview base is known)
- `layouts/**`, `i18n/**`, `configs/**` (unlinked, included for context)

Adds a small Hugo output format that emits `public/pageurls.json` with page metadata:
**Schema**: File path → title, relPermalink/permalink, kind, lang, bundle type

The workflow builds Hugo to generate `public/pageurls.json`, then:
1. Pre-creates the preview comment so that it is in a predictable location right below the Cloudflare comment.
1. Looks for the Cloudflare Pages preview base URL from existing PR comments
1. Resolves exact URLs/titles for `content/**` files
1. Creates direct preview links for `static/**` and `assets/**` when base is available
1. Upserts the comment with a hidden marker that contains the preview URL.
1. Upon push, runs again to recreate the report and upsert the comment.
1. If there were previously content changes but the PR has been updated such that there are no longer any, the comment updates to remove all the preview links.

### Behavior when Cloudflare deploy hasn’t finished

1. The comment renders immediately with unlinked entries
1. Links become clickable after Cloudflare Pages posts its preview comment; subsequent pushes update the same comment with links

## Files added

layouts/_default/home.pageurls.json and layouts/index.pageurls.json to emit public/pageurls.json
.github/workflows/pr-preview-links.yml GitHub Action

## Testing
The test commit has been removed to prepare to merge this change. To test this change in your own PR, cherry-pick its single commit and push, then your PR should show the preview links. Alternatively, you could cherry-pick the test commit using SHA `8745922af460be06838be9d80e3bafbac5a1093f`, which:

1. Adds: content/en/guides/inference/new-preview-page.md
1. Modifies: content/en/guides/core/secrets.md
1. Deletes: content/en/search.md

## Notes

- This respects Hugo/Docsy slugs, leaf/branch bundles, and multilingual paths, and follows Docsy includes
- Permissions set to allow updating PR comments only


[DOCS-1252]: https://wandb.atlassian.net/browse/DOCS-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-1262]: https://wandb.atlassian.net/browse/DOCS-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ