### PR TITLE
Fix bad link in Python SDK Runs page

### DIFF
--- a/content/en/ref/python/sdk/classes/Run.md
+++ b/content/en/ref/python/sdk/classes/Run.md
@@ -16,7 +16,7 @@ Call [`wandb.init()`](https://docs.wandb.ai/ref/python/init/) to create a new ru
 
 For distributed training experiments, you can either track each process separately using one run per process or track all processes to a single run. See [Log distributed training experiments](https://docs.wandb.ai/guides/track/log/distributed-training) for more information. 
 
-You can log data to a run with `wandb.Run.log()`. Anything you log using `wandb.Run.log()` is sent to that run. See [Create an experiment](https://docs.wandb.ai/guides/track/create-an-experiment) or [`wandb.init`](https://docs.wandb.ai/ref/python/init/) API reference page or more information. 
+You can log data to a run with `wandb.Run.log()`. Anything you log using `wandb.Run.log()` is sent to that run. See [Create an experiment](https://docs.wandb.ai/guides/track/create-an-experiment/) or [`wandb.init`](https://docs.wandb.ai/ref/python/init/) API reference page or more information. 
 
 There is a another `Run` object in the [`wandb.apis.public`](https://docs.wandb.ai/ref/python/public-api/api/) namespace. Use this object is to interact with runs that have already been created. 
 

--- a/content/en/ref/python/sdk/classes/Run.md
+++ b/content/en/ref/python/sdk/classes/Run.md
@@ -16,7 +16,7 @@ Call [`wandb.init()`](https://docs.wandb.ai/ref/python/init/) to create a new ru
 
 For distributed training experiments, you can either track each process separately using one run per process or track all processes to a single run. See [Log distributed training experiments](https://docs.wandb.ai/guides/track/log/distributed-training) for more information. 
 
-You can log data to a run with `wandb.Run.log()`. Anything you log using `wandb.Run.log()` is sent to that run. See [Create an experiment](https://docs.wandb.ai/guides/track/launch) or [`wandb.init`](https://docs.wandb.ai/ref/python/init/) API reference page or more information. 
+You can log data to a run with `wandb.Run.log()`. Anything you log using `wandb.Run.log()` is sent to that run. See [Create an experiment](https://docs.wandb.ai/guides/track/create-an-experiment) or [`wandb.init`](https://docs.wandb.ai/ref/python/init/) API reference page or more information. 
 
 There is a another `Run` object in the [`wandb.apis.public`](https://docs.wandb.ai/ref/python/public-api/api/) namespace. Use this object is to interact with runs that have already been created. 
 


### PR DESCRIPTION
Change bad link to /track/create-an-experiment

Description
-----------
Currently this link seems to 404 (https://docs.wandb.ai/guides/track/launch). Based off the description I am guessing it is supposed to link to https://docs.wandb.ai/guides/track/create-an-experiment/ . I also added the trailing slash since it seems to add it anyways if you leave it off (saves 1 redirect) but let me know if that's not the standard convention.



<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1596#issuecomment-3255429359)**