### PR TITLE
FAST FOLLOW: Weave reference links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1022,7 +1022,7 @@
                   },
                   {
                     "group": "Service API",
-                    "openapi": "https://raw.githubusercontent.com/wandb/weave/v0.52.10/sdks/node/weave.openapi.json"
+                    "openapi": "https://trace.wandb.ai/openapi.json"
                   }
                 ]
               },

--- a/models/evaluate-models.mdx
+++ b/models/evaluate-models.mdx
@@ -69,7 +69,7 @@ results = await evaluation.evaluate(model)
 
 ### Integrate Weave evaluations with W&B Models
 
-The [Models and Weave Integration Demo](/weave/reference/gen_notebooks/Models_and_Weave_Integration_Demo) shows the complete workflow for:
+The [Models and Weave Integration Demo](/weave/cookbooks/Models_and_Weave_Integration_Demo) shows the complete workflow for:
 
 1. **Load models from Registry**: Download fine-tuned models stored in W&B Models Registry
 2. **Create evaluation pipelines**: Build comprehensive evaluations with custom scorers
@@ -120,7 +120,7 @@ for model in models:
 ### Next steps
 
 * [Complete Weave evaluation tutorial](/weave/tutorial-eval/)
-* [Models and Weave integration example](/reference/gen_notebooks/Models_and_Weave_Integration_Demo)
+* [Models and Weave integration example](/weave/cookbooks/Models_and_Weave_Integration_Demo)
 
 
 

--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -232,7 +232,7 @@ In this cookbook, we demonstrated how to create a custom production monitoring d
 
 - **Data Input:**
   - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/weave/reference/service-api/call-start-call-start-post) for more details.
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/api-reference/calls/call-start) for more details.
 - **Data Output:**
   - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/api-reference/calls/call-start) for more details.
   - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.

--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -232,9 +232,9 @@ In this cookbook, we demonstrated how to create a custom production monitoring d
 
 - **Data Input:**
   - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/weave/reference/service-api/call-start) for more details.
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/api-reference/calls/call-start) for more details.
 - **Data Output:**
-  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/weave/reference/service-api/call-start) for more details.
+  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/api-reference/calls/call-start) for more details.
   - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.
 
 This custom dashboard extends Weave's native Traces view, allowing for tailored monitoring of LLM applications in production. If you're interested in viewing a more complex dashboard, check out a Streamlit example where you can add your own Weave project URL [in this repo](https://github.com/NiWaRe/agent-dev-collection).

--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -232,9 +232,9 @@ In this cookbook, we demonstrated how to create a custom production monitoring d
 
 - **Data Input:**
   - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/api-reference/calls/call-start) for more details.
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/weave/reference/service-api/call-start-call-start-post) for more details.
 - **Data Output:**
-  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/api-reference/calls/call-start) for more details.
+  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/weave/reference/service-api/call-start-call-start-post) for more details.
   - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.
 
 This custom dashboard extends Weave's native Traces view, allowing for tailored monitoring of LLM applications in production. If you're interested in viewing a more complex dashboard, check out a Streamlit example where you can add your own Weave project URL [in this repo](https://github.com/NiWaRe/agent-dev-collection).

--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -232,9 +232,9 @@ In this cookbook, we demonstrated how to create a custom production monitoring d
 
 - **Data Input:**
   - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/api-reference/calls/call-start) for more details.
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/weave/reference/service-api/call-start) for more details.
 - **Data Output:**
