### PR TITLE
Add Microsoft Clarity analytics and improve prod isolation/GDPR prompting behavior (DOCS-1759)

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -91,59 +91,10 @@
 
 
 {{- if not hugo.IsProduction -}}
-<!-- Analytics for Development/Staging/Preview - NO CONSENT PROMPTS -->
+<!-- No analytics in development/staging/preview environments -->
+<!-- This keeps development clean without any tracking or consent popups -->
 <script type="text/javascript">
-  // For non-production environments (localhost, CloudFlare previews, etc.)
-  // we load Segment analytics directly without consent management to avoid annoying popups during development
-  // Note: Microsoft Clarity is production-only
-  
-  // Load Segment Analytics  
-  !function(){
-    var analytics = window.analytics = window.analytics || [];
-    if (!analytics.initialize)
-      if (analytics.invoked)
-        window.console && console.error && console.error("Segment snippet included twice.");
-      else {
-        analytics.invoked = !0;
-        analytics.methods = [
-          "trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify",
-          "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on",
-          "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"
-        ];
-        analytics.factory = function(method){
-          return function(){
-            if (window.analytics.initialized) return window.analytics[method].apply(window.analytics, arguments);
-            var args = Array.prototype.slice.call(arguments);
-            args.unshift(method);
-            analytics.push(args);
-            return analytics;
-          }
-        };
-        for (var i = 0; i < analytics.methods.length; i++) {
-          var key = analytics.methods[i];
-          analytics[key] = analytics.factory(key);
-        }
-        analytics.load = function(writeKey, options){
-          var script = document.createElement("script");
-          script.type = "text/javascript";
-          script.async = true;
-          script.src = "https://wandb.ai/sa-docs.min.js"; // <-- Your self-hosted Segment build
-          var first = document.getElementsByTagName("script")[0];
-          first.parentNode.insertBefore(script, first);
-          analytics._loadOptions = options;
-        };
-        analytics._writeKey = "2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa"; // <-- Your real write key
-        analytics.SNIPPET_VERSION = "4.16.1";
-        analytics.load("2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa");
-
-        // 🚀 Fire analytics.page() when ready
-        analytics.ready(function() {
-          analytics.page();
-        });
-      }
-  }();
-  
-  console.log("📊 Segment Analytics loaded for development environment (no consent prompts, no Clarity)");
+  console.log("🚫 Development mode: No analytics loaded (no consent popups, no tracking)");
 </script>
 {{- else -}}
 <!-- Segment & Onetrust: Production -->

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -91,103 +91,65 @@
 
 
 {{- if not hugo.IsProduction -}}
-<!-- Segment & OneTrust: Staging -->
-<!-- OneTrust Consent SDK Loader -->
-<script
-  src="https://cdn.cookielaw.org/consent/29d3f242-6917-42f4-a828-bac6fba2e677/otSDKStub.js"
-  type="text/javascript"
-  charset="UTF-8"
-  data-domain-script="29d3f242-6917-42f4-a828-bac6fba2e677">
-</script>
-
-<!-- Your Consent Sync + Segment Loader -->
+<!-- Analytics for Development/Staging/Preview - NO CONSENT PROMPTS -->
 <script type="text/javascript">
