### PR TITLE
Models: Add missing ref landing pages + "Overview"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -589,8 +589,9 @@
                 "pages": [
                   "models/ref",
                   {
-                    "group": "Python SDK 0.22.0",
+                    "group": "Python",
                     "pages": [
+                      "models/ref/python",
                       {
                         "group": "Global Functions",
                         "pages": [
@@ -696,8 +697,9 @@
                     ]
                   },
                   {
-                    "group": "Command Line Interface",
+                    "group": "Command Line Interface (CLI)",
                     "pages": [
+                      "models/ref/cli",
                       "models/ref/cli/wandb-agent",
                       {
                         "group": "wandb artifact",
@@ -758,6 +760,7 @@
                   {
                     "group": "Query Expression Language",
                     "pages": [
+                      "models/ref/query-panel",
                       "models/ref/query-panel/artifact",
                       "models/ref/query-panel/artifact-type",
                       "models/ref/query-panel/artifact-version",

--- a/models/app/features/custom-charts.mdx
+++ b/models/app/features/custom-charts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Custom charts overview
 description: Create custom charts in W&B projects with Vega visualizations
 ---
 

--- a/models/app/features/panels.mdx
+++ b/models/app/features/panels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Panels overview
 description: Use and customize workspace panels to visualize your logged data
 ---
 

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -1,6 +1,6 @@
 ---
 description: Visualize metrics, customize axes, and compare multiple lines on a plot
-title: Overview
+title: Line plots overview
 ---
 
 Line plots show up by default when you plot metrics over time with `wandb.Run.log()`. Customize with chart settings to compare multiple lines on the same plot, calculate custom axes, and rename labels.

--- a/models/app/features/panels/query-panels.mdx
+++ b/models/app/features/panels/query-panels.mdx
@@ -1,7 +1,7 @@
 ---
 description: Some features on this page are in beta, hidden behind a feature flag.
   Add `weave-plot` to your bio on your profile page to unlock all related features.
-title: Overview
+title: Query panels overview
 ---
 
 

--- a/models/automations.mdx
+++ b/models/automations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Automations overview
+description: Use W&B Automations for triggering workflows based on events in W&B
 ---
 import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
 

--- a/models/ref.mdx
+++ b/models/ref.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference
+title: Reference overview
 description: Generated documentation for W&B APIs
 type: docs
 no_list: true

--- a/models/ref/cli.mdx
+++ b/models/ref/cli.mdx
@@ -1,5 +1,6 @@
 ---
-title: Command Line Interface
+title: CLI overview
+description: Use the W&B Command Line Interface (CLI) to log in, run jobs, execute sweeps, and more using shell commands
 ---
 
 **Usage**

--- a/models/ref/python/automations.mdx
+++ b/models/ref/python/automations.mdx
@@ -1,5 +1,6 @@
 ---
-title: Automations
+title: Automations overview
+description: Use the W&B Automations API to create and manage automated workflows in your ML pipelines
 module: wandb.automations
 no_list: true
 ---

--- a/models/ref/python/custom-charts.mdx
+++ b/models/ref/python/custom-charts.mdx
@@ -1,5 +1,6 @@
 ---
-title: Custom Charts
+title: Custom Charts overview
+description: Use custom charts in the W&B Python SDK for interactive visualizations in project dashboards
 module: wandb.plot
 no_list: true
 ---

--- a/models/ref/python/data-types.mdx
+++ b/models/ref/python/data-types.mdx
@@ -1,5 +1,6 @@
 ---
-title: Data Types
+title: Data Types overview
+description: Data Types in the W&B Python SDK for logging media and structured data
 module: wandb.sdk.data_types
 no_list: true
 ---

--- a/models/ref/python/experiments.mdx
+++ b/models/ref/python/experiments.mdx
@@ -1,5 +1,6 @@
 ---
-title: Experiments
+title: Experiments overview
+description: Use foundational classes in the W&B Python SDK for tracking experiments and managing artifacts
 module: wandb
 no_list: true
 ---

--- a/models/ref/python/functions.mdx
+++ b/models/ref/python/functions.mdx
@@ -1,5 +1,6 @@
 ---
-title: Global Functions
+title: Global Functions overview
+description: Global functions in the W&B Python SDK
 module: 
 no_list: true
 ---

--- a/models/ref/python/public-api.mdx
+++ b/models/ref/python/public-api.mdx
@@ -1,5 +1,6 @@
 ---
-title: Public API
+title: Public API overview
+description: Use the W&B Public API to programmatically access and manage W&B data
 module: wandb.apis.public
 no_list: true
 ---

--- a/models/ref/query-panel.mdx
+++ b/models/ref/query-panel.mdx
@@ -1,5 +1,6 @@
 ---
-title: Query Expression Language
+title: Query Expression Language overview
+description: A beta query language to select and aggregate data in W&B
 ---
 Use the query expressions to select and aggregate data across runs and projects. 
 Learn more about [query panels](/models/app/features/panels/query-panels/).

--- a/models/ref/wandb_workspaces.mdx
+++ b/models/ref/wandb_workspaces.mdx
@@ -1,5 +1,6 @@
 ---
-title: Reports and Workspaces API
+title: Reports and Workspaces API overview
+description: Use the W&B Reports and Workspaces API to create and manage reports and workspaces programmatically
 ---
 
 The W&B Reports and Workspaces API, accessible at `wandb_workspaces`, allows you to create [reports](/models/reports/), which can be published on the web to share findings, and well as customize a [workspace](/models/app/features/cascade-settings/) where training and fine-tuning work was done. 

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -1,5 +1,6 @@
 ---
 title: Registry overview
+description: W&B Registry to manage and share artifact versions across your organization
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" icon="python"/>
 

--- a/models/track/log.mdx
+++ b/models/track/log.mdx
@@ -1,6 +1,6 @@
 ---
 description: Keep track of metrics, videos, custom plots, and more
-title: Overivew
+title: Overview
 ---
 
 import MetricNamingRules from "/snippets/en/_includes/metric-naming-rules.mdx";


### PR DESCRIPTION
## Description

* Added some missing former _index.md files to docs.json (mostly w.r.t. ref docs).
* Added descriptions to said files.
* Added "Overview" to topic titles.

Note: There are two patterns I used for the latter:
1. If the title of the doc contains a product or feature name, persist the entire name.
2. Else, only keep "Overview"

E.g. "Experiments" -> Experiments overview
"What are runs?" -> Overview

<img width="247" height="319" alt="Screenshot 2025-10-20 at 3 13 51 PM" src="https://github.com/user-attachments/assets/f3be68b7-a981-4cde-aed9-ce32cc15ed97" />


<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
