### PR TITLE
Registry:  Action history v2

### DIFF
--- a/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
+++ b/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
@@ -1,35 +1,80 @@
 ---
-description: Traverse automatically created direct acyclic W&B Artifact graphs.
-title: Explore artifact graphs
+description: Traverse direct acyclic W&B Artifact graphs.
+title: Explore artifact lineage graphs
 ---
 
-W&B automatically tracks the artifacts a given run logged as well as the artifacts a given run uses. These artifacts can include datasets, models, evaluation results, or more. You can explore an artifact's lineage to track and manage the various artifacts produced throughout the machine learning lifecycle.
+W&B tracks the inputs and outputs of runs using directed acyclic graphs (DAGs) called _lineage graphs_. Lineage graphs are visual representations of the relationships between artifacts and runs in an ML experiment. They show how data and models
+flow through different stages of the ML lifecycle, from raw data ingestion to model training and evaluation.
 
-## Lineage
-Tracking an artifact's lineage has several key benefits:
+Tracking artifact lineage provides several key advantages:
 
-- Reproducibility: By tracking the lineage of all artifacts, teams can reproduce experiments, models, and results, which is essential for debugging, experimentation, and validating machine learning models.
+* **Reproducibility:** Enables teams to reproduce experiments, models, and results for debugging, experimentation, and validation.
+* **Version control:** Tracks changes to artifacts over time, allowing teams to revert to previous data or model versions when needed.
+* **Auditing:** Maintains a detailed record of artifacts and transformations to support compliance and governance.
+* **Collaboration:** Improves teamwork by making experiment history transparent, reducing duplicated effort, and accelerating development.
 
-- Version Control: Artifact lineage involves versioning artifacts and tracking their changes over time. This allows teams to roll back to previous versions of data or models if needed.
 
-- Auditing: Having a detailed history of the artifacts and their transformations enables organizations to comply with regulatory and governance requirements.
+##  View an artifact's lineage graph
 
-- Collaboration and Knowledge Sharing: Artifact lineage facilitates better collaboration among team members by providing a clear record of attempts as well as what worked, and what didn’t. This helps in avoiding duplication of efforts and accelerates the development process.
+To view an artifact's lineage graph:
 
-### Finding an artifact's lineage
-When selecting an artifact in the **Artifacts** tab, you can see your artifact's lineage. This graph view shows a general overview of your pipeline. 
-
-To view an artifact graph:
-
-1. Navigate to your project in the W&B App UI
-2. Choose the artifact icon on the left panel.
-3. Select **Lineage**.
+1. Navigate to the W&B App.
+2. Select the project that contains the run or artifact you want to explore.
+3. Click on the **Artifacts** tab on the left sidebar.
+4. Select the **Lineage** tab.
 
 <Frame>
     <img src="/images/artifacts/lineage1.gif" alt="Getting to the Lineage tab"  />
 </Frame>
 
