### PR TITLE
Add style guide prompt for agents, add a directory for AI-driven runbooks, add the first one

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -50,11 +50,13 @@ Repository-specific context that helps AI agents understand:
 
 ## Best Practices
 
-1. **Specificity**: Be explicit about every step, assumption, and requirement
-2. **Adaptability**: Include variations for common scenarios
-3. **Safety**: Always include cleanup steps and error handling
-4. **Testing**: Verify runbooks work with multiple AI providers
-5. **Maintenance**: Update runbooks when workflows or tools change
+1. **Capture knowledge immediately**: After completing any complex task with an AI agent, ask them to draft a runbook while the details are fresh
+2. **Specificity**: Be explicit about every step, assumption, and requirement
+3. **Adaptability**: Include variations for common scenarios
+4. **Safety**: Always include cleanup steps and error handling
+5. **Testing**: Verify runbooks work with multiple AI providers
+6. **Maintenance**: Update runbooks when workflows or tools change
+7. **Iterative improvement**: Have agents review and improve existing runbooks based on their experience
 
 ## Contributing
 

--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,8 +1,8 @@
-# AI Resources for wandb/docs
+# AI resources for wandb/docs
 
 This directory contains resources, prompts, and tools designed to help AI agents work effectively with the wandb/docs repository.
 
-## Directory Structure
+## Directory structure
 
 ### `runbooks/`
 Standardized, task-specific instructions for AI agents performing complex operations in this repository. These runbooks ensure consistent, reliable execution of recurring tasks.
@@ -14,7 +14,7 @@ Standardized, task-specific instructions for AI agents performing complex operat
 
 See [runbooks/README.md](./runbooks/README.md) for detailed information.
 
-### Future Directories (Planned)
+### Future directories (planned)
 
 #### `prompts/`
 System prompts and context for different types of AI interactions:
@@ -34,21 +34,21 @@ Repository-specific context that helps AI agents understand:
 - Historical context
 - Domain-specific knowledge
 
-## Usage Guidelines
+## Usage guidelines
 
-### For Repository Maintainers
+### For repository maintainers
 1. Keep runbooks up-to-date as processes change
 2. Test runbooks regularly with AI agents
 3. Document any repository-specific quirks or constraints
 4. Version control all AI resources alongside code
 
-### For AI Agent Users
+### For AI agent users
 1. Always check for relevant runbooks before starting complex tasks
 2. Provide runbooks as context to your AI agent
 3. Report issues or ambiguities in runbooks
 4. Contribute improvements based on your experience
 
-## Best Practices
+## Best practices
 
 1. **Capture knowledge immediately**: After completing any complex task with an AI agent, ask them to draft a runbook while the details are fresh
 2. **Specificity**: Be explicit about every step, assumption, and requirement
@@ -68,7 +68,7 @@ When adding AI resources:
 4. Update relevant README files
 5. Consider security implications of any shared context
 
-## Security Notes
+## Security notes
 
 - Never include sensitive information (API keys, passwords, etc.)
 - Be cautious about exposing internal URLs or infrastructure details

