### PR TITLE
fix: improve path matching logic for new pages in PR preview links

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -224,7 +224,7 @@ jobs:
             // Build lookup: support keys with and without language prefix
             const byPath = new Map();
             for (const p of pageMap) {
-              const lang = p.lang || '';
+              const lang = p.lang || 'en'; // Default to 'en' if no lang specified
               const rel = (p.path || '').replace(/^\/+/, '').replace(/\\/g, '/');
               const withLang = lang && !rel.startsWith(lang + '/') ? `${lang}/${rel}` : rel;
               const withoutLang = lang && rel.startsWith(lang + '/') ? rel.slice(lang.length + 1) : rel;
@@ -234,7 +234,25 @@ jobs:
                 withoutLang,
                 path.posix.join('content', withLang),
                 path.posix.join('content', withoutLang),
+                path.posix.join('content', rel),
+                // Add explicit handling for language in path
+                path.posix.join('content', lang, rel),
+                path.posix.join('content', lang, withoutLang),
+                // Add .md extension variations for content files
+                rel.endsWith('.md') ? rel : rel + '.md',
+                withLang.endsWith('.md') ? withLang : withLang + '.md',
+                withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md',
+                path.posix.join('content', lang, rel.endsWith('.md') ? rel : rel + '.md'),
+                path.posix.join('content', lang, withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
+                path.posix.join('content', withLang.endsWith('.md') ? withLang : withLang + '.md'),
+                path.posix.join('content', withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
               ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
+              
+              // Debug log for new pages
+              if (p.path && p.path.includes('dspy')) {
+                core.info(`Debug: Page ${p.path} (lang: ${lang}) has keys: ${Array.from(keys).join(', ')}`);
+              }
+              
               for (const k of keys) byPath.set(k, p);
             }
 
@@ -244,8 +262,19 @@ jobs:
 
             function mapEntry(filePath) {
               const norm = filePath.replace(/\\/g, '/');
-              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
-
+              
+              // Try multiple variations to find the item
+              let item = byPath.get(norm);
+              if (!item) item = byPath.get(norm.replace(/^content\//, ''));
+              if (!item) item = byPath.get(norm.replace(/\.md$/, ''));
+              if (!item) item = byPath.get(norm.replace(/^content\//, '').replace(/\.md$/, ''));
+              
+              // Debug log for unmatched files
+              if (!item && norm.includes('dspy')) {
+                core.info(`Debug: Could not find mapping for ${norm}`);
+                core.info(`Debug: Available keys containing 'dspy': ${Array.from(byPath.keys()).filter(k => k.includes('dspy')).join(', ')}`);
+              }
+              
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -294,7 +294,7 @@ jobs:
             // Build lookup: support keys with and without language prefix
             const byPath = new Map();
             for (const p of pageMap) {
-              const lang = p.lang || '';
+              const lang = p.lang || 'en'; // Default to 'en' if no lang specified
               const rel = (p.path || '').replace(/^\/+/, '').replace(/\\/g, '/');
               const withLang = lang && !rel.startsWith(lang + '/') ? `${lang}/${rel}` : rel;
               const withoutLang = lang && rel.startsWith(lang + '/') ? rel.slice(lang.length + 1) : rel;
@@ -310,7 +310,20 @@ jobs:
                 // Add explicit handling for language in path
                 path.posix.join('content', lang, rel),
                 path.posix.join('content', lang, withoutLang),
+                // Add .md extension variations for content files
+                rel.endsWith('.md') ? rel : rel + '.md',
+                withLang.endsWith('.md') ? withLang : withLang + '.md',
+                withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md',
+                path.posix.join('content', lang, rel.endsWith('.md') ? rel : rel + '.md'),
+                path.posix.join('content', lang, withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
+                path.posix.join('content', withLang.endsWith('.md') ? withLang : withLang + '.md'),
+                path.posix.join('content', withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
               ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
+              
+              // Debug log for new pages
+              if (p.path && p.path.includes('dspy')) {
+                core.info(`Debug: Page ${p.path} (lang: ${lang}) has keys: ${Array.from(keys).join(', ')}`);
+              }
               
               for (const k of keys) byPath.set(k, p);
             }
@@ -362,7 +375,19 @@ jobs:
 
             function mapEntry(filePath) {
               const norm = filePath.replace(/\\/g, '/');
-              const item = byPath.get(norm) || byPath.get(norm.replace(/^content\//, ''));
+              
+              // Try multiple variations to find the item
+              let item = byPath.get(norm);
+              if (!item) item = byPath.get(norm.replace(/^content\//, ''));
+              if (!item) item = byPath.get(norm.replace(/\.md$/, ''));
+              if (!item) item = byPath.get(norm.replace(/^content\//, '').replace(/\.md$/, ''));
+              
+              // Debug log for unmatched files
+              if (!item && norm.includes('dspy')) {
+                core.info(`Debug: Could not find mapping for ${norm}`);
+                core.info(`Debug: Available keys containing 'dspy': ${Array.from(byPath.keys()).filter(k => k.includes('dspy')).join(', ')}`);
+              }
+              
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
               const rel = item.relPermalink || '';
               const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';


### PR DESCRIPTION
## Summary

This PR fixes an issue where new documentation pages added in PRs were not being linked in the preview comment generated by GitHub Actions.

## Problem

The PR preview workflow correctly listed new pages but failed to generate clickable links for them. For example, in [PR #1539](https://github.com/wandb/docs/pull/1539), the new DSPy integration page was listed but not linked.

## Root Cause

The path matching logic in the workflows wasn't generating enough key variations to match content files with their corresponding entries in `pageurls.json`. Specifically:
- Missing `.md` extension variations
- Incomplete language path handling
- No default language fallback

## Solution

Enhanced the path matching logic to:
1. Default language to 'en' when not specified
2. Add `.md` extension variations for all path combinations
3. Improve debug logging for troubleshooting
4. Try multiple lookup variations in `mapEntry` function

## Testing

Tested in fork with [test PR](https://github.com/mdlinville/docs/pull/1) confirming:
- ✅ New pages get proper preview links
- ✅ Images continue to work correctly
- ✅ Existing functionality preserved

## Changes

- Updated path key generation in both `pr-preview-links.yml` and `pr-preview-links-on-comment.yml`
- Added more comprehensive path variations for content file matching
- Improved lookup logic with fallback attempts