### PR TITLE
fix: resolve shell syntax issues preventing PR creation in link checker

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -96,22 +96,42 @@ jobs:
       - name: Apply auto-fixes and generate report
         id: fix
         run: |
-          set -euo pipefail
-          node .github/scripts/fix_broken_links.mjs || true
+          echo "Running fix_broken_links.mjs..."
+          node .github/scripts/fix_broken_links.mjs || echo "Script exited with code $?"
           
-          # Check if there are any changes to commit
-          if [[ -n $(git status --porcelain) ]]; then
+          # Check if there are any changes to commit (including the report)
+          echo "Checking for changes..."
+          # First check for any markdown file changes
+          MD_CHANGES=$(git status --porcelain -- '*.md' '*.html' || echo "")
+          # Then check if report exists (it might be a new file)
+          if [[ -f .github/lychee-report.md ]] || [[ -n "$MD_CHANGES" ]]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Found changes in files or report exists"
+            # If report exists but isn't tracked, add it
+            if [[ -f .github/lychee-report.md ]]; then
+              git add .github/lychee-report.md || true
+            fi
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
           fi
           
           # Check if report exists
+          echo "Checking for report..."
           if [[ -f .github/lychee-report.md ]]; then
             echo "has_report=true" >> $GITHUB_OUTPUT
+            echo "Report file exists"
           else
             echo "has_report=false" >> $GITHUB_OUTPUT
+            echo "No report file found"
           fi
+          
+          # Debug output
+          echo "Current directory: $(pwd)"
+          echo "Git status:"
+          git status --short || true
+          echo "Files in .github:"
+          ls -la .github/ || true
 
       - name: Create Pull Request with fixes
         id: cpr
@@ -129,6 +149,10 @@ jobs:
             Please review the comments and report for follow-up.
           branch: chore/fix-broken-links-${{ github.run_id }}
           delete-branch: true
+          add-paths: |
+            content/**/*.md
+            content/**/*.html
+            .github/lychee-report.md
 
       - name: Comment manual follow-ups on PR
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'


### PR DESCRIPTION
## Description

This PR fixes the shell syntax issues in the link checker workflow that were preventing PR creation, as seen in [run #17112883335](https://github.com/wandb/docs/actions/runs/17112883335/job/48537948505#step:7:30).

## Problem

The "Apply auto-fixes and generate report" step was failing due to:
1. `set -euo pipefail` causing the script to exit when command substitution returned non-zero
2. The workflow not properly detecting when only a report file was created (no auto-fixes)
3. Missing explicit handling of the report file in git

## Solution

1. **Removed `set -euo pipefail`** - This was causing the script to exit prematurely
2. **Improved change detection**:
   - Properly capture `git status` output in a variable
   - Consider the report file as a "change" if it exists
   - Explicitly `git add` the report file if it exists
3. **Added debug output** to help diagnose issues in the future
4. **Added explicit paths** to the create-pull-request action to ensure all files are included

## Key Changes

```bash
# Before (failing):
if [[ -n $(git status --porcelain) ]]; then

# After (working):
MD_CHANGES=$(git status --porcelain -- '*.md' '*.html' || echo "")
if [[ -f .github/lychee-report.md ]] || [[ -n "$MD_CHANGES" ]]; then
```

The workflow will now:
- Create a PR when there are auto-fixed links
- Create a PR when there's only a report file (no auto-fixes possible)
- Create an issue when no PR is needed but manual fixes are required
- Provide better visibility through debug output

This should resolve the PR creation failures and make the workflow more robust.