--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,0 +1,73 @@
+# AI Resources for wandb/docs
+
+This directory contains resources, prompts, and tools designed to help AI agents work effectively with the wandb/docs repository.
+
+## Directory Structure
+
+### `/runbooks`
+Standardized, task-specific instructions for AI agents performing complex operations in this repository. These runbooks ensure consistent, reliable execution of recurring tasks.
+
+**Example tasks:**
+- Testing GitHub Actions changes
+- Performing large-scale refactoring
+- Managing release processes
+
+See [runbooks/README.md](./runbooks/README.md) for detailed information.
+
+### Future Directories (Planned)
+
+#### `/prompts`
+System prompts and context for different types of AI interactions:
+- Documentation writing guidelines
+- Code review standards
+- Style and tone specifications
+
+#### `/tools`
+Scripts and utilities that AI agents can use:
+- Validation scripts
+- Automation helpers
+- Analysis tools
+
+#### `/context`
+Repository-specific context that helps AI agents understand:
+- Architecture decisions
+- Historical context
+- Domain-specific knowledge
+
+## Usage Guidelines
+
+### For Repository Maintainers
+1. Keep runbooks up-to-date as processes change
+2. Test runbooks regularly with AI agents
+3. Document any repository-specific quirks or constraints
+4. Version control all AI resources alongside code
+
+### For AI Agent Users
+1. Always check for relevant runbooks before starting complex tasks
+2. Provide runbooks as context to your AI agent
+3. Report issues or ambiguities in runbooks
+4. Contribute improvements based on your experience
+
+## Best Practices
+
+1. **Specificity**: Be explicit about every step, assumption, and requirement
+2. **Adaptability**: Include variations for common scenarios
+3. **Safety**: Always include cleanup steps and error handling
+4. **Testing**: Verify runbooks work with multiple AI providers
+5. **Maintenance**: Update runbooks when workflows or tools change
+
+## Contributing
+
+When adding AI resources:
+
+1. Follow existing naming conventions and structure
+2. Include comprehensive documentation
+3. Test with at least one AI agent
+4. Update relevant README files
+5. Consider security implications of any shared context
+
+## Security Notes
+
+- Never include sensitive information (API keys, passwords, etc.)
+- Be cautious about exposing internal URLs or infrastructure details
+- Review all contributions for potential security risks

--- a/.ai/README.md
+++ b/.ai/README.md
@@ -4,7 +4,7 @@ This directory contains resources, prompts, and tools designed to help AI agents
 
 ## Directory Structure
 
-### `/runbooks`
+### `runbooks/`
 Standardized, task-specific instructions for AI agents performing complex operations in this repository. These runbooks ensure consistent, reliable execution of recurring tasks.
 
 **Example tasks:**
@@ -16,19 +16,19 @@ See [runbooks/README.md](./runbooks/README.md) for detailed information.
 
 ### Future Directories (Planned)
 
-#### `/prompts`
+#### `prompts/`
 System prompts and context for different types of AI interactions:
 - Documentation writing guidelines
 - Code review standards
 - Style and tone specifications
 
-#### `/tools`
+#### `tools/`
 Scripts and utilities that AI agents can use:
 - Validation scripts
 - Automation helpers
 - Analysis tools
 
-#### `/context`
+#### `context/`
 Repository-specific context that helps AI agents understand:
 - Architecture decisions
 - Historical context

--- a/.ai/runbooks/README.md
+++ b/.ai/runbooks/README.md
@@ -1,0 +1,74 @@
+# AI Agent Runbooks
+
+This directory contains standardized runbooks (task-specific prompts) for AI agents working with the wandb/docs repository.
+
+## What are AI Runbooks?
+
+AI runbooks are detailed, step-by-step instructions designed to help AI agents perform complex, recurring tasks consistently and correctly. They include:
+
+- **Context and constraints** specific to the task
+- **Prerequisites** the agent should gather from users
+- **Step-by-step procedures** with exact commands
+- **Common issues and solutions**
+- **Cleanup instructions**
+
+## Available Runbooks
+
+### [test-github-action-changes.md](./test-github-action-changes.md)
+Tests changes to GitHub Actions workflows using a fork, particularly for workflows that depend on Cloudflare Pages deployments.
+
+**Use cases:**
+- Testing dependency upgrades (e.g., Dependabot PRs)
+- Verifying workflow functionality changes
+- Debugging GitHub Actions issues
+
+## How to Use These Runbooks
+
+### For Humans
+1. Provide the runbook to your AI agent as context
+2. Answer any prerequisite questions the agent asks
+3. Follow along as the agent executes the steps
+4. Complete any manual steps the agent cannot perform
+
+### For AI Agents
+1. Read the entire runbook before starting
+2. Gather all prerequisites from the user
+3. Follow the steps exactly, adapting only where explicitly noted
+4. Ask for clarification if any step is unclear
+5. Clean up all temporary resources after completion
+
+## Creating New Runbooks
+
+When creating a new runbook:
+
+1. **Use the template structure**:
+   - Agent Prerequisites
+   - Task Overview
+   - Context and Constraints
+   - Step-by-Step Process
+   - Common Issues and Solutions
+   - Cleanup Instructions
+
+2. **Make it agent-friendly**:
+   - Use placeholders like `<username>` that agents should replace
+   - Include explicit instructions for what agents should ask users
+   - Provide fallback procedures when agents lack permissions
+
+3. **Include all necessary context**:
+   - Repository-specific constraints
+   - Tool-specific limitations
+   - Security considerations
+
+4. **Test the runbook**:
+   - Have an AI agent follow it exactly
+   - Note any ambiguities or missing steps
+   - Iterate until the process is smooth
+
+## Contributing
+
+To add or improve runbooks:
+
+1. Follow the existing format and style
+2. Test thoroughly with an AI agent
+3. Include real examples where helpful
+4. Update this README with your new runbook

