### PR TITLE
Sweeps: Update warning nesting admonition 

### DIFF
--- a/models/sweeps/define-sweep-configuration.mdx
+++ b/models/sweeps/define-sweep-configuration.mdx
@@ -228,9 +228,8 @@ parameters:
 {/* For example, the proceeding code snippets show a sweep config both in a YAML config file and a Python script. */}
 
 
-
-When a sweep sets a nested parameter, W&B applies that subtree to the run config rather than deep-merging it with your defaults. As
-a result, keys present under the same parent in `wandb.init(config=...)` may not be preserved.
+<Warning>
+Nested parameters defined in sweep configuration overwrite keys specified in a W&B run configuration.
 
 As an example, suppose you have `train.py` script that initializes a run with a nested default:
 
@@ -239,7 +238,7 @@ def main():
     run = wandb.init(config={"nested_param": {"manual_key": 1}})
 ```
 
-Your sweep configuration (Python dict form) defines nested parameters under a top-level `"parameters"` key:
+Your sweep configuration defines nested parameters under a top-level `"parameters"` key:
 
 ```python
 sweep_configuration = {
@@ -260,13 +259,12 @@ sweep_configuration = {
 
 sweep_id = wandb.sweep(sweep=sweep_configuration, project="<project>")
 wandb.agent(sweep_id, function=main, count=4)
-
 ```
 
 During a sweep run, `run.config["nested_param"]` reflects the subtree defined by the
 sweep (`learning_rate`, `double_nested_param`) config and does not include `manual_key` defined
 in `wandb.init(config=...)`.
-
+</Warning>
 
 ## Sweep configuration template
 

--- a/models/sweeps/define-sweep-configuration.mdx
+++ b/models/sweeps/define-sweep-configuration.mdx
@@ -74,51 +74,198 @@ Within the top level `parameters` key, the following keys are nested: `learning_
 
 ## Double nested parameters
 
-Sweep configurations support nested parameters. To delineate a nested parameter, use an additional `parameters` key under the top level parameter name. Sweep configs support multi-level nesting.
+Sweep configurations support nested parameters. To define a nested parameter, include an additional `parameters` key under the top-level parameter name.
 
-Specify a probability distribution for your random variables if you use a Bayesian or random hyperparameter search. For each hyperparameter:
+The following example shows a sweep configuration with three nested parameters: `nested_category_1`, `nested_category_2`, and `nested_category_3`. Each nested parameter includes two additional parameters: `momentum` and `weight_decay`.
+
+<Note>  
+`nested_category_1`, `nested_category_2`, and `nested_category_3` are placeholders. Replace them with names that fit your use case.  
+</Note>
+
+The following code snippets show how to define nested parameters in both a YAML file and a Python dictionary. 
+
+<Tabs>
+<Tab title="CLI">
+
+```yaml
+program: sweep_nest.py
+name: nested_sweep
+method: random
+metric:
+  name: loss
+  goal: minimize
+parameters:
+  optimizer:
+    values: ['adam', 'sgd']
+  fc_layer_size:
+    values: [128, 256, 512]
+  dropout:
+    values: [0.3, 0.4, 0.5]
+  epochs:
+    value: 1
+  learning_rate:
+    distribution: uniform
+    min: 0
+    max: 0.1
+  batch_size:
+    distribution: q_log_uniform_values
+    q: 8
+    min: 32
+    max: 256
+  nested_category_1:
+    parameters:
+      momentum:
+        distribution: uniform
+        min: 0.0
+        max: 0.9
+      weight_decay:
+        values: [0.0001, 0.0005, 0.001]
+  nested_category_2:
+    parameters:
+      momentum:
+        distribution: uniform
+        min: 0.0
+        max: 0.9
+      weight_decay:
+        values: [0.1, 0.2, 0.3]
+  nested_category_3:
+    parameters:
+      momentum:
+        distribution: uniform
+        min: 0.5
+        max: 0.7
+      weight_decay:
+        values: [0.2, 0.3, 0.4]
+```
+
+</Tab>
+<Tab title="Python script or notebook">
+
+```python
+{
+  "program": "sweep_nest.py",
+  "name": "nested_sweep",
+  "method": "random",
+  "metric": {
+    "name": "loss",
+    "goal": "minimize"
+  },
+  "parameters": {
+    "optimizer": {
+      "values": ["adam", "sgd"]
+    },
+    "fc_layer_size": {
+      "values": [128, 256, 512]
+    },
+    "dropout": {
+      "values": [0.3, 0.4, 0.5]
+    },
+    "epochs": {
+      "value": 1
+    },
+    "learning_rate": {
+      "distribution": "uniform",
+      "min": 0,
+      "max": 0.1
+    },
+    "batch_size": {
+      "distribution": "q_log_uniform_values",
+      "q": 8,
+      "min": 32,
+      "max": 256
+    },
+    "nested_category_1": {
+      "parameters": {
+        "momentum": {
+          "distribution": "uniform",
+          "min": 0.0,
+          "max": 0.9
+        },
+        "weight_decay": {
+          "values": [0.0001, 0.0005, 0.001]
+        }
+      }
+    },
+    "nested_category_2": {
+      "parameters": {
+        "momentum": {
+          "distribution": "uniform",
+          "min": 0.0,
+          "max": 0.9
+        },
+        "weight_decay": {
+          "values": [0.1, 0.2, 0.3]
+        }
+      }
+    },
+    "nested_category_3": {
+      "parameters": {
+        "momentum": {
+          "distribution": "uniform",
+          "min": 0.5,
+          "max": 0.7
+        },
+        "weight_decay": {
+          "values": [0.2, 0.3, 0.4]
+        }
+      }
+    }
+  }
+}
+```
+</Tab>
+</Tabs>
+
+{/* Specify a probability distribution for your random variables if you use a Bayesian or random hyperparameter search. For each hyperparameter:
 
 1. Create a top level `parameters` key in your sweep config.
 2. Within the `parameters`key, nest the following:
    1. Specify the name of hyperparameter you want to optimize. 
    2. Specify the distribution you want to use for the `distribution` key. Nest the `distribution` key-value pair underneath the hyperparameter name.
    3. Specify one or more values to explore. The value (or values) should be inline with the distribution key.  
-      1. (Optional) Use an additional parameters key under the top level parameter name to delineate a nested parameter.
+      1. (Optional) Use an additional parameters key under the top level parameter name to delineate a nested parameter. */}
 
 {/* For example, the proceeding code snippets show a sweep config both in a YAML config file and a Python script. */}
 
 
-{/* To do: what is a double-nested parameter */}
 
+When a sweep sets a nested parameter, W&B applies that subtree to the run config rather than deep-merging it with your defaults. As
+a result, keys present under the same parent in `wandb.init(config=...)` may not be preserved.
 
+As an example, suppose you have `train.py` script that initializes a run with a nested default:
 
-<Warning>
-Nested parameters defined in sweep configuration overwrite keys specified in a W&B run configuration.
-
-For example, suppose you initialize a W&B run with the following configuration in a `train.py` Python script (see Lines 1-2). Next, you define a sweep configuration in a dictionary called `sweep_configuration` (see Lines 4-13). You then pass the sweep config dictionary to `wandb.sweep` to initialize a sweep config (see Line 16).
-
-
-```python title="train.py" 
+```python
 def main():
     run = wandb.init(config={"nested_param": {"manual_key": 1}})
+```
 
+Your sweep configuration (Python dict form) defines nested parameters under a top-level `"parameters"` key:
 
+```python
 sweep_configuration = {
-    "top_level_param": 0,
-    "nested_param": {
-        "learning_rate": 0.01,
-        "double_nested_param": {"x": 0.9, "y": 0.8},
+    "method": "grid",
+    "metric": {"name": "score", "goal": "minimize"},
+    "parameters": {
+        "top_level_param": {"value": 0},
+        "nested_param": {
+            "parameters": {
+                "learning_rate": {"value": 0.01},
+                "double_nested_param": {
+                    "parameters": {"x": {"value": 0.9}, "y": {"value": 0.8}}
+                },
+            }
+        },
     },
 }
 
-# Initialize sweep by passing in config.
 sweep_id = wandb.sweep(sweep=sweep_configuration, project="<project>")
-
-# Start sweep job.
 wandb.agent(sweep_id, function=main, count=4)
+
 ```
-The `nested_param.manual_key` that is passed when the W&B run is initialized is not accessible. The `wandb.Run.config` only possess the key-value pairs that are defined in the sweep configuration dictionary.
-</Warning>
+
+During a sweep run, `run.config["nested_param"]` reflects the subtree defined by the
+sweep (`learning_rate`, `double_nested_param`) config and does not include `manual_key` defined
+in `wandb.init(config=...)`.
 
 
 ## Sweep configuration template


### PR DESCRIPTION
## Description

Nested sweep config block code example is incorrect. This PR fixes it.

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors or broken internal links (`hugo server`)
- [ ] PR tests succeed
- [ ] The Lychee Github action run against the PR branch reports no broken links

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.
-->


## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1696
- Fixes https://github.com/wandb/docs/issues/1491

