### PR TITLE
Python SDK: Remove extra line

### DIFF
--- a/content/en/ref/python/functions/init.md
+++ b/content/en/ref/python/functions/init.md
@@ -88,8 +88,7 @@ Run IDs must not contain any of the following special characters `/ \ # ? % :`
  - `fork_from`:  Specifies a point in a previous run from which to fork a new  run, using the format `{id}?_step={step}`. This creates a new run that  resumes logging from the specified step in the target run’s history.  The target run must be part of the current project.  If an `id` argument is also provided, it must be different from the  `fork_from` argument, an error will be raised if they are the same.  `resume`, `resume_from` and `fork_from` cannot be used together, only  one of them can be used at a time.  Note that this feature is in beta and may change in the future. 
  - `save_code`:  Enables saving the main script or notebook to W&B, aiding in  experiment reproducibility and allowing code comparisons across runs in  the UI. By default, this is disabled, but you can change the default to  enable on your settings page. 
  - `tensorboard`:  Deprecated. Use `sync_tensorboard` instead. 
- - `sync_tensorboard`:  Enables automatic syncing of W&B logs from TensorBoard  or TensorBoardX, saving relevant event files for viewing in the W&B UI. 
- - `saving relevant event files for viewing in the W&B UI. (Default`:  `False`) 
+ - `sync_tensorboard`:  Enables automatic syncing of W&B logs from TensorBoard  or TensorBoardX, saving relevant event files for viewing in the W&B UI.
  - `monitor_gym`:  Enables automatic logging of videos of the environment when  using OpenAI Gym. 
  - `settings`:  Specifies a dictionary or `wandb.Settings` object with advanced  settings for the run. 
 


### PR DESCRIPTION
## Description

Manually fixes docstring. PR to fix source docstring is here:  https://github.com/wandb/wandb/pull/10546


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->


<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1669#issuecomment-3320021566)**