-  // Sync consent categories
-  function wpConsentSync() {
-    if (typeof OnetrustActiveGroups === 'undefined') return;
+  // For non-production environments (localhost, CloudFlare previews, etc.)
+  // we load analytics directly without consent management to avoid annoying popups during development
+  
+  // Load Microsoft Clarity Analytics
+  (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "a6rlxhvc58");
 
-    const activeGroups = OnetrustActiveGroups || '';
-    const hasGroup = (id) => activeGroups.includes(`,${id},`);
-    const isOptIn = activeGroups === ',C0001,';
-
-    window.wp_consent_type = isOptIn ? 'optin' : 'optout';
-    document.dispatchEvent(new CustomEvent('wp_consent_type_defined'));
-
-    const consentMap = {
-      'statistics': hasGroup('C0002'),
-      'statistics-anonymous': hasGroup('C0002'),
-      'marketing': hasGroup('C0004') || hasGroup('C0005'),
-      'functional': hasGroup('C0001') || hasGroup('C0003'),
-      'preferences': false
-    };
-
-    if (typeof window.wp_set_consent === 'function') {
-      for (const [category, allowed] of Object.entries(consentMap)) {
-        window.wp_set_consent(category, allowed ? 'allow' : 'deny');
-      }
-    }
-
-    // 🚀 Load Segment only if marketing or statistics consent is given
-    if (consentMap.marketing || consentMap.statistics) {
-      loadSegment();
-    }
-  }
-
-  // Load Segment Analytics
-  function loadSegment() {
-    !function(){
-      var analytics = window.analytics = window.analytics || [];
-      if (!analytics.initialize)
-        if (analytics.invoked)
-          window.console && console.error && console.error("Segment snippet included twice.");
-        else {
-          analytics.invoked = !0;
-          analytics.methods = [
-            "trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify",
-            "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on",
-            "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"
-          ];
-          analytics.factory = function(method){
-            return function(){
-              if (window.analytics.initialized) return window.analytics[method].apply(window.analytics, arguments);
-              var args = Array.prototype.slice.call(arguments);
-              args.unshift(method);
-              analytics.push(args);
-              return analytics;
-            }
-          };
-          for (var i = 0; i < analytics.methods.length; i++) {
-            var key = analytics.methods[i];
-            analytics[key] = analytics.factory(key);
+  // Load Segment Analytics  
+  !function(){
+    var analytics = window.analytics = window.analytics || [];
+    if (!analytics.initialize)
+      if (analytics.invoked)
+        window.console && console.error && console.error("Segment snippet included twice.");
+      else {
+        analytics.invoked = !0;
+        analytics.methods = [
+          "trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify",
+          "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on",
+          "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"
+        ];
+        analytics.factory = function(method){
+          return function(){
+            if (window.analytics.initialized) return window.analytics[method].apply(window.analytics, arguments);
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(method);
+            analytics.push(args);
+            return analytics;
           }
-          analytics.load = function(writeKey, options){
-            var script = document.createElement("script");
-            script.type = "text/javascript";
-            script.async = true;
-            script.src = "https://wandb.ai/sa-docs.min.js"; // <-- Your self-hosted Segment build
-            var first = document.getElementsByTagName("script")[0];
-            first.parentNode.insertBefore(script, first);
-            analytics._loadOptions = options;
-          };
-          analytics._writeKey = "2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa"; // <-- Your real write key
-          analytics.SNIPPET_VERSION = "4.16.1";
-          analytics.load("2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa");
-
-          // 🚀 Fire analytics.page() when ready
-          analytics.ready(function() {
-            analytics.page();
-          });
+        };
+        for (var i = 0; i < analytics.methods.length; i++) {
+          var key = analytics.methods[i];
+          analytics[key] = analytics.factory(key);
         }
-    }();
-  }
+        analytics.load = function(writeKey, options){
+          var script = document.createElement("script");
+          script.type = "text/javascript";
+          script.async = true;
+          script.src = "https://wandb.ai/sa-docs.min.js"; // <-- Your self-hosted Segment build
+          var first = document.getElementsByTagName("script")[0];
+          first.parentNode.insertBefore(script, first);
+          analytics._loadOptions = options;
+        };
+        analytics._writeKey = "2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa"; // <-- Your real write key
+        analytics.SNIPPET_VERSION = "4.16.1";
+        analytics.load("2r0Di0ymuP5ugdT6SM64JqH7T3zUXTDa");
 
-  // Main hook called automatically by OneTrust
-  function OptanonWrapper() {
-    wpConsentSync();
-    if (typeof Optanon !== 'undefined' && typeof Optanon.ShowBanner === 'function') {
-      Optanon.ShowBanner();
-    }
-  }
+        // 🚀 Fire analytics.page() when ready
+        analytics.ready(function() {
+          analytics.page();
+        });
+      }
+  }();
+  
+  console.log("📊 Analytics loaded for development environment (no consent prompts)");
 </script>
 {{- else -}}
 <!-- Segment & Onetrust: Production -->
@@ -226,10 +188,20 @@
       }
     }
 
-    // 🚀 Load Segment only if marketing or statistics consent is given
+    // 🚀 Load analytics only if marketing or statistics consent is given
     if (consentMap.marketing || consentMap.statistics) {
       loadSegment();
+      loadClarity();
     }
+  }
+
+  // Load Microsoft Clarity Analytics
+  function loadClarity() {
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "a6rlxhvc58");
   }
 
   // Load Segment Analytics

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -90,14 +90,8 @@
 {{- if $lvl1 }}<div class="lvl1" style="display:none">{{ $lvl1.Name }}</div>{{- end }}
 
 
-{{- if not hugo.IsProduction -}}
-<!-- No analytics in development/staging/preview environments -->
-<!-- This keeps development clean without any tracking or consent popups -->
-<script type="text/javascript">
-  console.log("🚫 Development mode: No analytics loaded (no consent popups, no tracking)");
-</script>
-{{- else -}}
-<!-- Segment & Onetrust: Production -->
+{{- if hugo.IsProduction -}}
+<!-- Analytics and Consent Management: Production Only -->
 <!-- OneTrust Consent SDK Loader -->
 <script
   src="https://cdn.cookielaw.org/consent/29d3f242-6917-42f4-a828-bac6fba2e677/otSDKStub.js"

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -94,15 +94,9 @@
 <!-- Analytics for Development/Staging/Preview - NO CONSENT PROMPTS -->
 <script type="text/javascript">
   // For non-production environments (localhost, CloudFlare previews, etc.)
