### PR TITLE
Fix PR preview workflow issues

### DIFF
--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -2,7 +2,7 @@ name: PR Preview Links
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -344,11 +344,47 @@ jobs:
 
             function mapEntry(filePath) {
               const norm = filePath.replace(/\\/g, '/');
-              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+              let item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+              
+              // Debug logging for specific files
+              if (norm.includes('public-api/_index.md')) {
+                core.info(`Mapping ${norm}:`);
+                core.info(`  Direct lookup: ${byPath.has(norm)}`);
+                core.info(`  Without content prefix: ${byPath.has(norm.replace(/^content\//, ''))}`);
+                
+                // Try various path formats
+                const attempts = [
+                  norm,
+                  norm.replace(/^content\//, ''),
+                  'en/' + norm.replace(/^content\/en\//, ''),
+                  norm.replace(/^content\/en\//, ''),
+                  'ref/python/public-api/index.md',
+                  'ref/python/public-api/_index.md',
+                  'en/ref/python/public-api/_index.md'
+                ];
+                
+                for (const attempt of attempts) {
+                  if (byPath.has(attempt)) {
+                    core.info(`  Found with key: ${attempt}`);
+                    item = byPath.get(attempt);
+                    core.info(`  Title from pageMap: ${item.title}`);
+                    break;
+                  }
+                }
+                
+                if (!item) {
+                  core.info('  Available keys containing "public-api":');
+                  for (const [key, value] of byPath.entries()) {
+                    if (key.includes('public-api')) {
+                      core.info(`    ${key} => ${value.title}`);
+                    }
+                  }
+                }
+              }
+              
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
-              // Always use the actual title from pageMap if available
               const title = item.title || titleFromPath(norm);
               return { title, rel, href, path: norm };
             }

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -2,7 +2,7 @@ name: PR Preview Links
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -348,6 +348,7 @@ jobs:
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
+              // Always use the actual title from pageMap if available
               const title = item.title || titleFromPath(norm);
               return { title, rel, href, path: norm };
             }
@@ -457,25 +458,91 @@ jobs:
               return rows;
             }
 
-            const addedRows = buildRows(added);
-            const modifiedRows = buildRows(modified);
-            const deletedRows = buildRows(deleted);
+            // Calculate file sizes/changes for sorting by delta
+            function getFileStats(files) {
+              const { execSync } = require('child_process');
+              return files.map(fp => {
+                let size = 0;
+                try {
+                  // Use git to get the number of changed lines
+                  // For added files, count all lines; for modified, count insertions + deletions
+                  const diffStat = execSync(`git diff --numstat origin/${{ github.base_ref }}...HEAD -- "${fp}" 2>/dev/null || echo "0 0 ${fp}"`, { encoding: 'utf8' }).trim();
+                  const parts = diffStat.split(/\s+/);
+                  if (parts.length >= 2) {
+                    const insertions = parseInt(parts[0]) || 0;
+                    const deletions = parseInt(parts[1]) || 0;
+                    size = insertions + deletions;
+                  }
+                } catch (e) {
+                  // If git diff fails, try file size as fallback
+                  try {
+                    if (fs.existsSync(fp)) {
+                      const stats = fs.statSync(fp);
+                      size = stats.size;
+                    }
+                  } catch (e2) {
+                    // Ignore errors
+                  }
+                }
+                return { path: fp, size };
+              });
+            }
+
+            // Sort files by size (as a proxy for change delta) and limit to maxRows
+            function limitAndSortFiles(files, maxRows = 20) {
+              if (files.length <= maxRows) {
+                return { files: files.sort(), truncated: false };
+              }
+              
+              // Get file stats and sort by size descending
+              const stats = getFileStats(files);
+              stats.sort((a, b) => b.size - a.size);
+              
+              // Take top maxRows files
+              const topFiles = stats.slice(0, maxRows).map(s => s.path);
+              // Sort alphabetically for consistent display
+              topFiles.sort();
+              
+              return { files: topFiles, truncated: true, total: files.length };
+            }
+
+            const MAX_ROWS_PER_TABLE = 20;
+            const addedInfo = limitAndSortFiles(added, MAX_ROWS_PER_TABLE);
+            const modifiedInfo = limitAndSortFiles(modified, MAX_ROWS_PER_TABLE);
+            const deletedInfo = limitAndSortFiles(deleted, MAX_ROWS_PER_TABLE);
+
+            const addedRows = buildRows(addedInfo.files);
+            const modifiedRows = buildRows(modifiedInfo.files);
+            const deletedRows = buildRows(deletedInfo.files);
 
             const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + (previewBase || '') + ' -->\n**PR Preview: Changed content**' + (previewBase ? `\n\nBase preview: ${previewBase}` : '\n\n⏳ *Links will be added automatically when Cloudflare Pages finishes deploying (typically 2-5 minutes)*');
             if (!previewBase) {
               core.info('Preview base URL not available yet. Comment will be automatically updated when Cloudflare posts the Branch Preview URL.');
             }
-            function section(title, rows) {
-              if (rows.length === 0) return '';
-              return `\n\n### ${title}\n\n| Title | Path |\n| --- | --- |\n${rows.join('\n')}`;
+            
+            function section(title, rows, info) {
+              if (rows.length === 0 && !info.truncated) return '';
+              
+              let sectionTitle = title;
+              if (info.truncated) {
+                sectionTitle += ` (showing ${rows.length} of ${info.total} files with largest changes)`;
+              }
+              
+              return `\n\n### ${sectionTitle}\n\n| Title | Path |\n| --- | --- |\n${rows.join('\n')}`;
             }
 
             const body = [
               header,
-              section('Added', addedRows),
-              section('Modified', modifiedRows),
-              section('Deleted', deletedRows),
+              section('Added', addedRows, addedInfo),
+              section('Modified', modifiedRows, modifiedInfo),
+              section('Deleted', deletedRows, deletedInfo),
             ].join('');
+            
+            // Check if body exceeds GitHub's limit
+            const MAX_COMMENT_SIZE = 65536;
+            if (body.length > MAX_COMMENT_SIZE) {
+              core.warning(`Preview comment size (${body.length}) exceeds GitHub's limit (${MAX_COMMENT_SIZE}). This should not happen with row limits in place.`);
+            }
 
             // Update the existing comment
             const commentId = process.env.COMMENT_ID;

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -61,8 +61,19 @@ jobs:
       - name: Build Hugo (generate pageurls)
         if: steps.changed.outputs.any_changed == 'true'
         run: |
+          # Debug: Check what ref we're building
+          echo "Current branch: $(git branch --show-current)"
+          echo "HEAD commit: $(git rev-parse HEAD)"
+          echo "PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          
           hugo --minify
           test -f public/pageurls.json && echo "Found pageurls.json" || (echo "Missing pageurls.json" && ls -la public || true)
+          
+          # Debug: Check a specific file's title in the generated JSON
+          if [ -f public/pageurls.json ]; then
+            echo "Checking for public-api entries in pageurls.json:"
+            jq '.[] | select(.path | contains("public-api"))' public/pageurls.json || true
+          fi
 
       - name: Create or find preview comment
         if: steps.changed.outputs.any_changed == 'true'
@@ -287,13 +298,20 @@ jobs:
               const rel = (p.path || '').replace(/^\/+/, '').replace(/\\/g, '/');
               const withLang = lang && !rel.startsWith(lang + '/') ? `${lang}/${rel}` : rel;
               const withoutLang = lang && rel.startsWith(lang + '/') ? rel.slice(lang.length + 1) : rel;
+              
+              // Create all possible key variations
               const keys = new Set([
                 rel,
                 withLang,
                 withoutLang,
                 path.posix.join('content', withLang),
                 path.posix.join('content', withoutLang),
+                path.posix.join('content', rel),
+                // Add explicit handling for language in path
+                path.posix.join('content', lang, rel),
+                path.posix.join('content', lang, withoutLang),
               ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
+              
               for (const k of keys) byPath.set(k, p);
             }
 
@@ -344,44 +362,7 @@ jobs:
 
             function mapEntry(filePath) {
               const norm = filePath.replace(/\\/g, '/');
-              let item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
-              
-              // Debug logging for specific files
-              if (norm.includes('public-api/_index.md')) {
-                core.info(`Mapping ${norm}:`);
-                core.info(`  Direct lookup: ${byPath.has(norm)}`);
-                core.info(`  Without content prefix: ${byPath.has(norm.replace(/^content\//, ''))}`);
-                
-                // Try various path formats
-                const attempts = [
-                  norm,
-                  norm.replace(/^content\//, ''),
-                  'en/' + norm.replace(/^content\/en\//, ''),
-                  norm.replace(/^content\/en\//, ''),
-                  'ref/python/public-api/index.md',
-                  'ref/python/public-api/_index.md',
-                  'en/ref/python/public-api/_index.md'
-                ];
-                
-                for (const attempt of attempts) {
-                  if (byPath.has(attempt)) {
-                    core.info(`  Found with key: ${attempt}`);
-                    item = byPath.get(attempt);
-                    core.info(`  Title from pageMap: ${item.title}`);
-                    break;
-                  }
-                }
-                
-                if (!item) {
-                  core.info('  Available keys containing "public-api":');
-                  for (const [key, value] of byPath.entries()) {
-                    if (key.includes('public-api')) {
-                      core.info(`    ${key} => ${value.title}`);
-                    }
-                  }
-                }
-              }
-              
+              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';


### PR DESCRIPTION
Fix PR preview workflow issues

- Limit preview tables to max 20 rows to prevent GitHub comment size limit
- Sort files by change delta (lines changed) when truncating
- Show truncation indicator when tables are limited
- Add comment size check warning


