### PR TITLE
SCIM: Added Registry SCIM APIs (again)

### DIFF
--- a/platform/hosting/iam/scim.mdx
+++ b/platform/hosting/iam/scim.mdx
@@ -800,6 +800,216 @@ PATCH /scim/Users/abc
 </Tab>
 </Tabs>
 
+
+### Add to Registry
+
+Adds a user to a registry with an assigned registry-level role.
+
+#### Endpoint
+- **URL**: `<host-url>/scim/Users/{id}`
+- **Method**: PATCH
+
+#### Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | The unique ID of the user |
+| `op` | string | Yes | `add` |
+| `path` | string | Yes | `registryRoles` |
+| `value` | array | Yes | Array of objects with `registryName` and `roleName` |
+
+#### Example
+
+<Tabs>
+<Tab title="Add to Registry Request">
+```bash
+PATCH /scim/Users/abc
+```
+
+```json
+{
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+        {
+            "op": "replace",
+            "path": "registryRoles",
+            "value": [
+                {
+                    "roleName": "admin",
+                    "registryName": "hello-registry"
+                }
+            ]
+        }
+    ]
+}
+```
+</Tab>
+<Tab title="Add to Registry Response">
+
+```bash
+(Status 200)
+```
+
+```json
+{
+    "active": true,
+    "displayName": "Dev User 1",
+    "emails": {
+        "Value": "dev-user1@example.com",
+        "Display": "",
+        "Type": "",
+        "Primary": true
+    },
+    "id": "abc",
+    "meta": {
+        "resourceType": "User",
+        "created": "2023-10-01T00:00:00Z",
+        "lastModified": "2023-10-01T00:00:00Z",
+        "location": "Users/abc"
+    },
+    "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "dev-user1",
+    "registryRoles": [
+        {
+            "registryName": "hello-registry",
+            "roleName": "admin"
+        }
+    ],
+    "organizationRole": "admin"
+}
+```
+</Tab>
+</Tabs>
+
+
+### Remove from Registry
+
+Removes a user from a registry.
+
+<Note>
+The remove operations follow RFC 7644 SCIM protocol specifications. Use the filter syntax `"registryRoles[registryName eq \"{registry_name}\"]"` to remove a user from a specific registry, or `"registryRoles"` to remove the user from all registries.
+</Note>
+
+#### Endpoint
+- **URL**: `<host-url>/scim/Users/{id}`
+- **Method**: PATCH
+
+#### Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | Yes | The unique ID of the user |
+| `op` | string | Yes | `remove` |
+| `path` | string | Yes | `"registryRoles[registryName eq \"{registry_name}\"]"` or `"registryRoles"` |
+
+#### Example
+
+<Tabs>
+<Tab title="Remove from Registry Request">
+```bash
+PATCH /scim/Users/abc
+```
+
+```json
+{
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+        {
+            "op": "replace",
+            "path": "registryRoles[registryName eq \"goodbye-registry\"]"
+        }
+    ]
+}
+```
+</Tab>
+<Tab title="Remove from Registry Response">
+```bash
+(Status 200)
+```
+
+```json
+{
+    "active": true,
+    "displayName": "Dev User 1",
+    "emails": {
+        "Value": "dev-user1@example.com",
+        "Display": "",
+        "Type": "",
+        "Primary": true
+    },
+    "id": "abc",
+    "meta": {
+        "resourceType": "User",
+        "created": "2023-10-01T00:00:00Z",
+        "lastModified": "2023-10-01T00:00:00Z",
+        "location": "Users/abc"
+    },
+    "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "dev-user1",
+    "registryRoles": [
+        {
+            "registryName": "hello-registry",
+            "roleName": "admin"
+        }
+    ],
+    "organizationRole": "admin"
+}
+```
+</Tab>
+</Tabs>
+
+<Tabs>
+<Tab title="Remove from ALL Registries Request">
+```bash
+PATCH /scim/Users/abc
+```
+
+```json
+{
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+        {
+            "op": "replace",
+            "path": "registryRoles"
+        }
+    ]
+}
+```
+</Tab>
+<Tab title="Remove from ALL Registries Response">
+```bash
+(Status 200)
+```
+
+```json
+{
+    "active": true,
+    "displayName": "Dev User 1",
+    "emails": {
+        "Value": "dev-user1@example.com",
+        "Display": "",
+        "Type": "",
+        "Primary": true
+    },
+    "id": "abc",
+    "meta": {
+        "resourceType": "User",
+        "created": "2023-10-01T00:00:00Z",
+        "lastModified": "2023-10-01T00:00:00Z",
+        "location": "Users/abc"
+    },
+    "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:User"
+    ],
+    "userName": "dev-user1",
+    "organizationRole": "admin"
+}
+```
+</Tab>
+</Tabs>
+
 ## Group resource
 
 When you create a SCIM group in your IAM, it creates and maps to a W&B Team, and other SCIM group operations operate on the team.


### PR DESCRIPTION
## Description
Content was lost during the Mintlify migration. This PR adds said content again. See original PR: https://github.com/wandb/docs/pull/1697

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from 
opening to closing comment.
-->


## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1874

