### PR TITLE
Fix renamed files not appearing in PR preview links

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -170,7 +170,7 @@ jobs:
             }
 
             // Filter out renamed files from added and deleted arrays to avoid duplication
-            const addedFiltered = added.filter(f => !renamed.includes(f));
+            const addedFiltered = added.filter(f => !Array.from(renamedMapping.values()).includes(f));
             const deletedFiltered = deleted.filter(f => !Array.from(renamedMapping.keys()).includes(f));
 
             const allChanged = [...addedFiltered, ...modified, ...deletedFiltered, ...renamed];

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -266,7 +266,7 @@ jobs:
             }
 
             // Filter out renamed files from added and deleted arrays to avoid duplication
-            const addedFiltered = added.filter(f => !renamed.includes(f));
+            const addedFiltered = added.filter(f => !Array.from(renamedMapping.values()).includes(f));
             const deletedFiltered = deleted.filter(f => !Array.from(renamedMapping.keys()).includes(f));
 
             const allChanged = [...addedFiltered, ...modified, ...deletedFiltered, ...renamed];


### PR DESCRIPTION
## Description

This PR fixes an issue where renamed/moved files were not appearing in the PR preview links comment. The issue was discovered in #1580 where a file moved to an `archived` folder didn't show up in the preview.

## The Problem

The workflow was incorrectly filtering renamed files from the "Added" section:
```javascript
const addedFiltered = added.filter(f => !renamed.includes(f));
```

This worked in some cases by coincidence, but the `renamed` array contains the new paths of renamed files, not necessarily matching what needs to be filtered from `added`.

## The Fix

The fix properly uses the `renamedMapping` to filter:
```javascript
const addedFiltered = added.filter(f => !Array.from(renamedMapping.values()).includes(f));
```

Since `renamedMapping.values()` contains the new paths of renamed files, this correctly excludes them from the "Added" section, allowing them to appear in the dedicated "Renamed/Moved" section.

## Testing

This fix was tested in my fork (mdlinville/docs#2) with a PR that includes a renamed file. The renamed file now correctly appears in the "Renamed/Moved" section with a working preview link.

Before fix: Renamed files were ignored
After fix: Renamed files appear in the preview comment like this:

### Renamed/Moved
| Title | Path |
| --- | --- |
| [0.58.1](https://preview-url/ref/release-notes/archived/0.58.1/) | `content/en/ref/release-notes/releases/0.58.1.md` → `content/en/ref/release-notes/releases/archived/0.58.1.md` |

## Changes

- Fixed filtering logic in both `pr-preview-links.yml` and `pr-preview-links-on-comment.yml` workflows
- No other changes or side effects

Fixes the issue discovered in #1580