--- a/.ai/runbooks/README.md
+++ b/.ai/runbooks/README.md
@@ -64,6 +64,11 @@ When creating a new runbook:
    - Note any ambiguities or missing steps
    - Iterate until the process is smooth
 
+5. **Get an agent review**:
+   - Ask an AI agent to review the runbook for agent-friendliness
+   - Example prompt: "Please review this runbook and suggest improvements to make it more useful for AI agents. Focus on clarity, completeness, and removing ambiguity."
+   - Incorporate the suggested improvements
+
 ## Contributing
 
 To add or improve runbooks:

--- a/.ai/runbooks/README.md
+++ b/.ai/runbooks/README.md
@@ -1,8 +1,8 @@
-# AI Agent Runbooks
+# AI agent runbooks
 
 This directory contains standardized runbooks (task-specific prompts) for AI agents working with the wandb/docs repository.
 
-## What are AI Runbooks?
+## What are AI runbooks?
 
 AI runbooks are detailed, step-by-step instructions designed to help AI agents perform complex, recurring tasks consistently and correctly. They include:
 
@@ -12,7 +12,7 @@ AI runbooks are detailed, step-by-step instructions designed to help AI agents p
 - **Common issues and solutions**
 - **Cleanup instructions**
 
-## Available Runbooks
+## Available runbooks
 
 ### [test-github-action-changes.md](./test-github-action-changes.md)
 Tests changes to GitHub Actions workflows using a fork, particularly for workflows that depend on Cloudflare Pages deployments.
@@ -22,31 +22,31 @@ Tests changes to GitHub Actions workflows using a fork, particularly for workflo
 - Verifying workflow functionality changes
 - Debugging GitHub Actions issues
 
-## How to Use These Runbooks
+## How to use these runbooks
 
-### For Humans
+### For humans
 1. Provide the runbook to your AI agent as context
 2. Answer any prerequisite questions the agent asks
 3. Follow along as the agent executes the steps
 4. Complete any manual steps the agent cannot perform
 
-### For AI Agents
+### For AI agents
 1. Read the entire runbook before starting
 2. Gather all prerequisites from the user
 3. Follow the steps exactly, adapting only where explicitly noted
 4. Ask for clarification if any step is unclear
 5. Clean up all temporary resources after completion
 
-## Creating New Runbooks
+## Creating new runbooks
 
-### Best Practice: Agent-First Authoring
+### Best practice: Agent-first authoring
 The most effective runbooks are often created by having an AI agent write the first draft immediately after completing a complex task together. At the end of any challenging interactive task, consider asking your agent:
 
 > "Based on what we just did together, please create a runbook that would help another agent perform this same task in the future. Include all the context, gotchas, and workarounds we discovered."
 
 This captures the knowledge while it's fresh and ensures nothing important is forgotten.
 
