### PR TITLE
[DOCS-1801] move inference up in nav

### DIFF
--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "W&B Inference"
-weight: 4
+weight: 5
 description: >
   Access open-source foundation models through W&B Weave and an OpenAI-compatible API
 ---

--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "W&B Inference"
-weight: 8
+weight: 4
 description: >
   Access open-source foundation models through W&B Weave and an OpenAI-compatible API
 ---


### PR DESCRIPTION
Description
-----------
Moves W&B Inference in nav to group it with the other products.

Before:
<img width="260" height="251" alt="Screenshot 2025-09-04 at 9 54 26 AM" src="https://github.com/user-attachments/assets/aba33ce1-a233-4ce7-b2bc-24a166f917b6" />

After:

<img width="258" height="265" alt="Screenshot 2025-09-04 at 9 54 06 AM" src="https://github.com/user-attachments/assets/51fb0e44-9f18-4705-ad69-8b3cdb23f144" />

Related issues
-----------
- Part of DOCS-1801



<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1593#issuecomment-3254122269)**