### PR TITLE
Remove blank pages, rename other

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2506,6 +2506,10 @@
     {
       "source": "/models/core",
       "destination": "/models"
+    },
+    {
+      "source": "/inference/response-settings",
+      "destination": "/inference"
     }
   ],
   "baseUrl": "https://docs.wandb.ai"

--- a/docs.json
+++ b/docs.json
@@ -2510,6 +2510,10 @@
     {
       "source": "/inference/response-settings",
       "destination": "/inference"
+    },
+    {
+      "source": "/platform/hosting/self-managed/install-on-public-cloud",
+      "destination": "/platform/hosting/self-managed"
     }
   ],
   "baseUrl": "https://docs.wandb.ai"

--- a/inference/response-settings.mdx
+++ b/inference/response-settings.mdx
@@ -1,6 +1,0 @@
----
-title: Capabilities
-description: Capabilities of W&B Inference with examples of use
----
-
-The pages below demonstrate various features and capabilities of W&B Inference's hosted models.

--- a/inference/response-settings/tool-calling.mdx
+++ b/inference/response-settings/tool-calling.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Use tool calling"
+title: Call tools
 description: How to use Tool Calling with W&B Inference
 ---
 

--- a/inference/response-settings/tool-calling.mdx
+++ b/inference/response-settings/tool-calling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call tools
-description: How to use Tool Calling with W&B Inference
+description: How to call tools with W&B Inference
 ---
 
 Tool calling allows you to extend a model's capabilities to include invoking tools as part of its response. W&B Inference only supports calling functions at this time. 

--- a/platform/hosting/self-managed/install-on-public-cloud.mdx
+++ b/platform/hosting/self-managed/install-on-public-cloud.mdx
@@ -1,4 +1,0 @@
----
-title: Install on public cloud
----
-


### PR DESCRIPTION
## Summary
This PR removes some blank pages that used to be necessary in the Hugo days and are now vestigial. Also, `s/use tool calling/call tools`

## Related Issue
Resolves DOCS-1845
Resolves DOCS-1835
Resolves DOCS-1846