### PR TITLE
Hide W&B Launch section from main navigation while keeping it accessible via direct URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -154,79 +154,6 @@
                 ]
               },
               {
-                "group": "W&B Launch",
-                "pages": [
-                  "platform/launch",
-                  "platform/launch/walkthrough",
-                  "platform/launch/launch-terminology",
-                  {
-                    "group": "Set up Launch",
-                    "pages": [
-                      "platform/launch/set-up-launch",
-                      {
-                        "group": "Configure compute resources",
-                        "pages": [
-                          "platform/launch/setup-launch-docker",
-                          "platform/launch/setup-launch-kubernetes",
-                          "platform/launch/setup-launch-sagemaker",
-                          "platform/launch/setup-vertex"
-                        ]
-                      },
-                      "platform/launch/setup-queue-advanced",
-                      "platform/launch/setup-agent-advanced"
-                    ]
-                  },
-                  {
-                    "group": "Create and deploy jobs",
-                    "pages": [
-                      "platform/launch/create-and-deploy-jobs",
-                      "platform/launch/create-launch-job",
-                      "platform/launch/add-job-to-queue",
-                      "platform/launch/job-inputs",
-                      "platform/launch/launch-view-jobs"
-                    ]
-                  },
-                  {
-                    "group": "Advanced",
-                    "pages": [
-                      "platform/launch/sweeps-on-launch",
-                      "platform/launch/launch-queue-observability",
-                      "platform/launch/integration-guides"
-                    ]
-                  },
-                  {
-                    "group": "Launch FAQ",
-                    "pages": [
-                      "platform/launch/launch-faq",
-                      "platform/launch/launch-faq/best_practices_launch_effectively",
-                      "platform/launch/launch-faq/build_container_launch",
-                      "platform/launch/launch-faq/clicking_launch_without_going_ui",
-                      "platform/launch/launch-faq/control_push_queue",
-                      "platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact",
-                      "platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me",
-                      "platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment",
-                      "platform/launch/launch-faq/launch_build_images",
-                      "platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker",
-                      "platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job",
-                      "platform/launch/launch-faq/launch_tensorflow_gpu",
-                      "platform/launch/launch-faq/launcherror_permission_denied",
-                      "platform/launch/launch-faq/permissions_agent_require_kubernetes",
-                      "platform/launch/launch-faq/requirements_accelerator_base_image",
-                      "platform/launch/launch-faq/restrict_access_modify_example",
-                      "platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible"
-                    ]
-                  },
-                  {
-                    "group": "Launch Library API Reference",
-                    "pages": [
-                      "platform/launch/launch-library/launch",
-                      "platform/launch/launch-library/launch_add",
-                      "platform/launch/launch-library/launchagent"
-                    ]
-                  }
-                ]
-              },
-              {
                 "group": "Resources",
                 "pages": [
                   "pricing",
@@ -1163,6 +1090,81 @@
               "release-notes/server-releases",
               "release-notes/server-releases-archived",
               "release-notes/release-policies"
+            ]
+          },
+          {
+            "tab": "W&B Launch",
+            "icon": "/icons/Name=Launch, Mode=Dark.svg",
+            "hidden": true,
+            "pages": [
+              "platform/launch",
+              "platform/launch/walkthrough",
+              "platform/launch/launch-terminology",
+              {
+                "group": "Set up Launch",
+                "pages": [
+                  "platform/launch/set-up-launch",
+                  {
+                    "group": "Configure compute resources",
+                    "pages": [
+                      "platform/launch/setup-launch-docker",
+                      "platform/launch/setup-launch-kubernetes",
+                      "platform/launch/setup-launch-sagemaker",
+                      "platform/launch/setup-vertex"
+                    ]
+                  },
+                  "platform/launch/setup-queue-advanced",
+                  "platform/launch/setup-agent-advanced"
+                ]
+              },
+              {
+                "group": "Create and deploy jobs",
+                "pages": [
+                  "platform/launch/create-and-deploy-jobs",
+                  "platform/launch/create-launch-job",
+                  "platform/launch/add-job-to-queue",
+                  "platform/launch/job-inputs",
+                  "platform/launch/launch-view-jobs"
+                ]
+              },
+              {
+                "group": "Advanced",
+                "pages": [
+                  "platform/launch/sweeps-on-launch",
+                  "platform/launch/launch-queue-observability",
+                  "platform/launch/integration-guides"
+                ]
+              },
+              {
+                "group": "Launch FAQ",
+                "pages": [
+                  "platform/launch/launch-faq",
+                  "platform/launch/launch-faq/best_practices_launch_effectively",
+                  "platform/launch/launch-faq/build_container_launch",
+                  "platform/launch/launch-faq/clicking_launch_without_going_ui",
+                  "platform/launch/launch-faq/control_push_queue",
+                  "platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact",
+                  "platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me",
+                  "platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment",
+                  "platform/launch/launch-faq/launch_build_images",
+                  "platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker",
+                  "platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job",
+                  "platform/launch/launch-faq/launch_tensorflow_gpu",
+                  "platform/launch/launch-faq/launcherror_permission_denied",
+                  "platform/launch/launch-faq/permissions_agent_require_kubernetes",
+                  "platform/launch/launch-faq/requirements_accelerator_base_image",
+                  "platform/launch/launch-faq/restrict_access_modify_example",
+                  "platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible"
+                ]
+              },
+              {
+                "group": "Launch Library API Reference",
+                "pages": [
+                  "platform/launch/launch-library/launch",
+                  "platform/launch/launch-library/launch_add",
+                  "platform/launch/launch-library/launchagent"
+                ]
+              }
             ]
           }
         ]


### PR DESCRIPTION
## Summary

This PR moves the W&B Launch documentation section to a separate hidden tab, making it accessible only via direct URLs while removing it from the main site navigation.

## Changes

1. **Removed W&B Launch from Platform tab** - The entire Launch section has been removed from the Platform tab navigation
2. **Created separate W&B Launch tab** - All Launch documentation and navigation structure has been moved to its own tab
3. **Added `hidden: true` flag** - Attempting to hide the tab from the main navigation bar

## Intent

The goal is to make the W&B Launch section:
- ✅ Accessible via direct URLs (e.g., `/platform/launch`, `/platform/launch/walkthrough`)
- ✅ Maintain full navigation structure when accessed
- ✅ Hidden from the main documentation navigation

## Note

The `hidden: true` flag on tabs may not be fully supported by Mintlify. This PR proposes the configuration for testing and discussion. Alternative approaches may be needed such as:
- Custom CSS to hide the tab
- Keeping the section in the Platform tab but using other visibility controls
- Moving to a separate documentation instance

## Testing

- Access any Launch URL directly to verify the pages are still accessible
- Check if the Launch tab appears in the main navigation (it should be hidden if Mintlify supports it)
- Verify all internal Launch navigation works when on Launch pages