### PR TITLE
Added overview to titles, added app redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -421,8 +421,7 @@
                   {
                     "group": "W&B App UI",
                     "pages": [
-                      "models/app",
-                      "models/app/keyboard-shortcuts",
+                      "models/app/features/cascade-settings",
                       {
                         "group": "Panels",
                         "pages": [
@@ -460,7 +459,7 @@
                         ]
                       },
                       "models/app/console-logs",
-                      "models/app/features/cascade-settings"
+                      "models/app/keyboard-shortcuts"
                     ]
                   }
                 ]
@@ -2224,11 +2223,11 @@
   "redirects": [
     {
       "source": "/app/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/app/features/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/app/features/alerts/",
@@ -2312,7 +2311,7 @@
     },
     {
       "source": "/app/visualizations/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/artifacts/",
@@ -3264,7 +3263,7 @@
     },
     {
       "source": "/library/plots/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/library/plots/heatmap/",
@@ -3364,7 +3363,7 @@
     },
     {
       "source": "/ref/app/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/ref/app/feature/",
@@ -3376,7 +3375,7 @@
     },
     {
       "source": "/ref/app/features/alerts/",
-      "destination": "/guides/app/"
+      "destination": "/guides/models/app/features/cascade-settings"
     },
     {
       "source": "/ref/app/features/anon/",

--- a/models/artifacts.mdx
+++ b/models/artifacts.mdx
@@ -1,6 +1,6 @@
 ---
 description: Overview of W&B Artifacts, how they work, and how to get started using them.
-title: Artifacts
+title: Artifacts overview
 ---
 
 

--- a/models/automations.mdx
+++ b/models/automations.mdx
@@ -1,5 +1,5 @@
 ---
-title: Automations
+title: Automations overview
 ---
 import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
 

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Registry
+title: Registry overview
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" icon="python"/>
 

--- a/models/reports.mdx
+++ b/models/reports.mdx
@@ -1,6 +1,6 @@
 ---
 description: Project management and collaboration tools for machine learning projects
-title: Reports
+title: Reports overview
 ---
 
 

--- a/models/sweeps.mdx
+++ b/models/sweeps.mdx
@@ -1,6 +1,6 @@
 ---
 description: Hyperparameter search and model optimization with W&B Sweeps
-title: Sweeps
+title: Sweeps overview
 ---
 <CardGroup cols={2}>
 <Card title="Try in Colab" href="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/pytorch/Organizing_Hyperparameter_Sweeps_in_PyTorch_with_W%26B.ipynb" icon="python"/>

--- a/models/tables.mdx
+++ b/models/tables.mdx
@@ -1,6 +1,6 @@
 ---
 description: Iterate on datasets and understand model predictions
-title: Tables
+title: Tables overview
 ---
 
 <CardGroup cols={2}>

--- a/models/track.mdx
+++ b/models/track.mdx
@@ -1,6 +1,6 @@
 ---
 description: Track machine learning experiments with W&B.
-title: Experiments
+title: Experiments overview
 ---
 <CardGroup cols={2}>
 <Card title="Try in Colab" href="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Intro_to_Weights_%26_Biases.ipynb" icon="python"/>


### PR DESCRIPTION
## Description

<!-- Uncomment and add a description of the change -->

* Adds "Overview" to top most page (formally _index.md) w/in each Models product area. 
* Deletes W&B App landing page since it's redundant.
* Reorders W&B App content
Adds redirect for W&B App landing page .


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
