### PR TITLE
GPC -> GCP

### DIFF
--- a/ja/platform/hosting/hosting-options/multi_tenant_cloud.mdx
+++ b/ja/platform/hosting/hosting-options/multi_tenant_cloud.mdx
@@ -2,7 +2,7 @@
 title: W&B マルチテナント SaaS を使用する
 ---
 
-W&B マルチテナントクラウドは、W&B の Google Cloud Platform (GCP) アカウントに展開されている完全管理型のプラットフォームで、[GPC の北米リージョン](https://cloud.google.com/compute/docs/regions-zones)で利用可能です。W&B マルチテナントクラウドは、GCP の自動スケーリングを利用しており、トラフィックの増減に応じて適切にプラットフォームがスケールします。
+W&B マルチテナントクラウドは、W&B の Google Cloud Platform (GCP) アカウントに展開されている完全管理型のプラットフォームで、[GCP の北米リージョン](https://cloud.google.com/compute/docs/regions-zones)で利用可能です。W&B マルチテナントクラウドは、GCP の自動スケーリングを利用しており、トラフィックの増減に応じて適切にプラットフォームがスケールします。
 
 <Frame>
     <img src="/images/hosting/multi_tenant_cloud_arch.png"  />

--- a/ko/platform/hosting/hosting-options/multi_tenant_cloud.mdx
+++ b/ko/platform/hosting/hosting-options/multi_tenant_cloud.mdx
@@ -2,7 +2,7 @@
 title: Use W&B Multi-tenant SaaS
 ---
 
-W&B Multi-tenant Cloud는 W&B의 Google Cloud Platform (GCP) 계정의 [GPC의 북미 지역](https://cloud.google.com/compute/docs/regions-zones)에 배포된 완전 관리형 플랫폼입니다. W&B Multi-tenant Cloud는 트래픽 증가 또는 감소에 따라 플랫폼이 적절하게 확장되도록 GCP에서 자동 확장을 활용합니다.
+W&B Multi-tenant Cloud는 W&B의 Google Cloud Platform (GCP) 계정의 [GCP의 북미 지역](https://cloud.google.com/compute/docs/regions-zones)에 배포된 완전 관리형 플랫폼입니다. W&B Multi-tenant Cloud는 트래픽 증가 또는 감소에 따라 플랫폼이 적절하게 확장되도록 GCP에서 자동 확장을 활용합니다.
 
 <Frame>
     <img src="/images/hosting/multi_tenant_cloud_arch.png"  />

--- a/platform/hosting/hosting-options.mdx
+++ b/platform/hosting/hosting-options.mdx
@@ -4,14 +4,14 @@ title: Deployment options
 This section describes the different ways can you can deploy W&B.
 
 ## W&B Multi-tenant Cloud
-[W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) is fully managed by W&B, including upgrades, maintenance, platform security, and capacity planning. Multi-tenant Cloud is deployed in W&B's Google Cloud Platform (GCP) account in [GPC's North America regions](https://cloud.google.com/compute/docs/regions-zones). [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store W&B Artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
+[W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) is fully managed by W&B, including upgrades, maintenance, platform security, and capacity planning. Multi-tenant Cloud is deployed in W&B's Google Cloud Platform (GCP) account in [GCP's North America regions](https://cloud.google.com/compute/docs/regions-zones). [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store W&B Artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 
 See [W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) or [get started for free](https://app.wandb.ai/login?signup=true).
 
 ## W&B Dedicated Cloud
 [W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) is a single-tenant, fully managed platform designed with enterprise organizations in mind. W&B Dedicated Cloud is deployed in W&B's AWS, GCP or Azure account. Dedicated Cloud provides more flexibility than Multi-tenant Cloud, but less complexity than W&B Self-Managed. Upgrades, maintenance, platform security, and capacity planning are managed by W&B. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances.
 
-Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store artifacts and other related sensitive data in your own cloud or on-premises infrastructure. 
+Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 
 W&B Dedicated Cloud includes an [enterprise license](/platform/hosting/hosting-options/self-managed/) with support for important security and other enterprise-friendly capabilities.
 

--- a/platform/hosting/hosting-options/multi_tenant_cloud.mdx
+++ b/platform/hosting/hosting-options/multi_tenant_cloud.mdx
@@ -3,7 +3,7 @@ title: Multi-tenant Cloud
 description: Deploy Multi-tenant Cloud in production
 ---
 
-W&B Multi-tenant Cloud is a fully managed platform deployed in W&B's Google Cloud Platform (GCP) account in [GPC's North America regions](https://cloud.google.com/compute/docs/regions-zones). W&B Multi-tenant Cloud utilizes autoscaling in GCP to ensure that the platform scales appropriately based on increases or decreases in traffic. 
+W&B Multi-tenant Cloud is a fully managed platform deployed in W&B's Google Cloud Platform (GCP) account in [GCP's North America regions](https://cloud.google.com/compute/docs/regions-zones). W&B Multi-tenant Cloud utilizes autoscaling in GCP to ensure that the platform scales appropriately based on increases or decreases in traffic.
 
 <Frame>
     <img src="/images/hosting/multi_tenant_cloud_arch.png" alt="Multi-tenant Cloud architecture diagram"  />
@@ -32,7 +32,7 @@ Organization admins can manage usage and billing for their account from the `Bil
 ## Maintenance
 W&B Multi-tenant Cloud is a multi-tenant, fully managed platform. Since W&B Multi-tenant Cloud is managed by W&B, you do not incur the overhead and costs of provisioning and maintaining the W&B platform.
 
-## Compliance 
+## Compliance
 Security controls for Multi-tenant Cloud are periodically audited internally and externally. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request the SOC2 report and other security and compliance documents.
 
 ## Next steps


### PR DESCRIPTION
## Description

Fixed a typo in multiple files where "GPC" was incorrectly used instead of "GCP" when referring to Google Cloud Platform regions.