-### When creating a new runbook:
+### When creating a new runbook
 
 1. **Use the template structure**:
    - Agent Prerequisites

--- a/.ai/runbooks/README.md
+++ b/.ai/runbooks/README.md
@@ -39,7 +39,14 @@ Tests changes to GitHub Actions workflows using a fork, particularly for workflo
 
 ## Creating New Runbooks
 
-When creating a new runbook:
+### Best Practice: Agent-First Authoring
+The most effective runbooks are often created by having an AI agent write the first draft immediately after completing a complex task together. At the end of any challenging interactive task, consider asking your agent:
+
+> "Based on what we just did together, please create a runbook that would help another agent perform this same task in the future. Include all the context, gotchas, and workarounds we discovered."
+
+This captures the knowledge while it's fresh and ensures nothing important is forgotten.
+
+### When creating a new runbook:
 
 1. **Use the template structure**:
    - Agent Prerequisites

--- a/.ai/runbooks/test-github-action-changes.md
+++ b/.ai/runbooks/test-github-action-changes.md
@@ -1,0 +1,171 @@
+# Agent Prompt: Testing GitHub Actions Changes in wandb/docs
+
+## Task Overview
+Test changes to GitHub Actions workflows in the wandb/docs repository, particularly the PR preview link generation workflows that depend on Cloudflare Pages deployments.
+
+> **Note**: If you are testing changes to an action that doesn't depend on Cloudflare, adjust your interpretation of this runbook accordingly.
+
+## Context and Constraints
+
+### Repository Setup
+- **Main repository**: `wandb/docs` (origin)
+- **Fork for testing**: `<username>/docs` (fork remote)
+- **Important**: GitHub Actions in PRs always run from the base branch (main), not from the PR branch
+- **Cloudflare limitation**: Cloudflare Pages only builds for the main wandb/docs repository, not for forks
+
+These instructions assume that you are using a fork that doesn't contain real work in `main`. An agent can have trouble committing to a fork, so the agent may need to temporarily push a branch to the main repo so the human can push the same branch to the fork.
+
+### Key Workflows
+1. `.github/workflows/pr-preview-links.yml` - Runs on PR open/sync
+2. `.github/workflows/pr-preview-links-on-comment.yml` - Triggered by Cloudflare comments
+
+### Testing Requirements
+To test workflow changes, you must:
+1. Sync the fork's `main` with the main repo's `main`, throwing away all temporary commits.
+2. Apply changes to the fork's main branch (not just a feature branch)
+2. Override Cloudflare URLs since they won't generate for forks
+3. Create a test PR with content changes to trigger the workflows
+
+## Step-by-Step Testing Process
+
+### 1. Initial Setup
+```bash
+# Ensure you have both remotes configured
+git remote -v  # Should show 'origin' (wandb/docs) and 'fork' (mdlinville/docs)
+
+# If fork remote is missing:
+git remote add fork https://github.com/<username>/docs.git
+```
+
+### 2. Prepare Test Branch
+```bash
+# Start from latest main
+git checkout main
+git pull origin main
+
+# Create test branch for the workflow changes
+git checkout -b test-[description]-[date]
+```
+
+### 3. Apply Workflow Changes
+Make your changes to the workflow files. For dependency upgrades:
+- Update version numbers in `uses:` statements
+- Check both workflow files if the dependency is used in multiple places
+
+### 4. Add Cloudflare URL Override
+Since Cloudflare won't build for forks, add this override to BOTH workflow files:
+
+For `pr-preview-links.yml`, after the URL extraction logic (around line ~220):
+```javascript
+// TEMPORARY OVERRIDE FOR FORK TESTING
+// Since Cloudflare won't run on forks, use a hardcoded URL
+if (!base && context.repo.owner === 'mdlinville') {
+  base = 'https://main.docodile.pages.dev';
+  core.warning('Using temporary override URL for fork testing: ' + base);
+}
+```
+
+For `pr-preview-links-on-comment.yml`, after the URL extraction (around line ~126):
+```javascript
+// TEMPORARY OVERRIDE FOR FORK TESTING
+// Since Cloudflare won't run on forks, use a hardcoded URL
+if (!branchUrl && context.repo.owner === 'mdlinville') {
+  branchUrl = 'https://main.docodile.pages.dev';
+  core.warning('Using temporary override URL for fork testing: ' + branchUrl);
+}
+```
+
+### 5. Commit and Push to Fork's Main
+```bash
+# Commit all changes
+git add -A
+git commit -m "test: [Description of what you're testing]
+
+- Add Cloudflare URL override for fork testing
+- [Other changes made]"
+
+# Push to fork's main branch
+git push fork HEAD:main --force-with-lease
+```
+
+Agents: If you can't push to the fork yourself, give the human the command to push from your temporary branch in `wandb/docs` to the fork, then give them the URL to create the PR in the fork. At the end of this runbook, don't forget to prompt them to remove the temporary branch from `wandb/docs`.
+
+
+### 6. Create Test PR
+```bash
+# Create new branch from the updated fork main
+git checkout -b test-pr-[description]
+
+# Make a small content change to trigger workflows
+echo "<!-- Test change for PR preview -->" >> content/en/guides/quickstart.md
+
+# Commit and push
+git add content/en/guides/quickstart.md
+git commit -m "test: Add content change to trigger PR preview"
+git push fork test-pr-[description]
+```
+
+Then create PR via GitHub UI from `<username>:test-pr-[description]` to `<username>:main`
+
+### 7. Monitor and Verify
+
+Expected behavior:
+1. GitHub Actions bot creates initial comment with "Generating preview links..."
+2. Workflow should complete without errors
+3. Comment should update with preview links pointing to `https://main.docodile.pages.dev/...`
+
+Check for:
+- ✅ Workflow completes successfully
+- ✅ Preview comment is created and updated
+- ✅ Links use the override URL
+- ✅ File categorization works (Added/Modified/Deleted/Renamed)
+- ❌ Any errors in the Actions logs
+- ❌ Security warnings or exposed secrets
+
+### 8. Cleanup
+After testing:
+```bash
+# Reset fork's main to match upstream
+git checkout main
+git fetch origin
+git reset --hard origin/main
+git push fork main --force
+
+# Delete test branches from fork and origin
+git branch -D test-[description]-[date] test-pr-[description]
+```
+
+## Common Issues and Solutions
+
+### Issue: Permission denied when pushing to fork
+- The GitHub token might be read-only
+- Solution: Use SSH or push manually from your local machine
+
+### Issue: Workflows not triggering
+- Remember: Workflows run from the base branch (main), not the PR branch
+- Ensure changes are in fork's main branch
+
+### Issue: Preview links not generating
+- Check if Cloudflare override is properly added
+- Verify the override URL is correct: `https://main.docodile.pages.dev`
+
+### Issue: Changed files not detected
+- Ensure content changes are in tracked directories (content/, static/, assets/, etc.)
+- Check the `files:` filter in the workflow configuration
+
+## Testing Checklist
+
+- [ ] Both remotes (origin and fork) are configured
+- [ ] Workflow changes applied to both relevant files
+- [ ] Cloudflare URL override added with fork owner check
+- [ ] Changes pushed to fork's main branch
+- [ ] Test PR created with content changes
+- [ ] Preview comment generated successfully
+- [ ] No errors in GitHub Actions logs
+- [ ] Fork's main branch reset after testing
+
+## Notes
+- The Cloudflare preview domain is `docodile.pages.dev`
+- Branch previews normally use pattern: `https://[branch-name].docodile.pages.dev`
+- The override uses the main branch preview as a stable fallback
+- Always remember to remove the Cloudflare override before merging to production

