### PR TITLE
Fix model list output, indicate project is optional

### DIFF
--- a/content/en/guides/inference/_index.md
+++ b/content/en/guides/inference/_index.md
@@ -22,11 +22,11 @@ import openai
 client = openai.OpenAI(
     # The custom base URL points to W&B Inference
     base_url='https://api.inference.wandb.ai/v1',
-    
+
     # Get your API key from https://wandb.ai/authorize
     api_key="<your-api-key>",
-    
-    # Team and project are required for usage tracking
+
+    # Optional: Team and project for usage tracking
     project="<your-team>/<your-project>",
 )
 
@@ -53,7 +53,7 @@ print(response.choices[0].message.content)
 {{< alert title="Important" color="warning" >}}
 W&B Inference credits come with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise accounts. When credits run out:
 
-- **Free users** must upgrade to a paid plan to continue using Inference.  
+- **Free users** must upgrade to a paid plan to continue using Inference.
   [Upgrade to Pro or Enterprise](https://wandb.ai/subscriptions)
 - **Pro users** are billed monthly for usage beyond free credits, up to a default cap of $6,000/month. See [Account tiers and default usage caps]({{< relref "usage-limits#account-tiers-and-default-usage-caps" >}})
 - **Enterprise usage** is capped at $700,000/year. Your account executive handles billing and limit increases. See [Account tiers and default usage caps]({{< relref "usage-limits#account-tiers-and-default-usage-caps" >}})

--- a/content/en/guides/inference/api-reference.md
+++ b/content/en/guides/inference/api-reference.md
@@ -24,9 +24,8 @@ https://api.inference.wandb.ai/v1
 To use this endpoint, you need:
 - A W&B account with Inference credits
 - A valid W&B API key
-- A W&B entity (team) and project
 
-In code samples, these appear as `<your-team>/<your-project>`.
+If you belong to more than one team or want to attribute your usage to a project you will also need team and project IDs. In code samples, these appear as `<your-team>/<your-project>`. Your default entity and the project name "inference" will be used if unspecified.
 {{< /alert >}}
 
 ## Available methods
@@ -40,7 +39,7 @@ Create a chat completion using the `/chat/completions` endpoint. This endpoint f
 To create a chat completion, provide:
 - The Inference service base URL: `https://api.inference.wandb.ai/v1`
 - Your W&B API key: `<your-api-key>`
-- Your W&B entity and project: `<your-team>/<your-project>`
+- Optional: Your W&B team and project: `<your-team>/<your-project>`
 - A model ID from the [available models]({{< relref "models" >}})
 
 {{< tabpane text=true >}}
@@ -74,7 +73,7 @@ client = openai.OpenAI(
     # Consider setting it in the environment as OPENAI_API_KEY instead for safety
     api_key="<your-api-key>",
 
-    # Team and project are required for usage tracking
+    # Optional: Team and project for usage tracking
     project="<your-team>/<your-project>",
 )
 
@@ -93,42 +92,7 @@ print(response.choices[0].message.content)
 {{% /tab %}}
 {{< /tabpane >}}
 
-### List supported models
-
-Get all available models and their IDs. Use this to select models dynamically or check what's available.
-
-{{< tabpane text=true >}}
-{{% tab header="Bash" value="bash" %}}
-
-```bash
-curl https://api.inference.wandb.ai/v1/models \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <your-api-key>" \
-  -H "OpenAI-Project: <your-team>/<your-project>" 
-```
-
-{{% /tab %}}
-{{% tab header="Python" value="python" %}}
-
-```python
-import openai
-
-client = openai.OpenAI(
-    base_url="https://api.inference.wandb.ai/v1",
-    api_key="<your-api-key>",
-    project="<your-team>/<your-project>"
-)
-
-response = client.models.list()
-
-for model in response.data:
-    print(model.id)
-```
-
-{{% /tab %}}
-{{< /tabpane >}}
-
-## Response format
+#### Response format
 
 The API returns responses in OpenAI-compatible format:
 
@@ -156,7 +120,69 @@ The API returns responses in OpenAI-compatible format:
 }
 ```
 
+### List supported models
+
+Get all available models and their IDs. Use this to select models dynamically or check what's available.
+
+{{< tabpane text=true >}}
+{{% tab header="Bash" value="bash" %}}
+
+```bash
+curl https://api.inference.wandb.ai/v1/models \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "OpenAI-Project: <your-team>/<your-project>"
+```
+
+{{% /tab %}}
+{{% tab header="Python" value="python" %}}
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="https://api.inference.wandb.ai/v1",
+    api_key="<your-api-key>",
+    project="<your-team>/<your-project>"  # Optional, for usage tracking
+)
+
+response = client.models.list()
+
+for model in response.data:
+    print(model.id)
+```
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+#### Response format
+
+The API returns responses in OpenAI-compatible format:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "deepseek-ai/DeepSeek-V3.1",
+      "object": "model",
+      "created": 0,
+      "owned_by": "system",
+      "root": "deepseek-ai/DeepSeek-V3.1"
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "object": "model",
+      "created": 0,
+      "owned_by": "system",
+      "root": "openai/gpt-oss-20b"
+    },
+    ...
+  ]
+}
+```
+
 ## Next steps
 
 - Try the [usage examples]({{< relref "examples" >}}) to see the API in action
-- Explore models in the [UI]({{< relref "ui-guide" >}}) 
+- Explore models in the [UI]({{< relref "ui-guide" >}})

--- a/content/en/guides/inference/api-reference.md
+++ b/content/en/guides/inference/api-reference.md
@@ -25,7 +25,7 @@ To use this endpoint, you need:
 - A W&B account with Inference credits
 - A valid W&B API key
 
-If you belong to more than one team or want to attribute your usage to a project you will also need team and project IDs. In code samples, these appear as `<your-team>/<your-project>`. Your default entity and the project name "inference" will be used if unspecified.
+If you belong to more than one team or want to attribute your usage to a project you will also need team and project IDs. In code samples, these appear as `<your-team>/<your-project>`. Your default entity and the project name `inference` will be used if unspecified.
 {{< /alert >}}
 
 ## Available methods

--- a/content/en/guides/inference/examples.md
+++ b/content/en/guides/inference/examples.md
@@ -37,7 +37,7 @@ client = openai.OpenAI(
     # Get your API key from https://wandb.ai/authorize
     api_key="<your-api-key>",
 
-    # Required for W&B inference usage tracking
+    # Optional: Team and project for usage tracking
     project="wandb/inference-demo",
 )
 
@@ -97,7 +97,7 @@ class WBInferenceModel(weave.Model):
             base_url="https://api.inference.wandb.ai/v1",
             # Get your API key from https://wandb.ai/authorize
             api_key="<your-api-key>",
-            # Required for W&B inference usage tracking
+            # Optional: Team and project for usage tracking
             project="<your-team>/<your-project>",
         )
         resp = client.chat.completions.create(
@@ -153,4 +153,4 @@ After running this code, go to your W&B account at [https://wandb.ai/](https://w
 ## Next steps
 
 - Explore the [API reference]({{< relref "api-reference" >}}) for all available methods
-- Try models in the [UI]({{< relref "ui-guide" >}}) 
+- Try models in the [UI]({{< relref "ui-guide" >}})


### PR DESCRIPTION
Description
-----------
- Team/project is now optional, fix several mentions of it being required.
- The chat completions output was appearing below the models list API. Move it to proper place and heading level, and add an example of model list API output.



<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1613#issuecomment-3271422704)**