### PR TITLE
test: Introduce MDX parsing error to test GitHub Action

### DIFF
--- a/models/registry/configure_registry.mdx
+++ b/models/registry/configure_registry.mdx
@@ -133,7 +133,7 @@ The registry's membership list shows each user's inherited (effective) registry 
 
 <Frame>
     <img src="/images/registry/role_conflict.png" alt="Registry membership list showing the user's effective registry role"  />
-</Frame>
+</Frame
 
 A user's effective role in a particular registry matches their _highest_ role among their role in the organization, the registry, and the team that owns the registry, whether inherited or explicitly assigned. For example:
 

--- a/models/registry/configure_registry.mdx
+++ b/models/registry/configure_registry.mdx
@@ -133,7 +133,8 @@ The registry's membership list shows each user's inherited (effective) registry 
 
 <Frame>
     <img src="/images/registry/role_conflict.png" alt="Registry membership list showing the user's effective registry role"  />
-</Frame
+</Frame>
+
 
 A user's effective role in a particular registry matches their _highest_ role among their role in the organization, the registry, and the team that owns the registry, whether inherited or explicitly assigned. For example:
 


### PR DESCRIPTION
This commit intentionally introduces a parsing error (missing closing > in </Frame tag) to verify that the MDX linting GitHub Action catches parsing errors in PRs.

## Description

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