--- a/.ai/runbooks/test-github-action-changes.md
+++ b/.ai/runbooks/test-github-action-changes.md
@@ -77,6 +77,9 @@ if (!base && context.repo.owner === '<username>') {  // Replace <username> with 
 }
 ```
 
+**Pro tip**: Before finalizing any runbook, ask an AI agent to review it with a prompt like:
+> "Please review this runbook and suggest improvements to make it more useful for AI agents. Focus on clarity, completeness, and removing ambiguity."
+
 For `pr-preview-links-on-comment.yml`, after the URL extraction (around line ~126):
 ```javascript
 // TEMPORARY OVERRIDE FOR FORK TESTING

--- a/.ai/runbooks/test-github-action-changes.md
+++ b/.ai/runbooks/test-github-action-changes.md
@@ -1,43 +1,43 @@
-# Agent Prompt: Testing GitHub Actions Changes in wandb/docs
+# Agent prompt: Testing GitHub Actions changes in wandb/docs
 
-## Agent Prerequisites
+## Agent prerequisites
 Before starting, gather this information from the user:
 1. **GitHub username** - Needed to identify their fork
 2. **Fork status** - Confirm they have a fork of wandb/docs that can be used for testing
 3. **Test scope** - What specific changes are being tested (dependency upgrade, functionality change, etc.)
 
