### PR TITLE
Python SDK: Add File Public API Class

### DIFF
--- a/content/en/ref/python/public-api/File.md
+++ b/content/en/ref/python/public-api/File.md
@@ -1,0 +1,101 @@
+---
+title: File
+namespace: public_apis_namespace
+python_object_type: class
+---
+{{< readfile file="/_includes/public-api-use.md" >}}
+
+
+{{< cta-button githubLink=https://github.com/wandb/wandb/blob/main/wandb/apis/public/files.py >}}
+
+
+
+
+## <kbd>class</kbd> `File`
+File saved to W&B. 
+
+Represents a single file stored in W&B. Includes access to file metadata. Files are associated with a specific run and can include text files, model weights, datasets, visualizations, and other artifacts. You can download the file, delete the file, and access file properties. 
+
+Specify one or more attributes in a dictionary to fine a specific file logged to a specific run. You can search using the following keys: 
+
+
+- id (str): The ID of the run that contains the file 
+- name (str): Name of the file 
+- url (str): path to file 
+- direct_url (str): path to file in the bucket 
+- sizeBytes (int): size of file in bytes 
+- md5 (str): md5 of file 
+- mimetype (str): mimetype of file 
+- updated_at (str): timestamp of last update 
+- path_uri (str): path to file in the bucket, currently only available for S3 objects and reference files 
+
+
+
+**Args:**
+ 
+ - `client`:  The run object that contains the file 
+ - `attrs` (dict):  A dictionary of attributes that define the file 
+ - `run`:  The run object that contains the file 
+
+
+### <kbd>property</kbd> File.path_uri
+
+Returns the URI path to the file in the storage bucket. 
+
+
+
+**Returns:**
+ 
+ - `str`:  The S3 URI (e.g., 's3://bucket/path/to/file') if the file is stored in S3,  the direct URL if it's a reference file, or an empty string if unavailable. 
+
+
+
+**Returns:**
+ - `str`: The path_uri property value.
+---
+
+### <kbd>property</kbd> File.size
+
+Returns the size of the file in bytes. 
+
+
+
+---
+
+### <kbd>method</kbd> `File.delete`
+
+```python
+delete()
+```
+
+Delete the file from the W&B server. 
+
+---
+
+### <kbd>method</kbd> `File.download`
+
+```python
+download(
+    root: 'str' = '.',
+    replace: 'bool' = False,
+    exist_ok: 'bool' = False,
+    api: 'Api | None' = None
+) → io.TextIOWrapper
+```
+
+Downloads a file previously saved by a run from the wandb server. 
+
+
+
+**Args:**
+ 
+ - `root`:  Local directory to save the file. Defaults to the  current working directory ("."). 
+ - `replace`:  If `True`, download will overwrite a local file  if it exists. Defaults to `False`. 
+ - `exist_ok`:  If `True`, will not raise ValueError if file already  exists and will not re-download unless replace=True.  Defaults to `False`. 
+ - `api`:  If specified, the `Api` instance used to download the file. 
+
+
+
+**Raises:**
+ `ValueError` if file already exists, `replace=False` and `exist_ok=False`. 
+


### PR DESCRIPTION
## Description

Accidentally removed File Class from Public API ref docs.  This adds it back using `lazydocs`.

## Status

This PR will be ready to merge once the source code is updated with this PR: https://github.com/wandb/wandb/pull/10560

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
