### PR TITLE
Registry: Added section on action history

### DIFF
--- a/content/en/guides/core/registry/lineage.md
+++ b/content/en/guides/core/registry/lineage.md
@@ -1,23 +1,31 @@
 ---
-description: Create a lineage map in the W&B Registry.
+description: Create and view lineage maps, audit a collection's history
 menu:
   default:
     parent: registry
     identifier: lineage
-title: Create and view lineage maps
+title: Lineage maps and audit history
 weight: 8
 ---
 
+Use lineage maps to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
+
+## Lineage maps
+
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
-{{% pageinfo color="info" %}}
+{{% alert color="info" %}}
 You can also view lineage graphs for artifacts you log to W&B that are not part of a collection.
-{{% /pageinfo %}}
+{{% /alert %}}
 
-Lineage graphs can show the specific run that logs an artifact. In addition, lineage graphs can also show which run used an artifact as an input. In other words, lineage graphs can show the input and output of a run. 
+Lineage graphs show:
+* If a run used an artifact as an input.
+* If a run created an artifact as an output.
+
+In other words, lineage graphs show the input and output of a run. 
 
 
-For example, the proceeding image shows artifacts created and used throughout an ML experiment:
+For example, the following image shows a typical lineage graph for artifacts created and used throughout an ML experiment:
 
 {{< img src="/images/registry/registry_lineage.png" alt="Registry lineage" >}}
 
@@ -28,60 +36,76 @@ From left to right, the image shows:
 4. A run called "northern-lake-21" uses the model artifact `zoo-ylbchv20:v0` to evaluate the model.
 
 
-## Track the input of a run
+### Track the input of a run
 
-Mark an artifact as an input or dependency of a run with the `wandb.init.use_artifact` API.
+Mark an artifact as the input (or dependency) of a run with the [`wandb.Run.use_artifact()`]({{< relref "/ref/python/experiments/run/#method-runuse_artifact" >}}) method. Specify the name of the artifact and an optional alias to reference a specific version of that artifact. The name of the artifact is in the format `<artifact_name>:<version>` or `<artifact_name>:<alias>`.
 
-The proceeding code snippet shows how to use the `use_artifact`. Replace values enclosed in angle brackets (`< >`) with your values:
+Replace values enclosed in angle brackets (`< >`) with your values:
 
 ```python
 import wandb
 
 # Initialize a run
-run = wandb.init(project="<project>", entity="<entity>")
-
-# Get artifact, mark it as a dependency
-artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
+with wandb.init(entity="<entity>", project="<project>") as run:
+  # Get artifact, mark it as a dependency
+  artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
 ```
 
 
-## Track the output of a run
+### Track the output of a run
 
-Use ([`wandb.init.log_artifact`]({{< relref "/ref/python/experiments/run.md#log_artifact" >}})) to declare an artifact as an output of a run.
+Use [`wandb.Run.log_artifact()`]({{< relref "/ref/python/experiments/run.md#log_artifact" >}}) to declare an artifact as an output of a run. First, create an artifact with the [`wandb.Artifact()`]({{< relref "/ref/python/experiments/artifact/#wandb.Artifact" >}}) constructor. Then, log the artifact as an output of the run with `wandb.Run.log_artifact()`.
 
-The proceeding code snippet shows how to use the `wandb.init.log_artifact` API. Ensure to replace values enclosed in angle brackets (`< >`) with your values:
+Replace values enclosed in angle brackets (`< >`) with your values:
 
 ```python
 import wandb
 
 # Initialize a run
-run = wandb.init(entity  "<entity>", project = "<project>",)
-artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
-artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
+with wandb.init(entity="<entity>", project="<project>") as run:
+  
+  # Create an artifact
+  artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
+  artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
 
-# Log the artifact as an output of the run
-run.log_artifact(artifact_or_path = artifact)
+  # Log the artifact as an output of the run
+  run.log_artifact(artifact_or_path = artifact)
 ```
 
 For more information on about creating artifacts, see [Create an artifact]({{< relref "guides/core/artifacts/construct-an-artifact.md" >}}).
 
 
-## View lineage graphs in a collection
+### View lineage graphs in a collection
 
 View the lineage of an artifact linked to a collection in the W&B Registry.
 
 1. Navigate to the W&B Registry.
 2. Select the collection that contains the artifact.
-3. From the dropdown, click the artifact version you want to view its lineage graph.
+3. From the dropdown, select the artifact version you want to view its lineage graph.
 4. Select the "Lineage" tab.
+5. Select a node to view detailed information about the run or artifact.
 
 
-Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
- 
-Select a run node to view that run's details, such as the run's ID, the run's name, the run's state, and more. As an example, the proceeding image shows information about the `rural-feather-20` run:
+The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:
 
 {{< img src="/images/registry/lineage_expanded_node.png" alt="Expanded lineage node" >}}
 
-Select an artifact node to view that artifact's details, such as its full name, type, creation time, and associated aliases.
+The following image shows the expanded detailed view of an artifact (`zoo-ylbchv20:v0`) when you select an artifact node in the lineage graph:
 
 {{< img src="/images/registry/lineage_expanded_artifact_node.png" alt="Expanded artifact node details" >}}
+
+## Audit a collection's history
+
+View actions that members of your organization take on that collection. You can view:
+
+- If an alias was added or removed from an artifact version.
+- If an artifact version was added or removed from a collection.
+
+For both actions, you can view the user that performed the action and the date the action occurred.
+
+To view a collection's action history:
+
+1. Navigate to the W&B Registry.
+2. Select the collection you want to view its action history.
+3. Select the dropdown menu next to the collection name.
+4. Select the **Action History** option.

--- a/content/en/guides/core/registry/lineage.md
+++ b/content/en/guides/core/registry/lineage.md
@@ -1,5 +1,5 @@
 ---
-description: Create and view lineage maps, audit a collection's history
+description: Create and view lineage maps to audit a collection's history
 menu:
   default:
     parent: registry
@@ -8,7 +8,7 @@ title: Lineage maps and audit history
 weight: 8
 ---
 
-Use lineage maps to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
+Use a lineage map to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
 
 ## Lineage maps
 
@@ -18,12 +18,11 @@ Within a collection in the W&B Registry, you can view a history of the artifacts
 You can also view lineage graphs for artifacts you log to W&B that are not part of a collection.
 {{% /alert %}}
 
-Lineage graphs show:
+A lineage graph shows:
 * If a run used an artifact as an input.
 * If a run created an artifact as an output.
 
-In other words, lineage graphs show the input and output of a run. 
-
+In other words, a lineage graph shows the input and output of a run.  
 
 For example, the following image shows a typical lineage graph for artifacts created and used throughout an ML experiment:
 
@@ -82,7 +81,7 @@ View the lineage of an artifact linked to a collection in the W&B Registry.
 1. Navigate to the W&B Registry.
 2. Select the collection that contains the artifact.
 3. From the dropdown, select the artifact version you want to view its lineage graph.
-4. Select the "Lineage" tab.
+4. Select the **Lineage** tab.
 5. Select a node to view detailed information about the run or artifact.
 
 


### PR DESCRIPTION
## Description

<!-- Uncomment and add a description of the change -->

Added a section on viewing a collection's action history. Added this section to the formerly called "Create and view lineage" because I wasn't positive that this section needed it's own page.  This means that I also changed some H2 markdown headings to H3 for navigation reasons.

<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.
-->

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1703




<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1689#issuecomment-3362794164)**