-## Task Overview
+## Task overview
 Test changes to GitHub Actions workflows in the wandb/docs repository, particularly the PR preview link generation workflows that depend on Cloudflare Pages deployments.
 
 > **Note**: If you are testing changes to an action that doesn't depend on Cloudflare, adjust your interpretation of this runbook accordingly.
 
-## Context and Constraints
+## Context and constraints
 
-### Repository Setup
+### Repository setup
 - **Main repository**: `wandb/docs` (origin)
 - **Fork for testing**: `<username>/docs` (fork remote) - Agent should ask user for their fork username
 - **Important**: GitHub Actions in PRs always run from the base branch (main), not from the PR branch
 - **Cloudflare limitation**: Cloudflare Pages only builds for the main wandb/docs repository, not for forks
 
-**Agent Note**: You'll need to:
+**Agent note**: You'll need to:
 1. Ask the user for their GitHub username to identify their fork
 2. Verify they have a fork of wandb/docs that can be used for testing
 3. If you can't push to the fork directly, create a temporary branch in wandb/docs for the user to push from
 
-### Key Workflows
+### Key workflows
 1. `.github/workflows/pr-preview-links.yml` - Runs on PR open/sync
 2. `.github/workflows/pr-preview-links-on-comment.yml` - Triggered by Cloudflare comments
 
-### Testing Requirements
+### Testing requirements
 To test workflow changes, you must:
 1. Sync the fork's `main` with the main repo's `main`, throwing away all temporary commits.
 2. Apply changes to the fork's main branch (not just a feature branch)
 2. Override Cloudflare URLs since they won't generate for forks
 3. Create a test PR with content changes to trigger the workflows
 
-## Step-by-Step Testing Process
+## Step-by-step testing process
 
-### 1. Initial Setup
+### 1. Initial setup
 ```bash
 # First, ask the user for their GitHub username
 # Example: "What is your GitHub username for the fork we'll use for testing?"
@@ -49,7 +49,7 @@ git remote -v  # Should show 'origin' (wandb/docs) and 'fork' (<username>/docs)
 git remote add fork https://github.com/<username>/docs.git  # Replace <username> with actual username
 ```
 
-### 2. Prepare Test Branch
+### 2. Prepare test branch
 ```bash
 # Start from latest main
 git checkout main
@@ -59,12 +59,12 @@ git pull origin main
 git checkout -b test-[description]-[date]
 ```
 
-### 3. Apply Workflow Changes
+### 3. Apply workflow changes
 Make your changes to the workflow files. For dependency upgrades:
 - Update version numbers in `uses:` statements
 - Check both workflow files if the dependency is used in multiple places
 
