### PR TITLE
Fix a parsing error in a callout

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2490,7 +2490,7 @@
       "source": "/guides/core/reports/:slug*",
       "destination": "/models/automations/:slug*"
     },
-        {
+    {
       "source": "/guides/core/tables/:slug*",
       "destination": "/models/tables/:slug*"
     },

--- a/models/registry/configure_registry.mdx
+++ b/models/registry/configure_registry.mdx
@@ -144,9 +144,11 @@ A user's effective role in a particular registry matches their _highest_ role am
 ### SDK compatibility
 
 <Note>
+
 **SDK version requirement**
 
 To use the W&B SDK to access artifacts as a **Restricted Viewer**, you must use W&B SDK version 0.19.9 or higher. Otherwise, some SDK commands will result in permission errors.
+
 </Note>
 
 When a **Restricted Viewer** uses the SDK, certain functions are not available or work differently.


### PR DESCRIPTION
## Description

Fix a parsing error caused by the bold text right after the `<Note>` tag

## Tests
- [x] Local build
- [x] Local link check
- [ ] PR tests
