### PR TITLE
fix: make link checker workflow more robust to handle no-changes scenario

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -41,9 +41,24 @@ jobs:
         run: |
           set -euo pipefail
           node .github/scripts/fix_broken_links.mjs || true
+          
+          # Check if there are any changes to commit
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+          
+          # Check if report exists
+          if [[ -f .github/lychee-report.md ]]; then
+            echo "has_report=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_report=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Pull Request with fixes
         id: cpr
+        if: steps.fix.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "docs: fix broken links (automated)"
@@ -82,3 +97,51 @@ jobs:
                 body,
               });
             }
+
+      - name: Create issue for manual fixes if no PR created
+        if: steps.fix.outputs.has_changes == 'false' && steps.fix.outputs.has_report == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = '.github/lychee-report.md';
+            
+            let reportContent = 'No report found.';
+            if (fs.existsSync(reportPath)) {
+              reportContent = fs.readFileSync(reportPath, 'utf8');
+            }
+            
+            // Check if report contains manual follow-ups
+            if (reportContent.includes('Manual follow-up needed')) {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Link Check Report: Manual fixes needed (Run #${context.runId})`,
+                body: `The automated link checker found broken links that require manual intervention.\n\n${reportContent}`,
+                labels: ['documentation', 'maintenance']
+              });
+              
+              console.log(`Created issue #${issue.data.number} for manual link fixes`);
+            } else {
+              console.log('No manual fixes needed, skipping issue creation');
+            }
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Link Check Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ "${{ steps.fix.outputs.has_changes }}" == "true" ]]; then
+            echo "✅ Created PR #${{ steps.cpr.outputs.pull-request-number }} with auto-fixed links" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ steps.fix.outputs.has_report }}" == "true" ]]; then
+            echo "📋 No auto-fixable changes, but manual fixes are needed (see issue created)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✨ No broken links found!" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ -f .github/lychee-report.md ]]; then
+            echo "### Report Preview" >> $GITHUB_STEP_SUMMARY
+            head -20 .github/lychee-report.md >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Description

This PR fixes the link checker workflow that was failing in [run #17112443036](https://github.com/wandb/docs/actions/runs/17112443036/job/48536639778#step:7:1) when there were no auto-fixable changes to commit.

## Problem

The `peter-evans/create-pull-request` action fails when there are no changes to commit. This happens when:
- All broken links require manual intervention (true 404s)
- No broken links are found
- The lychee checker finds links but none can be auto-fixed

## Solution

1. **Added change detection**: The workflow now checks if there are actual file changes before attempting to create a PR
2. **Conditional PR creation**: Only creates a PR if there are auto-fixed changes
3. **Issue creation fallback**: When there are no auto-fixes but manual fixes are needed, creates an issue instead
4. **Workflow summary**: Added a summary step to clearly show what actions were taken

## Changes Made

- Modified `.github/workflows/linkcheck.yml` to:
  - Check for file changes using `git status --porcelain`
  - Check if a report was generated
  - Only create PR when `has_changes=true`
  - Create an issue when `has_changes=false` but `has_report=true` and manual fixes are needed
  - Add a summary step that shows what happened in the workflow run

## Testing

Tested locally using the `.github/test-link-checker.sh` script to verify:
- ✅ Auto-fixes are applied when possible
- ✅ Report is generated correctly
- ✅ Change detection logic works
- ✅ Generated reference docs are skipped

## Expected Behavior

After this fix:
- If auto-fixable links are found → Creates PR with fixes
- If only manual fixes needed → Creates issue with report
- If no broken links → Workflow succeeds with summary
- No more workflow failures due to "nothing to commit"