### PR TITLE
Fixes typo for OTEL endpoint

### DIFF
--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -14,7 +14,7 @@ Weave supports ingestion of OpenTelemetry compatible trace data through a dedica
 **Base URL**: The base URL for the OTEL trace endpoint depends on your W&B deployment type:
 
 - Multi-tenant Cloud:  
-  `https://traces.wandb.ai/otel/v1/traces`
+  `https://trace.wandb.ai/otel/v1/traces`
 
 - Dedicated Cloud and Self-Managed instances:  
   `https://<your-subdomain>.wandb.io/traces/otel/v1/traces`


### PR DESCRIPTION
## Description
Resolves DOCS-1853. Fixes a typo in the Weave traces OTEL endpoint. 