-  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/api-reference/calls/call-start) for more details.
+  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/weave/reference/service-api/call-start) for more details.
   - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.
 
 This custom dashboard extends Weave's native Traces view, allowing for tailored monitoring of LLM applications in production. If you're interested in viewing a more complex dashboard, check out a Streamlit example where you can add your own Weave project URL [in this repo](https://github.com/NiWaRe/agent-dev-collection).

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -27,9 +27,9 @@ Before beginning, complete the [prerequisites](#prerequisites-set-variables-and-
 
 The following code sets the URL endpoints that will be used to access the Service API:
 
-- [`https://trace.wandb.ai/call/start`](/api-reference/calls/call-start)
-- [`https://trace.wandb.ai/call/end`](/api-reference/calls/call-end)
-- [`https://trace.wandb.ai/calls/stream_query`](/api-reference/calls/calls-stream-query)
+- [`https://trace.wandb.ai/call/start`](/weave/reference/service-api/call-start-call-start-post)
+- [`https://trace.wandb.ai/call/end`](/weave/reference/service-api/call-end-call-end-post)
+- [`https://trace.wandb.ai/calls/stream_query`](/weave/reference/service-api/calls-query-stream-calls-stream-query-post)
 
 Additionally, you must set the following variables:
 

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -27,9 +27,9 @@ Before beginning, complete the [prerequisites](#prerequisites-set-variables-and-
 
 The following code sets the URL endpoints that will be used to access the Service API:
 
-- [`https://trace.wandb.ai/call/start`](/weave/reference/service-api/call-start)
-- [`https://trace.wandb.ai/call/end`](/weave/reference/service-api/call-end)
-- [`https://trace.wandb.ai/calls/stream_query`](/weave/reference/service-api/calls-stream-query)
+- [`https://trace.wandb.ai/call/start`](/api-reference/calls/call-start)
+- [`https://trace.wandb.ai/call/end`](/api-reference/calls/call-end)
+- [`https://trace.wandb.ai/calls/stream_query`](/api-reference/calls/calls-stream-query)
 
 Additionally, you must set the following variables:
 

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -27,9 +27,9 @@ Before beginning, complete the [prerequisites](#prerequisites-set-variables-and-
 
 The following code sets the URL endpoints that will be used to access the Service API:
 
-- [`https://trace.wandb.ai/call/start`](/api-reference/calls/call-start)
-- [`https://trace.wandb.ai/call/end`](/api-reference/calls/call-end)
-- [`https://trace.wandb.ai/calls/stream_query`](/api-reference/calls/calls-query-stream)
+- [`https://trace.wandb.ai/call/start`](/weave/reference/service-api/call-start)
+- [`https://trace.wandb.ai/call/end`](/weave/reference/service-api/call-end)
+- [`https://trace.wandb.ai/calls/stream_query`](/weave/reference/service-api/calls-stream-query)
 
 Additionally, you must set the following variables:
 

--- a/weave/index.mdx
+++ b/weave/index.mdx
@@ -19,9 +19,9 @@ W&B Weave helps you build better language model apps. Use Weave to track, test, 
 - **Add Safety**: Protect your app with content filters and prompt guards.
 
 Connect Weave to your code with:
-- [Python SDK](./reference/python-sdk/weave/index)
-- [TypeScript SDK](./reference/typescript-sdk/weave/index.mdx)
-- [Service API](./reference/service-api/index)
+- [Python SDK](/weave/reference/python-sdk/weave/index)
+- [TypeScript SDK](/weave/reference/typescript-sdk/weave/index)
+- [Service API](/weave/reference/service-api/index)
 
 Weave works with many language model providers, local models, and tools.
 

--- a/weave/index.mdx
+++ b/weave/index.mdx
@@ -6,7 +6,7 @@ mode: wide
 
 <Info>
 W&B Inference comes free with your account. Get access to open source models through the API and Weave Playground.
-- [Developer documentation](./guides/integrations/inference)
+- [Quickstart](/weave/quickstart-inference)
 - [Product page](https://wandb.ai/site/inference)
 </Info>
 

--- a/weave/reference/service-api/index.mdx
+++ b/weave/reference/service-api/index.mdx
@@ -26,64 +26,63 @@ curl -H "Authorization: Bearer YOUR_API_KEY" https://trace.wandb.ai/...
 
 ### Calls
 
-- **POST /call/start** - Call Start
-- **POST /call/end** - Call End
-- **POST /call/upsert_batch** - Call Start Batch
-- **POST /calls/delete** - Calls Delete
-- **POST /call/update** - Call Update
-- **POST /call/read** - Call Read
-- **POST /calls/query_stats** - Calls Query Stats
-- **POST /calls/stream_query** - Calls Query Stream
+- **[POST /call/start](/api-reference/calls/call-start)** - Call Start
+- **[POST /call/end](/api-reference/calls/call-end)** - Call End
+- **[POST /call/upsert_batch](/api-reference/calls/call-start-batch)** - Call Start Batch
+- **[POST /calls/delete](/api-reference/calls/calls-delete)** - Calls Delete
+- **[POST /call/update](/api-reference/calls/call-update)** - Call Update
+- **[POST /call/read](/api-reference/calls/call-read)** - Call Read
+- **[POST /calls/query_stats](/api-reference/calls/calls-query-stats)** - Calls Query Stats
+- **[POST /calls/stream_query](/api-reference/calls/calls-query-stream)** - Calls Query Stream
 
 ### Costs
 
-- **POST /cost/create** - Cost Create
-- **POST /cost/query** - Cost Query
-- **POST /cost/purge** - Cost Purge
+- **[POST /cost/create](/api-reference/costs/cost-create)** - Cost Create
+- **[POST /cost/query](/api-reference/costs/cost-query)** - Cost Query
+- **[POST /cost/purge](/api-reference/costs/cost-purge)** - Cost Purge
 
 ### Feedback
 
-- **POST /feedback/create** - Feedback Create
-- **POST /feedback/query** - Feedback Query
-- **POST /feedback/purge** - Feedback Purge
-- **POST /feedback/replace** - Feedback Replace
+- **[POST /feedback/create](/api-reference/feedback/feedback-create)** - Feedback Create
+- **[POST /feedback/query](/api-reference/feedback/feedback-query)** - Feedback Query
+- **[POST /feedback/purge](/api-reference/feedback/feedback-purge)** - Feedback Purge
+- **[POST /feedback/replace](/api-reference/feedback/feedback-replace)** - Feedback Replace
 
 ### Files
 
-- **POST /file/create** - File Create
-- **POST /file/content** - File Content
-- **POST /files/query_stats** - Files Stats
+- **[POST /file/create](/api-reference/files/file-create)** - File Create
+- **[POST /file/content](/api-reference/files/file-content)** - File Content
+- **[POST /files/query_stats](/api-reference/files/files-stats)** - Files Stats
 
 ### Objects
 
-- **POST /obj/create** - Obj Create
-- **POST /obj/read** - Obj Read
-- **POST /objs/query** - Objs Query
-- **POST /obj/delete** - Obj Delete
+- **[POST /obj/create](/api-reference/objects/obj-create)** - Obj Create
+- **[POST /obj/read](/api-reference/objects/obj-read)** - Obj Read
+- **[POST /obj/delete](/api-reference/objects/obj-delete)** - Obj Delete
 
 ### OpenTelemetry
 
-- **POST /otel/v1/traces** - Export Trace
+- **[POST /otel/v1/traces](/api-reference/opentelemetry/export-trace)** - Export Trace
 
 ### Refs
 
-- **POST /refs/read_batch** - Refs Read Batch
+- **[POST /refs/read_batch](/api-reference/refs/refs-read-batch)** - Refs Read Batch
 
 ### Service
 
-- **GET /health** - Read Root
-- **GET /version** - Read Version
-- **GET /geolocate** - Get Caller Location
-- **GET /server_info** - Server Info
+- **[GET /health](/api-reference/service/read-root)** - Read Root
+- **[GET /version](/api-reference/service/read-version)** - Read Version
+- **[GET /geolocate](/api-reference/service/get-caller-location)** - Get Caller Location
+- **[GET /server_info](/api-reference/service/server-info)** - Server Info
 
 ### Tables
 
-- **POST /table/create** - Table Create
-- **POST /table/update** - Table Update
-- **POST /table/query** - Table Query
-- **POST /table/query_stats** - Table Query Stats
-- **POST /table/query_stats_batch** - Table Query Stats Batch
+- **[POST /table/create](/api-reference/tables/table-create)** - Table Create
+- **[POST /table/update](/api-reference/tables/table-update)** - Table Update
+- **[POST /table/query](/api-reference/tables/table-query)** - Table Query
+- **[POST /table/query_stats](/api-reference/tables/table-query-stats)** - Table Query Stats
+- **[POST /table/query_stats_batch](/api-reference/tables/table-query-stats-batch) - Table Query Stats Batch
 
 ### Threads
 
-- **POST /threads/stream_query** - Threads Query Stream
+- **[POST /threads/stream_query](/api-reference/threads/threads-query-stream)** - Threads Query Stream

--- a/weave/reference/service-api/index.mdx
+++ b/weave/reference/service-api/index.mdx
@@ -81,7 +81,7 @@ curl -H "Authorization: Bearer YOUR_API_KEY" https://trace.wandb.ai/...
 - **[POST /table/update](/api-reference/tables/table-update)** - Table Update
 - **[POST /table/query](/api-reference/tables/table-query)** - Table Query
 - **[POST /table/query_stats](/api-reference/tables/table-query-stats)** - Table Query Stats
-- **[POST /table/query_stats_batch](/api-reference/tables/table-query-stats-batch) - Table Query Stats Batch
+- **[POST /table/query_stats_batch](/api-reference/tables/table-query-stats-batch)** - Table Query Stats Batch
 
 ### Threads
 


### PR DESCRIPTION
## Description
This fixes broken links for the Weave reference doc on the front page and properly utilizes the reference index pages.