-  // we load analytics directly without consent management to avoid annoying popups during development
+  // we load Segment analytics directly without consent management to avoid annoying popups during development
+  // Note: Microsoft Clarity is production-only
   
-  // Load Microsoft Clarity Analytics
-  (function(c,l,a,r,i,t,y){
-      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-  })(window, document, "clarity", "script", "a6rlxhvc58");
-
   // Load Segment Analytics  
   !function(){
     var analytics = window.analytics = window.analytics || [];
@@ -149,7 +143,7 @@
       }
   }();
   
-  console.log("📊 Analytics loaded for development environment (no consent prompts)");
+  console.log("📊 Segment Analytics loaded for development environment (no consent prompts, no Clarity)");
 </script>
 {{- else -}}
 <!-- Segment & Onetrust: Production -->

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -19,15 +19,15 @@ if [ -n "$CF_PAGES" ] && [ -n "$CF_PAGES_URL" ]; then
     echo "  CF_PAGES_COMMIT_SHA: $CF_PAGES_COMMIT_SHA"
     echo "  CF_PAGES_BRANCH: $CF_PAGES_BRANCH"
     if [ "$CF_PAGES_BRANCH" = "main" ]; then
-        echo "Building the main site"
-        hugo
+        echo "Building the main site (production mode)"
+        hugo --environment production
     else
-        echo "Building a PR preview"
-        hugo -b $CF_PAGES_URL
+        echo "Building a PR preview (development mode)"
+        hugo --environment development -b $CF_PAGES_URL
     fi
 else
-    echo "Building locally with Hugo version $(hugo version)"
-    hugo
+    echo "Building locally with Hugo version $(hugo version) (development mode)"
+    hugo --environment development
 fi
 
 # Move English sitemap into root


### PR DESCRIPTION
## Summary

This PR resolves [DOCS-1759](https://wandb.atlassian.net/browse/DOCS-1759) by adding Microsoft Clarity analytics (per request from Dave Davies) to the production documentation site, while keeping development environments completely clean (no more annoying cookie popup on every page load on `localhost`). After merging this, no analytics will be collection on deploy previews and localhost activity which also simplifies our codebase a lot; previously we were logging a slightly different analytics stack in our localhost/preview activity which is just creating noise. 

The isolation of prod vs preview was already present in `production.sh` but was not properly setting the env var Hugo expects that enables this kind of branching logic, which has also been fixed.

You can see all this working in the build logs in CloudFlare and by enjoying the GDPR-free preview link on this PR. 

```
14:51:40.173 | Building a PR preview (development mode)
```

## Changes

### 1. Microsoft Clarity Integration (DOCS-1759)
- ✅ Added Microsoft Clarity tracking script with project ID `a6rlxhvc58`
- ✅ **Production-only** - Only loads in production with user consent
- ✅ Integrated with existing OneTrust consent management
- ✅ Respects user privacy preferences alongside Segment analytics

### 2. Fixed CloudFlare Build Environment Detection
- ⚠️ **Critical fix**: CloudFlare was building all branches in production mode
- ✅ Updated `scripts/production.sh` to explicitly set environments:
  - Main branch: `hugo --environment production` (consent enabled)
  - PR previews: `hugo --environment development` (no consent)
  - Local builds: `hugo --environment development` (no consent)

### 3. Simplified Analytics Loading
- ✅ Single conditional: `{{- if hugo.IsProduction -}}`
- ✅ No analytics or consent popups in development/staging
- ✅ Clean, maintainable code structure
- ✅ Production maintains full GDPR/CCPA compliance

## Implementation

**How CloudFlare Pages Detection Works:**
- CloudFlare sets `CF_PAGES_BRANCH` environment variable
- Main branch (`CF_PAGES_BRANCH=main`) → builds with `--environment production`
- Other branches (PR previews) → builds with `--environment development`
- This ensures `hugo.IsProduction` is only true for production deployments

## Files Changed
- `layouts/partials/hooks/body-end.html` - Added Clarity, simplified to production-only analytics
- `scripts/production.sh` - Fixed environment detection for CloudFlare builds

## Testing
- [x] Verified `hugo.IsProduction` responds correctly to environment flags
- [x] Confirmed no analytics or popups in development builds
- [x] Confirmed production maintains consent management
- [x] Both Segment and Clarity respect user consent in production
- [x] No linting errors introduced

## Related Issues
- Fixes DOCS-1759: Add Microsoft Clarity analytics to production documentation

cc @johnmulhausen

[DOCS-1759]: https://wandb.atlassian.net/browse/DOCS-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