### PR TITLE
Update the HTML preview Github action to follow a newly-added include and list pages that now use it

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -237,7 +237,6 @@ jobs:
             // Function to find pages that use a specific include
             function findPagesUsingInclude(includePath) {
               const includeFileName = includePath.split('/').pop();
-              const includeRef = `/_includes/${includeFileName}`;
               const pagesUsingInclude = [];
               
               // Search through all pages in pageMap
@@ -248,9 +247,20 @@ jobs:
                     const contentPath = path.join('content', page.lang || 'en', page.path);
                     if (fs.existsSync(contentPath)) {
                       const content = fs.readFileSync(contentPath, 'utf8');
-                      // Check for both readfile syntaxes
-                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+["']${includeRef}["']\\s*%\\}\\}`, 'i');
-                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["']${includeRef}["']\\s*>\\}\\}`, 'i');
+                      
+                      // Check for usage of the include file with various path formats
+                      // The include might be referenced as:
+                      // - /_includes/filename.md
+                      // - /content/en/_includes/filename.md
+                      // - /content/<lang>/_includes/filename.md
+                      const escapedFileName = includeFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                      
+                      // Pattern to match any path ending with /_includes/filename
+                      const includePattern = `[^"']*\\/_includes\\/${escapedFileName}`;
+                      
+                      // Check for both readfile syntaxes with flexible path matching
+                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+(?:file=)?["'](${includePattern})["']\\s*%\\}\\}`, 'i');
+                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["'](${includePattern})["']\\s*>\\}\\}`, 'i');
                       
                       if (pattern1.test(content) || pattern2.test(content)) {
                         pagesUsingInclude.push(page);

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -361,7 +361,6 @@ jobs:
             // Function to find pages that use a specific include
             function findPagesUsingInclude(includePath) {
               const includeFileName = includePath.split('/').pop();
-              const includeRef = `/_includes/${includeFileName}`;
               const pagesUsingInclude = [];
               
               // Search through all pages in pageMap
@@ -372,9 +371,20 @@ jobs:
                     const contentPath = path.join('content', page.lang || 'en', page.path);
                     if (fs.existsSync(contentPath)) {
                       const content = fs.readFileSync(contentPath, 'utf8');
-                      // Check for both readfile syntaxes
-                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+["']${includeRef}["']\\s*%\\}\\}`, 'i');
-                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["']${includeRef}["']\\s*>\\}\\}`, 'i');
+                      
+                      // Check for usage of the include file with various path formats
+                      // The include might be referenced as:
+                      // - /_includes/filename.md
+                      // - /content/en/_includes/filename.md
+                      // - /content/<lang>/_includes/filename.md
+                      const escapedFileName = includeFileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                      
+                      // Pattern to match any path ending with /_includes/filename
+                      const includePattern = `[^"']*\\/_includes\\/${escapedFileName}`;
+                      
+                      // Check for both readfile syntaxes with flexible path matching
+                      const pattern1 = new RegExp(`\\{\\{%\\s*readfile\\s+(?:file=)?["'](${includePattern})["']\\s*%\\}\\}`, 'i');
+                      const pattern2 = new RegExp(`\\{\\{<\\s*readfile\\s+file=["'](${includePattern})["']\\s*>\\}\\}`, 'i');
                       
                       if (pattern1.test(content) || pattern2.test(content)) {
                         pagesUsingInclude.push(page);


### PR DESCRIPTION
#1516 added a Github action to generate HTML preview links. After it merged, I noticed in #1515, which adds a new include and uses it in two existing pages, that the action did not follow the new include and show the pages that now use it (although those pages were listed in the Modified section so they did have an HTML preview). This fix makes sure that newly-added includes are treated as expected in the Added section.

To test this fix, I tried to temporarily merge it into #1515, but Github actions that exist in `main` always run from `main` so that a malicious PR doesn't cause trouble. So instead, I will need to merge this fix and then update #1515.
