### PR TITLE
DOCS-1764: Add redirect from old wandb_workspaces URL to new location

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -468,3 +468,4 @@
 /ref/release-notes/releases/* /ref/releases/:splat 301
 /ref/release-notes/releases/archived/* /ref/releases/archived/:splat 301
 /ref/python/sdk/* /ref/python/:splat 301
+/ref/python/wandb_workspaces/* /ref/wandb_workspaces/:splat 301


### PR DESCRIPTION
## Summary
This PR resolves DOCS-1764 by adding a redirect from the old URL structure to the new one.

## Changes
- Added a splat rule to redirect all URLs under  to 
- This ensures that all sub-paths are properly redirected (e.g.,  → )

## Type of change
- [x] Bug fix / Redirect fix
- [ ] New feature
- [ ] Documentation update

## Testing
The redirect rule follows the established pattern in the _redirects file and uses the splat syntax to catch all sub-URLs.

<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1678#issuecomment-3335122316)**