### PR TITLE
Serverless RL fast-follow changes

### DIFF
--- a/content/en/guides/training/serverless-rl/_index.md
+++ b/content/en/guides/training/serverless-rl/_index.md
@@ -17,6 +17,8 @@ Serverless RL is ideal for tasks like:
 
 Serverless RL trains low-rank adapters (LoRAs) to specialize a model for your agent's specific task. This extends the original model’s capabilities with on-the-job experience. The LoRAs you train are automatically stored as artifacts in your W&B account, and can be saved locally or to a third party for backup. Models that you train through Serverless RL are also automatically hosted on W&B Inference.
 
+See the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start) or [Google Colab notebook](https://colab.research.google.com/github/openpipe/art-notebooks/blob/main/examples/2048/2048.ipynb) to get started.
+
 ## Why Serverless RL?
 
 Reinforcement learning (RL) is a set of powerful training techniques that you can use in many kinds of training setups, including on GPUs that you own or rent directly. Serverless RL can provide the following advantages in your RL post-training:

--- a/content/en/guides/training/serverless-rl/available-models.md
+++ b/content/en/guides/training/serverless-rl/available-models.md
@@ -14,4 +14,4 @@ To express interest in a particular model, contact [support](mailto:support@wand
 
 | Model | Model ID (for API usage) | Type | Context Window | Parameters | Description |
 |-------|--------------------------|------|----------------|------------|-------------|
-| Qwen2.5 14B | Qwen/Qwen2.5-14B-Instruct | Text | 32K | 14B (Active-Total) | Dense model optimized for throughput and quality |
+| Qwen2.5 14B Instruct | `Qwen/Qwen2.5-14B-Instruct` | Text | 32.8K | 14.7B-14.7B (Active-Total) | Dense multilingual instruction-tuned model with tool-use and structured output support |

--- a/content/en/guides/training/serverless-rl/serverless-rl.md
+++ b/content/en/guides/training/serverless-rl/serverless-rl.md
@@ -6,4 +6,6 @@ weight: 10
 
 Serverless RL is supported through [OpenPipe's ART framework](https://art.openpipe.ai/getting-started/about) and the [W&B Training API]({{< relref "ref/training" >}}). 
 
-To start using Serverless RL, satisfy the [prerequisites]({{< relref "guides/training/prerequisites.md" >}}) to use W&B tools, and then see the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start) (or see the [Google Colab notebook](https://colab.research.google.com/github/openpipe/art-notebooks/blob/main/examples/2048/2048.ipynb)) for code examples and workflows. To learn about Serverless RL's API endpoints, see the [W&B Training API reference]({{< relref "ref/training" >}}).
+To start using Serverless RL, satisfy the [prerequisites]({{< relref "guides/training/prerequisites.md" >}}) to use W&B tools, and then go through the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start).
+- For code examples and workflows, see the [Google Colab notebook](https://colab.research.google.com/github/openpipe/art-notebooks/blob/main/examples/2048/2048.ipynb)).
+- To learn about Serverless RL's API endpoints, see the [W&B Training API reference]({{< relref "ref/training" >}}).

--- a/content/en/guides/training/serverless-rl/serverless-rl.md
+++ b/content/en/guides/training/serverless-rl/serverless-rl.md
@@ -6,4 +6,4 @@ weight: 10
 
 Serverless RL is supported through [OpenPipe's ART framework](https://art.openpipe.ai/getting-started/about) and the [W&B Training API]({{< relref "ref/training" >}}). 
 
-To start using Serverless RL, see the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start) for code examples and workflows. To learn about Serverless RL's API endpoints, see the W&B Training API.
+To start using Serverless RL, satisfy the [prerequisites]({{< relref "guides/training/prerequisites.md" >}}) to use W&B tools, and then see the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start) (or see the [Google Colab notebook](https://colab.research.google.com/github/openpipe/art-notebooks/blob/main/examples/2048/2048.ipynb)) for code examples and workflows. To learn about Serverless RL's API endpoints, see the [W&B Training API reference]({{< relref "ref/training" >}}).


### PR DESCRIPTION
## Description

Adds the following:

* Shallower linking to the external quickstart
* Matches "Qwen2.5 14B Instruct" copy on the Available model page to the copy on the Inference models page
* Adds more explicit linking in the Serverless "How-to"

<!-- preview-links-comment -->

📄 **[View preview links for changed content](https://github.com/wandb/docs/pull/1700#issuecomment-3382502767)**