### PR TITLE
Fix preview workflow new files

### DIFF
--- a/.github/workflows/pr-preview-links-on-comment.yml
+++ b/.github/workflows/pr-preview-links-on-comment.yml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-
-          
       - name: Get PR details
         id: pr
         uses: actions/github-script@v8
@@ -39,6 +32,12 @@ jobs:
             });
             core.setOutput('head_sha', pr.data.head.sha);
             core.setOutput('base_sha', pr.data.base.sha);
+            
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_sha }}
             
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -267,6 +266,9 @@ jobs:
                 path.posix.join('content', lang, withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
                 path.posix.join('content', withLang.endsWith('.md') ? withLang : withLang + '.md'),
                 path.posix.join('content', withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
+                // Special handling for index files
+                path.posix.join('content', lang, '_index.md'),
+                path.posix.join('content', lang, 'index.md'),
               ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
               
               // Debug log for new pages
@@ -291,9 +293,33 @@ jobs:
               if (!item) item = byPath.get(norm.replace(/^content\//, '').replace(/\.md$/, ''));
               
               // Debug log for unmatched files
-              if (!item && norm.includes('dspy')) {
+              if (!item) {
                 core.info(`Debug: Could not find mapping for ${norm}`);
-                core.info(`Debug: Available keys containing 'dspy': ${Array.from(byPath.keys()).filter(k => k.includes('dspy')).join(', ')}`);
+                // For new files, construct the URL based on the file path
+                if (norm.startsWith('content/') && norm.endsWith('.md')) {
+                  // Extract language and path
+                  const pathParts = norm.replace(/^content\//, '').replace(/\.md$/, '').split('/');
+                  let lang = 'en';
+                  let urlPath = pathParts.join('/');
+                  
+                  // Check if first part is a language code
+                  if (['en', 'ja', 'ko'].includes(pathParts[0])) {
+                    lang = pathParts[0];
+                    urlPath = pathParts.slice(1).join('/');
+                  }
+                  
+                  // Handle _index.md files
+                  if (urlPath.endsWith('/_index') || urlPath === '_index') {
+                    urlPath = urlPath.replace(/\/_index$/, '').replace(/^_index$/, '');
+                  }
+                  
+                  // Construct the URL
+                  const rel = lang === 'en' ? `/${urlPath}/` : `/${lang}/${urlPath}/`;
+                  const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
+                  
+                  core.info(`Debug: Constructed URL for new file ${norm}: ${href}`);
+                  return { title: titleFromPath(norm), rel, href, path: norm };
+                }
               }
               
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
@@ -325,8 +351,12 @@ jobs:
               for (const page of pageMap) {
                 if (page.path && page.path.endsWith('.md')) {
                   try {
-                    // Construct the correct file path: content/<lang>/<page.path>
-                    const contentPath = path.join('content', page.lang || 'en', page.path);
+                    // Construct the correct file path
+                    // page.path might already include content/ prefix, so handle both cases
+                    let contentPath = page.path;
+                    if (!contentPath.startsWith('content/')) {
+                      contentPath = path.join('content', page.lang || 'en', page.path);
+                    }
                     if (fs.existsSync(contentPath)) {
                       const content = fs.readFileSync(contentPath, 'utf8');
                       
@@ -357,7 +387,7 @@ jobs:
               return pagesUsingInclude;
             }
 
-            function buildRows(files) {
+            function buildRows(files, isDeleted = false) {
               const rows = [];
               
               for (const fp of files) {
@@ -388,7 +418,8 @@ jobs:
                   } else {
                     // Regular content file
                     const e = mapEntry(fp);
-                    const titleCell = e.href ? `[${e.title}](${e.href})` : e.title;
+                    // Don't create links for deleted files
+                    const titleCell = (e.href && !isDeleted) ? `[${e.title}](${e.href})` : e.title;
                     const pathCell = '`' + e.path + '`';
                     rows.push(`| ${titleCell} | ${pathCell} |`);
                   }
@@ -397,7 +428,7 @@ jobs:
                   // Only link common web assets; skip JSON, map files, etc.
                   const isLinkableAsset = /\.(png|jpe?g|gif|webp|svg|css|js|ico|txt|pdf|mp4|webm)$/i.test(fp);
                   const rel = fp.replace(/^static\//, '/').replace(/^assets\//, '/assets/');
-                  const href = (previewBase && isLinkableAsset) ? (previewBase + rel) : '';
+                  const href = (previewBase && isLinkableAsset && !isDeleted) ? (previewBase + rel) : '';
                   const title = titleFromPath(fp);
                   const titleCell = href ? `[${title}](${href})` : title;
                   const pathCell = '`' + fp + '`';
@@ -438,7 +469,7 @@ jobs:
 
             const addedRows = buildRows(addedFiltered);
             const modifiedRows = buildRows(modified);
-            const deletedRows = buildRows(deletedFiltered);
+            const deletedRows = buildRows(deletedFiltered, true); // Pass true for deleted files
             const renamedRows = buildRenamedRows(renamedFiles);
 
             const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + previewBase + ' -->\n**PR Preview: Changed content**\n\nBase preview: ' + previewBase;

--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -339,6 +340,9 @@ jobs:
                 path.posix.join('content', lang, withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
                 path.posix.join('content', withLang.endsWith('.md') ? withLang : withLang + '.md'),
                 path.posix.join('content', withoutLang.endsWith('.md') ? withoutLang : withoutLang + '.md'),
+                // Special handling for index files
+                path.posix.join('content', lang, '_index.md'),
+                path.posix.join('content', lang, 'index.md'),
               ].filter(Boolean).map(k => k.replace(/\\/g, '/')));
               
               // Debug log for new pages
@@ -404,9 +408,33 @@ jobs:
               if (!item) item = byPath.get(norm.replace(/^content\//, '').replace(/\.md$/, ''));
               
               // Debug log for unmatched files
-              if (!item && norm.includes('dspy')) {
+              if (!item) {
                 core.info(`Debug: Could not find mapping for ${norm}`);
-                core.info(`Debug: Available keys containing 'dspy': ${Array.from(byPath.keys()).filter(k => k.includes('dspy')).join(', ')}`);
+                // For new files, construct the URL based on the file path
+                if (norm.startsWith('content/') && norm.endsWith('.md')) {
+                  // Extract language and path
+                  const pathParts = norm.replace(/^content\//, '').replace(/\.md$/, '').split('/');
+                  let lang = 'en';
+                  let urlPath = pathParts.join('/');
+                  
+                  // Check if first part is a language code
+                  if (['en', 'ja', 'ko'].includes(pathParts[0])) {
+                    lang = pathParts[0];
+                    urlPath = pathParts.slice(1).join('/');
+                  }
+                  
+                  // Handle _index.md files
+                  if (urlPath.endsWith('/_index') || urlPath === '_index') {
+                    urlPath = urlPath.replace(/\/_index$/, '').replace(/^_index$/, '');
+                  }
+                  
+                  // Construct the URL
+                  const rel = lang === 'en' ? `/${urlPath}/` : `/${lang}/${urlPath}/`;
+                  const href = previewBase ? (previewBase.replace(/\/$/, '') + rel) : '';
+                  
+                  core.info(`Debug: Constructed URL for new file ${norm}: ${href}`);
+                  return { title: titleFromPath(norm), rel, href, path: norm };
+                }
               }
               
               if (!item) return { title: titleFromPath(norm), rel: '', href: '', path: norm };
@@ -438,8 +466,12 @@ jobs:
               for (const page of pageMap) {
                 if (page.path && page.path.endsWith('.md')) {
                   try {
-                    // Construct the correct file path: content/<lang>/<page.path>
-                    const contentPath = path.join('content', page.lang || 'en', page.path);
+                    // Construct the correct file path
+                    // page.path might already include content/ prefix, so handle both cases
+                    let contentPath = page.path;
+                    if (!contentPath.startsWith('content/')) {
+                      contentPath = path.join('content', page.lang || 'en', page.path);
+                    }
                     if (fs.existsSync(contentPath)) {
                       const content = fs.readFileSync(contentPath, 'utf8');
                       
@@ -470,7 +502,7 @@ jobs:
               return pagesUsingInclude;
             }
 
-            function buildRows(files) {
+            function buildRows(files, isDeleted = false) {
               const rows = [];
               
               for (const fp of files) {
@@ -501,7 +533,8 @@ jobs:
                   } else {
                     // Regular content file
                     const e = mapEntry(fp);
-                    const titleCell = e.href ? `[${e.title}](${e.href})` : e.title;
+                    // Don't create links for deleted files
+                    const titleCell = (e.href && !isDeleted) ? `[${e.title}](${e.href})` : e.title;
                     const pathCell = '`' + e.path + '`';
                     rows.push(`| ${titleCell} | ${pathCell} |`);
                   }
@@ -510,7 +543,7 @@ jobs:
                   // Only link common web assets; skip JSON, map files, etc.
                   const isLinkableAsset = /\.(png|jpe?g|gif|webp|svg|css|js|ico|txt|pdf|mp4|webm)$/i.test(fp);
                   const rel = fp.replace(/^static\//, '/').replace(/^assets\//, '/assets/');
-                  const href = (previewBase && isLinkableAsset) ? (previewBase + rel) : '';
+                  const href = (previewBase && isLinkableAsset && !isDeleted) ? (previewBase + rel) : '';
                   const title = titleFromPath(fp);
                   const titleCell = href ? `[${title}](${href})` : title;
                   const pathCell = '`' + fp + '`';
@@ -605,7 +638,7 @@ jobs:
 
             const addedRows = buildRows(addedInfo.files);
             const modifiedRows = buildRows(modifiedInfo.files);
-            const deletedRows = buildRows(deletedInfo.files);
+            const deletedRows = buildRows(deletedInfo.files, true); // Pass true for deleted files
             const renamedRows = buildRenamedRows(renamedInfo.files);
 
             const header = '<!-- docs-preview-links -->\n<!-- preview-base: ' + (previewBase || '') + ' -->\n**PR Preview: Changed content**' + (previewBase ? `\n\nBase preview: ${previewBase}` : '\n\n⏳ *Links will be added automatically when Cloudflare Pages finishes deploying (typically 2-5 minutes)*');


### PR DESCRIPTION
## Summary

This PR fixes issues with the HTML preview comment workflow where new/added files in PRs weren't getting preview links.

Ready for review.

## Issues Fixed

1. **Added files not getting preview links** - The workflow now checks out the PR branch at the start to ensure new files added to the base branch are included in the Hugo build
2. **Include files not showing dependent pages** - Fixed path construction when searching for pages that use includes
3. **Modified index files not getting links** - Added special handling for `_index.md` files in path mapping
4. **Deleted files incorrectly showing links** - Added `isDeleted` flag to prevent link generation for deleted files

## Key Changes

- Checkout PR branch at workflow level using `ref: ${{ github.event.pull_request.head.sha }}`
- Add fallback URL construction for new files not yet in `pageurls.json`
- Fix include file path construction to handle cases where `page.path` already contains `content/` prefix
- Add special handling for index files in the path mapping logic
- Pass `isDeleted` parameter to `buildRows` function to control link generation

## Testing

Validated in fork PR: https://github.com/mdlinville/docs/pull/3 which uses the same branch where I saw the bug, but temporarily overrides the Cloudflare branch URL since the Cloudflare build does not run on forks. Existing Github actions run with the state in main, even if a PR updates them, so I needed to test in my fork's `main`.

The fix successfully shows:
- ✅ Added files WITH preview links
- ✅ Modified files WITH preview links (including index files)
- ✅ Deleted files WITHOUT links
- ✅ Include files are detected (with dependent pages when they exist)

## Before
New files added in PRs would show in the preview comment but without clickable preview links.

## After
All files get proper preview links based on their path, even if they're brand new and not yet in Hugo's `pageurls.json`.