### PR TITLE
Fix typo in system metrics logging configuration

### DIFF
--- a/content/en/support/kb-articles/how_can_i_reduce_how_frequently_to_log_system_metrics.md
+++ b/content/en/support/kb-articles/how_can_i_reduce_how_frequently_to_log_system_metrics.md
@@ -8,8 +8,8 @@ support:
   - runs
 ---
 
-To configure the frequency to log [system metrics]({{< relref "/ref/system-metrics.md" >}}), set `_stats_sampling_interval` to a number of seconds, expressed as a float. Default: `10.0`.
+To configure the frequency to log [system metrics]({{< relref "/ref/system-metrics.md" >}}), set `x_stats_sampling_interval` to a number of seconds, expressed as a float.
 
 ```python
-wandb.init(settings=wandb.Settings(x_stats_sampling_interval=30.0))
+wandb.init(settings=wandb.Settings(x_stats_sampling_interval=15))
 ```


### PR DESCRIPTION
Removes default value since it was and will continue to get stale over time.

## Description

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->


<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1660#issuecomment-3304743654)**