-### 4. Add Cloudflare URL Override
+### 4. Add Cloudflare URL override
 Since Cloudflare won't build for forks, add this override to BOTH workflow files:
 
 For `pr-preview-links.yml`, after the URL extraction logic (around line ~220):
@@ -90,7 +90,7 @@ if (!branchUrl && context.repo.owner === '<username>') {  // Replace <username> 
 }
 ```
 
-### 5. Commit and Push to Fork's Main
+### 5. Commit and push to fork's main
 ```bash
 # Commit all changes
 git add -A
@@ -103,7 +103,7 @@ git commit -m "test: [Description of what you're testing]
 git push fork HEAD:main --force-with-lease
 ```
 
-**Agent Instructions for Fork Access**:
+**Agent instructions for fork access**:
 If you can't push to the fork directly:
 1. Create a temporary branch in wandb/docs with the changes
 2. Provide the user with this command:
@@ -115,7 +115,7 @@ If you can't push to the fork directly:
 4. Remember to delete the temporary branch from wandb/docs after testing
 
 
-### 6. Create Test PR
+### 6. Create test PR
 ```bash
 # Create new branch from the updated fork main
 git checkout -b test-pr-[description]
@@ -131,7 +131,7 @@ git push fork test-pr-[description]
 
 Then create PR via GitHub UI from `<username>:test-pr-[description]` to `<username>:main`
 
-### 7. Monitor and Verify
+### 7. Monitor and verify
 
 Expected behavior:
 1. GitHub Actions bot creates initial comment with "Generating preview links..."
