### PR TITLE
Make CW principal wandb-integration-public for saas

### DIFF
--- a/content/en/guides/hosting/data-security/secure-storage-connector.md
+++ b/content/en/guides/hosting/data-security/secure-storage-connector.md
@@ -137,7 +137,7 @@ For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.core
           "arn:aws:s3:::<cw-bucket>"
         ],
         "Principal": {
-          "CW": "arn:aws:iam::wandb:static/wandb-integration"
+          "CW": "arn:aws:iam::wandb:static/wandb-integration-public"
         },
         "Condition": {
           "StringLike": {


### PR DESCRIPTION
Description
-----------
change the principal for multi-tenant saas to the correct principal `wandb-integration-public` note we changed this recently as `wandb-integration` will now be used for dedicated customers. There will be a follow up PR for introducing dedicated cloud usage of principals but for now to enable saas first going to put out a quicker PR to change the principal.

