### PR TITLE
Pre commit hook that checks for secrets

### DIFF
--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# .pre-commit-config.yaml
+repos:
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+    -   id: detect-secrets-hook
+        args: ['--baseline', '.secrets.baseline']
+        exclude: package.lock.json

--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -1,8 +1,14 @@
 # .pre-commit-config.yaml
 repos:
+# Out of the box pre-commit hook
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0  # Use the ref you want to point at
+    hooks:
+    -   id: detect-private-key
+# Yelps version of key detection
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:
     -   id: detect-secrets-hook
         args: ['--baseline', '.secrets.baseline']
-        exclude: package.lock.json
+        exclude: package.lock.json    

--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-# .pre-commit-config.yaml
 repos:
 # Out of the box pre-commit hook
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Description
-----------
Not sure which pre commit hook (if any) we want to use, added both (remove the one we don't want):

* Out of the box pre-commit: https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#detect-private-key
* Yelp's version: https://github.com/yelp/detect-secrets#pre-commit-hook

Note: Before merging, add note on how to install pre-commit to `wandb/docs` README.md

Alternatively, we could set up GitHub's Push protection. An admin would need to set this up: https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection
