### PR TITLE
Add Z.AI GLM 4.5 model to inference models documentation

### DIFF
--- a/content/en/guides/inference/models.md
+++ b/content/en/guides/inference/models.md
@@ -24,7 +24,7 @@ W&B Inference provides access to several open-source foundation models. Each mod
 | Qwen3 235B A22B Thinking-2507 | `Qwen/Qwen3-235B-A22B-Thinking-2507` | Text | 262K | 22B-235B (Active-Total) | High-performance Mixture-of-Experts model optimized for structured reasoning, math, and long-form generation |
 | Qwen3 235B A22B-2507 | `Qwen/Qwen3-235B-A22B-Instruct-2507` | Text | 262K | 22B-235B (Active-Total) | Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning |
 | Qwen3 Coder 480B A35B | `Qwen/Qwen3-Coder-480B-A35B-Instruct` | Text | 262K | 35B-480B (Active-Total) | Mixture-of-Experts model optimized for coding tasks such as function calling, tooling use, and long-context reasoning |
-| Z.AI GLM 4.5 | `zai-org/GLM-4.5` | Text | 131K | 23B-355B (Active-Total) | Mixture-of-Experts model with user-controllable thinking/non-thinking modes for reasoning, code, and agents |
+| Z.AI GLM 4.5 | `zai-org/GLM-4.5` | Text | 131K | 32B-355B (Active-Total) | Mixture-of-Experts model with user-controllable thinking/non-thinking modes for reasoning, code, and agents |
 
 ## Using model IDs
 

--- a/content/en/guides/inference/models.md
+++ b/content/en/guides/inference/models.md
@@ -24,6 +24,7 @@ W&B Inference provides access to several open-source foundation models. Each mod
 | Qwen3 235B A22B Thinking-2507 | `Qwen/Qwen3-235B-A22B-Thinking-2507` | Text | 262K | 22B-235B (Active-Total) | High-performance Mixture-of-Experts model optimized for structured reasoning, math, and long-form generation |
 | Qwen3 235B A22B-2507 | `Qwen/Qwen3-235B-A22B-Instruct-2507` | Text | 262K | 22B-235B (Active-Total) | Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning |
 | Qwen3 Coder 480B A35B | `Qwen/Qwen3-Coder-480B-A35B-Instruct` | Text | 262K | 35B-480B (Active-Total) | Mixture-of-Experts model optimized for coding tasks such as function calling, tooling use, and long-context reasoning |
+| Z.AI GLM 4.5 | `zai-org/GLM-4.5` | Text | 131K | 23B-355B (Active-Total) | Mixture-of-Experts model with user-controllable thinking/non-thinking modes for reasoning, code, and agents |
 
 ## Using model IDs
 


### PR DESCRIPTION
## Description

This PR adds documentation for the Z.AI GLM 4.5 model to the W&B Inference models list.

## Changes

- Added Z.AI GLM 4.5 model entry to the inference models table in `content/en/guides/inference/models.md`
  - Model ID: `zai-org/GLM-4.5`
  - Type: Text
  - Context Length: 131K
  - Parameters: 23B-355B (Active-Total)
  - Description: Mixture-of-Experts model with user-controllable thinking/non-thinking modes for reasoning, code, and agents

## Testing

- [ ] Verified markdown formatting is correct
- [ ] Confirmed model information accuracy

## Related

This adds support documentation for the newly available Z.AI GLM 4.5 model in W&B Inference.

<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1606#issuecomment-3267816548)**