### PR TITLE
Tables, Registry, and Automation docs have consistent URLs

### DIFF
--- a/content/en/guides/core/automations/_index.md
+++ b/content/en/guides/core/automations/_index.md
@@ -5,6 +5,11 @@ menu:
     parent: core
 title: Automations
 weight: 4
+url: guides/automations
+cascade:
+- url: guides/:filename
+aliases:
+- /guides/core/automations/
 ---
 {{% pageinfo color="info" %}}
 {{< readfile file="/_includes/enterprise-cloud-only.md" >}}

--- a/content/en/guides/core/registry/_index.md
+++ b/content/en/guides/core/registry/_index.md
@@ -9,7 +9,7 @@ url: guides/registry
 cascade:
 - url: guides/registry/:filename
 aliases:
-- /guides/core/registry
+- /guides/core/registry/
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" >}}
 

--- a/content/en/guides/core/registry/_index.md
+++ b/content/en/guides/core/registry/_index.md
@@ -5,9 +5,11 @@ menu:
     parent: core
 title: Registry
 weight: 3
-url: guides/core/registry
+url: guides/registry
 cascade:
-- url: guides/core/registry/:filename
+- url: guides/registry/:filename
+aliases:
+- guides/core/registry
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" >}}
 

--- a/content/en/guides/core/registry/_index.md
+++ b/content/en/guides/core/registry/_index.md
@@ -9,7 +9,7 @@ url: guides/registry
 cascade:
 - url: guides/registry/:filename
 aliases:
-- guides/core/registry
+- /guides/core/registry
 ---
 {{< cta-button colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" >}}
 

--- a/content/en/guides/models/tables/_index.md
+++ b/content/en/guides/models/tables/_index.md
@@ -6,9 +6,11 @@ menu:
     parent: models
 title: Tables
 weight: 2
-url: guides/models/tables
+url: guides/tables
 cascade:
-- url: guides/models/tables/:filename
+- url: guides/tables/:filename
+aliases:
+- /guides/models/tables/
 ---
 
 {{< cta-button productLink="https://wandb.ai/wandb/examples/reports/AlphaFold-ed-Proteins-in-W-B-Tables--Vmlldzo4ODc0MDc" colabLink="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/datasets-predictions/W%26B_Tables_Quickstart.ipynb" >}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -22,6 +22,7 @@
 
 # Consistent URLs
 /guides/models/tables/* /guides/tables/:splat
+/guides/core/automations/* /guides/automations/:splat
 
 ## Individual page rules
 /app/features/alerts/ /guides/runs/alert/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -20,6 +20,9 @@
 ##   but preserve subfolder structure
 # /app/features/* /guides/runs/:splat   
 
+# Consistent URLs
+/guides/models/tables/* /guides/tables/:splat
+
 ## Individual page rules
 /app/features/alerts/ /guides/runs/alert/ 301
 /app/features/custom-charts/walkthrough/ /guides/app/features/custom-charts/walkthrough/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -23,6 +23,7 @@
 # Consistent URLs
 /guides/models/tables/* /guides/tables/:splat
 /guides/core/automations/* /guides/automations/:splat
+/guides/core/registry/* /guides/registry/:splat
 
 ## Individual page rules
 /app/features/alerts/ /guides/runs/alert/ 301


### PR DESCRIPTION
- Remove `models` from Tables docs URL
- Remove `core` from Registry and Automation docs URL
- Set up aliases & redirects to handle these changes

Resolves DOCS-1443

<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1578#issuecomment-3237876246)**