### PR TITLE
Registry: Restores Registry landing page

### DIFF
--- a/content/en/guides/core/registry/model_registry/_index.md
+++ b/content/en/guides/core/registry/model_registry/_index.md
@@ -6,6 +6,7 @@ menu:
     parent: registry
 title: Model registry
 weight: 9
+url: /guides/registry/model_registry
 ---
 
 {{% alert %}}


### PR DESCRIPTION
Description
-----------
We seem to have "lost" our Registry landing page. A pseudo redirect is happening, when you click on Registry `(guides/core/registry/_index.md),` reverts to Model Registry `(guides/core/registry/model_registry/_index.md)`.

Adding `url` front matter seems to solve the issue.

https://github.com/user-attachments/assets/ebc08f24-cc74-448a-ae42-73f2581f5bf5


Related Issues
---------------
PR: Tables, Registry, and Automation have inconsistant URLs https://github.com/wandb/docs/pull/1578