@@ -159,7 +159,7 @@ git push fork main --force
 git branch -D test-[description]-[date] test-pr-[description]
 ```
 
-## Common Issues and Solutions
+## Common issues and solutions
 
 ### Issue: Permission denied when pushing to fork
 - The GitHub token might be read-only
@@ -177,7 +177,7 @@ git branch -D test-[description]-[date] test-pr-[description]
 - Ensure content changes are in tracked directories (content/, static/, assets/, etc.)
 - Check the `files:` filter in the workflow configuration
 
-## Testing Checklist
+## Testing checklist
 
 - [ ] Asked user for their GitHub username and fork details
 - [ ] Both remotes (origin and fork) are configured

--- a/.ai/style-guide.md
+++ b/.ai/style-guide.md
@@ -22,9 +22,17 @@ This document provides style guidance for AI agents creating or editing content 
   - ❌ "Integrating With GitHub Actions"
 
 ### Product names
-- W&B (not Weights & Biases in running text)
-- Weave (when referring to the product)
-- Keep consistent with existing documentation
+- **Company name**: W&B (not Weights & Biases in running text)
+- **First mention pattern**: Use "W&B [Product]" on first mention in a page, then drop "W&B" for subsequent mentions
+- **Capitalization patterns**:
+  - Products that remain capitalized: W&B Weave → Weave, W&B Models → Models, W&B Launch → Launch
+  - Products that become lowercase: W&B Run → run, W&B Sweep → sweep
+  - Special case: W&B artifact (lowercase even on first mention due to API object naming)
+- **General rule**: Check existing content for the established pattern - consistency matters more than guessing
+- **Examples**:
+  - "Configure W&B Automations to monitor your runs. Automations can send alerts..."
+  - "Create a W&B Run to track your experiment. The run will capture..."
+  - "W&B artifact versioning helps manage datasets. Each artifact can..."
 
 ### Voice and tone
 - Direct and concise

--- a/.ai/style-guide.md
+++ b/.ai/style-guide.md
@@ -1,0 +1,57 @@
+# Style guide for wandb/docs content
+
+## Overview
+
+This document provides style guidance for AI agents creating or editing content in the wandb/docs repository.
+
+## Style hierarchy
+
+1. **Match existing content first**: When editing near existing content, match its style to maintain consistency
+2. **Google Developer Style Guide**: Primary reference for new content
+3. **Microsoft Style Guide**: Secondary reference when Google doesn't cover something
+4. **Chicago Manual of Style**: Tertiary reference for edge cases
+
+## Key style rules
+
+### Headings
+- Use sentence case for all headings (capitalize only the first word and proper nouns)
+- Examples:
+  - ✅ "Getting started with W&B"
+  - ❌ "Getting Started with W&B"
+  - ✅ "Integrating with GitHub Actions"
+  - ❌ "Integrating With GitHub Actions"
+
+### Product names
+- W&B (not Weights & Biases in running text)
+- Weave (when referring to the product)
+- Keep consistent with existing documentation
+
+### Voice and tone
+- Direct and concise
+- Second person ("you") for instructions
+- Active voice preferred
+- Present tense for descriptions
+
+### Code and technical terms
+- Use backticks for:
+  - File names: `config.yaml`
+  - Commands: `git push`
+  - Code elements: `wandb.init()`
+  - Directory paths: `runbooks/`
+
+### Lists
+- Use sentence case for list items
+- Include periods for complete sentences
+- Omit periods for fragments
+
+### Important principle
+**Avoid mixing style refactors with content changes**. If you're adding or editing content, match the existing style even if it's not perfect. Style refactors should be separate PRs.
+
+## For AI agents
+
+When editing wandb/docs content:
+
+1. **First check**: Is this near existing content? If yes, match its style exactly
+2. **New content**: Follow this guide and the Google Developer Style Guide
+3. **When in doubt**: Prioritize consistency over perfection
+4. **Always**: Keep style changes separate from content changes

--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ The markdown files are generated from docstrings in https://github.com/wandb/wan
 
 Once you are done, create a pull request from https://github.com/wandb/wandb. The PR you create will get reviewed and (if approved) merged by the SDK Team. The Docs are updated when the W&B SDK Team makes an W&BSDK Release. SDK Releases occur about every 2-4 weeks.
 
+## AI resources
+
+The `.ai/` directory contains resources specifically designed for AI agents working with this repository. These include:
+
+- **[Runbooks](.ai/runbooks/)**: Step-by-step instructions for complex, recurring tasks (e.g., testing GitHub Actions changes)
+- **[Style guide](.ai/style-guide.md)**: Quick reference for AI agents on wandb/docs style conventions
+
+If you're using an AI agent to help with documentation tasks, provide these resources as context to ensure consistent, high-quality contributions. See the [.ai/README.md](.ai/README.md) for more details.
+
 ## License
 
 The source for this documentation is offered under the Apache 2.0 license. 


### PR DESCRIPTION
This PR adds:
- `.ai/`: A directory for materials for AI agents, also useful for humans.
- `.ai/style-guide.md`: A very basic prompt with style guidance for agents and humans
- `.ai/runbooks/`: A directory for AI-driven runbooks
- `.ai/runbooks/test-github-action-changes.md`: A runbook that guides an AI agent to help a human user to test an upgrade to a Github action and gives some additional context specific to the HTML preview action. Because Github actions always run from main, not from a PR that changes the action, it can be tricky to test. This is especially true when an action depends on state that you need to temporary override, such as a Cloudflare preview URL.
- Some `README`s at different levels of the hierarchy, to guide agents and humans developing and working with agentic materials

It also updates the main `README` to point agents and humans toward the `.ai/` directory.

## Testing
PR-level testing isn't so relevant for this sort of materials. The best test is to try using them and giving feedback based on the results. I have a lot of experience by now with the specifics of testing a Github action, and an agent drafted the runbook at the end of our interactive testing of a recent Github action upgrade. I also have some experience getting an agent to do a good copyedit pass with the sort of guidance and context that is in this style guide prompt. I've done a series of copyedits and gotten an agent to do the same.
