### PR TITLE
[DOCS-1208] Update docs about managing run groups in the UI

### DIFF
--- a/models/runs/grouping.mdx
+++ b/models/runs/grouping.mdx
@@ -21,20 +21,7 @@ Pass an optional group and `job_type` to `wandb.init()`. This gives you a dedica
 
 Use `WANDB_RUN_GROUP` to specify a group for your runs as an environment variable. For more on this, check our docs for [Environment Variables](/models/track/environment-variables/). **Group** should be unique within your project and shared by all runs in the group. You can use `wandb.util.generate_id()` to generate a unique 8 character string to use in all your processes— for example, `os.environ["WANDB_RUN_GROUP"] = "experiment-" + wandb.util.generate_id()`
 
-### 3. Set a group in the UI
-
-
-After a run is initialized, you can move it to a new group from your workspace or its **Runs** page.
-
-1. Navigate to your W&B project.
-1. Select the **Workspace** or **Runs** tab from the project sidebar.
-1. Search or scroll to the run you want to rename.
-
-    Hover over the run name, click the three vertical dots, then click **Move to another group**.
-1. To create a new group, click **New group**. Type a group name, then submit the form.
-1. Select the run's new group from the list, then click **Move**.
-
-### 4. Toggle grouping by columns in the UI
+### 3. Toggle grouping by columns in the UI
 
 You can dynamically group by any column, including a column that is hidden. For example, if you use `wandb.Run.config` to log batch size or learning rate, you can then group by those hyperparameters dynamically in the web app. The **Group by** feature is distinct from a [run's run group](/models/runs/grouping/). You can group runs by run group. To move a run to a different run group, refer to [Set a group in the UI](#set-a-group-in-the-ui).
 
@@ -48,6 +35,34 @@ To group runs by one or more columns:
 1. Click the names of one or more columns.
 1. If you selected more than one column, drag them to change the grouping order.
 1. Click anywhere outside of the form to dismiss it.
+
+### 4. Manage groups in the UI
+
+#### Manage a run
+After a run is initialized, you can move it to a new group from your workspace or its **Runs** page.
+
+1. Navigate to your W&B project.
+1. Select the **Workspace** or **Runs** tab from the project sidebar.
+1. To move a single run, search or scroll to it. Hover over the run name, click the three vertical dots, then click **Move to another group**.
+1. To create a new group, click **New group**. Type a group name, then submit the form.
+1. To delete a run, click the three vertical dots, then click **Delete run**.
+1. To move a run, select the new group from the list, then click **Move**.
+
+#### Manage runs in bulk
+1. If necessary, [toggle grouping by columns](#toggle-grouping-by-column-in-the-ui), grouping by the **Group** column.
+1. Expand a group to view its runs. In a single bulk operation, you can move runs from different groups to the same target group. Expand all relevant groups.
+1. To select all runs in a group, click the checkbox next to the group name.
+1. To select individual runs, click their checkboxes.
+1. To select all runs in all groups, click the checkbox next to the **Name** column heading.
+1. Above the table, choose a bulk operation: **Tag**, **Move to group**, **Move to project**, or **New sweep**.
+
+#### Create a group
+1. Navigate to your W&B project.
+1. Select the **Workspace** or **Runs** tab from the project sidebar.
+1. Click **New group**. Type a group name, then submit the form.
+
+#### Delete a group
+When you move or remove all runs from a group, the group is deleted.
 
 ### Customize how runs are displayed
 You can customize how runs are displayed in your project from the **Workspace** or **Runs** tabs. Both tabs use the same display configuration.

--- a/models/runs/grouping.mdx
+++ b/models/runs/grouping.mdx
@@ -49,6 +49,8 @@ After a run is initialized, you can move it to a new group from your workspace o
 1. To move a run, select the new group from the list, then click **Move**.
 
 #### Manage runs in bulk
+This section shows how to manage multiple runs at once, across one or more run groups.
+
 1. If necessary, [toggle grouping by columns](#toggle-grouping-by-column-in-the-ui), grouping by the **Group** column.
 1. Expand a group to view its runs. In a single bulk operation, you can move runs from different groups to the same target group. Expand all relevant groups.
 1. To select all runs in a group, click the checkbox next to the group name.
@@ -57,12 +59,13 @@ After a run is initialized, you can move it to a new group from your workspace o
 1. Above the table, choose a bulk operation: **Tag**, **Move to group**, **Move to project**, or **New sweep**.
 
 #### Create a group
+To create a new run group:
 1. Navigate to your W&B project.
 1. Select the **Workspace** or **Runs** tab from the project sidebar.
 1. Click **New group**. Type a group name, then submit the form.
 
 #### Delete a group
-When you move or remove all runs from a group, the group is deleted.
+To delete a group, remove all runs from it. This automatically deletes the group.
 
 ### Customize how runs are displayed
 You can customize how runs are displayed in your project from the **Workspace** or **Runs** tabs. Both tabs use the same display configuration.


### PR DESCRIPTION
[DOCS-1208] Update docs about managing run groups in the UI

- Bulk operations
- Delete a run group by emptying it
- Some light restructuring

Ready for review

## Testing
- [x] Validated in https://wandb.ai/wandb/run-groups-test/
- [x] `mint dev`
- [x] `mint broken-links`
- [x] PR checks  


[DOCS-1208]: https://wandb.atlassian.net/browse/DOCS-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