-### Navigating the lineage graph
+
+## Enable lineage graph tracking 
+
+To enable lineage graph tracking, you need to mark artifacts as [inputs](/models/artifacts/explore-and-traverse-an-artifact-graph) or
+[outputs](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-output-of-a-run) of a run using the W&B Python SDK.
+
+###  Track the input of a run
+
+Mark an artifact as the input (or dependency) of a run with the [`wandb.Run.use_artifact()`](/ref/python/experiments/run/#method-runuse_artifact)
+method. Specify the name of the artifact and an optional alias to reference a specific version of that artifact. The name of the
+artifact is in the format `<artifact_name>:<version>` or `<artifact_name>:<alias>`.
+
+Replace values enclosed in angle brackets (`< >`) with your values:
+
+```python
+import wandb
+
+# Initialize a run
+with wandb.init(entity="<entity>", project="<project>") as run:
+  # Get artifact, mark it as a dependency
+  artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
+```
+
+
+###  Track the output of a run
+
+Use [`wandb.Run.log_artifact()`](/ref/python/experiments/run#log_artifact) to declare an artifact as an output of a run. First,
+create an artifact with the [`wandb.Artifact()`](/ref/python/experiments/artifact/#wandb.Artifact) constructor. Then, log the
+artifact as an output of the run with `wandb.Run.log_artifact()`.
+
+Replace values enclosed in angle brackets (`< >`) with your values:
+
+```python
+import wandb
+
+# Initialize a run
+with wandb.init(entity="<entity>", project="<project>") as run:
+  
+  # Create an artifact
+  artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
+  artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
+
+  # Log the artifact as an output of the run
+  run.log_artifact(artifact_or_path = artifact)
+```
+
+
+## Navigate lineage graphs
 
 The artifact or job type you provide appears in front of its name, with artifacts represented by blue icons and runs represented by green icons. Arrows detail the input and output of a run or artifact on the graph. 
 
@@ -51,7 +96,7 @@ For a more detailed view, click any individual artifact or run to get more infor
     <img src="/images/artifacts/lineage3a.gif" alt="Previewing a run"  />
 </Frame>
 
-### Artifact clusters
+##  Artifact clusters
 
 When a level of the graph has five or more runs or artifacts, it creates a cluster. A cluster has a search bar to find specific versions of runs or artifacts and pulls an individual node from a cluster to continue investigating the lineage of a node inside a cluster. 
 
@@ -61,24 +106,16 @@ Clicking on a node opens a preview with an overview of the node. Clicking on the
     <img src="/images/artifacts/lineage3b.gif" alt="Searching a run cluster"  />
 </Frame>
 
-## Use the API to track lineage
-You can also navigate a graph using the [W&B API](/models/ref/python/public-api/api). 
+## Programmatically navigate an artifact graph
+You can programmatically navigate a graph using the W&B Python SDK.
 
-Create an artifact. First, create a run with `wandb.init`. Then,create a new artifact or retrieve an existing one with `wandb.Artifact`. Next, add files to the artifact with `.add_file`. Finally, log the artifact to the run with `.log_artifact`. The finished code looks something like this:
-
-```python
-with wandb.init() as run:
-    artifact = wandb.Artifact("artifact_name", "artifact_type")
-
-    # Add Files and Assets to the artifact using
-    # `.add`, `.add_file`, `.add_dir`, and `.add_reference`
-    artifact.add_file("image1.png")
-    run.log_artifact(artifact)
-```
 
 Use the artifact object's [`logged_by`](/models/ref/python/experiments/artifact#logged_by) and [`used_by`](/models/ref/python/experiments/artifact#used_by) methods to walk the graph from the artifact:
 
 ```python
+with wandb.init() as run:
+    artifact = run.use_artifact("artifact_name:latest")
+
 # Walk up and down the graph from an artifact:
 producer_run = artifact.logged_by()
 consumer_runs = artifact.used_by()

--- a/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
+++ b/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
@@ -8,13 +8,13 @@ flow through different stages of the ML lifecycle, from raw data ingestion to mo
 
 Tracking artifact lineage provides several key advantages:
 
-* **Reproducibility:** Enables teams to reproduce experiments, models, and results for debugging, experimentation, and validation.
-* **Version control:** Tracks changes to artifacts over time, allowing teams to revert to previous data or model versions when needed.
-* **Auditing:** Maintains a detailed record of artifacts and transformations to support compliance and governance.
-* **Collaboration:** Improves teamwork by making experiment history transparent, reducing duplicated effort, and accelerating development.
+* **Reproducibility**: Enables teams to reproduce experiments, models, and results for debugging, experimentation, and validation.
+* **Version control**: Tracks changes to artifacts over time, allowing teams to revert to previous data or model versions when needed.
+* **Auditing**: Maintains a detailed record of artifacts and transformations to support compliance and governance.
+* **Collaboration**: Helps to improve teamwork by making experiment history transparent, reducing duplicated effort, and accelerating development.
 
 
-##  View an artifact's lineage graph
+## View an artifact's lineage graph
 
 To view an artifact's lineage graph:
 
@@ -33,7 +33,7 @@ To view an artifact's lineage graph:
 To enable lineage graph tracking, you need to mark artifacts as [inputs](/models/artifacts/explore-and-traverse-an-artifact-graph) or
 [outputs](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-output-of-a-run) of a run using the W&B Python SDK.
 
-###  Track the input of a run
+### Track the input of a run
 
 Mark an artifact as the input (or dependency) of a run with the [`wandb.Run.use_artifact()`](/ref/python/experiments/run/#method-runuse_artifact)
 method. Specify the name of the artifact and an optional alias to reference a specific version of that artifact. The name of the
@@ -51,7 +51,7 @@ with wandb.init(entity="<entity>", project="<project>") as run:
 ```
 
 
-###  Track the output of a run
+### Track the output of a run
 
 Use [`wandb.Run.log_artifact()`](/ref/python/experiments/run#log_artifact) to declare an artifact as an output of a run. First,
 create an artifact with the [`wandb.Artifact()`](/ref/python/experiments/artifact/#wandb.Artifact) constructor. Then, log the
@@ -96,7 +96,7 @@ For a more detailed view, click any individual artifact or run to get more infor
     <img src="/images/artifacts/lineage3a.gif" alt="Previewing a run"  />
 </Frame>
 
-##  Artifact clusters
+## Artifact clusters
 
 When a level of the graph has five or more runs or artifacts, it creates a cluster. A cluster has a search bar to find specific versions of runs or artifacts and pulls an individual node from a cluster to continue investigating the lineage of a node inside a cluster. 
 
@@ -106,7 +106,7 @@ Clicking on a node opens a preview with an overview of the node. Clicking on the
     <img src="/images/artifacts/lineage3b.gif" alt="Searching a run cluster"  />
 </Frame>
 
-## Programmatically navigate an artifact graph
+## Navigate an artifact graph programmatically
 Programmatically navigate a graph using the W&B Python SDK. Use an artifact object's
 [`logged_by()`](/models/ref/python/experiments/artifact#method-artifact-logged-by) and [`used_by()`](/models/ref/python/experiments/artifact#method-artifact-used-by) methods to walk the graph:
 

--- a/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
+++ b/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
@@ -107,20 +107,14 @@ Clicking on a node opens a preview with an overview of the node. Clicking on the
 </Frame>
 
 ## Programmatically navigate an artifact graph
-You can programmatically navigate a graph using the W&B Python SDK.
-
-
-Use the artifact object's [`logged_by`](/models/ref/python/experiments/artifact#logged_by) and [`used_by`](/models/ref/python/experiments/artifact#used_by) methods to walk the graph from the artifact:
+Programmatically navigate a graph using the W&B Python SDK. Use an artifact object's
+[`logged_by()`](/models/ref/python/experiments/artifact#method-artifact-logged-by) and [`used_by()`](/models/ref/python/experiments/artifact#method-artifact-used-by) methods to walk the graph:
 
 ```python
 with wandb.init() as run:
     artifact = run.use_artifact("artifact_name:latest")
 
-# Walk up and down the graph from an artifact:
-producer_run = artifact.logged_by()
-consumer_runs = artifact.used_by()
+    # Walk up and down the graph from an artifact:
+    producer_run = artifact.logged_by()
+    consumer_runs = artifact.used_by()
 ```
-## Next steps
-- [Explore artifacts in more detail](/models/artifacts/artifacts-walkthrough/)
-- [Manage artifact storage](/models/artifacts/delete-artifacts/)
-- [Explore an artifacts project](https://wandb.ai/wandb-smle/artifact_workflow/artifacts/raw_dataset/raw_data/v0/lineage)

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -1,11 +1,11 @@
 ---
-description: Use lineage maps to visualize linked artifacts' history and audit a collection's history to track changes made to artifacts in that collection.
-title: Lineage maps and audit history
+description: Use lineage graphs to visualize linked artifacts' history and audit a collection's history to track changes made to artifacts in that collection.
+title: Lineage graphs and audit history
 ---
 
-Use a lineage map to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
+Use a lineage graph to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
 
-## Lineage maps
+## Lineage graphs
 
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
@@ -31,6 +31,31 @@ From left to right, the image shows:
 2. The "rural-feather-20" run uses the `split_zoo_dataset:v4` artifact for training.
 3. The output of the "rural-feather-20" run is a model artifact called `zoo-ylbchv20:v0`.
 4. A run called "northern-lake-21" uses the model artifact `zoo-ylbchv20:v0` to evaluate the model.
+
+
+To view a lineage graph for an artifact in a collection:
+
+1. Navigate to the W&B Registry.
+2. Select the collection that contains the artifact.
+3. From the dropdown, select the artifact version you want to view its lineage graph.
+4. Select the **Lineage** tab.
+5. Select a node to view detailed information about the run or artifact.
+
+
+The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:
+
+<Frame>
+    <img src="/images/registry/lineage_expanded_node.png" alt="Expanded lineage node"  />
+</Frame>
+
+
+The following image shows the expanded detailed view of an artifact (`zoo-ylbchv20:v0`) when you select an artifact node in the lineage graph:
+
+<Frame>
+    <img src="/images/registry/lineage_expanded_artifact_node.png" alt="Expanded artifact node details"  />
+</Frame>
+
+Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
 
 
 ### Track the input of a run
@@ -74,33 +99,6 @@ with wandb.init(entity="<entity>", project="<project>") as run:
 ```
 
 For more information on about creating artifacts, see [Create an artifact](/models/artifacts/construct-an-artifact/).
-
-
-### View lineage graphs in a collection
-
-View the lineage of an artifact linked to a collection in the W&B Registry.
-
-1. Navigate to the W&B Registry.
-2. Select the collection that contains the artifact.
-3. From the dropdown, select the artifact version you want to view its lineage graph.
-4. Select the **Lineage** tab.
-5. Select a node to view detailed information about the run or artifact.
-
-
-The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:
-
-<Frame>
-    <img src="/images/registry/lineage_expanded_node.png" alt="Expanded lineage node"  />
-</Frame>
-
-
-The following image shows the expanded detailed view of an artifact (`zoo-ylbchv20:v0`) when you select an artifact node in the lineage graph:
-
-<Frame>
-    <img src="/images/registry/lineage_expanded_artifact_node.png" alt="Expanded artifact node details"  />
-</Frame>
-
-Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
  
 
 ## Audit a collection's history

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -10,8 +10,8 @@ Use a lineage graph to visualize a linked artifact's history. Audit a collection
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
 A lineage graph shows:
-* If a run used an [artifact as an input](/models/registry/lineage#track-the-input-of-a-run).
-* If a run created an [artifact as an output](/models/registry/lineage#track-the-output-of-a-run).
+* If a run used an [artifact as an input](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-input-of-a-run).
+* If a run created an [artifact as an output](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-output-of-a-run).
 
 In other words, a lineage graph shows the input and output of a run.
 
@@ -37,6 +37,10 @@ To view a lineage graph for an artifact in a collection:
 5. Select a node to view detailed information about the run or artifact.
 
 
+<Info>
+See [Enable lineage graph tracking](/models/artifacts/explore-and-traverse-an-artifact-graph#enable-lineage-graph-tracking) in [Explore artifact lineage graphs](/models/artifacts/explore-and-traverse-an-artifact-graph) to learn how to track the input and output of a run using the W&B Python SDK.
+</Info>
+
 The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:
 
 <Frame>
@@ -54,49 +58,6 @@ The following image shows the expanded detailed view of an artifact (`zoo-ylbchv
 <Info>
 You can also view lineage graphs for artifacts you log to W&B that are not part of a collection. See E[xplore artifact graphs](/models/artifacts/explore-and-traverse-an-artifact-graph) for more information.
 </Info>
-
-
-### Track the input of a run
-
-Mark an artifact as the input (or dependency) of a run with the [`wandb.Run.use_artifact()`](/ref/python/experiments/run/#method-runuse_artifact)
-method. Specify the name of the artifact and an optional alias to reference a specific version of that artifact. The name of the
-artifact is in the format `<artifact_name>:<version>` or `<artifact_name>:<alias>`.
-
-Replace values enclosed in angle brackets (`< >`) with your values:
-
-```python
-import wandb
-
-# Initialize a run
-with wandb.init(entity="<entity>", project="<project>") as run:
-  # Get artifact, mark it as a dependency
-  artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
-```
-
-
-### Track the output of a run
-
-Use [`wandb.Run.log_artifact()`](/ref/python/experiments/run#log_artifact) to declare an artifact as an output of a run. First,
-create an artifact with the [`wandb.Artifact()`](/ref/python/experiments/artifact/#wandb.Artifact) constructor. Then, log the
-artifact as an output of the run with `wandb.Run.log_artifact()`.
-
-Replace values enclosed in angle brackets (`< >`) with your values:
-
-```python
-import wandb
-
-# Initialize a run
-with wandb.init(entity="<entity>", project="<project>") as run:
-  
-  # Create an artifact
-  artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
-  artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
-
-  # Log the artifact as an output of the run
-  run.log_artifact(artifact_or_path = artifact)
-```
-
-For more information on about creating artifacts, see [Create an artifact](/models/artifacts/construct-an-artifact/).
  
 
 ## Audit a collection's history

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -14,8 +14,8 @@ You can also view lineage graphs for artifacts you log to W&B that are not part 
 </Info>
 
 A lineage graph shows:
-* If a run used an artifact as an input.
-* If a run created an artifact as an output.
+* If a run used an [artifact as an input](/models/registry/lineage#track-the-input-of-a-run).
+* If a run created an [artifact as an output](/models/registry/lineage#track-the-output-of-a-run).
 
 In other words, a lineage graph shows the input and output of a run.
 

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -1,7 +1,11 @@
 ---
-description: Create a lineage map in the W&B Registry.
-title: Create and view lineage maps
+description: Use lineage maps to visualize linked artifacts' history and audit a collection's history to track changes made to artifacts in that collection.
+title: Lineage maps and audit history
 ---
+
+Use a lineage map to visualize a linked artifact's history. Audit a collection's history to track changes made to artifacts in that collection.
+
+## Lineage maps
 
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
@@ -9,10 +13,14 @@ Within a collection in the W&B Registry, you can view a history of the artifacts
 You can also view lineage graphs for artifacts you log to W&B that are not part of a collection.
 </Info>
 
-Lineage graphs can show the specific run that logs an artifact. In addition, lineage graphs can also show which run used an artifact as an input. In other words, lineage graphs can show the input and output of a run. 
+A lineage graph shows:
+* If a run used an artifact as an input.
+* If a run created an artifact as an output.
+
+In other words, a lineage graph shows the input and output of a run.
 
 
-For example, the proceeding image shows artifacts created and used throughout an ML experiment:
+For example, the following image shows a typical lineage graph for artifacts created and used throughout an ML experiment:
 
 <Frame>
     <img src="/images/registry/registry_lineage.png" alt="Registry lineage"  />
@@ -25,64 +33,95 @@ From left to right, the image shows:
 4. A run called "northern-lake-21" uses the model artifact `zoo-ylbchv20:v0` to evaluate the model.
 
 
-## Track the input of a run
+### Track the input of a run
 
-Mark an artifact as an input or dependency of a run with the `wandb.init.use_artifact` API.
+Mark an artifact as the input (or dependency) of a run with the [`wandb.Run.use_artifact()`](/ref/python/experiments/run/#method-runuse_artifact)
+method. Specify the name of the artifact and an optional alias to reference a specific version of that artifact. The name of the
+artifact is in the format `<artifact_name>:<version>` or `<artifact_name>:<alias>`.
 
-The proceeding code snippet shows how to use the `use_artifact`. Replace values enclosed in angle brackets (`< >`) with your values:
+Replace values enclosed in angle brackets (`< >`) with your values:
 
 ```python
 import wandb
 
 # Initialize a run
-run = wandb.init(project="<project>", entity="<entity>")
-
-# Get artifact, mark it as a dependency
-artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
+with wandb.init(entity="<entity>", project="<project>") as run:
+  # Get artifact, mark it as a dependency
+  artifact = run.use_artifact(artifact_or_name="<name>", aliases="<alias>")
 ```
 
 
-## Track the output of a run
+### Track the output of a run
 
-Use ([`wandb.init.log_artifact`](/models/ref/python/experiments/run#log_artifact)) to declare an artifact as an output of a run.
+Use [`wandb.Run.log_artifact()`](/ref/python/experiments/run#log_artifact) to declare an artifact as an output of a run. First,
+create an artifact with the [`wandb.Artifact()`](/ref/python/experiments/artifact/#wandb.Artifact) constructor. Then, log the
+artifact as an output of the run with `wandb.Run.log_artifact()`.
 
-The proceeding code snippet shows how to use the `wandb.init.log_artifact` API. Ensure to replace values enclosed in angle brackets (`< >`) with your values:
+Replace values enclosed in angle brackets (`< >`) with your values:
 
 ```python
 import wandb
 
 # Initialize a run
-run = wandb.init(entity  "<entity>", project = "<project>",)
-artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
-artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
+with wandb.init(entity="<entity>", project="<project>") as run:
+  
+  # Create an artifact
+  artifact = wandb.Artifact(name = "<artifact_name>", type = "<artifact_type>")
+  artifact.add_file(local_path = "<local_filepath>", name="<optional-name>")
 
-# Log the artifact as an output of the run
-run.log_artifact(artifact_or_path = artifact)
+  # Log the artifact as an output of the run
+  run.log_artifact(artifact_or_path = artifact)
 ```
 
 For more information on about creating artifacts, see [Create an artifact](/models/artifacts/construct-an-artifact/).
 
 
-## View lineage graphs in a collection
+### View lineage graphs in a collection
 
 View the lineage of an artifact linked to a collection in the W&B Registry.
 
 1. Navigate to the W&B Registry.
 2. Select the collection that contains the artifact.
-3. From the dropdown, click the artifact version you want to view its lineage graph.
-4. Select the "Lineage" tab.
+3. From the dropdown, select the artifact version you want to view its lineage graph.
+4. Select the **Lineage** tab.
+5. Select a node to view detailed information about the run or artifact.
 
 
-Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
- 
-Select a run node to view that run's details, such as the run's ID, the run's name, the run's state, and more. As an example, the proceeding image shows information about the `rural-feather-20` run:
+The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:
 
 <Frame>
     <img src="/images/registry/lineage_expanded_node.png" alt="Expanded lineage node"  />
 </Frame>
 
-Select an artifact node to view that artifact's details, such as its full name, type, creation time, and associated aliases.
+
+The following image shows the expanded detailed view of an artifact (`zoo-ylbchv20:v0`) when you select an artifact node in the lineage graph:
 
 <Frame>
     <img src="/images/registry/lineage_expanded_artifact_node.png" alt="Expanded artifact node details"  />
 </Frame>
+
+Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
+ 
+
+## Audit a collection's history
+
+View actions that members of your organization take on that collection. You can view:
+
+- If an alias was added or removed from an artifact version.
+- If an artifact version was added or removed from a collection.
+
+For both actions, you can view the user that performed the action and the date the action occurred.
+
+To view a collection's action history:
+
+1. Navigate to the W&B Registry.
+2. Select the collection you want to view its action history.
+3. Select the dropdown menu next to the collection name.
+4. Select the **Action History** option.
+
+{/* Select a run node to view that run's details, such as the run's ID, the run's name, the run's state, and more. As an example, the proceeding image shows information about the `rural-feather-20` run:
+
+
+
+Select an artifact node to view that artifact's details, such as its full name, type, creation time, and associated aliases. */}
+

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -9,16 +9,11 @@ Use a lineage graph to visualize a linked artifact's history. Audit a collection
 
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
-<Info>
-You can also view lineage graphs for artifacts you log to W&B that are not part of a collection.
-</Info>
-
 A lineage graph shows:
 * If a run used an [artifact as an input](/models/registry/lineage#track-the-input-of-a-run).
 * If a run created an [artifact as an output](/models/registry/lineage#track-the-output-of-a-run).
 
 In other words, a lineage graph shows the input and output of a run.
-
 
 For example, the following image shows a typical lineage graph for artifacts created and used throughout an ML experiment:
 
@@ -55,7 +50,10 @@ The following image shows the expanded detailed view of an artifact (`zoo-ylbchv
     <img src="/images/registry/lineage_expanded_artifact_node.png" alt="Expanded artifact node details"  />
 </Frame>
 
-Once you are in an artifact's lineage graph page, you can view additional information about any node in that lineage graph. 
+
+<Info>
+You can also view lineage graphs for artifacts you log to W&B that are not part of a collection. See E[xplore artifact graphs](/models/artifacts/explore-and-traverse-an-artifact-graph) for more information.
+</Info>
 
 
 ### Track the input of a run

--- a/models/registry/lineage.mdx
+++ b/models/registry/lineage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use lineage graphs to visualize linked artifacts' history and audit a collection's history to track changes made to artifacts in that collection.
+description: Use lineage graphs to visualize a linked artifact's history and audit a collection's history.
 title: Lineage graphs and audit history
 ---
 
@@ -10,8 +10,8 @@ Use a lineage graph to visualize a linked artifact's history. Audit a collection
 Within a collection in the W&B Registry, you can view a history of the artifacts that an ML experiment uses. This history is called a _lineage graph_.
 
 A lineage graph shows:
-* If a run used an [artifact as an input](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-input-of-a-run).
-* If a run created an [artifact as an output](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-output-of-a-run).
+* Artifacts used as [inputs to a run](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-input-of-a-run).
+* Artifacts created as [outputs from a run](/models/artifacts/explore-and-traverse-an-artifact-graph#track-the-output-of-a-run).
 
 In other words, a lineage graph shows the input and output of a run.
 
@@ -38,7 +38,7 @@ To view a lineage graph for an artifact in a collection:
 
 
 <Info>
-See [Enable lineage graph tracking](/models/artifacts/explore-and-traverse-an-artifact-graph#enable-lineage-graph-tracking) in [Explore artifact lineage graphs](/models/artifacts/explore-and-traverse-an-artifact-graph) to learn how to track the input and output of a run using the W&B Python SDK.
+See [Enable lineage graph tracking](/models/artifacts/explore-and-traverse-an-artifact-graph#enable-lineage-graph-tracking) to learn how to track the input and output of a run using the W&B Python SDK.
 </Info>
 
 The following image shows the expanded detailed view of a run (`rural-feather-20`) when you select a node in the lineage graph:


### PR DESCRIPTION
## Description

This PR builds off of this pre Mintlify PR: https://github.com/wandb/docs/pull/1689. Main differences include:

* Moving content from registry lineage page to the more artifact lineage page
* Added links referencing lineage graphs
* Adding content on how to enable lineage graph tracking
* Word smithing

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

-->

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1703
- Fixes #12345

