### PR TITLE
Remove hard-coded Weave links and fix some reference links

### DIFF
--- a/ja/guides/weave.mdx
+++ b/ja/guides/weave.mdx
@@ -17,7 +17,7 @@ W&B Weave を使用すると、次のことが可能です：
 * 実験から評価、プロダクションまでの LLM ワークフローで生成されたすべての情報を整理
 
 <Note>
-Weave のドキュメントをお探しですか？[W&B Weave Docs](https://weave-docs.wandb.ai/) をご覧ください。
+Weave のドキュメントをお探しですか？[W&B Weave Docs](/weave) をご覧ください。
 </Note>
 
 ## 開始方法

--- a/ja/models/ref.mdx
+++ b/ja/models/ref.mdx
@@ -24,5 +24,5 @@ Node サーバーからメトリクスをトラッキングするベータ版の
 </CardGroup>
 
 <Note>
-Weave API をお探しですか？ [W&B Weave Docs](https://weave-docs.wandb.ai/)を参照してください。
+Weave API をお探しですか？ [W&B Weave Docs](/weave)を参照してください。
 </Note>

--- a/ko/guides/weave.mdx
+++ b/ko/guides/weave.mdx
@@ -17,7 +17,7 @@ W&B Weave를 사용하면 다음을 수행할 수 있습니다.
 * 실험에서 평가, production에 이르기까지 LLM 워크플로우에서 생성된 모든 정보 구성
 
 <Note>
-Weave 문서를 찾고 계십니까? [W&B Weave Docs](https://weave-docs.wandb.ai/)를 참조하세요.
+Weave 문서를 찾고 계십니까? [W&B Weave Docs](/weave)를 참조하세요.
 </Note>
 
 ## 시작 방법

--- a/ko/models/ref.mdx
+++ b/ko/models/ref.mdx
@@ -24,5 +24,5 @@ Node 서버에서 메트릭을 추적하는 베타 JavaScript/TypeScript 클라�
 </CardGroup>
 
 <Note>
-Weave API를 찾고 계십니까? [W&B Weave Docs](https://weave-docs.wandb.ai/)를 참조하십시오.
+Weave API를 찾고 계십니까? [W&B Weave Docs](/weave)를 참조하십시오.
 </Note>

--- a/models/evaluate-models.mdx
+++ b/models/evaluate-models.mdx
@@ -69,7 +69,7 @@ results = await evaluation.evaluate(model)
 
 ### Integrate Weave evaluations with W&B Models
 
-The [Models and Weave Integration Demo](https://weave-docs.wandb.ai/reference/gen_notebooks/Models_and_Weave_Integration_Demo) shows the complete workflow for:
+The [Models and Weave Integration Demo](/weave/reference/gen_notebooks/Models_and_Weave_Integration_Demo) shows the complete workflow for:
 
 1. **Load models from Registry**: Download fine-tuned models stored in W&B Models Registry
 2. **Create evaluation pipelines**: Build comprehensive evaluations with custom scorers
@@ -120,7 +120,7 @@ for model in models:
 ### Next steps
 
 * [Complete Weave evaluation tutorial](/weave/tutorial-eval/)
-* [Models and Weave integration example](https://weave-docs.wandb.ai/reference/gen_notebooks/Models_and_Weave_Integration_Demo)
+* [Models and Weave integration example](/reference/gen_notebooks/Models_and_Weave_Integration_Demo)
 
 
 

--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -40,14 +40,14 @@ W&B v0.74 delivers SCIM API improvements for enterprise identity management, inc
     - **Quickly toggle between runs using the keyboard.** In full-screen view, use the keyboard **left / right arrow** keys to move between runs, and use **Cmd + left / right arrow** (macOS) or **Ctrl + left / right arrow** (Windows / Linux) to move between steps of the same image.
 
 ### Weave
-- From the **Evaluations** sidebar tab, you can now update prompt values and run LLM judge evaluations to test the changes. Try it out in the [Playground](https://weave-docs.wandb.ai/guides/tools/playground/).
-- You can now integrate Weave into your Reinforcement Learning (RL) training workflows and [view the traces and evaluations](https://weave-docs.wandb.ai/guides/tools/weave-in-workspaces) captured during training in the W&B Workspace, together with run metrics panels.
-- Weave now includes an integration with [Verifiers](https://verifiers.readthedocs.io/en/latest/), a library of modular components for creating Reinforcement Learning (RL) environments and training LLM agents. Environments built with Verifiers can serve as LLM evaluations, synthetic data pipelines, agent harnesses for OpenAI-compatible endpoints, and RL training. [Learn more](https://weave-docs.wandb.ai/guides/integrations/verifiers).
+- From the **Evaluations** sidebar tab, you can now update prompt values and run LLM judge evaluations to test the changes. Try it out in the [Playground](/weave/guides/tools/playground).
+- You can now integrate Weave into your Reinforcement Learning (RL) training workflows and [view the traces and evaluations](/weave/guides/tools/weave-in-workspaces) captured during training in the W&B Workspace, together with run metrics panels.
+- Weave now includes an integration with [Verifiers](https://verifiers.readthedocs.io/en/latest/), a library of modular components for creating Reinforcement Learning (RL) environments and training LLM agents. Environments built with Verifiers can serve as LLM evaluations, synthetic data pipelines, agent harnesses for OpenAI-compatible endpoints, and RL training. [Learn more](/weave/guides/integrations/verifiers).
 - From the **Threads** sidebar tab, you can now view tool calls for a multi-turn Thread together with its message history.
 - A Team's **Project** page now shows the number of Weave traces for each project together with data about the project's runs.
-- The [DSPy integration](https://weave-docs.wandb.ai/guides/integrations/dspy) has been improved. For details, see [`wandb/weave` #5184](https://github.com/wandb/weave/pull/5184).
+- The [DSPy integration](/weave/guides/integrations/dspy) has been improved. For details, see [`wandb/weave` #5184](https://github.com/wandb/weave/pull/5184).
 - If your Weave code calls `wandb.init()`, it no longer needs to explicitly call `weave.init()`.
-- New convenience method [`delete_all_object_versions`](https://weave-docs.wandb.ai/reference/python-sdk/weave/trace/weave.trace.weave_client/).
+- New convenience method [`delete_all_object_versions`](/weave/reference/python-sdk/weave/trace/weave_client).
 - The output from an OpenAI streaming endpoint call now includes a new field, `time_to_first_token`, expressed in milliseconds.
 
 ### Inference
@@ -98,10 +98,10 @@ In v0.73.0, resizing or reordering workspace panels may not be reflected in save
 - BYOB with CoreWeave AI Object Storage now supports authentication with service principals in Multi-tenant Cloud, Dedicated Cloud, and Self-Managed deployments. This helps you to avoid using static credentials in your deployment. Learn more at [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector/).
 
 ### Weave
-- You can now group sessions or conversations across multiple traces with [Weave Threads](https://weave-docs.wandb.ai/guides/tracking/threads/).
-- The **Trace view**'s new [Graph view](https://weave-docs.wandb.ai/guides/tracking/trace-tree#graph-view) visualizes the call tree structure as a graph.
-- The **Trace view** includes new specialized views for [documents](https://weave-docs.wandb.ai/guides/core-types/media#documents) retrieved with ChromaDB and Langchain improves handling of schemas such as chats. In **Trace view**, click a document to open its detailed view in a drawer to the right. Learn more at [Navigate the trace view](https://weave-docs.wandb.ai/guides/tracking/trace-tree/).
-- You can now attach [HTML](https://weave-docs.wandb.ai/guides/core-types/media#html) to a trace as a media type.
+- You can now group sessions or conversations across multiple traces with [Weave Threads](/weave/guides/tracking/threads).
+- The **Trace view**'s new [Graph view](/weave/guides/tracking/trace-tree#graph-view) visualizes the call tree structure as a graph.
+- The **Trace view** includes new specialized views for [documents](/weave/guides/core-types/media#documents) retrieved with ChromaDB and Langchain improves handling of schemas such as chats. In **Trace view**, click a document to open its detailed view in a drawer to the right. Learn more at [Navigate the trace view](/weave/guides/tracking/trace-tree).
+- You can now attach [HTML](/weave/guides/core-types/media#html) to a trace as a media type.
 - From the **Assets** tab, you can now create and edit prompts. Click **Assets**, then in the navigation, click **Prompts**. Click **New prompt** or click the name of an existing prompt to view its details. From there, click the pencil icon to edit and republish the prompt.
 
 ## Fixes
@@ -165,9 +165,9 @@ With W&B Server 0.71, Registry is turned on by default for all organizations. Fo
 - The Run Comparer includes a new **Meta** section with metadata about the run, such as the command, Python version, and GPU type.
 
 ### Weave
-- The **Trace plots** tool allows you to explore, visualize, and debug trace-level metrics like latency, cost, or tokens over time using custom interactive charts. [Learn more](https://weave-docs.wandb.ai/guides/tracking/trace-plots/).
-- **Online Evaluations**: Monitor your traces in Dedicated Cloud by attaching Monitors to your incoming traces. Monitors run in the background as LLM judges and score a subset of calls that you specify. Use Monitors to track production behavior, catch regressions, collect real-world production data, and more. [Learn more](https://weave-docs.wandb.ai/guides/evaluation/guardrails_and_monitors).
-- Added [AutoGen](https://weave-docs.wandb.ai/guides/integrations/autogen) and [LlamaIndex](https://weave-docs.wandb.ai/guides/integrations/llamaindex) integrations. _AutoGen_ is a framework from Microsoft for building AI agents and applications, with components for conversational AI, core multi-agent functionalities, and integrations with external services, and tools for no-code agent prototyping. _LlamaIndex_ is a powerful framework for building LLM-driven applications like RAG systems, chatbots, and agents.
+- The **Trace plots** tool allows you to explore, visualize, and debug trace-level metrics like latency, cost, or tokens over time using custom interactive charts. [Learn more](/weave/guides/tracking/trace-plots).
+- **Online Evaluations**: Monitor your traces in Dedicated Cloud by attaching Monitors to your incoming traces. Monitors run in the background as LLM judges and score a subset of calls that you specify. Use Monitors to track production behavior, catch regressions, collect real-world production data, and more. [Learn more](/weave/guides/tracking/trace-plots).
+- Added [AutoGen](/weave/guides/integrations/autogen) and [LlamaIndex](/weave/guides/integrations/llamaindex) integrations. _AutoGen_ is a framework from Microsoft for building AI agents and applications, with components for conversational AI, core multi-agent functionalities, and integrations with external services, and tools for no-code agent prototyping. _LlamaIndex_ is a powerful framework for building LLM-driven applications like RAG systems, chatbots, and agents.
 - Improved Integrations with OpenAI, LangChain, ChromaDB, Verdict, including:
   - Document view for Langchain and ChromaDB.
   - Chat view rendering for LangChain.
@@ -177,7 +177,7 @@ With W&B Server 0.71, Registry is turned on by default for all organizations. Fo
     - `Qwen/Qwen3-Coder-480B-A35B-Instruct`
     - `Qwen/Qwen3-235B-A22B-Instruct-2507`
     - `Kimi-K2-Instruct`
-- Added support to the TypeScript SDK for creating and publishing prompts. [Learn more](https://weave-docs.wandb.ai/guides/core-types/prompts/).
+- Added support to the TypeScript SDK for creating and publishing prompts. [Learn more](/weave/guides/core-types/prompts).
 - The new `Content` class allows you safely to upload data of any MIME type, with automatic Base-64 encoding, automatic metadata extraction, and more.
 
 ## Fixes
@@ -298,14 +298,14 @@ Private preview features are available by invitation only. To request enrollment
 - [Personal workspace templates](/models/track/workspaces/#workspace-templates){/* TODO change to a relref after workspace templates docs merge */} allow you to save core line plot settings and automatically reapply them in new views. These settings include x-axis key, smoothing algorithm, smoothing factor, max number of lines, whether to use the run selector’s grouping, and which aggregation to apply.
 
 ### Weave
-- [Saved views](https://weave-docs.wandb.ai/guides/tools/saved-views/) simplify team collaboration and allow you to persist filter and column settings.
+- [Saved views](/weave/guides/tools/saved-views) simplify team collaboration and allow you to persist filter and column settings.
 - PDFs and generic files are now supported.
-- The new [`EvaluationLogger` API](https://weave-docs.wandb.ai/guides/evaluation/evaluation_logger) provides flexible imperative-style evaluation logging.
-- You can now import [human annotations](https://weave-docs.wandb.ai/guides/tracking/feedback#add-human-annotations) into Weave datasets
-- [Playground](https://weave-docs.wandb.ai/guides/tools/playground/) now supports saved configurations and prompts.
+- The new [`EvaluationLogger` API](/weave/guides/evaluation/evaluation_logger) provides flexible imperative-style evaluation logging.
+- You can now import [human annotations](/weave/guides/tracking/feedback#add-human-annotations) into Weave datasets
+- [Playground](/weave/guides/tools/playground/) now supports saved configurations and prompts.
 - Decorators are now supported in TypeScript.
-- Added support for [tracing generator functions](https://weave-docs.wandb.ai/guides/tracking/tracing#trace-sync--async-generator-functions).
-- The new [`dataset.add_rows`](https://weave-docs.wandb.ai/reference/python-sdk/weave/#method-add_rows) helper improves the efficiency of appending to an existing dataset.
+- Added support for [tracing generator functions](/weave/guides/tracking/tracing#trace-sync-%26-async-generator-functions).
+- The new [`dataset.add_rows`](/weave/reference/python-sdk/weave/#method-add-rows) helper improves the efficiency of appending to an existing dataset.
 - To help you understand your usage, trace and object sizes are now shown through the UI.
 
 ## Performance
@@ -363,11 +363,11 @@ Private preview features are available by invitation only. To request enrollment
 - **Improved Exponentially-weighted Moving Average (EMA) smoothing** provides more reliable [smoothed lines](/models/app/features/panels/line-plot/smoothing/) when operating on complete, unbinned data. In most cases, smoothing is handled at the back end for improved performance.
 
 ### Weave
-- Chat with fine-tuned models from within your W&B instance. [Playground](https://weave-docs.wandb.ai/guides/tools/playground/) is now supported in Dedicated Cloud. Playground is a chat interface for comparing different LLMs on historical traces. Admins can add API keys to different model providers or hook up [custom hosted LLM providers](https://weave-docs.wandb.ai/guides/tools/playground/#add-a-custom-provider) so your team can interact with them from within Weave.
-- Open Telemetry Support. Now you can log traces via OpenTelemetry (OTel). See [OpenTelemetry tracing](https://weave-docs.wandb.ai/guides/tracking/otel/?utm_source=beamer&utm_medium=sidebar&utm_campaign=OpenTelemetry-support-in-Weave&utm_content=ctalink).
-- Weave [tracing](https://weave-docs.wandb.ai/guides/tracking/) has new framework integrations: CrewAI, OpenAI’s Agent SDK, DSPy 2.x and Google's genai Python SDK.
-- Playground supports new [OpenAI models](https://weave-docs.wandb.ai/guides/tools/playground/#openai): GPT‑4.1, GPT‑4.1 mini, and GPT‑4.1 nano.
-- Build labeled datasets directly from traces, with your annotations automatically converted into dataset columns. See [Dataset creation from traces](https://weave-docs.wandb.ai/guides/core-types/datasets/#create-edit-and-delete-a-dataset-in-the-ui).
+- Chat with fine-tuned models from within your W&B instance. [Playground](/weave/guides/tools/playground/) is now supported in Dedicated Cloud. Playground is a chat interface for comparing different LLMs on historical traces. Admins can add API keys to different model providers or hook up [custom hosted LLM providers](/weave/guides/tools/playground/#add-a-custom-provider) so your team can interact with them from within Weave.
+- Open Telemetry Support. Now you can log traces via OpenTelemetry (OTel). See [OpenTelemetry tracing](/weave/guides/tracking/otel/?utm_source=beamer&utm_medium=sidebar&utm_campaign=OpenTelemetry-support-in-Weave&utm_content=ctalink).
+- Weave [tracing](/weave/guides/tracking/) has new framework integrations: CrewAI, OpenAI’s Agent SDK, DSPy 2.x and Google's genai Python SDK.
+- Playground supports new [OpenAI models](/weave/guides/tools/playground/#openai): GPT‑4.1, GPT‑4.1 mini, and GPT‑4.1 nano.
+- Build labeled datasets directly from traces, with your annotations automatically converted into dataset columns. See [Dataset creation from traces](/weave/guides/core-types/datasets/#create-edit-and-delete-a-dataset-in-the-ui).
 
 ## Security
 - Registry admins can now designate a [service account](/platform/hosting/iam/service-accounts/) in a registry as either a Registry Admin or a Member. Previously, the service account’s role was always Registry Admin. See [Registry service account configuration](/models/registry/configure_registry/).
@@ -417,8 +417,8 @@ Private preview features are available by invitation only. To request enrollment
 - In Tables and Query panels that use the `runs` expression, you can use the new Runs History step slider and drop-down controls to view a table of metrics at each step of a run.
 - Playground in W&B Weave supports new models: OpenAI's `gpt-4.5-preview`  and Deepseek's `deepseek-chat` and `deepseek-reasoner`.
 - Weave tracing has two new agent framework integrations: CrewAI and OpenAI’s Agent SDK.
-- In the Weave UI, you can now build Datasets from traces. Learn more: https://weave-docs.wandb.ai/guides/core-types/datasets#create-edit-and-delete-a-dataset-in-the-ui
-- The Weave Python SDK now provides a way to filter the inputs and outputs of your Weave data to ensure sensitive data does not leave your network perimeter. You can configure to redact sensitive data. Learn more: https://weave-docs.wandb.ai/guides/tracking/redact-pii/
+- In the Weave UI, you can now build Datasets from traces. Learn more: /weave/guides/core-types/datasets#create-edit-and-delete-a-dataset-in-the-ui
+- The Weave Python SDK now provides a way to filter the inputs and outputs of your Weave data to ensure sensitive data does not leave your network perimeter. You can configure to redact sensitive data. Learn more: /weave/guides/tracking/redact-pii/
 - To streamline your experience, the System tab in the individual run workspace view will be removed in an upcoming release. View full information about system metrics in the System section of the workspace. For questions, contact [support@wandb.com](mailto:support@wandb.com).
 
 ## Security
@@ -491,8 +491,8 @@ The release includes the following additional updates:
 
 **This is a mini-feature and patch release, delivered at a different schedule than the monthly W&B server major releases**
 
-* Organization admins can now configure Models seats and access control for both Models & [W&B Weave](https://weave-docs.wandb.ai/) in a seamless manner from their organization dashboard. This change allows for a efficient user management when [Weave](https://weave-docs.wandb.ai/) is enabled for a Dedicated Cloud or Self-Managed instance.
-    * [Weave](https://weave-docs.wandb.ai/) pricing is consumption-based rather than based on number of seats used. Seat management only applies to the Models product.
+* Organization admins can now configure Models seats and access control for both Models & [W&B Weave](/weave/) in a seamless manner from their organization dashboard. This change allows for a efficient user management when [Weave](/weave/) is enabled for a Dedicated Cloud or Self-Managed instance.
+    * [Weave](/weave/) pricing is consumption-based rather than based on number of seats used. Seat management only applies to the Models product.
 * You can now configure [access roles at the project level for team and restricted scoped projects](https://docs.wandb.ai/platform/hosting/iam/access-management/restricted-projects/). It allows assigning different access roles to a user within different projects in the same team, and thus adding another strong control to conform to enterprise governance needs.
 
 

--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -417,7 +417,7 @@ Private preview features are available by invitation only. To request enrollment
 - In Tables and Query panels that use the `runs` expression, you can use the new Runs History step slider and drop-down controls to view a table of metrics at each step of a run.
 - Playground in W&B Weave supports new models: OpenAI's `gpt-4.5-preview`  and Deepseek's `deepseek-chat` and `deepseek-reasoner`.
 - Weave tracing has two new agent framework integrations: CrewAI and OpenAI’s Agent SDK.
-- In the Weave UI, you can now build Datasets from traces. Learn more: /weave/guides/core-types/datasets#create-edit-and-delete-a-dataset-in-the-ui
+- In the Weave UI, you can now build Datasets from traces. [Learn more](/weave/guides/core-types/datasets#create-edit-and-delete-a-dataset-in-the-ui)
 - The Weave Python SDK now provides a way to filter the inputs and outputs of your Weave data to ensure sensitive data does not leave your network perimeter. You can configure to redact sensitive data. Learn more: /weave/guides/tracking/redact-pii/
 - To streamline your experience, the System tab in the individual run workspace view will be removed in an upcoming release. View full information about system metrics in the System section of the workspace. For questions, contact [support@wandb.com](mailto:support@wandb.com).
 

--- a/weave/cookbooks/Intro_to_Weave_Hello_Eval.mdx
+++ b/weave/cookbooks/Intro_to_Weave_Hello_Eval.mdx
@@ -122,5 +122,5 @@ await evaluation.evaluate(model)
 
 ## 🚀 Looking for more examples?
 
-- Learn how to build an [evlauation pipeline end-to-end](https://weave-docs.wandb.ai/tutorial-eval). 
-- Learn how to evaluate a [RAG application by building](https://weave-docs.wandb.ai/tutorial-rag).
+- Learn how to build an [evlauation pipeline end-to-end](/weave/tutorial-eval). 
+- Learn how to evaluate a [RAG application by building](/weave/tutorial-rag).

--- a/weave/cookbooks/Intro_to_Weave_Hello_Trace.mdx
+++ b/weave/cookbooks/Intro_to_Weave_Hello_Trace.mdx
@@ -75,7 +75,7 @@ extract_fruit(sentence)
 ```
 
 ## 🚀 Looking for more examples?
-- Check out the [Quickstart guide](https://weave-docs.wandb.ai/quickstart).
-- Learn more about [advanced tracing topics](https://weave-docs.wandb.ai/tutorial-tracing_2).
-- Learn more about [tracing in Weave](https://weave-docs.wandb.ai/guides/tracking/tracing)
+- Check out the [Quickstart guide](/weave/quickstart).
+- Learn more about [advanced tracing topics](/weave/tutorial-tracing_2).
+- Learn more about [tracing in Weave](/weave/guides/tracking/tracing)
 

--- a/weave/cookbooks/import_from_csv.mdx
+++ b/weave/cookbooks/import_from_csv.mdx
@@ -278,4 +278,4 @@ weave.publish(dset)
 ![image.png](/images/screenshots/csv-4.png)
 </Frame>
 
-To learn more about evaluations, check out our [Quickstart](https://weave-docs.wandb.ai/tutorial-rag) on using your newly created dataset to evaluate your RAG application!
+To learn more about evaluations, check out our [Quickstart](/weave/tutorial-rag) on using your newly created dataset to evaluate your RAG application!

--- a/weave/cookbooks/multi-agent-structured-output.mdx
+++ b/weave/cookbooks/multi-agent-structured-output.mdx
@@ -19,7 +19,7 @@ By using the new parameter `strict: true`, we are able to guarantee the response
 
 The use of structured outputs in a multi-agent system enhances communication by ensuring consistent, easily processed data between agents. It also improves safety by allowing explicit refusals and boosts performance by eliminating the need for retries or validations. This simplifies interactions and increases overall system efficiency.
 
-This tutorial demonstrates how we can utilize structured outputs in multi-agent system and trace them with [Weave](https://weave-docs.wandb.ai/).
+This tutorial demonstrates how we can utilize structured outputs in multi-agent system and trace them with [Weave](/weave).
 
 <Tip>
 **Source**: This cookbook is based on [sample code from OpenAI's structured outputs](https://cookbook.openai.com/examples/structured_outputs_multi_agent), with some modifications added for improved visualization using Weave.

--- a/weave/cookbooks/ocr-pipeline.mdx
+++ b/weave/cookbooks/ocr-pipeline.mdx
@@ -146,7 +146,7 @@ Now, create a function called `named_entity_recognation` that:
 - Passes the image data to the NER pipeline
 - Returns correctly formatted JSON with the results
 
-Use the [`@weave.op()` decorator](https://weave-docs.wandb.ai/reference/python-sdk/weave/trace/weave.trace.op) decorator to automatically track and trace function execution in the W&B UI. 
+Use the [`@weave.op()` decorator](/weave/reference/python-sdk/weave/trace/op) decorator to automatically track and trace function execution in the W&B UI. 
 
 Every `named_entity_recognation` is run, the full trace results are visible in the Weave UI. To view the traces, navigate to the **Traces** tab of your Weave project. 
 
@@ -198,9 +198,9 @@ You will see something similar to the following in the **Traces** table in the W
 
 ## 4. Evaluate the pipeline using Weave
 
-Now that you have created a pipeline to perform NER using a VLM, you can use Weave to systematically evaluate it and find out how well it performs. You can learn more about Evaluations in Weave in [Evaluations Overview](https://weave-docs.wandb.ai/guides/core-types/evaluations). 
+Now that you have created a pipeline to perform NER using a VLM, you can use Weave to systematically evaluate it and find out how well it performs. You can learn more about Evaluations in Weave in [Evaluations Overview](/weave/guides/core-types/evaluations). 
 
-A fundamental part of a Weave Evaluation are [Scorers](https://weave-docs.wandb.ai/guides/evaluation/scorers). Scorers are used to evaluate AI outputs and return evaluation metrics. They take the AI's output, analyze it, and return a dictionary of results. Scorers can use your input data as reference if needed and can also output extra information, such as explanations or reasonings from the evaluation.
+A fundamental part of a Weave Evaluation are [Scorers](/weave/guides/evaluation/scorers). Scorers are used to evaluate AI outputs and return evaluation metrics. They take the AI's output, analyze it, and return a dictionary of results. Scorers can use your input data as reference if needed and can also output extra information, such as explanations or reasonings from the evaluation.
 
 In this section, you will create two Scorers to evaluate the pipeline:
 1. Programatic Scorer 

--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -38,7 +38,7 @@ To follow along this tutorial you'll only need to install the following packages
 First, we'll set up a function to initialize the Weave client and add costs for each model.
 
 - We have included the standard costs for many standard models but we also make it easy to add your own custom costs and custom models. In the following we'll show how to add custom costs for a few models and use the standard costs for the rest.
-- The costs are calculate based on the tracked tokens for each call in Weave. For many LLM vendor libraries, we will automatically track the token usage, but it is also possible to return custom token counts for any call. See this cookbook on how to define the token count and cost calculation for a custom model - [custom cost cookbook](https://weave-docs.wandb.ai/cookbooks/custom_model_cost#setting-up-a-model-with-weave).
+- The costs are calculate based on the tracked tokens for each call in Weave. For many LLM vendor libraries, we will automatically track the token usage, but it is also possible to return custom token counts for any call. See this cookbook on how to define the token count and cost calculation for a custom model - [custom cost cookbook](/weave/cookbooks/custom_model_cost#setting-up-a-model-with-weave).
 
 ```python lines
 PROJECT_NAME = "wandb-smle/weave-cookboook-demo"
@@ -86,7 +86,7 @@ In order to fetch call data from Weave, we have two options:
 The first option to access data from Weave is to retrieve a list of filtered calls and extract the wanted data call-by-call. For that we can use the `calls_query_stream` API to fetch the calls data from Weave:
 
 - `calls_query_stream` API: This API allows us to fetch the calls data from Weave.
-- `filter` dictionary: This dictionary contains the filter parameters to fetch the calls data - see [here](https://weave-docs.wandb.ai/reference/python-sdk/weave/trace_server/weave.trace_server.trace_server_interface/#class-callschema) for more details.
+- `filter` dictionary: This dictionary contains the filter parameters to fetch the calls data - see [here](/weave/reference/python-sdk/weave/trace_server/trace_server_interface#class-callschema) for more details.
 - `expand_columns` list: This list contains the columns to expand in the calls data.
 - `sort_by` list: This list contains the sorting parameters for the calls data.
 - `include_costs` boolean: This boolean indicates whether to include the costs in the calls data.
@@ -231,11 +231,11 @@ plot_model_cost_distribution(df_costs)
 In this cookbook, we demonstrated how to create a custom production monitoring dashboard using Weave's APIs and functions. Weave currently focuses on fast integrations for easy input of data as well as extraction of the data for custom processes.
 
 - **Data Input:**
-  - Framework-agnostic tracing with [@weave-op()](https://weave-docs.wandb.ai/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](https://weave-docs.wandb.ai/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](https://weave-docs.wandb.ai/reference/service-api/call-start-call-start-post) for more details.
+  - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/weave/reference/service-api/call-start-call-start-post) for more details.
 - **Data Output:**
-  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](https://weave-docs.wandb.ai/guides/tracking/tracing#querying--exporting-calls) for more details.
-  - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](https://weave-docs.wandb.ai/guides/tracking/tracing#querying--exporting-calls) for more details.
+  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/api-reference/calls/call-start) for more details.
+  - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.
 
 This custom dashboard extends Weave's native Traces view, allowing for tailored monitoring of LLM applications in production. If you're interested in viewing a more complex dashboard, check out a Streamlit example where you can add your own Weave project URL [in this repo](https://github.com/NiWaRe/agent-dev-collection).
 

--- a/weave/cookbooks/pii.mdx
+++ b/weave/cookbooks/pii.mdx
@@ -19,7 +19,7 @@ In this guide, you'll learn how to use W&B Weave while ensuring your Personally 
 2. **Microsoft's [Presidio](https://microsoft.github.io/presidio/)**, a python-based data protection SDK. This tool provides redaction and replacement functionalities.
 3. **[Faker](https://faker.readthedocs.io/en/master/)**, a Python library to generate fake data, combined with Presidio to anonymize PII data.
 
-Additionally, you'll learn how to use _`weave.op` input/output logging customization_ and _`autopatch_settings`_ to integrate PII redaction and anonymization into the workflow. For more information, see [Customize logged inputs and outputs](https://weave-docs.wandb.ai/guides/tracking/ops/#customize-logged-inputs-and-outputs).
+Additionally, you'll learn how to use _`weave.op` input/output logging customization_ and _`autopatch_settings`_ to integrate PII redaction and anonymization into the workflow. For more information, see [Customize logged inputs and outputs](/weave/guides/tracking/ops/#customize-logged-inputs-and-outputs).
 
 To get started, do the following:
 

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -27,9 +27,9 @@ Before beginning, complete the [prerequisites](#prerequisites-set-variables-and-
 
 The following code sets the URL endpoints that will be used to access the Service API:
 
-- [`https://trace.wandb.ai/call/start`](https://weave-docs.wandb.ai/reference/service-api/call-start-call-start-post)
-- [`https://trace.wandb.ai/call/end`](https://weave-docs.wandb.ai/reference/service-api/call-end-call-end-post)
-- [`https://trace.wandb.ai/calls/stream_query`](https://weave-docs.wandb.ai/reference/service-api/calls-query-stream-calls-stream-query-post)
+- [`https://trace.wandb.ai/call/start`](/api-reference/calls/call-start)
+- [`https://trace.wandb.ai/call/end`](/api-reference/calls/call-end)
+- [`https://trace.wandb.ai/calls/stream_query`](/api-reference/calls/calls-query-stream)
 
 Additionally, you must set the following variables:
 

--- a/weave/guides/core-types/media.mdx
+++ b/weave/guides/core-types/media.mdx
@@ -838,7 +838,7 @@ content = Content.from_bytes(video_bytes, mimetype='video/mp4')
 
 ### Content properties
 
-For a comprehensive list of class attributes and methods, view the [Content reference docs](https://weave-docs.wandb.ai/reference/python-sdk/weave/#class-content)
+For a comprehensive list of class attributes and methods, view the [Content reference docs](/weave/reference/python-sdk/weave#class-content)
 
 #### Attributes
 

--- a/weave/guides/integrations/langchain.mdx
+++ b/weave/guides/integrations/langchain.mdx
@@ -39,7 +39,7 @@ print(output)
 
 ## Tracking Call Metadata
 
-To track metadata from your LangChain calls, you can use the [`weave.attributes`](https://weave-docs.wandb.ai/reference/python-sdk/weave/#function-attributes) context manager. This context manager allows you to set custom metadata for a specific block of code, such as a chain or a single request.
+To track metadata from your LangChain calls, you can use the [`weave.attributes`](/weave/reference/python-sdk/weave#function-attributes) context manager. This context manager allows you to set custom metadata for a specific block of code, such as a chain or a single request.
 
 ```python lines
 import weave

--- a/weave/guides/integrations/verdict.mdx
+++ b/weave/guides/integrations/verdict.mdx
@@ -42,7 +42,7 @@ print(output)
 
 ## Tracking Call Metadata
 
-To track metadata from your Verdict pipeline calls, you can use the [`weave.attributes`](https://weave-docs.wandb.ai/reference/python-sdk/weave/#function-attributes) context manager. This context manager allows you to set custom metadata for a specific block of code, such as a pipeline run or evaluation batch.
+To track metadata from your Verdict pipeline calls, you can use the [`weave.attributes`](/weave/reference/python-sdk/weave#function-attributes) context manager. This context manager allows you to set custom metadata for a specific block of code, such as a pipeline run or evaluation batch.
 
 ```python lines
 import weave

--- a/weave/guides/tools/evaluation_playground.mdx
+++ b/weave/guides/tools/evaluation_playground.mdx
@@ -56,7 +56,7 @@ It is also important to appropriately name the columns in your dataset `user_inp
 
 ### Add a model
 
-[Models](https://weave-docs.wandb.ai/guides/core-types/models), in the context of Weave, are a combination of an AI model (such as GPT) and the environment (in this case the system prompt) that defines how the model operates during the evaluation. You can select existing models in your project or create new ones to evaluate, and you can add multiple models at once to evaluate them simultaneously with the same dataset and scorer. **You can only use models created using the playground feature.**
+[Models](/weave/guides/core-types/models), in the context of Weave, are a combination of an AI model (such as GPT) and the environment (in this case the system prompt) that defines how the model operates during the evaluation. You can select existing models in your project or create new ones to evaluate, and you can add multiple models at once to evaluate them simultaneously with the same dataset and scorer. **You can only use models created using the playground feature.**
 
 To add a model in the **Models** section of the Evaluation Playground:
 

--- a/weave/guides/tracking/costs.mdx
+++ b/weave/guides/tracking/costs.mdx
@@ -7,7 +7,7 @@ description: "Track and manage costs for LLM operations in Weave"
 
 <Tabs>
   <Tab title="Python">
-    You can add a custom cost by using the [`add_cost`](/weave/reference/python-sdk/weave/trace/weave_client.mdx#add_cost) method.
+    You can add a custom cost by using the [`add_cost`](/weave/reference/python-sdk/weave/trace/weave_client#method-add-cost) method.
     The three required fields are `llm_id`, `prompt_token_cost`, and `completion_token_cost`.
     `llm_id` is the name of the LLM (e.g. `gpt-4o`). `prompt_token_cost` and `completion_token_cost` are cost per token for the LLM (if the LLM prices were specified inper million tokens, make sure to convert the value).
     You can also set `effective_date` to a datetime, to make the cost effective at a specific date, this defaults to the current date.
@@ -47,7 +47,7 @@ description: "Track and manage costs for LLM operations in Weave"
 
 <Tabs>
   <Tab title="Python">
-    You can query for costs by using the [`query_costs`](/weave/reference/python-sdk/weave/trace/weave_client.mdx#query_costs) method.
+    You can query for costs by using the [`query_costs`](/weave/reference/python-sdk/weave/trace/weave_client#method-query-costs) method.
     There are a few ways to query for costs, you can pass in a singular cost id, or a list of LLM model names.
 
     ```python lines
@@ -74,7 +74,7 @@ description: "Track and manage costs for LLM operations in Weave"
 
 <Tabs>
   <Tab title="Python">
-    You can purge a custom cost by using the [`purge_costs`](/weave/reference/python-sdk/weave/trace/weave_client.mdx#purge_costs) method. You pass in a list of cost ids, and the costs with those ids are purged.
+    You can purge a custom cost by using the [`purge_costs`](/weave/reference/python-sdk/weave/trace/weave_client#method-purge-costs) method. You pass in a list of cost ids, and the costs with those ids are purged.
 
     ```python lines
     import weave

--- a/weave/guides/tracking/tracing.mdx
+++ b/weave/guides/tracking/tracing.mdx
@@ -685,7 +685,7 @@ You can perform all of these mutations from the UI by navigating to the call det
 
 <Tabs>
     <Tab title="Python">
-    In order to set the display name of a call, you can use the [`Call.set_display_name`](/weave/reference/python-sdk/weave/trace/weave_client#method-set_display_name) method.
+    In order to set the display name of a call, you can use the [`Call.set_display_name`](/weave/reference/python-sdk/weave/trace/weave_client#method-set-display-name) method.
 
     ```python lines lines
     import weave


### PR DESCRIPTION
## Description
This PR replaces hard-coded Weave links and replaces them with internal references. This also fixes WEave reference links across the docs that were using an old schema.
