### PR TITLE
Fix malformed code block in generated wandb-docker reference

### DIFF
--- a/content/en/ref/cli/wandb-docker.md
+++ b/content/en/ref/cli/wandb-docker.md
@@ -17,9 +17,10 @@ can pass additional args which will be added to `docker run` before the
 image name is declared, we'll choose a default image for you if one isn't
 passed:
 
-```sh wandb docker -v /mnt/dataset:/app/data wandb docker gcr.io/kubeflow-
-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0 --jupyter wandb docker
-wandb/deepo:keras-gpu --no-tty --cmd "python train.py --epochs=5" ```
+    wandb docker -v /mnt/dataset:/app/data
+    wandb docker gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0 --jupyter
+    wandb docker
+    wandb/deepo:keras-gpu --no-tty --cmd "python train.py --epochs=5"
 
 By default, we override the entrypoint to check for the existence of wandb
 and install it if not present.  If you pass the --jupyter flag we will


### PR DESCRIPTION
## Description

Coming from `wandb/wandb`, code fences and everything within them gets concatenated into a single line, which breaks the output as reported in DOCS-1327. The permanent fix is in https://github.com/wandb/wandb/pull/10677.

## Related issues

- Fixes DOCS-1327


<!-- preview-links-comment -->
📄 **[View preview links for changed pages](https://github.com/wandb/docs/pull/1703#issuecomment-3387178912)**