### PR TITLE
Models: Move evals with weave and models page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -244,7 +244,6 @@
               "models",
               "models/quickstart",
               "models/models_quickstart",
-              "models/evaluate-models",
               {
                 "group": "Guides",
                 "pages": [
@@ -552,7 +551,8 @@
                       "models/tutorials/sweeps",
                       "models/tutorials/artifacts",
                       "models/tutorials/workspaces",
-                      "models/tutorials/weave_models_registry"
+                      "models/tutorials/weave_models_registry",
+                      "models/evaluate-models"
                     ]
                   },
                   {

--- a/models/evaluate-models.mdx
+++ b/models/evaluate-models.mdx
@@ -1,6 +1,6 @@
 ---
-title: Evaluate models
-description:
+title: Evaluate models with W&B Weave and W&B Tables
+description: Learn how to evaluate machine learning models using W&B Weave and Tables.
 ---
 
 ## Evaluate models with Weave


### PR DESCRIPTION
## Description

Moved "Weave and Models integration" demo from top of TOC (super high visibility) to within `Tutorials -> Fundamentals `section (with other Weave + WB Models) tutorial.

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
