### PR TITLE
Make links to OpenAPI URLs fully-qualified (which passes link check)

### DIFF
--- a/weave/cookbooks/online_monitoring.mdx
+++ b/weave/cookbooks/online_monitoring.mdx
@@ -232,9 +232,9 @@ In this cookbook, we demonstrated how to create a custom production monitoring d
 
 - **Data Input:**
   - Framework-agnostic tracing with [@weave-op()](/weave/quickstart#2-log-a-trace-to-a-new-project) decorator and the possibility to import calls from CSV (see related [import cookbook](/weave/cookbooks/import_from_csv))
-  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](/api-reference/calls/call-start) for more details.
+  - Service API endpoints to log to Weave from for various programming frameworks and languages, see [here](https://docs.wandb.ai/api-reference/calls/call-start) for more details.
 - **Data Output:**
-  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](/weave/reference/service-api/call-start-call-start-post) for more details.
+  - Easy download of the data in CSV, TSV, JSONL, JSON formats - see [here](https://docs.wandb.ai/weave/reference/service-api/call-start-call-start-post) for more details.
   - Easy export using programmatic access to the data - see "Use Python" section in the export panel as described in this cookbook. See [here](/weave/guides/tracking/tracing#querying-and-exporting-calls) for more details.
 
 This custom dashboard extends Weave's native Traces view, allowing for tailored monitoring of LLM applications in production. If you're interested in viewing a more complex dashboard, check out a Streamlit example where you can add your own Weave project URL [in this repo](https://github.com/NiWaRe/agent-dev-collection).

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -27,9 +27,9 @@ Before beginning, complete the [prerequisites](#prerequisites-set-variables-and-
 
 The following code sets the URL endpoints that will be used to access the Service API:
 
-- [`https://trace.wandb.ai/call/start`](/weave/reference/service-api/call-start-call-start-post)
-- [`https://trace.wandb.ai/call/end`](/weave/reference/service-api/call-end-call-end-post)
-- [`https://trace.wandb.ai/calls/stream_query`](/weave/reference/service-api/calls-query-stream-calls-stream-query-post)
+- [`https://trace.wandb.ai/call/start`](https://docs.wandb.ai/weave/reference/service-api/call-start-call-start-post)
+- [`https://trace.wandb.ai/call/end`](https://docs.wandb.ai/weave/reference/service-api/call-end-call-end-post)
+- [`https://trace.wandb.ai/calls/stream_query`](https://docs.wandb.ai/weave/reference/service-api/calls-query-stream-calls-stream-query-post)
 
 Additionally, you must set the following variables:
 

--- a/weave/guides/tracking/tracing.mdx
+++ b/weave/guides/tracking/tracing.mdx
@@ -456,8 +456,8 @@ You can also manually create Calls using the API directly.
     </Tab>
 
     <Tab title="HTTP API">
-    * Start a call: [POST `/call/start`](/weave/reference/service-api/index)
-    * End a call: [POST `/call/end`](/weave/reference/service-api/index)
+    * Start a call: [POST `/call/start`](https://docs.wandb.ai/weave/reference/service-api/index)
+    * End a call: [POST `/call/end`](https://docs.wandb.ai/weave/reference/service-api/index)
     ```bash
     curl -L 'https://trace.wandb.ai/call/start' \
     -H 'Content-Type: application/json' \
@@ -588,7 +588,7 @@ You can also track class and object methods.
     </Tab>
 
     <Tab title="HTTP API">
-    To view a call using the Service API, you can make a request to the [`/call/read`](/weave/reference/service-api/index) endpoint.
+    To view a call using the Service API, you can make a request to the [`/call/read`](https://docs.wandb.ai/weave/reference/service-api/index) endpoint.
 
     ```bash
     curl -L 'https://trace.wandb.ai/call/read' \
@@ -706,7 +706,7 @@ You can perform all of these mutations from the UI by navigating to the call det
     ```
     </Tab>
     <Tab title="HTTP API">
-    To set the display name of a call using the Service API, you can make a request to the [`/call/update`](/weave/reference/service-api/index) endpoint.
+    To set the display name of a call using the Service API, you can make a request to the [`/call/update`](https://docs.wandb.ai/weave/reference/service-api/index) endpoint.
 
     ```bash
     curl -L 'https://trace.wandb.ai/call/update' \
@@ -751,7 +751,7 @@ Please see the [Feedback Documentation](/weave/guides/tracking/feedback) for mor
     ```
     </Tab>
     <Tab title="HTTP API">
-    To delete a call using the Service API, you can make a request to the [`/calls/delete`](/weave/reference/service-api/index) endpoint.
+    To delete a call using the Service API, you can make a request to the [`/calls/delete`](https://docs.wandb.ai/weave/reference/service-api/index) endpoint.
 
     ```bash
     curl -L 'https://trace.wandb.ai/calls/delete' \
@@ -851,7 +851,7 @@ The easiest way to get started is to construct a view in the UI, then learn more
     ```
     </Tab>
     <Tab title="HTTP API">
-    The most powerful query layer is at the Service API. To fetch calls using the Service API, you can make a request to the [`/calls/stream_query`](/weave/reference/service-api/index) endpoint.
+    The most powerful query layer is at the Service API. To fetch calls using the Service API, you can make a request to the [`/calls/stream_query`](https://docs.wandb.ai/weave/reference/service-api/index) endpoint.
 
     ```bash
     curl -L 'https://trace.wandb.ai/calls/stream_query' \

--- a/weave/index.mdx
+++ b/weave/index.mdx
@@ -21,7 +21,7 @@ W&B Weave helps you build better language model apps. Use Weave to track, test, 
 Connect Weave to your code with:
 - [Python SDK](/weave/reference/python-sdk/weave/index)
 - [TypeScript SDK](/weave/reference/typescript-sdk/weave/index)
-- [Service API](/weave/reference/service-api/index)
+- [Service API](https://docs.wandb.ai/weave/reference/service-api/index)
 
 Weave works with many language model providers, local models, and tools.
 

--- a/weave/reference/service-api/index.mdx
+++ b/weave/reference/service-api/index.mdx
@@ -26,63 +26,63 @@ curl -H "Authorization: Bearer YOUR_API_KEY" https://trace.wandb.ai/...
 
 ### Calls
 
-- **[POST /call/start](/api-reference/calls/call-start)** - Call Start
-- **[POST /call/end](/api-reference/calls/call-end)** - Call End
-- **[POST /call/upsert_batch](/api-reference/calls/call-start-batch)** - Call Start Batch
-- **[POST /calls/delete](/api-reference/calls/calls-delete)** - Calls Delete
-- **[POST /call/update](/api-reference/calls/call-update)** - Call Update
-- **[POST /call/read](/api-reference/calls/call-read)** - Call Read
-- **[POST /calls/query_stats](/api-reference/calls/calls-query-stats)** - Calls Query Stats
-- **[POST /calls/stream_query](/api-reference/calls/calls-query-stream)** - Calls Query Stream
+- **[POST /call/start](https://docs.wandb.ai/api-reference/calls/call-start)** - Call Start
+- **[POST /call/end](https://docs.wandb.ai/api-reference/calls/call-end)** - Call End
+- **[POST /call/upsert_batch](https://docs.wandb.ai/api-reference/calls/call-start-batch)** - Call Start Batch
+- **[POST /calls/delete](https://docs.wandb.ai/api-reference/calls/calls-delete)** - Calls Delete
+- **[POST /call/update](https://docs.wandb.ai/api-reference/calls/call-update)** - Call Update
+- **[POST /call/read](https://docs.wandb.ai/api-reference/calls/call-read)** - Call Read
+- **[POST /calls/query_stats](https://docs.wandb.ai/api-reference/calls/calls-query-stats)** - Calls Query Stats
+- **[POST /calls/stream_query](https://docs.wandb.ai/api-reference/calls/calls-query-stream)** - Calls Query Stream
 
 ### Costs
 
-- **[POST /cost/create](/api-reference/costs/cost-create)** - Cost Create
-- **[POST /cost/query](/api-reference/costs/cost-query)** - Cost Query
-- **[POST /cost/purge](/api-reference/costs/cost-purge)** - Cost Purge
+- **[POST /cost/create](https://docs.wandb.ai/api-reference/costs/cost-create)** - Cost Create
+- **[POST /cost/query](https://docs.wandb.ai/api-reference/costs/cost-query)** - Cost Query
+- **[POST /cost/purge](https://docs.wandb.ai/api-reference/costs/cost-purge)** - Cost Purge
 
 ### Feedback
 
-- **[POST /feedback/create](/api-reference/feedback/feedback-create)** - Feedback Create
-- **[POST /feedback/query](/api-reference/feedback/feedback-query)** - Feedback Query
-- **[POST /feedback/purge](/api-reference/feedback/feedback-purge)** - Feedback Purge
-- **[POST /feedback/replace](/api-reference/feedback/feedback-replace)** - Feedback Replace
+- **[POST /feedback/create](https://docs.wandb.ai/api-reference/feedback/feedback-create)** - Feedback Create
+- **[POST /feedback/query](https://docs.wandb.ai/api-reference/feedback/feedback-query)** - Feedback Query
+- **[POST /feedback/purge](https://docs.wandb.ai/api-reference/feedback/feedback-purge)** - Feedback Purge
+- **[POST /feedback/replace](https://docs.wandb.ai/api-reference/feedback/feedback-replace)** - Feedback Replace
 
 ### Files
 
-- **[POST /file/create](/api-reference/files/file-create)** - File Create
-- **[POST /file/content](/api-reference/files/file-content)** - File Content
-- **[POST /files/query_stats](/api-reference/files/files-stats)** - Files Stats
+- **[POST /file/create](https://docs.wandb.ai/api-reference/files/file-create)** - File Create
+- **[POST /file/content](https://docs.wandb.ai/api-reference/files/file-content)** - File Content
+- **[POST /files/query_stats](https://docs.wandb.ai/api-reference/files/files-stats)** - Files Stats
 
 ### Objects
 
-- **[POST /obj/create](/api-reference/objects/obj-create)** - Obj Create
-- **[POST /obj/read](/api-reference/objects/obj-read)** - Obj Read
-- **[POST /obj/delete](/api-reference/objects/obj-delete)** - Obj Delete
+- **[POST /obj/create](https://docs.wandb.ai/api-reference/objects/obj-create)** - Obj Create
+- **[POST /obj/read](https://docs.wandb.ai/api-reference/objects/obj-read)** - Obj Read
+- **[POST /obj/delete](https://docs.wandb.ai/api-reference/objects/obj-delete)** - Obj Delete
 
 ### OpenTelemetry
 
-- **[POST /otel/v1/traces](/api-reference/opentelemetry/export-trace)** - Export Trace
+- **[POST /otel/v1/traces](https://docs.wandb.ai/api-reference/opentelemetry/export-trace)** - Export Trace
 
 ### Refs
 
-- **[POST /refs/read_batch](/api-reference/refs/refs-read-batch)** - Refs Read Batch
+- **[POST /refs/read_batch](https://docs.wandb.ai/api-reference/refs/refs-read-batch)** - Refs Read Batch
 
 ### Service
 
-- **[GET /health](/api-reference/service/read-root)** - Read Root
-- **[GET /version](/api-reference/service/read-version)** - Read Version
-- **[GET /geolocate](/api-reference/service/get-caller-location)** - Get Caller Location
-- **[GET /server_info](/api-reference/service/server-info)** - Server Info
+- **[GET /health](https://docs.wandb.ai/api-reference/service/read-root)** - Read Root
+- **[GET /version](https://docs.wandb.ai/api-reference/service/read-version)** - Read Version
+- **[GET /geolocate](https://docs.wandb.ai/api-reference/service/get-caller-location)** - Get Caller Location
+- **[GET /server_info](https://docs.wandb.ai/api-reference/service/server-info)** - Server Info
 
 ### Tables
 
-- **[POST /table/create](/api-reference/tables/table-create)** - Table Create
-- **[POST /table/update](/api-reference/tables/table-update)** - Table Update
-- **[POST /table/query](/api-reference/tables/table-query)** - Table Query
-- **[POST /table/query_stats](/api-reference/tables/table-query-stats)** - Table Query Stats
-- **[POST /table/query_stats_batch](/api-reference/tables/table-query-stats-batch)** - Table Query Stats Batch
+- **[POST /table/create](https://docs.wandb.ai/api-reference/tables/table-create)** - Table Create
+- **[POST /table/update](https://docs.wandb.ai/api-reference/tables/table-update)** - Table Update
+- **[POST /table/query](https://docs.wandb.ai/api-reference/tables/table-query)** - Table Query
+- **[POST /table/query_stats](https://docs.wandb.ai/api-reference/tables/table-query-stats)** - Table Query Stats
+- **[POST /table/query_stats_batch](https://docs.wandb.ai/api-reference/tables/table-query-stats-batch)** - Table Query Stats Batch
 
 ### Threads
 
-- **[POST /threads/stream_query](/api-reference/threads/threads-query-stream)** - Threads Query Stream
+- **[POST /threads/stream_query](https://docs.wandb.ai/api-reference/threads/threads-query-stream)** - Threads Query Stream


### PR DESCRIPTION
By switching links to OpenAPI-spec-generated URLs to be fully-qualified, we can get around the fact that the `link-rot` check falsely flags them as invalid, and enable it. 

As you can see, [the `link-rot` check is green on this PR](https://github.com/wandb/docs/pull/1760/checks?check_run_id=53397849939). Keep in mind Lychee should be checking https-bound links, as well, so it's not like these will go unvalidated. This workaround would only be necessary until Mintlify fixes the OpenAPI URL bug.