### PR TITLE
Add some redirects to catch /guides/core URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2478,17 +2478,21 @@
       "source": "/guides/core/automations/:slug*",
       "destination": "/models/automations/:slug*"
     },
-        {
+    {
       "source": "/guides/core/artifacts/:slug*",
       "destination": "/models/artifacts/:slug*"
     },
-        {
+    {
       "source": "/guides/core/registry/:slug*",
       "destination": "/models/registry/:slug*"
     },
-        {
+    {
       "source": "/guides/core/reports/:slug*",
       "destination": "/models/automations/:slug*"
+    },
+        {
+      "source": "/guides/core/tables/:slug*",
+      "destination": "/models/tables/:slug*"
     },
     {
       "source": "/guides",

--- a/docs.json
+++ b/docs.json
@@ -2475,6 +2475,14 @@
       "destination": "/models"
     },
     {
+      "source": "/guides/core/automations/:slug*",
+      "destination": "/models/automations/:slug*"
+    },
+    {
+      "source": "/guides",
+      "destination": "/models"
+    },
+    {
       "source": "/models/core",
       "destination": "/models"
     }

--- a/docs.json
+++ b/docs.json
@@ -2478,6 +2478,18 @@
       "source": "/guides/core/automations/:slug*",
       "destination": "/models/automations/:slug*"
     },
+        {
+      "source": "/guides/core/artifacts/:slug*",
+      "destination": "/models/artifacts/:slug*"
+    },
+        {
+      "source": "/guides/core/registry/:slug*",
+      "destination": "/models/registry/:slug*"
+    },
+        {
+      "source": "/guides/core/reports/:slug*",
+      "destination": "/models/automations/:slug*"
+    },
     {
       "source": "/guides",
       "destination": "/models"


### PR DESCRIPTION
The URL structure pre-moving stuff out of `/core` is two generations of URL structures old, thus we didn't handle them in the new redirect regime. But it's not a big deal to; this PR adds support.