### PR TITLE
Runs: Remove mention of immutable run IDs

### DIFF
--- a/models/runs/forking.mdx
+++ b/models/runs/forking.mdx
@@ -37,16 +37,6 @@ forked_run = wandb.init(
 )
 ```
 
-### Using an immutable run ID
-
-Use an immutable run ID to ensure you have a consistent and unchanging reference to a specific run. Follow these steps to obtain the immutable run ID from the user interface:
-
-1. **Access the Overview Tab:** Navigate to the [**Overview** tab](./#overview-tab) on the source run's page.
-
-2. **Copy the Immutable Run ID:** Click on the `...` menu (three dots) located in the top-right corner of the **Overview** tab. Select the `Copy Immutable Run ID` option from the dropdown menu.
-
-By following these steps, you will have a stable and unchanging reference to the run, which can be used for forking a run.
-
 ## Continue from a forked run
 After initializing a forked run, you can continue logging to the new run. You can log the same metrics for continuity and introduce new metrics. 
 

--- a/models/runs/rewind.mdx
+++ b/models/runs/rewind.mdx
@@ -29,8 +29,6 @@ When you rewind a run, W&B resets the state of the run to the specified step, pr
 
 - **Run archiving**: W&B archives the original runs. Runs are accessible from the [Run Overview](./#overview-tab) tab.
 - **Artifact association**: Associates artifacts with the run that produce them.
-- **Immutable run IDs**: Introduced for consistent forking from a precise state.
-- **Copy immutable run ID**: A button to copy the immutable run ID for improved run management.
 
 <Note>
 **Rewind and forking compatibility**


### PR DESCRIPTION
## Description

<!-- Uncomment and add a description of the change -->


From Jira ticket:

"""
We shouldn’t be using the “immutable run ID” reference anymore in the application. 

Currently, this is referenced in forking a run documentation here: https://docs.wandb.ai/models/runs/forking#using-an-immutable-run-id 

We could just remove the entire section “Using an immutable run ID” section.
"""


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.
-->

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1855

