### PR TITLE
fix: add error parameters to Lychee action to catch blocks for Node.js compatibility

### DIFF
--- a/.github/scripts/fix_broken_links.mjs
+++ b/.github/scripts/fix_broken_links.mjs
@@ -29,7 +29,7 @@ function normalizeUrl(u) {
 	try {
 		const url = new URL(u);
 		return url.toString();
-	} catch {
+	} catch (e) {
 		return u;
 	}
 }
@@ -112,7 +112,7 @@ async function probeRedirect(url) {
 	} catch (e) {
 		return { ok: false, finalUrl: url, error: String(e) };
 	} finally {
-		for (const c of controllers) try { c.abort(); } catch {}
+		for (const c of controllers) try { c.abort(); } catch (e) {}
 	}
 }
 
@@ -143,7 +143,7 @@ function candidateVariants(url) {
 			u.hostname = 'www.' + u.hostname;
 			variants.push(u.toString());
 		}
-	} catch {
+	} catch (e) {
 		// ignore parse errors
 	}
 	return unique(variants).filter(v => v !== url);
@@ -228,7 +228,7 @@ function generateFromCandidates(fromUrl) {
 			withSlash.pathname = withSlash.pathname + '/';
 			set.add(withSlash.toString());
 		}
-	} catch {}
+	} catch (e) {}
 	return Array.from(set);
 }
 


### PR DESCRIPTION
## Description

This PR fixes a potential syntax error in the link checker script that was causing issues in [GitHub Actions run #17112743303](https://github.com/wandb/docs/actions/runs/17112743303/job/48537533886#step:7:32).

## Problem

The `fix_broken_links.mjs` script was using optional catch binding syntax (`catch {}` without an error parameter), which might not be supported in all Node.js environments or could be causing parsing issues in the GitHub Actions runner.

## Solution

Updated all catch blocks to include the error parameter:
- `catch {}` → `catch (e) {}`

This ensures compatibility across different Node.js versions and environments.

## Changes

- Updated 4 catch blocks in `fix_broken_links.mjs`:
  - Line 32: `normalizeUrl` function
  - Line 115: Controller cleanup in `probeRedirect`
  - Line 146: URL parsing in `candidateVariants`
  - Line 231: URL manipulation in `generateFromCandidates`

## Testing

The updated code maintains the same functionality while being more compatible with different JavaScript environments. The error parameter is added but not used (as was the original intent with optional catch binding).