### PR TITLE
Fix SCIM API documentation formatting inconsistencies

### DIFF
--- a/platform/hosting/iam/scim.mdx
+++ b/platform/hosting/iam/scim.mdx
@@ -822,17 +822,21 @@ GET /scim/Groups?filter=displayName eq "engineering-team"
 
 ### Get team
 
-- **Endpoint**: **`<host-url>/scim/Groups/{id}`**
-- **Method**: GET
-- **Description**: Retrieve team information by providing the team's unique ID.
-- **Request Example**:
+Retrieve team information by providing the team's unique ID.
 
+#### Endpoint
+- **URL**: `<host-url>/scim/Groups/{id}`
+- **Method**: GET
+
+#### Example
+
+<Tabs>
+<Tab title="Request">
 ```bash
 GET /scim/Groups/ghi
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 200)
 ```
@@ -860,20 +864,26 @@ GET /scim/Groups/ghi
     ]
 }
 ```
+</Tab>
+</Tabs>
 
 ### List teams
 
-- **Endpoint**: **`<host-url>/scim/Groups`**
-- **Method**: GET
-- **Description**: Retrieve a list of teams.
-- **Request Example**:
+Retrieve a list of teams.
 
+#### Endpoint
+- **URL**: `<host-url>/scim/Groups`
+- **Method**: GET
+
+#### Example
+
+<Tabs>
+<Tab title="Request">
 ```bash
 GET /scim/Groups
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 200)
 ```
@@ -911,6 +921,8 @@ GET /scim/Groups
     "totalResults": 1
 }
 ```
+</Tab>
+</Tabs>
 
 ### Create team
 
@@ -923,10 +935,12 @@ GET /scim/Groups
 | --- | --- | --- |
 | `displayName` | String | Yes |
 | `members` | Multi-Valued Array | Yes (`value` sub-field is required and maps to a user ID) |
-- **Request Example**:
+#### Example
 
 Creating a team called `wandb-support` with `dev-user2` as its member.
 
+<Tabs>
+<Tab title="Request">
 ```bash
 POST /scim/Groups
 ```
@@ -942,9 +956,8 @@ POST /scim/Groups
     ]
 }
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 201)
 ```
@@ -972,6 +985,8 @@ POST /scim/Groups
     ]
 }
 ```
+</Tab>
+</Tabs>
 
 ### Update team
 
@@ -1230,17 +1245,21 @@ The SCIM role resource maps to W&B custom roles. As mentioned earlier, the `/Rol
 
 ### Get custom role
 
-- **Endpoint:** **`<host-url>/scim/Roles/{id}`**
-- **Method**: GET
-- **Description**: Retrieve information for a custom role by providing the role's unique ID.
-- **Request Example**:
+Retrieve information for a custom role by providing the role's unique ID.
 
+#### Endpoint
+- **URL**: `<host-url>/scim/Roles/{id}`
+- **Method**: GET
+
+#### Example
+
+<Tabs>
+<Tab title="Request">
 ```bash
 GET /scim/Roles/abc
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 200)
 ```
@@ -1275,20 +1294,26 @@ GET /scim/Roles/abc
     ]
 }
 ```
+</Tab>
+</Tabs>
 
 ### List custom roles
 
-- **Endpoint:** **`<host-url>/scim/Roles`**
-- **Method**: GET
-- **Description**: Retrieve information for all custom roles in the W&B organization
-- **Request Example**:
+Retrieve information for all custom roles in the W&B organization.
 
+#### Endpoint
+- **URL**: `<host-url>/scim/Roles`
+- **Method**: GET
+
+#### Example
+
+<Tabs>
+<Tab title="Request">
 ```bash
 GET /scim/Roles
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 200)
 ```
@@ -1360,6 +1385,8 @@ GET /scim/Roles
     "totalResults": 2
 }
 ```
+</Tab>
+</Tabs>
 
 ### Create custom role
 
@@ -1374,8 +1401,10 @@ GET /scim/Roles
 | `description` | String | Description of the custom role |
 | `permissions` | Object array | Array of permission objects where each object includes a `name` string field that has value of the form `w&bobject:operation`. For example, a permission object for delete operation on W&B runs would have `name` as `run:delete`. |
 | `inheritedFrom` | String | The predefined role which the custom role would inherit from. It can either be `member` or `viewer`. |
-- **Request Example**:
+#### Example
 
+<Tabs>
+<Tab title="Request">
 ```bash
 POST /scim/Roles
 ```
@@ -1393,9 +1422,8 @@ POST /scim/Roles
     "inheritedFrom": "member"
 }
 ```
-
-- **Response Example**:
-
+</Tab>
+<Tab title="Response">
 ```bash
 (Status 201)
 ```
@@ -1430,6 +1458,8 @@ POST /scim/Roles
     ]
 }
 ```
+</Tab>
+</Tabs>
 
 ### Update custom role
 
@@ -1555,14 +1585,26 @@ Returns the completely replaced role definition.
 
 ### Delete custom role
 
-- **Endpoint**: **`<host-url>/scim/Roles/{id}`**
-- **Method**: DELETE
-- **Description**: Delete a custom role in the W&B organization. **Use it with caution**. The predefined role from which the custom role inherited is now assigned to all users that were assigned the custom role before the operation.
-- **Request Example**:
+Delete a custom role in the W&B organization. **Use it with caution**. The predefined role from which the custom role inherited is now assigned to all users that were assigned the custom role before the operation.
 
+#### Endpoint
+- **URL**: `<host-url>/scim/Roles/{id}`
+- **Method**: DELETE
+
+#### Example
+
+<Tabs>
+<Tab title="Request">
 ```bash
 DELETE /scim/Roles/abc
 ```
+</Tab>
+<Tab title="Response">
+```bash
+(Status 204 No Content)
+```
+</Tab>
+</Tabs>
 
 ## Advanced Features
 


### PR DESCRIPTION
## Description
Fix SCIM API documentation formatting inconsistencies
- Fixed request/response tabs in sections: Get team, List teams, Create team, Get custom role, List custom roles, Create custom role, Delete custom role
- Improve consistency of formatting to match other sections