### PR TITLE
fix: Add support for localized content preview links

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+
           
       - name: Get PR details
         id: pr
@@ -83,6 +85,7 @@ jobs:
         run: |
           hugo --minify
           test -f public/pageurls.json && echo "Found pageurls.json" || (echo "Missing pageurls.json" && ls -la public || true)
+
 
       - name: Extract Branch Preview URL
         id: extract-url
@@ -183,12 +186,39 @@ jobs:
             }
 
             let pageMap = [];
+            // Build candidate pageurls.json paths by scanning public/
+            const candidatePaths = new Set();
             try {
-              const raw = fs.readFileSync('public/pageurls.json', 'utf8');
-              pageMap = JSON.parse(raw);
+              if (fs.existsSync('public/pageurls.json')) candidatePaths.add('public/pageurls.json');
             } catch (e) {
-              core.warning('Could not read public/pageurls.json. Proceeding with unlinked entries. ' + e.message);
-              pageMap = [];
+              core.warning(`Root pageurls existence check failed: ${e.message}`);
+            }
+            try {
+              if (fs.existsSync('public')) {
+                const entries = fs.readdirSync('public', { withFileTypes: true });
+                for (const ent of entries) {
+                  if (ent.isDirectory()) {
+                    candidatePaths.add(path.posix.join('public', ent.name, 'pageurls.json'));
+                    candidatePaths.add(path.posix.join('public', ent.name, 'index.pageurls.json'));
+                  }
+                }
+              }
+            } catch (e) {
+              core.warning(`Could not scan public/ for languages: ${e.message}`);
+            }
+
+            core.info(`Attempting to load page maps from: ${Array.from(candidatePaths).join(', ') || '(none)'}`);
+            for (const pageurlsPath of candidatePaths) {
+              try {
+                if (!fs.existsSync(pageurlsPath)) continue;
+                const raw = fs.readFileSync(pageurlsPath, 'utf8');
+                const langPages = JSON.parse(raw);
+                pageMap = pageMap.concat(langPages);
+                core.info(`Loaded ${langPages.length} pages from ${pageurlsPath}`);
+
+              } catch (e) {
+                core.warning(`Could not read ${pageurlsPath}. ${e.message}`);
+              }
             }
 
             // Build lookup: support keys with and without language prefix
@@ -208,12 +238,14 @@ jobs:
               for (const k of keys) byPath.set(k, p);
             }
 
+
             const previewBase = (process.env.PREVIEW_BASE || '').replace(/\/$/, '');
             core.info(`Using Branch Preview URL: ${previewBase}`);
 
             function mapEntry(filePath) {
               const norm = filePath.replace(/\\/g, '/');
               const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';


### PR DESCRIPTION
This brings the localization fixes from PR #1527 that were stuck in the preview-links-staging branch to main.

Changes:
- Update pr-preview-links-on-comment.yml to scan for language-specific pageurls.json files in public/ subdirectories
- Add support for loading pageurls from multiple languages (ja, ko, etc.)
- Build lookup keys with proper language prefix handling

The workflow now properly generates preview links for:
- Added localized content
- Modified localized content
- Deleted localized content

This fixes the issue where localized content changes weren't generating preview links in PR comments.

Related: #1527

