### PR TITLE
Improve efficiency of Cloudflare redirect edge function

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,95 +1,64 @@
 /**
  * Cloudflare Pages middleware to handle trailing slash redirects
  * 
- * This middleware addresses the known Cloudflare Pages issue where URLs without
- * trailing slashes don't match redirect rules that include trailing slashes.
+ * HIGHLY OPTIMIZED: Minimal processing to avoid rate limits
+ * Only checks specific patterns known to have redirect issues
  */
 
 export async function onRequest(context) {
   const { request, env, next } = context;
-  const url = new URL(request.url);
   
-  // Only process GET and HEAD requests
+  // OPTIMIZATION: Only check GET/HEAD requests
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return next();
   }
   
-  // Skip if the path already has a trailing slash
-  if (url.pathname.endsWith('/')) {
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+  
+  // OPTIMIZATION: Skip if already has trailing slash
+  if (pathname.endsWith('/')) {
     return next();
   }
   
-  // Skip if the path has a file extension
-  const hasFileExtension = /\.[a-zA-Z0-9]+$/.test(url.pathname);
-  if (hasFileExtension) {
+  // OPTIMIZATION: Skip if has file extension (quick check)
+  if (pathname.includes('.')) {
     return next();
   }
   
-  // Skip certain system paths
-  const skipPaths = ['/robots.txt', '/sitemap.xml', '/_redirects', '/favicon.ico'];
-  if (skipPaths.includes(url.pathname)) {
+  // OPTIMIZATION: Only process paths with 2+ segments
+  // Single segment paths like /about rarely need this fix
+  const segments = pathname.split('/').filter(s => s);
+  if (segments.length < 2) {
     return next();
   }
   
-  // Skip paths with dots that might not be file extensions
-  // but could be version numbers or other valid path segments
-  // Only skip if the dot is followed by common file extensions
-  const commonExtensions = /\.(html|htm|css|js|json|xml|txt|pdf|jpg|jpeg|png|gif|svg|ico|woff|woff2|ttf|eot)$/i;
-  if (commonExtensions.test(url.pathname)) {
+  // OPTIMIZATION: Only check paths that match common redirect patterns
+  // Add more patterns here as needed based on your _redirects file
+  const needsCheck = 
+    pathname.startsWith('/wandb/') ||
+    pathname.startsWith('/library/') ||
+    pathname.startsWith('/guides/') ||
+    pathname.startsWith('/ref/') ||
+    pathname.startsWith('/sweeps/') ||
+    pathname.startsWith('/artifacts/') ||
+    pathname.startsWith('/frameworks/') ||
+    pathname.startsWith('/company/') ||
+    pathname.startsWith('/tutorials/');
+  
+  if (!needsCheck) {
     return next();
   }
   
-  // Create URL with trailing slash, preserving query and hash
-  const urlWithSlash = new URL(request.url);
-  urlWithSlash.pathname = url.pathname + '/';
+  // At this point, we have a high-probability redirect candidate
+  // Redirect to path with trailing slash
+  const redirectUrl = pathname + '/' + url.search + url.hash;
   
-  // Create a new request with the trailing slash
-  const requestWithSlash = new Request(urlWithSlash.toString(), {
-    method: request.method,
-    headers: request.headers,
-    redirect: 'manual' // Important: don't follow redirects
+  return new Response(null, {
+    status: 301,
+    headers: {
+      'Location': redirectUrl,
+      'Cache-Control': 'public, max-age=3600'
+    }
   });
-  
-  try {
-    // Fetch with the trailing slash URL
-    const response = await env.ASSETS.fetch(requestWithSlash);
-    
-    // If we get a redirect response (301, 302, etc.), redirect to URL with slash
-    if (response.status >= 301 && response.status <= 308) {
-      // The path with trailing slash matches a redirect rule
-      // Redirect the browser to the URL with slash, which will then trigger the actual redirect
-      // Preserve query parameters and hash
-      const redirectUrl = new URL(request.url);
-      redirectUrl.pathname = url.pathname + '/';
-      
-      return new Response(null, {
-        status: 301,
-        headers: {
-          'Location': redirectUrl.pathname + redirectUrl.search + redirectUrl.hash,
-          'Cache-Control': 'public, max-age=3600'
-        }
-      });
-    }
-    
-    // If the response is successful (200), it means the trailing slash version exists
-    // In this case, we should also redirect to maintain consistency
-    if (response.status === 200) {
-      const redirectUrl = new URL(request.url);
-      redirectUrl.pathname = url.pathname + '/';
-      
-      return new Response(null, {
-        status: 301,
-        headers: {
-          'Location': redirectUrl.pathname + redirectUrl.search + redirectUrl.hash,
-          'Cache-Control': 'public, max-age=3600'
-        }
-      });
-    }
-  } catch (error) {
-    // Log error but continue with original request
-    console.error('Trailing slash middleware error:', error);
-  }
-  
-  // No redirect found, continue with the original request
-  return next();
 }

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -7,35 +7,35 @@
 
 export async function onRequest(context) {
   const { request, env, next } = context;
-  
+
   // OPTIMIZATION: Only check GET/HEAD requests
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return next();
   }
-  
+
   const url = new URL(request.url);
   const pathname = url.pathname;
-  
+
   // OPTIMIZATION: Skip if already has trailing slash
   if (pathname.endsWith('/')) {
     return next();
   }
-  
+
   // OPTIMIZATION: Skip if has file extension (quick check)
   if (pathname.includes('.')) {
     return next();
   }
-  
+
   // OPTIMIZATION: Only process paths with 2+ segments
   // Single segment paths like /about rarely need this fix
   const segments = pathname.split('/').filter(s => s);
   if (segments.length < 2) {
     return next();
   }
-  
+
   // OPTIMIZATION: Only check paths that match common redirect patterns
   // Add more patterns here as needed based on your _redirects file
-  const needsCheck = 
+  const needsCheck =
     pathname.startsWith('/wandb/') ||
     pathname.startsWith('/library/') ||
     pathname.startsWith('/guides/') ||
@@ -45,15 +45,15 @@ export async function onRequest(context) {
     pathname.startsWith('/frameworks/') ||
     pathname.startsWith('/company/') ||
     pathname.startsWith('/tutorials/');
-  
+
   if (!needsCheck) {
     return next();
   }
-  
+
   // At this point, we have a high-probability redirect candidate
   // Redirect to path with trailing slash
   const redirectUrl = pathname + '/' + url.search + url.hash;
-  
+
   return new Response(null, {
     status: 301,
     headers: {


### PR DESCRIPTION
Improves on the fix deployed in https://github.com/wandb/docs/pull/1631 so that the function fires only when the URL is missing the trailing slash and would result in a 404. Should reduce the likelihood of hitting Cloudflare rate limiting, while slightly increasing the likelihood of getting an obscure 404 if it is not in one of the top level directories we are considering. I think it's a good tradeoff since we will not be on Cloudflare forever.

Quick test: https://cloudflare-trailing-slash-ed.docodile.pages.dev/guides/automations gets redirected to https://cloudflare-trailing-slash-ed.docodile.pages.dev/guides/automations/ ✅ 