### PR TITLE
Fix more context managers

### DIFF
--- a/models/app/console-logs.mdx
+++ b/models/app/console-logs.mdx
@@ -124,13 +124,14 @@ You can filter console logs based on the labels you pass as arguments for `x_lab
 import wandb
 
 # Initialize a run in the primary node
-run = wandb.init(
+with wandb.init(
     entity="entity",
     project="project",
-	settings=wandb.Settings(
+    settings=wandb.Settings(
         x_label="custom_label"  # (Optional) Custom label for filtering logs
-        )
-)
+    )
+) as run:
+    # Your code here
 ```
 
 ## Download console logs

--- a/models/artifacts.mdx
+++ b/models/artifacts.mdx
@@ -29,18 +29,18 @@ You can use artifacts throughout your entire ML workflow as inputs and outputs o
 
 
 <Note>
-The proceeding code snippets are meant to be run in order.
+The following code snippets are meant to be run in order.
 </Note>
 
 ## Create an artifact
 
 Create an artifact with four lines of code:
 1. Create a [W&B run](/models/runs/).
-2. Create an artifact object with the [`wandb.Artifact`](/models/ref/python/experiments/artifact) API.
-3. Add one or more files, such as a model file or dataset, to your artifact object.
-4. Log your artifact to W&B.
+2. Create an artifact object with [`wandb.Artifact`](/models/ref/python/experiments/artifact).
+3. Add one or more files, such as a model file or dataset, to the artifact object with `wandb.Artifact.add_file()`.
+4. Log your artifact to W&B with `wandb.Run.log_artifact()`.
 
-For example, the proceeding code snippet shows how to log a file called `dataset.h5` to an artifact called `example_artifact`:
+For example, the following code snippet shows how to log a file called `dataset.h5` to an artifact called `example_artifact`:
 
 ```python
 import wandb
@@ -48,6 +48,7 @@ import wandb
 with wandb.init(project="artifacts-example", job_type="add-dataset") as run:
     artifact = wandb.Artifact(name="example_artifact", type="dataset")
     artifact.add_file(local_path="./dataset.h5", name="training_dataset")
+    run.log_artifact(artifact)
 ```
 
 - The `type` of the artifact affects how it appears in the W&B platform. If you do not specify a `type`, it defaults to `unspecified`.
@@ -58,24 +59,21 @@ See the [track external files](/models/artifacts/track-external-files/) page for
 </Note>
 
 ## Download an artifact
-Indicate the artifact you want to mark as input to your run with the [`use_artifact`](/models/ref/python/experiments/run#use_artifact) method.
+Indicate the artifact you want to mark as input to your run with the [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) method.
 
-Following the preceding code snippet, this next code block shows how to use the `training_dataset` artifact: 
+Continuing from the previous code snippet, the following code example shows how to use the artifact called `example_artifact` that was created earlier:
+
 
 ```python
 with wandb.init(project="artifacts-example", job_type="add-dataset") as run:
-    artifact = run.use_artifact(
-        "training_dataset:latest"
-    )  # returns a run object using the "my_data" artifact
+    artifact = run.use_artifact("training_dataset:latest")  # returns a run object using the "my_data" artifact
 ```
 This returns an artifact object.
 
 Next, use the returned object to download all contents of the artifact:
 
 ```python
-datadir = (
-    artifact.download()
-)  # downloads the full `my_data` artifact to the default directory.
+datadir = artifact.download()  # downloads the full `my_data` artifact to the default directory.
 ```
 
 <Note>

--- a/models/artifacts.mdx
+++ b/models/artifacts.mdx
@@ -45,12 +45,9 @@ For example, the proceeding code snippet shows how to log a file called `dataset
 ```python
 import wandb
 
-run = wandb.init(project="artifacts-example", job_type="add-dataset")
-artifact = wandb.Artifact(name="example_artifact", type="dataset")
-artifact.add_file(local_path="./dataset.h5", name="training_dataset")
-artifact.save()
-
-# Logs the artifact version "my_data" as a dataset with data from dataset.h5
+with wandb.init(project="artifacts-example", job_type="add-dataset") as run:
+    artifact = wandb.Artifact(name="example_artifact", type="dataset")
+    artifact.add_file(local_path="./dataset.h5", name="training_dataset")
 ```
 
 - The `type` of the artifact affects how it appears in the W&B platform. If you do not specify a `type`, it defaults to `unspecified`.
@@ -66,9 +63,10 @@ Indicate the artifact you want to mark as input to your run with the [`use_artif
 Following the preceding code snippet, this next code block shows how to use the `training_dataset` artifact: 
 
 ```python
-artifact = run.use_artifact(
-    "training_dataset:latest"
-)  # returns a run object using the "my_data" artifact
+with wandb.init(project="artifacts-example", job_type="add-dataset") as run:
+    artifact = run.use_artifact(
+        "training_dataset:latest"
+    )  # returns a run object using the "my_data" artifact
 ```
 This returns an artifact object.
 

--- a/models/artifacts/artifacts-walkthrough.mdx
+++ b/models/artifacts/artifacts-walkthrough.mdx
@@ -1,11 +1,10 @@
 ---
-description: >-
-  Artifacts quickstart shows how to create, track, and use a dataset artifact
-  with W&B.
-displayed_sidebar: default
+description:
+  Create, track, and use a dataset artifact with W&B.
 title: "Tutorial: Create, track, and use a dataset artifact"
 ---
-This walkthrough demonstrates how to create, track, and use a dataset artifact from [W&B Runs](/models/runs/).
+
+This walkthrough demonstrates how to create, track, and use a dataset artifact.
 
 ## 1. Log into W&B
 
@@ -19,17 +18,18 @@ wandb.login()
 
 ## 2. Initialize a run
 
-Use the [`wandb.init()`](/models/ref/python/functions/init) API to generate a background process to sync and log data as a W&B Run. Provide a project name and a job type:
+Use [`wandb.init()`](/models/ref/python/functions/init) to intialize a run. This generates a background process to sync and log data. Provide a project name and a job type:
 
 ```python
 # Create a W&B Run. Here we specify 'dataset' as the job type since this example
 # shows how to create a dataset artifact.
-run = wandb.init(project="artifacts-example", job_type="upload-dataset")
+with wandb.init(project="artifacts-example", job_type="upload-dataset") as run:
+    # Your code here
 ```
 
 ## 3. Create an artifact object
 
-Create an artifact object with the [`wandb.Artifact()`](/models/ref/python/experiments/artifact) API. Provide a name for the artifact and a description of the file type for the `name` and `type` parameters, respectively.
+Create an artifact object with the [`wandb.Artifact()`](/models/ref/python/experiments/artifact). Provide a name for the artifact and a description of the file type for the `name` and `type` parameters, respectively.
 
 For example, the following code snippet demonstrates how to create an artifact called `‘bicycle-dataset’` with a `‘dataset’` label:
 
@@ -39,7 +39,7 @@ artifact = wandb.Artifact(name="bicycle-dataset", type="dataset")
 
 For more information about how to construct an artifact, see [Construct artifacts](./construct-an-artifact).
 
-## Add the dataset to the artifact
+## 4. Add the dataset to the artifact
 
 Add a file to the artifact. Common file types include models and datasets. The following example adds a dataset named `dataset.h5` that is saved locally on our machine to the artifact:
 
@@ -48,11 +48,12 @@ Add a file to the artifact. Common file types include models and datasets. The f
 artifact.add_file(local_path="dataset.h5")
 ```
 
-Replace the filename `dataset.h5` in the preceding code snippet with the path to the file you want to add to the artifact.
+Replace the filename `dataset.h5` in the previous code snippet with the path to the file you want to add to the artifact.
 
-## 4. Log the dataset
 
-Use the W&B run objects `log_artifact()` method to both save your artifact version and declare the artifact as an output of the run.
+## 5. Log the dataset
+
+Use the W&B run objects `wandb.Run.log_artifact()` method to both save your artifact version and declare the artifact as an [output of the run](/models/artifacts/explore-and-traverse-an-artifact-graph).
 
 ```python
 # Save the artifact version to W&B and mark it
@@ -60,26 +61,41 @@ Use the W&B run objects `log_artifact()` method to both save your artifact versi
 run.log_artifact(artifact)
 ```
 
-A `'latest'` alias is created by default when you log an artifact. For more information about artifact aliases and versions, see [Create a custom alias](./create-a-custom-alias) and [Create new artifact versions](./create-a-new-artifact-version), respectively.
+A `'latest'` [alias](/models/artifacts/create-a-custom-alias) is created by default when you log an artifact. For more information about artifact aliases and versions, see [Create a custom alias](./create-a-custom-alias) and [Create new artifact versions](./create-a-new-artifact-version), respectively.
 
-## 5. Download and use the artifact
+
+Putting this together, you script so far should look like this:
+
+```python
+import wandb
+
+wandb.login()
+
+with wandb.init(project="artifacts-example", job_type="upload-dataset") as run:
+    artifact = wandb.Artifact(name="bicycle-dataset", type="dataset")
+    artifact.add_file(local_path="dataset.h5")
+    run.log_artifact(artifact)
+```
+
+
+## 6. Download and use the artifact
 
 The following code example demonstrates the steps you can take to use an artifact you have logged and saved to the W&B servers.
 
 1. First, initialize a new run object with **`wandb.init()`.**
-2. Second, use the run objects [`use_artifact()`](/models/ref/python/experiments/run#use_artifact) method to tell W&B what artifact to use. This returns an artifact object.
-3. Third, use the artifacts [`download()`](/models/ref/python/experiments/artifact#download) method to download the contents of the artifact.
+2. Second, use the run objects [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) method to tell W&B what artifact to use. This returns an artifact object.
+3. Third, use the artifacts [`wandb.Artifact.download()`](/models/ref/python/experiments/artifact#download) method to download the contents of the artifact.
 
 ```python
 # Create a W&B Run. Here we specify 'training' for 'type'
 # because we will use this run to track training.
-run = wandb.init(project="artifacts-example", job_type="training")
+with wandb.init(project="artifacts-example", job_type="training") as run:
 
-# Query W&B for an artifact and mark it as input to this run
-artifact = run.use_artifact("bicycle-dataset:latest")
+  # Query W&B for an artifact and mark it as input to this run
+  artifact = run.use_artifact("bicycle-dataset:latest")
 
-# Download the artifact's contents
-artifact_dir = artifact.download()
+  # Download the artifact's contents
+  artifact_dir = artifact.download()
 ```
 
 Alternatively, you can use the Public API (`wandb.Api`) to export (or update data) data already saved in a W&B outside of a Run. See [Track external files](./track-external-files) for more information.

--- a/models/artifacts/construct-an-artifact.mdx
+++ b/models/artifacts/construct-an-artifact.mdx
@@ -45,27 +45,26 @@ Replace the string arguments in the preceding code snippet with your own name an
 
 ### 2. Add one more files to the artifact
 
-Add files, directories, external URI references (such as Amazon S3) and more with artifact methods. For example, to add a single text file, use the [`add_file`](/models/ref/python/experiments/artifact#add_file) method:
+Add files, directories, external URI references (such as Amazon S3) and more with artifact methods. For example, to add a single text file, use the artifact object's [`Artifact.add_file()`](/models/ref/python/experiments/artifact#add_file) method:
 
 ```python
 artifact.add_file(local_path="hello_world.txt", name="optional-name")
 ```
 
-You can also add multiple files with the [`add_dir`](/models/ref/python/experiments/artifact#add_dir) method. To add files, see [Update an artifact](./update-an-artifact).
+You can also add multiple files with the [`Artifact.add_dir()`](/models/ref/python/experiments/artifact#add_dir) method. To add files, see [Update an artifact](./update-an-artifact).
 
 ### 3. Save your artifact to the W&B server
 
-Finally, save your artifact to the W&B server. Artifacts are associated with a run. Therefore, use a run objects [`log_artifact()`](/models/ref/python/experiments/run#log_artifact) method to save the artifact.
+Finally, save your artifact to the W&B server. Artifacts are associated with a run. Therefore, use a run objects [`wandb.Run.log_artifact()`](/models/ref/python/experiments/run#log_artifact) method to save the artifact.
 
 ```python
 # Create a W&B Run. Replace 'job-type'.
-run = wandb.init(project="artifacts-example", job_type="job-type")
-
-run.log_artifact(artifact)
+with wandb.init(project="artifacts-example", job_type="job-type") as run:
+    run.log_artifact(artifact)
 ```
 
 <Note>
-**When to use Artifact.save() or wandb.Run.log_artifact()**
+**When to use `Artifact.save()` or `wandb.Run.log_artifact()`**
 
 - Use `Artifact.save()` to update an existing artifact without creating a new run.
 - Use `wandb.Run.log_artifact()` to create a new artifact and associate it with a specific run.

--- a/models/artifacts/construct-an-artifact.mdx
+++ b/models/artifacts/construct-an-artifact.mdx
@@ -1,10 +1,9 @@
 ---
-description: Create, construct a W&B Artifact. Learn how to add one or more files
-  or a URI reference to an Artifact.
+description: Create and log a W&B Artifact. Learn how to add one or more files or a URI reference to an Artifact.
 title: Create an artifact
 ---
 
-Use the W&B Python SDK to construct artifacts from [W&B Runs](/models/ref/python/experiments/run). You can add [files, directories, URIs, and files from parallel runs to artifacts](#add-files-to-an-artifact). After you add a file to an artifact, save the artifact to the W&B Server or [your own private server](/platform/hosting/hosting-options/self-managed).
+Use the W&B Python SDK to construct artifacts from [W&B Runs](/models/ref/python/experiments/run). You can add [files, directories, URIs, and files from parallel runs to artifacts](#add-files-to-an-artifact). After you add a file to an artifact, save the artifact to the W&B Server or [your own private server](/platform/hosting/hosting-options/self-managed). Each artifact is associated with a run.
 
 For information on how to track external files, such as files stored in Amazon S3, see the [Track external files](./track-external-files) page.
 
@@ -21,9 +20,7 @@ Initialize the [`wandb.Artifact()`](/models/ref/python/experiments/artifact) cla
 
 
 <Note>
-The "name" and "type" you provide is used to create a directed acyclic graph. This means you can view the lineage of an artifact on the W&B App. 
-
-See the [Explore and traverse artifact graphs](./explore-and-traverse-an-artifact-graph) for more information.
+W&B uses the "name" and "type" you provide to create a directed acyclic graph. View the lineage of an artifact on the W&B App. See the [Explore and traverse artifact graphs](./explore-and-traverse-an-artifact-graph) for more information.
 </Note>
 
 
@@ -33,35 +30,57 @@ Artifacts can not have the same name, even if you specify a different type for t
 
 You can optionally provide a description and metadata when you initialize an artifact object. For more information on available attributes and parameters, see the [`wandb.Artifact`](/models/ref/python/experiments/artifact) Class definition in the Python SDK Reference Guide.
 
-The proceeding example demonstrates how to create a dataset artifact:
+Copy and paste the following code snippet to create an artifact object. Replace the `<name>` and `<type>` placeholders with your own values.:
 
 ```python
 import wandb
 
-artifact = wandb.Artifact(name="<replace>", type="<replace>")
+# Create an artifact object
+artifact = wandb.Artifact(name="<name>", type="<type>")
 ```
-
-Replace the string arguments in the preceding code snippet with your own name and type.
 
 ### 2. Add one more files to the artifact
 
-Add files, directories, external URI references (such as Amazon S3) and more with artifact methods. For example, to add a single text file, use the artifact object's [`Artifact.add_file()`](/models/ref/python/experiments/artifact#add_file) method:
+Add files, directories, external URI references (such as Amazon S3) and more to your artifact object.
+
+To add a single file, use the artifact object's [`Artifact.add_file()`](/models/ref/python/experiments/artifact#add_file) method:
 
 ```python
-artifact.add_file(local_path="hello_world.txt", name="optional-name")
+artifact.add_file(local_path="path/to/file.txt", name="<name>")
 ```
 
-You can also add multiple files with the [`Artifact.add_dir()`](/models/ref/python/experiments/artifact#add_dir) method. To add files, see [Update an artifact](./update-an-artifact).
+See the next section, [Add a single file](/models/artifacts/construct-an-artifact#add-a-single-file), for more information on adding different file types to an artifact.
+
+To add a directory, use the [`Artifact.add_dir()`](/models/ref/python/experiments/artifact#add_dir) method:
+
+```python
+artifact.add_dir(local_path="path/to/directory", name="<name>")
+```
+
+See the next section, [Add multiple files](/models/artifacts/construct-an-artifact#add-multiple-files), for more information on adding different file types to an artifact.
 
 ### 3. Save your artifact to the W&B server
 
-Finally, save your artifact to the W&B server. Artifacts are associated with a run. Therefore, use a run objects [`wandb.Run.log_artifact()`](/models/ref/python/experiments/run#log_artifact) method to save the artifact.
+Finally, save your artifact to the W&B server. Use a run objects [`wandb.Run.log_artifact()`](/models/ref/python/experiments/run#log_artifact) method to save the artifact.
 
 ```python
-# Create a W&B Run. Replace 'job-type'.
-with wandb.init(project="artifacts-example", job_type="job-type") as run:
+with wandb.init(project="<project>", job_type="<job-type>") as run:
     run.log_artifact(artifact)
 ```
+
+Putting this all together, the following code snippet demonstrates how to create a dataset artifact, add a file to the artifact, and save the artifact to W&B:
+
+```python
+import wandb
+
+artifact = wandb.Artifact(name="<name>", type="<type>")
+artifact.add_file(local_path="path/to/file.txt", name="<name>")
+artifact.add_dir(local_path="path/to/directory", name="<name>")
+
+with wandb.init(project="<project>", job_type="<job-type>") as run:
+    run.log_artifact(artifact)
+```
+
 
 <Note>
 **When to use `Artifact.save()` or `wandb.Run.log_artifact()`**
@@ -107,7 +126,7 @@ project-directory
 
 ### Add a single file
 
-The proceeding code snippet demonstrates how to add a single, local file to your artifact:
+The following code snippet demonstrates how to add a single, local file to your artifact:
 
 ```python
 # Add a single file
@@ -146,7 +165,7 @@ new/path/file.txt
 
 ### Add multiple files
 
-The proceeding code snippet demonstrates how to add an entire, local directory to your artifact:
+The following code snippet demonstrates how to add an entire, local directory to your artifact:
 
 ```python
 # Recursively add a directory

--- a/models/artifacts/create-a-custom-alias.mdx
+++ b/models/artifacts/create-a-custom-alias.mdx
@@ -3,16 +3,16 @@ description: Create custom aliases for W&B Artifacts.
 title: Create an artifact alias
 ---
 
-Use aliases as pointers to specific versions. By default, `Run.log_artifact` adds the `latest` alias to the logged version.
+Use aliases as pointers to specific versions. By default, `wandb.Run.log_artifact()` adds the `latest` alias to the logged version.
 
-An artifact version `v0` is created and attached to your artifact when you log an artifact for the first time. W&B checksums the contents when you log again to the same artifact. If the artifact changed, W&B saves a new version `v1`.
+W&B creates an artifact version `v0` and attaches it to your artifact when you log that artifact for the first time. W&B checksums the contents when you log again to the same artifact. If the artifact changed, W&B saves a new version `v1`.
 
 For example, if you want your training script to pull the most recent version of a dataset, specify `latest` when you use that artifact. The following code example demonstrates how to download a recent dataset artifact named `bike-dataset` that has an alias, `latest`:
 
 ```python
 import wandb
 
-with wandb.init(project="<example-project>") as run:
+with wandb.init(project="<project>") as run:
     artifact = run.use_artifact("bike-dataset:latest")
     artifact.download()
 ```
@@ -20,7 +20,7 @@ with wandb.init(project="<example-project>") as run:
 You can also apply a custom alias to an artifact version. For example, if you want to mark that model checkpoint is the best on the metric AP-50, you could add the string `'best-ap50'` as an alias when you log the model artifact.
 
 ```python
-with wandb.init(project="<example-project>") as run:
+with wandb.init(project="<project>") as run:
     artifact = wandb.Artifact("run-3nq3ctyy-bike-model", type="model")
     artifact.add_file("model.h5")
     run.log_artifact(artifact, aliases=["latest", "best-ap50"])

--- a/models/artifacts/create-a-custom-alias.mdx
+++ b/models/artifacts/create-a-custom-alias.mdx
@@ -7,22 +7,21 @@ Use aliases as pointers to specific versions. By default, `Run.log_artifact` add
 
 An artifact version `v0` is created and attached to your artifact when you log an artifact for the first time. W&B checksums the contents when you log again to the same artifact. If the artifact changed, W&B saves a new version `v1`.
 
-For example, if you want your training script to pull the most recent version of a dataset, specify `latest` when you use that artifact. The proceeding code example demonstrates how to download a recent dataset artifact named `bike-dataset` that has an alias, `latest`:
+For example, if you want your training script to pull the most recent version of a dataset, specify `latest` when you use that artifact. The following code example demonstrates how to download a recent dataset artifact named `bike-dataset` that has an alias, `latest`:
 
 ```python
 import wandb
 
-run = wandb.init(project="<example-project>")
-
-artifact = run.use_artifact("bike-dataset:latest")
-
-artifact.download()
+with wandb.init(project="<example-project>") as run:
+    artifact = run.use_artifact("bike-dataset:latest")
+    artifact.download()
 ```
 
 You can also apply a custom alias to an artifact version. For example, if you want to mark that model checkpoint is the best on the metric AP-50, you could add the string `'best-ap50'` as an alias when you log the model artifact.
 
 ```python
-artifact = wandb.Artifact("run-3nq3ctyy-bike-model", type="model")
-artifact.add_file("model.h5")
-run.log_artifact(artifact, aliases=["latest", "best-ap50"])
+with wandb.init(project="<example-project>") as run:
+    artifact = wandb.Artifact("run-3nq3ctyy-bike-model", type="model")
+    artifact.add_file("model.h5")
+    run.log_artifact(artifact, aliases=["latest", "best-ap50"])
 ```

--- a/models/artifacts/data-privacy-and-compliance.mdx
+++ b/models/artifacts/data-privacy-and-compliance.mdx
@@ -23,9 +23,9 @@ Create a reference artifact similar to how you create a non reference artifact:
 ```python
 import wandb
 
-run = wandb.init()
-artifact = wandb.Artifact("animals", type="dataset")
-artifact.add_reference("s3://my-bucket/animals")
+with wandb.init(project="my-project") as run:
+    artifact = wandb.Artifact("animals", type="dataset")
+    artifact.add_reference("s3://my-bucket/animals")
 ```
 
 For alternatives, contact us at [contact@wandb.com](mailto:contact@wandb.com) to talk about private cloud and on-premises installations.

--- a/models/artifacts/data-privacy-and-compliance.mdx
+++ b/models/artifacts/data-privacy-and-compliance.mdx
@@ -12,20 +12,10 @@ Files are uploaded to Google Cloud bucket managed by W&B when you log artifacts.
 
 When you delete a version of an artifact, it is marked for soft deletion in our database and removed from your storage cost. When you delete an entire artifact, it is queued for permanently deletion and all of its contents are removed from the W&B bucket. If you have specific needs around file deletion please reach out to [Customer Support](mailto:support@wandb.com).
 
-For sensitive datasets that cannot reside in a multi-tenant environment, you can use either a private W&B server connected to your cloud bucket or _reference artifacts_. Reference artifacts track references to private buckets without sending file contents to W&B. Reference artifacts maintain links to files on your buckets or servers. In other words, W&B only keeps track of the metadata associated with the files and not the files themselves.
+For sensitive datasets that cannot reside in a multi-tenant environment, you can use either a private W&B server connected to your cloud bucket or [reference artifacts](/models/artifacts/track-external-files). Reference artifacts track references to private buckets without sending file contents to W&B. Reference artifacts maintain links to files on your buckets or servers. In other words, W&B only keeps track of the metadata associated with the files and not the files themselves.
 
 <Frame>
     <img src="/images/artifacts/data_and_privacy_compliance_2.png" alt="W&B Client Server Cloud diagram"  />
 </Frame>
-
-Create a reference artifact similar to how you create a non reference artifact:
-
-```python
-import wandb
-
-with wandb.init(project="my-project") as run:
-    artifact = wandb.Artifact("animals", type="dataset")
-    artifact.add_reference("s3://my-bucket/animals")
-```
 
 For alternatives, contact us at [contact@wandb.com](mailto:contact@wandb.com) to talk about private cloud and on-premises installations.

--- a/models/artifacts/delete-artifacts.mdx
+++ b/models/artifacts/delete-artifacts.mdx
@@ -93,7 +93,7 @@ for artifact in run.logged_artifacts():
 
 ### Delete multiple artifact versions with a specific alias
 
-The proceeding code demonstrates how to delete multiple artifact versions that have a specific alias. Provide the entity, project name, and run ID that created the artifacts. Replace the deletion logic with your own:
+The following code demonstrates how to delete multiple artifact versions that have a specific alias. Provide the entity, project name, and run ID that created the artifacts. Replace the deletion logic with your own:
 
 ```python
 import wandb

--- a/models/artifacts/download-and-use-an-artifact.mdx
+++ b/models/artifacts/download-and-use-an-artifact.mdx
@@ -12,7 +12,7 @@ Team members with view-only seats cannot download artifacts.
 
 ### Download and use an artifact stored on W&B
 
-Download and use an artifact stored in W&B either inside or outside of a W&B Run. Use the Public API ([`wandb.Api`](/models/ref/python/public-api/api)) to export (or update data) already saved in W&B. For more information, see the W&B [Public API Reference guide](/models/ref/python/public-api/).
+Download and use an artifact stored in W&B either inside or outside of a W&B Run. Use the Public API ([`wandb.Api`](/models/ref/python/public-api/api)) to export (or update data) already saved in W&B.
 
 <Tabs>
 <Tab title="During a run">
@@ -25,7 +25,7 @@ with wandb.init(project="<example>", job_type="<job-type>") as run:
     # See next step
 ```
 
-Indicate the artifact you want to use with the [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) method. This returns a run object. In the proceeding code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
+Indicate the artifact you want to use with the [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) method. This returns a run object. In the following code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
 
 ```python
 # Indicate the artifact to use. Format is "name:alias"
@@ -39,9 +39,9 @@ Use the object returned to download all the contents of the artifact:
 datadir = artifact.download()
 ```
 
-You can optionally pass a path to the root parameter to download the contents of the artifact to a specific directory. For more information, see the [Python SDK Reference Guide](/models/ref/python/experiments/artifact#download).
+You can optionally pass a path to the root parameter to download the contents of the artifact to a specific directory.
 
-Use the [`wandb.Artifact.get_entry()`](/models/ref/python/experiments/artifact#get_entry) method to download only subset of files:
+Use the [`wandb.Artifact.get_entry()`](/models/ref/python/experiments/artifact#get_entry) method to download only a subset of files:
 
 ```python
 # Download a specific file

--- a/models/artifacts/download-and-use-an-artifact.mdx
+++ b/models/artifacts/download-and-use-an-artifact.mdx
@@ -21,38 +21,60 @@ First, import the W&B Python SDK. Next, create a W&B [Run](/models/ref/python/ex
 ```python
 import wandb
 
-run = wandb.init(project="<example>", job_type="<job-type>")
+with wandb.init(project="<example>", job_type="<job-type>") as run:
+    # See next step
 ```
 
-Indicate the artifact you want to use with the [`use_artifact`](/models/ref/python/experiments/run#use_artifact) method. This returns a run object. In the proceeding code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
+Indicate the artifact you want to use with the [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) method. This returns a run object. In the proceeding code snippet specifies an artifact called `'bike-dataset'` with the alias `'latest'`:
 
 ```python
+# Indicate the artifact to use. Format is "name:alias"
 artifact = run.use_artifact("bike-dataset:latest")
 ```
 
 Use the object returned to download all the contents of the artifact:
 
 ```python
+# Download the entire artifact
 datadir = artifact.download()
 ```
 
 You can optionally pass a path to the root parameter to download the contents of the artifact to a specific directory. For more information, see the [Python SDK Reference Guide](/models/ref/python/experiments/artifact#download).
 
-Use the [`get_path`](/models/ref/python/experiments/artifact#get_path) method to download only subset of files:
+Use the [`wandb.Artifact.get_entry()`](/models/ref/python/experiments/artifact#get_entry) method to download only subset of files:
 
 ```python
-path = artifact.get_path(name)
+# Download a specific file
+entry = artifact.get_entry(name)
 ```
+
+Putting this together, the complete code example looks like this:
+
+```python
+import wandb    
+
+with wandb.init(project="<example>", job_type="<job-type>") as run:
+    # Indicate the artifact to use. Format is "name:alias"
+    artifact = run.use_artifact("bike-dataset:latest")
+
+    # Download the entire artifact
+    datadir = artifact.download()
+
+    # Download a specific file
+    entry = artifact.get_entry("bike.png")
+```
+
 
 This fetches only the file at the path `name`. It returns an `Entry` object with the following methods:
 
 * `Entry.download`: Downloads file from the artifact at path `name`
 * `Entry.ref`: If `add_reference` stored the entry as a reference, returns the URI
 
-References that have schemes that W&B knows how to handle get downloaded just like artifact files. For more information, see [Track external files](/models/artifacts/track-external-files/).
+{/* References that have schemes that W&B knows how to handle get downloaded just like artifact files. For more information, see [Track external files](/models/artifacts/track-external-files/). */}
+
 </Tab>
 <Tab title="Outside of a run">
-First, import the W&B SDK. Next, create an artifact from the Public API Class. Provide the entity, project, artifact, and alias associated with that artifact:
+First, import the W&B SDK. Next, create an artifact object from the Public API Class. Provide the entity, project, artifact, and alias associated with that artifact:
 
 ```python
 import wandb
@@ -67,7 +89,7 @@ Use the object returned to download the contents of the artifact:
 artifact.download()
 ```
 
-You can optionally pass a path the `root` parameter to download the contents of the artifact to a specific directory. For more information, see the [API Reference Guide](/models/ref/python/experiments/artifact#download).
+You can optionally pass a path the `root` parameter to download the contents of the artifact to a specific directory. For more information, see the [Python SDK Reference Guide](/models/ref/python/experiments/artifact#download).
 </Tab>
 <Tab title="W&B CLI">
 Use the `wandb artifact get` command to download an artifact from the W&B server.
@@ -81,18 +103,22 @@ $ wandb artifact get project/artifact:alias --root mnist/
 
 ### Partially download an artifact
 
-You can optionally download part of an artifact based on a prefix. Using the `path_prefix` parameter, you can download a single file or the content of a sub-folder.
+You can optionally download part of an artifact based on a prefix. Use the `path_prefix=` (`wandb.Artifact.download(path_prefix=)`) parameter to download a single file or the content of a sub-folder.
 
 ```python
-artifact = run.use_artifact("bike-dataset:latest")
+with wandb.init(project="<example>", job_type="<job-type>") as run:
+    # Indicate the artifact to use. Format is "name:alias"
+    artifact = run.use_artifact("bike-dataset:latest")
 
-artifact.download(path_prefix="bike.png") # downloads only bike.png
+    # Download a specific file or sub-folder
+    artifact.download(path_prefix="bike.png") # downloads only bike.png
 ```
 
-Alternatively, you can download files from a certain directory:
+Alternatively, you can download files from a certain directory. To do so, specify the directory within the `path_prefix=` parameter. Continuing from the previous code snippet:
 
 ```python
-artifact.download(path_prefix="images/bikes/") # downloads files in the images/bikes directory
+# downloads files in the images/bikes directory
+artifact.download(path_prefix="images/bikes/") 
 ```
 ### Use an artifact from a different project
 
@@ -101,28 +127,28 @@ Specify the name of artifact along with its project name to reference an artifac
 The following code example demonstrates how to query an artifact from another project as input to the current W&B run.
 
 ```python
-import wandb
+with wandb.init(project="<example>", job_type="<job-type>") as run:
+    # Query W&B for an artifact from another project and mark it
+    # as an input to this run.
+    artifact = run.use_artifact("my-project/artifact:alias")
 
-run = wandb.init(project="<example>", job_type="<job-type>")
-# Query W&B for an artifact from another project and mark it
-# as an input to this run.
-artifact = run.use_artifact("my-project/artifact:alias")
+    # Use an artifact from another entity and mark it as an input
+    # to this run.
+    artifact = run.use_artifact("my-entity/my-project/artifact:alias")
 
-# Use an artifact from another entity and mark it as an input
-# to this run.
-artifact = run.use_artifact("my-entity/my-project/artifact:alias")
 ```
 
 ### Construct and use an artifact simultaneously
 
-Simultaneously construct and use an artifact. Create an artifact object and pass it to use_artifact. This creates an artifact in W&B if it does not exist yet. The [`use_artifact`](/models/ref/python/experiments/run#use_artifact) API is idempotent, so you can call it as many times as you like.
+Simultaneously construct and use an artifact. Create an artifact object and pass it to use_artifact. This creates an artifact in W&B if it does not exist yet. The [`wandb.Run.use_artifact()`](/models/ref/python/experiments/run#use_artifact) API is idempotent, so you can call it as many times as you like.
 
 ```python
 import wandb
 
-artifact = wandb.Artifact("reference model")
-artifact.add_file("model.h5")
-run.use_artifact(artifact)
+with wandb.init(project="<example>", job_type="<job-type>") as run:
+    artifact = wandb.Artifact("reference model")
+    artifact.add_file("model.h5")
+    run.use_artifact(artifact)
 ```
 
 For more information about constructing an artifact, see [Construct an artifact](/models/artifacts/construct-an-artifact/).

--- a/models/artifacts/storage.mdx
+++ b/models/artifacts/storage.mdx
@@ -27,7 +27,7 @@ Depending on the machine on `wandb` is initialized on, these default folders may
 
 W&B caches artifact files to speed up downloads across versions that share files in common. Over time this cache directory can become large. Run the [`wandb artifact cache cleanup`](/models/ref/cli/wandb-artifact/wandb-artifact-cache/) command to prune the cache and to remove any files that have not been used recently.
 
-The proceeding code snippet demonstrates how to limit the size of the cache to 1GB. Copy and paste the code snippet into your terminal:
+The following code snippet demonstrates how to limit the size of the cache to 1GB. Copy and paste the code snippet into your terminal:
 
 ```bash
 $ wandb artifact cache cleanup 1GB

--- a/models/artifacts/track-external-files.mdx
+++ b/models/artifacts/track-external-files.mdx
@@ -3,17 +3,16 @@ description: Track files saved in an external bucket, HTTP file server, or an NF
 title: Track external files
 ---
 
-Use **reference artifacts** to track and use files saved outside of W&B servers, for example in CoreWeave AI Object Storage, an Amazon Simple Storage Service (Amazon S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
+Use *reference artifacts* to track and use files saved outside of W&B servers. Common external storage solutions include: CoreWeave AI Object Storage, an Amazon Simple Storage Service (Amazon S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
 
-W&B logs metadata about the the object, such as the object's ETag and size. If object versioning is enabled on the bucket, the version ID is also logged.
 
 <Note>
 If you log an artifact that does not track external files, W&B saves the artifact's files to W&B servers. This is the default behavior when you log artifacts with the W&B Python SDK.
 
-See the [Artifacts quickstart](/models/artifacts/artifacts-walkthrough/) for information on how to save files and directories to W&B servers instead.
+If you log an artifact that does tracks external files, W&B logs metadata about the the object, such as the object's ETag and size. If object versioning is enabled on the bucket, the version ID is also logged.
 </Note>
 
-The following describes how to construct reference artifacts.
+The following sections describe how to track external reference artifacts.
 
 ## Track an artifact in an external bucket
 
@@ -21,27 +20,26 @@ Use the W&B Python SDK to track references to files stored outside of W&B.
 
 1. Initialize a run with `wandb.init()`.
 2. Create an artifact object with `wandb.Artifact()`.
-3. Specify the reference to the bucket path with the artifact object's `add_reference()` method.
+3. Specify the reference to the bucket path with the artifact object's `wandb.Artifact.add_reference()` method.
 4. Log the artifact's metadata with `run.log_artifact()`.
 
 ```python
 import wandb
 
 # Initialize a W&B run
-run = wandb.init()
+with wandb.init(project="my-project") as run:
 
-# Create an artifact object
-artifact = wandb.Artifact(name="name", type="type")
+  # Create an artifact object
+  artifact = wandb.Artifact(name="name", type="type")
 
-# Add a reference to the bucket path
-artifact.add_reference(uri = "uri/to/your/bucket/path")
+  # Add a reference to the bucket path
+  artifact.add_reference(uri = "uri/to/your/bucket/path")
 
-# Log the artifact's metadata
-run.log_artifact(artifact)
-run.finish()
+  # Log the artifact's metadata
+  run.log_artifact(artifact)
 ```
 
-Suppose your bucket has the following directory structure:
+As an example, suppose your bucket has the following directory structure:
 
 ```text
 s3://my-bucket
@@ -52,16 +50,22 @@ s3://my-bucket
   |---- cnn/
 ```
 
-The `datasets/mnist/` directory contains a collection of images. Track the directory as a dataset with `wandb.Artifact.add_reference()`. The following code sample creates a reference artifact `mnist:latest` using the artifact object's `add_reference()` method.
+The `datasets/mnist/` directory contains a collection of images. To track the image `datasets/mnist/` directory as a dataset artifact, specify:
+
+1. Provide a name for the artifact, such as `"mnist"`.
+1. Set the `type` parameter to `"dataset"` when you construct the artifact object (`wandb.Artifact(type="dataset")`).
+1. Provide the path to the `datasets/mnist/` directory as an Amazon S3 URI (`s3://my-bucket/datasets/mnist/`) when you call `wandb.Artifact.add_reference()`.
+1. Log the artifact with `run.log_artifact()`.
+
+The following code sample creates a reference artifact `mnist:latest`:
 
 ```python
 import wandb
 
-run = wandb.init()
-artifact = wandb.Artifact(name="mnist", type="dataset")
-artifact.add_reference(uri="s3://my-bucket/datasets/mnist")
-run.log_artifact(artifact)
-run.finish()
+with wandb.init(project="my-project") as run:
+  artifact = wandb.Artifact(name="mnist", type="dataset")
+  artifact.add_reference(uri="s3://my-bucket/datasets/mnist")
+  run.log_artifact(artifact)
 ```
 
 Within the W&B App, you can look through the contents of the reference artifact using the file browser, [explore the full dependency graph](/models/artifacts/explore-and-traverse-an-artifact-graph/), and scan through the versioned history of your artifact. The W&B App does not render rich media such as images, audio, and so forth because the data itself is not contained within the artifact.
@@ -71,7 +75,7 @@ W&B Artifacts support any Amazon S3 compatible interface, including CoreWeave St
 </Note>
 
 <Warning>
-By default, W&B imposes a 10,000 object limit when adding an object prefix. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
+By default, W&B imposes a 10,000 object limit when adding an object prefix. You can adjust this limit by specifying `max_objects=` when you call `wandb.Artifact.add_reference()`.
 </Warning>
 
 ## Download an artifact from an external bucket
@@ -83,9 +87,9 @@ The following code sample shows how to download a reference artifact. The the AP
 ```python
 import wandb
 
-run = wandb.init()
-artifact = run.use_artifact("mnist:latest", type="dataset")
-artifact_dir = artifact.download()
+with wandb.init(project="my-project") as run:
+  artifact = run.use_artifact("mnist:latest", type="dataset")
+  artifact_dir = artifact.download()
 ```
 
 <Note>
@@ -102,17 +106,16 @@ The following code sample uploads a dataset to an Amazon S3 bucket, tracks it wi
 import boto3
 import wandb
 
-run = wandb.init()
+with wandb.init() as run:
+  # Training here...
 
-# Training here...
+  s3_client = boto3.client("s3")
+  s3_client.upload_file(file_name="my_model.h5", bucket="my-bucket", object_name="models/cnn/my_model.h5")
 
-s3_client = boto3.client("s3")
-s3_client.upload_file(file_name="my_model.h5", bucket="my-bucket", object_name="models/cnn/my_model.h5")
-
-# Log the model artifact
-model_artifact = wandb.Artifact("cnn", type="model")
-model_artifact.add_reference("s3://my-bucket/models/cnn/")
-run.log_artifact(model_artifact)
+  # Log the model artifact
+  model_artifact = wandb.Artifact("cnn", type="model")
+  model_artifact.add_reference("s3://my-bucket/models/cnn/")
+  run.log_artifact(model_artifact)
 ```
 
 At a later point, you can download the model artifact. Specify the name of the artifact and its type:
@@ -120,9 +123,9 @@ At a later point, you can download the model artifact. Specify the name of the a
 ```python
 import wandb
 
-run = wandb.init()
-artifact = run.use_artifact(artifact_or_name = "cnn", type="model")
-datadir = artifact.download()
+with wandb.init() as run:
+  artifact = run.use_artifact(artifact_or_name = "cnn", type="model")
+  datadir = artifact.download()
 ```
 
 <Note>
@@ -151,71 +154,75 @@ Rich media such as images, audio, video, and point clouds may fail to render in 
 If rich media such as images, audio, video, and point clouds does not render in the App UI, ensure that `app.wandb.ai` is allowlisted in your bucket's CORS policy.
 </Warning>
 
+
 ## Track an artifact in a filesystem
 
-Another common pattern for fast access to datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an even simpler solution than a cloud storage bucket because from the perspective of the training script, the files look just like they are sitting on your local filesystem. Luckily, that ease of use extends into using Artifacts to track references to file systems, whether they are mounted or not.
+A common pattern for accessing datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an alternative solution to a cloud storage bucket because from the perspective of the training script, the files seem local to your filesystem.
+
+W&B Artifacts can be used to track references to file systems, regardless if they are mounted or not.
 
 Suppose you have a filesystem mounted at `/mount` with the following structure:
 
-```bash
+```text
 mount
 |datasets/
-		|-- mnist/
+  |-- mnist/
 |models/
-		|-- cnn/
+  |-- cnn/
 ```
 
-Within `mnist/` is a dataset, a collection of images. You can track it with an artifact:
+Within `mnist/` is a dataset, a collection of images. 
+
+You can track it with an artifact. Specify the path to the `datasets/mnist/` directory as a filesystem URI (`file:///mount/datasets/mnist/`) when you call `wandb.Artifact.add_reference()`.
 
 ```python
 import wandb
 
-run = wandb.init()
-artifact = wandb.Artifact("mnist", type="dataset")
-artifact.add_reference("file:///mount/datasets/mnist/")
-run.log_artifact(artifact)
+with wandb.init() as run:
+  artifact = wandb.Artifact("mnist", type="dataset")
+  artifact.add_reference("file:///mount/datasets/mnist/")
+  run.log_artifact(artifact)
 ```
 <Warning>
-By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `add_reference()`.
+By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `wandb.Artifact.add_reference()`.
 </Warning>
 
 Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second component begins the path to the dataset, `/mount/datasets/mnist/`.
 
-The resulting artifact `mnist:latest` looks and acts like a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
+The artifact that is created (`mnist:latest`) behaves similar to a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
 
 You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI cannot render rich media such as images, audio, because the data itself is not contained within the artifact.
 
 Downloading a reference artifact:
 
 ```python
-import wandb
-
-run = wandb.init()
-artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
-artifact_dir = artifact.download()
+with wandb.init() as run:
+  artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
+  artifact_dir = artifact.download()
 ```
 
-For a filesystem reference, a `download()` operation copies the files from the referenced paths to construct the artifact directory. In the above example, the contents of `/mount/datasets/mnist` are copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
+For filesystem references, calling `Artifact.download()` method copies the files from the referenced paths to construct the artifact directory. In the previous example, the contents of `/mount/datasets/mnist` are copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
 
 Putting it all together, you can use the following code to track a dataset under a mounted filesystem that feeds into a training job:
 
 ```python
-import wandb
+with wandb.init() as run:
 
-run = wandb.init()
+  # Create an artifact object
+  artifact = wandb.Artifact("mnist", type="dataset")
 
-artifact = wandb.Artifact("mnist", type="dataset")
-artifact.add_reference("file:///mount/datasets/mnist/")
+  # Add a reference to the dataset directory
+  artifact.add_reference("file:///mount/datasets/mnist/")
 
-# Track the artifact and mark it as an input to
-# this run in one swoop. A new artifact version
-# is only logged if the files under the directory
-# changed.
-run.use_artifact(artifact)
+  # Track the artifact and mark it as an input to
+  # this run in one swoop. A new artifact version
+  # is only logged if the files under the directory
+  # changed.
+  run.use_artifact(artifact)
 
-artifact_dir = artifact.download()
+  artifact_dir = artifact.download()
 
-# Perform training here...
+  # Perform training here...
 ```
 
 To track a model, log the model artifact after the training script writes the model files to the mount point:
@@ -223,15 +230,20 @@ To track a model, log the model artifact after the training script writes the mo
 ```python
 import wandb
 
-run = wandb.init()
+with wandb.init() as run:
 
-# Training here...
+  # Training here...
 
-# Write model to disk
+  # Write model to disk
 
-model_artifact = wandb.Artifact("cnn", type="model")
-model_artifact.add_reference("file:///mount/cnn/my_model.h5")
-run.log_artifact(model_artifact)
+  # Create an artifact object
+  model_artifact = wandb.Artifact("cnn", type="model")
+
+  # Add a reference to the model file path
+  model_artifact.add_reference("file:///mount/cnn/my_model.h5")
+
+  # Log the artifact to W&B
+  run.log_artifact(model_artifact)
 ```
 
 

--- a/models/artifacts/track-external-files.mdx
+++ b/models/artifacts/track-external-files.mdx
@@ -5,6 +5,9 @@ title: Track external files
 
 Use *reference artifacts* to track and use files saved outside of W&B servers. Common external storage solutions include: CoreWeave AI Object Storage, an Amazon Simple Storage Service (Amazon S3) bucket, GCS bucket, Azure blob, HTTP file server, or NFS share.
 
+Reference artifacts behave similar to non-reference artifacts. The key difference is that the reference artifacts only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
+
+You can interact with reference artifact similarly to non-reference artifacts. In the W&B App, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI cannot render rich media such as images, audio, because the data itself is not contained within the artifact.
 
 <Note>
 If you log an artifact that does not track external files, W&B saves the artifact's files to W&B servers. This is the default behavior when you log artifacts with the W&B Python SDK.
@@ -45,9 +48,9 @@ As an example, suppose your bucket has the following directory structure:
 s3://my-bucket
 
 |datasets/
-  |---- mnist/
+  |-- mnist/
 |models/
-  |---- cnn/
+  |-- cnn/
 ```
 
 The `datasets/mnist/` directory contains a collection of images. To track the image `datasets/mnist/` directory as a dataset artifact, specify:
@@ -93,12 +96,14 @@ with wandb.init(project="my-project") as run:
 ```
 
 <Note>
-W&B recommends that you enable 'Object Versioning' on your storage buckets if you overwrite files as part of your workflow. With versioning enabled on your buckets, artifacts with references to files that have been overwritten will still be intact because the older object versions are retained. 
+W&B recommends that you enable 'Object Versioning' on your storage buckets if you overwrite files as part of your workflow. 
+
+If versioning is enabled, W&B can always retrieve the correct version of the file when you download an artifact, even if the file has been overwritten since the artifact was logged.
 
 Based on your use case, read the instructions to enable object versioning: [AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html), [Google Cloud](https://cloud.google.com/storage/docs/using-object-versioning#set), [Azure](https://learn.microsoft.com/azure/storage/blobs/versioning-enable).
 </Note>
 
-### Add and download an external reference example
+## Add and download an external from a bucket
 
 The following code sample uploads a dataset to an Amazon S3 bucket, tracks it with a reference artifact, then downloads it:
 
@@ -149,7 +154,7 @@ W&B uses the default mechanism to look for credentials based on the cloud provid
 For AWS, if the bucket is not located in the configured user's default region, you must set the `AWS_REGION` environment variable to match the bucket region.
 
 <Warning>
-Rich media such as images, audio, video, and point clouds may fail to render in the App UI depending on the CORS configuration of your bucket. Allow listing **app.wandb.ai** in your bucket's CORS settings will allow the App UI to properly render such rich media.
+Rich media such as images, audio, video, and point clouds may fail to render in the App UI depending on the CORS configuration of your bucket. Allow listing **app.wandb.ai** in your bucket's CORS settings will allow the W&B App to properly render such rich media.
 
 If rich media such as images, audio, video, and point clouds does not render in the App UI, ensure that `app.wandb.ai` is allowlisted in your bucket's CORS policy.
 </Warning>
@@ -157,11 +162,39 @@ If rich media such as images, audio, video, and point clouds does not render in 
 
 ## Track an artifact in a filesystem
 
-A common pattern for accessing datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an alternative solution to a cloud storage bucket because from the perspective of the training script, the files seem local to your filesystem.
+A common pattern for accessing datasets is to expose an NFS mount point to a remote filesystem on all machines running training jobs. This can be an alternative solution to a cloud storage bucket because from the perspective of the training script, the files appear local to your filesystem. 
 
-W&B Artifacts can be used to track references to file systems, regardless if they are mounted or not.
+{/* Use W&B Artifacts to track references to file systems, regardless if they are mounted or not. */}
 
-Suppose you have a filesystem mounted at `/mount` with the following structure:
+
+To track an artifact in a filesystem:
+
+1. Initialize a run with `wandb.init()`.
+2. Create an artifact object with `wandb.Artifact()`.
+3. Specify the reference to the filesystem path with the artifact object's `wandb.Artifact.add_reference()` method.
+4. Log the artifact's metadata with `run.log_artifact()`.
+
+Copy and paste the following code snippet to track files in a mounted filesystem. Replace the values enclosed in angle brackets (`< >`) with your own values.
+
+```python
+import wandb
+
+# Initialize a run
+with wandb.init(entity="<entity>", project="<project>") as run:
+
+  # Create an artifact object
+  artifact = wandb.Artifact(name="<name>", type="<type>")
+
+  # Add a reference to the filesystem path
+  artifact.add_reference("file:///path/to/dataset/")
+
+  # Log the artifact (metadata only)
+  run.log_artifact(artifact)
+```
+
+Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second component is the root `/` of the filesystem. The remaining components are the path to the directory or file you want to track.
+
+As an example, suppose you have a filesystem mounted at `/mount` with the following structure:
 
 ```text
 mount
@@ -171,9 +204,7 @@ mount
   |-- cnn/
 ```
 
-Within `mnist/` is a dataset, a collection of images. 
-
-You can track it with an artifact. Specify the path to the `datasets/mnist/` directory as a filesystem URI (`file:///mount/datasets/mnist/`) when you call `wandb.Artifact.add_reference()`.
+You want to track the `datasets/mnist/` directory as a dataset artifact. To track it, you could use the following code snippet.
 
 ```python
 import wandb
@@ -183,49 +214,14 @@ with wandb.init() as run:
   artifact.add_reference("file:///mount/datasets/mnist/")
   run.log_artifact(artifact)
 ```
+
+This creates a reference artifact `mnist:latest` that points to the files stored under `/mount/datasets/mnist/`.
+
 <Warning>
 By default, W&B imposes a 10,000 file limit when adding a reference to a directory. You can adjust this limit by specifying `max_objects=` when you call `wandb.Artifact.add_reference()`.
 </Warning>
 
-Note the triple slash in the URL. The first component is the `file://` prefix that denotes the use of filesystem references. The second component begins the path to the dataset, `/mount/datasets/mnist/`.
-
-The artifact that is created (`mnist:latest`) behaves similar to a regular artifact. The only difference is that the artifact only consists of metadata about the files, such as their sizes and MD5 checksums. The files themselves never leave your system.
-
-You can interact with this artifact just as you would a normal artifact. In the UI, you can browse the contents of the reference artifact using the file browser, explore the full dependency graph, and scan through the versioned history of your artifact. However, the UI cannot render rich media such as images, audio, because the data itself is not contained within the artifact.
-
-Downloading a reference artifact:
-
-```python
-with wandb.init() as run:
-  artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
-  artifact_dir = artifact.download()
-```
-
-For filesystem references, calling `Artifact.download()` method copies the files from the referenced paths to construct the artifact directory. In the previous example, the contents of `/mount/datasets/mnist` are copied into the directory `artifacts/mnist:v0/`. If an artifact contains a reference to a file that was overwritten, then `download()` will throw an error because the artifact can no longer be reconstructed.
-
-Putting it all together, you can use the following code to track a dataset under a mounted filesystem that feeds into a training job:
-
-```python
-with wandb.init() as run:
-
-  # Create an artifact object
-  artifact = wandb.Artifact("mnist", type="dataset")
-
-  # Add a reference to the dataset directory
-  artifact.add_reference("file:///mount/datasets/mnist/")
-
-  # Track the artifact and mark it as an input to
-  # this run in one swoop. A new artifact version
-  # is only logged if the files under the directory
-  # changed.
-  run.use_artifact(artifact)
-
-  artifact_dir = artifact.download()
-
-  # Perform training here...
-```
-
-To track a model, log the model artifact after the training script writes the model files to the mount point:
+Similarly, to track a model stored at `models/cnn/my_model.h5`, you could use the following code snippet:
 
 ```python
 import wandb
@@ -245,6 +241,28 @@ with wandb.init() as run:
   # Log the artifact to W&B
   run.log_artifact(model_artifact)
 ```
+
+## Download an artifact from an external filesystem
+
+
+Download files from a referenced filesystem using the same APIs as non-reference artifacts:
+
+1. Initialize a run with `wandb.init()`.
+2. Use the `wandb.Run.use_artifact()` method to indicate the artifact you want to download.
+3. Call the artifact's `wandb.Artifact.download()` method to download the files from the referenced filesystem
+
+```python
+with wandb.init() as run:
+  artifact = run.use_artifact("entity/project/mnist:latest", type="dataset")
+  artifact_dir = artifact.download()
+```
+
+W&B copies the contents of `/mount/datasets/mnist` to the `artifacts/mnist:v0/` directory. 
+
+<Info>
+
+`Artifact.download()` throws an error if it cannot reconstruct the artifact. For example, if an artifact contains a reference to a file that was overwritten, `Artifact.download()` will throw an error because the artifact can no longer be reconstructed.
+</Info>
 
 
 {/* ### Log artifacts outside of runs

--- a/models/artifacts/ttl.mdx
+++ b/models/artifacts/ttl.mdx
@@ -32,9 +32,9 @@ You can check an Artifact's type on the [W&B platform](/models/artifacts/explore
 ```python
 import wandb
 
-run = wandb.init(project="<my-project-name>")
-artifact = run.use_artifact(artifact_or_name="<my-artifact-name>")
-print(artifact.type)
+with wandb.init(project="<my-project-name>") as run:
+    artifact = run.use_artifact(artifact_or_name="<my-artifact-name>")
+    print(artifact.type)
 ```
 
 Replace the values enclosed with `<>` with your own.
@@ -82,12 +82,12 @@ The following code snippet demonstrates how to create an artifact and set a TTL 
 import wandb
 from datetime import timedelta
 
-run = wandb.init(project="<my-project-name>", entity="<my-entity>")
-artifact = wandb.Artifact(name="<artifact-name>", type="<type>")
-artifact.add_file("<my_file>")
+with wandb.init(project="<my-project-name>", entity="<my-entity>") as run:
+    artifact = wandb.Artifact(name="<artifact-name>", type="<type>")
+    artifact.add_file("<my_file>")
 
-artifact.ttl = timedelta(days=30)  # Set TTL policy
-run.log_artifact(artifact)
+    artifact.ttl = timedelta(days=30)  # Set TTL policy
+    run.log_artifact(artifact)
 ```
 
 The preceding code snippet sets the TTL policy for the artifact to 30 days. In other words, W&B deletes the artifact after 30 days.

--- a/models/artifacts/update-an-artifact.mdx
+++ b/models/artifacts/update-an-artifact.mdx
@@ -25,10 +25,10 @@ The proceeding code example demonstrates how to update the description of an art
 ```python
 import wandb
 
-run = wandb.init(project="<example>")
-artifact = run.use_artifact("<artifact-name>:<alias>")
-artifact.description = "<description>"
-artifact.save()
+with wandb.init(project="<example>") as run:
+    artifact = run.use_artifact("<artifact-name>:<alias>")
+    artifact.description = "<description>"
+    artifact.save()
 ```
 </Tab>
 <Tab title="Outside of a run">
@@ -70,12 +70,12 @@ You can also update an Artifact collection in the same way as a singular artifac
 
 ```python
 import wandb
-run = wandb.init(project="<example>")
-api = wandb.Api()
-artifact = api.artifact_collection(type="<type-name>", collection="<collection-name>")
-artifact.name = "<new-collection-name>"
-artifact.description = "<This is where you'd describe the purpose of your collection.>"
-artifact.save()
+with wandb.init(project="<example>") as run:
+    api = wandb.Api()
+    artifact = api.artifact_collection(type="<type-name>", collection="<collection-name>")
+    artifact.name = "<new-collection-name>"
+    artifact.description = "<This is where you'd describe the purpose of your collection.>"
+    artifact.save()
 ```
 For more information, see the [Artifacts Collection](/models/ref/python/public-api/api) reference.
 </Tab>

--- a/models/artifacts/update-an-artifact.mdx
+++ b/models/artifacts/update-an-artifact.mdx
@@ -20,7 +20,7 @@ You can not update the alias of artifact linked to a model in Model Registry.
 
 <Tabs>
 <Tab title="During a run">
-The proceeding code example demonstrates how to update the description of an artifact using the [`wandb.Artifact`](/models/ref/python/experiments/artifact) API:
+The following code example demonstrates how to update the description of an artifact using the [`wandb.Artifact`](/models/ref/python/experiments/artifact) API:
 
 ```python
 import wandb
@@ -32,7 +32,7 @@ with wandb.init(project="<example>") as run:
 ```
 </Tab>
 <Tab title="Outside of a run">
-The proceeding code example demonstrates how to update the description of an artifact using the `wandb.Api` API:
+The following code example demonstrates how to update the description of an artifact using the `wandb.Api` API:
 
 ```python
 import wandb

--- a/models/evaluate-models.mdx
+++ b/models/evaluate-models.mdx
@@ -37,10 +37,10 @@ class ChatModel(weave.Model):
     
     def model_post_init(self, __context):
         # Download model from W&B Models Registry
-        run = wandb.init(project="your-project", job_type="model_download")
-        artifact = run.use_artifact(self.model_name)
-        self.model_path = artifact.download()
-        # Initialize your model here
+        with wandb.init(project="your-project", job_type="model_download") as run:
+            artifact = run.use_artifact(self.model_name)
+            self.model_path = artifact.download()
+            # Initialize your model here
     
     @weave.op()
     async def predict(self, query: str) -> str:

--- a/models/models_quickstart.mdx
+++ b/models/models_quickstart.mdx
@@ -130,10 +130,9 @@ COLLECTION_NAME = "DemoModels"  # Name of the collection in the registry
 target_path = f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
 print("Target path: ", target_path)
 
-run = wandb.init(entity=TEAM_ENTITY, project=PROJECT)
-model_artifact = run.use_artifact(artifact_or_name=artifact_name, type="model")
-run.link_artifact(artifact=model_artifact, target_path=target_path)
-run.finish()
+with wandb.init(entity=TEAM_ENTITY, project=PROJECT) as run:
+    model_artifact = run.use_artifact(artifact_or_name=artifact_name, type="model")
+    run.link_artifact(artifact=model_artifact, target_path=target_path)
 ```
 
 After running `wandb.Run.link_artifact()`, the model artifact will be in the `DemoModels` collection in your registry. From there, you can view details such as the version history, [lineage map](/models/registry/lineage/), and other [metadata](/models/registry/registry_cards/). 
@@ -152,9 +151,9 @@ VERSION = 0 # Version of the artifact to retrieve
 model_artifact_name = f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}:v{VERSION}"
 print(f"Model artifact name: {model_artifact_name}")
 
-run = wandb.init(entity=TEAM_ENTITY, project=PROJECT)
-registry_model = run.use_artifact(artifact_or_name=model_artifact_name)
-local_model_path = registry_model.download()
+with wandb.init(entity=TEAM_ENTITY, project=PROJECT) as run:
+    registry_model = run.use_artifact(artifact_or_name=model_artifact_name)
+    local_model_path = registry_model.download()
 ```
 
 For more information on how to retrieve artifacts from a registry, see [Download an artifact from a registry](/models/registry/download_use_artifact/).

--- a/models/quickstart.mdx
+++ b/models/quickstart.mdx
@@ -48,25 +48,40 @@ wandb.login()
 </Tab>
 </Tabs>
 
-## Start a run and track hyperparameters
+## Initialize a run and track hyperparameters
 
-In your Python script or notebook, initialize a W&B run object with [`wandb.init()`](/models/ref/python/experiments/run/). Use a dictionary for the `config` parameter to specify hyperparameter names and values.
+In your Python script or notebook, initialize a W&B run object with [`wandb.init()`](/models/ref/python/experiments/run/). Use a dictionary for the `config` parameter
+to specify hyperparameter names and values. Within the `with` statement, you can log metrics and other information to W&B.
 
 ```python
-run = wandb.init(
-    project="my-awesome-project",  # Specify your project
-    config={                        # Track hyperparameters and metadata
-        "learning_rate": 0.01,
-        "epochs": 10,
-    },
-)
+import wandb
+
+wandb.login()
+
+# Project that the run is recorded to
+project = "my-awesome-project"
+
+# Dictionary with hyperparameters
+config = {
+    'epochs' : 10,
+    'lr' : 0.01
+}
+
+with wandb.init(project=project, config=config) as run:
+    # Training code here
+    # Log values to W&B with run.log()
+    run.log({"accuracy": 0.9, "loss": 0.1})
 ```
 
-A [run](/models/runs/) serves as the core element of W&B, used to [track metrics](/models/track/), [create logs](/models/track/log/), and more.
+See the next section for a complete example that simulates a training run and logs accuracy and loss metrics to W&B.
 
-## Assemble the components
+<Info>
+A [run](/models/runs/) is a core element of W&B. You use runs to [track metrics](/models/track/), [create logs](/models/track/log/), track artifacts, and more.
+</Info>
 
-This mock training script logs simulated accuracy and loss metrics to W&B:
+## Create a machine learning training experiment
+
+This mock training script logs simulated accuracy and loss metrics to W&B. Copy and paste the following code into a Python script or notebook cell and run it:
 
 ```python
 import wandb

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -44,7 +44,7 @@ Once you log an artifact to W&B, you can then link that specific artifact versio
 The term "link" refers to pointers that connect where W&B stores the artifact and where the artifact is accessible in the registry. W&B does not duplicate artifacts when you link an artifact to a collection.
 </Note>
 
-As an example, the proceeding code example shows how to log and link a model artifact called "my_model.txt" to a collection named "first-collection" in the [core registry](/models/registry/registry_types/):
+As an example, the following code example shows how to log and link a model artifact called "my_model.txt" to a collection named "first-collection" in the [core registry](/models/registry/registry_types/):
 
 1. Initialize a W&B Run.
 2. Log the artifact to W&B.

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -58,29 +58,29 @@ import wandb
 import random
 
 # Initialize a W&B Run to track the artifact
-run = wandb.init(project="registry_quickstart") 
+with wandb.init(project="registry_quickstart") as run:
 
-# Create a simulated model file so that you can log it
-with open("my_model.txt", "w") as f:
-   f.write("Model: " + str(random.random()))
+    # Create a simulated model file so that you can log it
+    with open("my_model.txt", "w") as f:
+    f.write("Model: " + str(random.random()))
 
-# Log the artifact to W&B
-logged_artifact = run.log_artifact(
-    artifact_or_path="./my_model.txt", 
-    name="gemma-finetuned", 
-    type="model" # Specifies artifact type
-)
+    # Log the artifact to W&B
+    logged_artifact = run.log_artifact(
+        artifact_or_path="./my_model.txt", 
+        name="gemma-finetuned", 
+        type="model" # Specifies artifact type
+    )
 
-# Specify the name of the collection and registry
-# you want to publish the artifact to
-COLLECTION_NAME = "first-collection"
-REGISTRY_NAME = "model"
+    # Specify the name of the collection and registry
+    # you want to publish the artifact to
+    COLLECTION_NAME = "first-collection"
+    REGISTRY_NAME = "model"
 
-# Link the artifact to the registry
-run.link_artifact(
-    artifact=logged_artifact, 
-    target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
-)
+    # Link the artifact to the registry
+    run.link_artifact(
+        artifact=logged_artifact, 
+        target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
+    )
 ```
 
 W&B automatically creates a collection for you if the collection you specify in the returned run object's `link_artifact(target_path = "")` method does not exist within the registry you specify.

--- a/models/registry/aliases.mdx
+++ b/models/registry/aliases.mdx
@@ -57,29 +57,29 @@ The following code snippet demonstrates how to link an artifact version to a col
 import wandb
 
 # Initialize a run
-run = wandb.init(entity = "<team_entity>", project = "<project_name>")
+with wandb.init(entity = "<team_entity>", project = "<project_name>") as run:
 
-# Create an artifact object
-# The type parameter specifies both the type of the 
-# artifact object and the collection type
-artifact = wandb.Artifact(name = "<name>", type = "<type>")
+    # Create an artifact object
+    # The type parameter specifies both the type of the 
+    # artifact object and the collection type
+    artifact = wandb.Artifact(name = "<name>", type = "<type>")
 
-# Add the file to the artifact object. 
-# Specify the path to the file on your local machine.
-artifact.add_file(local_path = "<local_path_to_artifact>")
+    # Add the file to the artifact object. 
+    # Specify the path to the file on your local machine.
+    artifact.add_file(local_path = "<local_path_to_artifact>")
 
-# Specify the collection and registry to link the artifact to
-REGISTRY_NAME = "<registry_name>"
-COLLECTION_NAME = "<collection_name>"
-target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
+    # Specify the collection and registry to link the artifact to
+    REGISTRY_NAME = "<registry_name>"
+    COLLECTION_NAME = "<collection_name>"
+    target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
 
-# Link the artifact version to the collection
-# Add one or more aliases to this artifact version
-run.link_artifact(
-    artifact = artifact, 
-    target_path = target_path, 
-    aliases = ["<alias_1>", "<alias_2>"]
-    )
+    # Link the artifact version to the collection
+    # Add one or more aliases to this artifact version
+    run.link_artifact(
+        artifact = artifact, 
+        target_path = target_path, 
+        aliases = ["<alias_1>", "<alias_2>"]
+        )
 ```
 </Tab>
 </Tabs>
@@ -138,30 +138,30 @@ The following code snippet shows how to create an artifact version and add custo
 import wandb
 
 # Initialize a run
-run = wandb.init(entity = "smle-reg-team-2", project = "zoo_experiment")
+with wandb.init(entity = "smle-reg-team-2", project = "zoo_experiment") as run:
 
-# Create an artifact object
-# The type parameter specifies both the type of the 
-# artifact object and the collection type
-artifact = wandb.Artifact(name = "zoo_dataset", type = "dataset")
+    # Create an artifact object
+    # The type parameter specifies both the type of the 
+    # artifact object and the collection type
+    artifact = wandb.Artifact(name = "zoo_dataset", type = "dataset")
 
-# Add the file to the artifact object. 
-# Specify the path to the file on your local machine.
-artifact.add_file(local_path="zoo_dataset.pt", name="zoo_dataset")
-artifact.add_file(local_path="zoo_labels.pt", name="zoo_labels")
+    # Add the file to the artifact object. 
+    # Specify the path to the file on your local machine.
+    artifact.add_file(local_path="zoo_dataset.pt", name="zoo_dataset")
+    artifact.add_file(local_path="zoo_labels.pt", name="zoo_labels")
 
-# Specify the collection and registry to link the artifact to
-REGISTRY_NAME = "Model"
-COLLECTION_NAME = "Zoo_Classifier_Models"
-target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
+    # Specify the collection and registry to link the artifact to
+    REGISTRY_NAME = "Model"
+    COLLECTION_NAME = "Zoo_Classifier_Models"
+    target_path=f"wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}"
 
-# Link the artifact version to the collection
-# Add one or more aliases to this artifact version
-run.link_artifact(
-    artifact = artifact,
-    target_path = target_path,
-    aliases = ["production-us", "production-eu"]
-    )
+    # Link the artifact version to the collection
+    # Add one or more aliases to this artifact version
+    run.link_artifact(
+        artifact = artifact,
+        target_path = target_path,
+        aliases = ["production-us", "production-eu"]
+        )
 ```
 
 1. First, you create an artifact object (`wandb.Artifact()`).

--- a/models/registry/create_collection.mdx
+++ b/models/registry/create_collection.mdx
@@ -32,16 +32,16 @@ You specify an artifact's type when you create that artifact object. Note the `t
 import wandb
 
 # Initialize a run
-run = wandb.init(
+with wandb.init(
   entity = "<team_entity>",
   project = "<project>"
-  )
+  ) as run:
 
-# Create an artifact object
-artifact = wandb.Artifact(
-    name="<artifact_name>", 
-    type="<artifact_type>"
-    )
+  # Create an artifact object
+  artifact = wandb.Artifact(
+      name="<artifact_name>", 
+      type="<artifact_type>"
+      )
 ```
 </Note>
  
@@ -125,22 +125,20 @@ The proceeding code snippet shows how to programmatically create a collection. E
 import wandb
 
 # Initialize a run
-run = wandb.init(entity = "<team_entity>", project = "<project>")
+with wandb.init(entity = "<team_entity>", project = "<project>") as run:
 
-# Create an artifact object
-artifact = wandb.Artifact(
-  name = "<artifact_name>",
-  type = "<artifact_type>"
-  )
+  # Create an artifact object
+  artifact = wandb.Artifact(
+    name = "<artifact_name>",
+    type = "<artifact_type>"
+    )
 
-registry_name = "<registry_name>"
-collection_name = "<collection_name>"
-target_path = f"wandb-registry-{registry_name}/{collection_name}"
+  registry_name = "<registry_name>"
+  collection_name = "<collection_name>"
+  target_path = f"wandb-registry-{registry_name}/{collection_name}"
 
-# Link the artifact to a collection
-run.link_artifact(artifact = artifact, target_path = target_path)
-
-run.finish()
+  # Link the artifact to a collection
+  run.link_artifact(artifact = artifact, target_path = target_path)
 ```
 
 ### Interactively create a collection

--- a/models/registry/create_collection.mdx
+++ b/models/registry/create_collection.mdx
@@ -91,7 +91,7 @@ print(artifact_type.name for artifact_type in artifact_types)
 ```
 
 <Note>
-Note that you do not initialize a run with the proceeding code snippet. This is because it is unnecessary to create a run if you are only querying the W&B API and not tracking an experiment, artifact and so on.
+Note that you do not initialize a run with the following code snippet. This is because it is unnecessary to create a run if you are only querying the W&B API and not tracking an experiment, artifact and so on.
 </Note>
 </Tab>
 </Tabs>
@@ -119,7 +119,7 @@ Where `registry_name` is the name of the registry and `collection_name` is the n
 W&B automatically creates a collection for you if you try to link an artifact to a collection that does not exist. If you specify a collection that does exists, W&B links the artifact to the existing collection.
 </Note>
 
-The proceeding code snippet shows how to programmatically create a collection. Ensure to replace other the values enclosed in `<>` with your own:
+The following code snippet shows how to programmatically create a collection. Ensure to replace other the values enclosed in `<>` with your own:
 
 ```python
 import wandb

--- a/models/registry/download_use_artifact.mdx
+++ b/models/registry/download_use_artifact.mdx
@@ -36,15 +36,11 @@ REGISTRY = '<registry_name>'
 COLLECTION = '<collection_name>'
 ALIAS = '<artifact_alias>'
 
-run = wandb.init(
-   entity = '<team_name>',
-   project = '<project_name>'
-   )  
-
-artifact_name = f"wandb-registry-{REGISTRY}/{COLLECTION}:{ALIAS}"
-# artifact_name = '<artifact_name>' # Copy and paste Full name specified in the W&B Registry UI
-fetched_artifact = run.use_artifact(artifact_or_name = artifact_name)  
-download_path = fetched_artifact.download()  
+with wandb.init(entity = '<team_name>', project = '<project_name>')  as run:
+    artifact_name = f"wandb-registry-{REGISTRY}/{COLLECTION}:{ALIAS}"
+    # artifact_name = '<artifact_name>' # Copy and paste Full name specified in the W&B Registry UI
+    fetched_artifact = run.use_artifact(artifact_or_name = artifact_name)  
+    download_path = fetched_artifact.download()  
 ```
 
 The `.use_artifact()` method both creates a [run](/models/runs/) and marks the artifact you download as the input to that run. 
@@ -80,15 +76,15 @@ COLLECTION = "phi3-finetuned"
 ALIAS = 'production'
 
 # Initialize a run inside the specified team and project
-run = wandb.init(entity=TEAM_ENTITY, project = PROJECT_NAME)
+with wandb.init(entity=TEAM_ENTITY, project = PROJECT_NAME) as run:
 
-artifact_name = f"wandb-registry-{REGISTRY}/{COLLECTION}:{ALIAS}"
+    artifact_name = f"wandb-registry-{REGISTRY}/{COLLECTION}:{ALIAS}"
 
-# Access an artifact and mark it as input to your run for lineage tracking
-fetched_artifact = run.use_artifact(artifact_or_name = name)  
+    # Access an artifact and mark it as input to your run for lineage tracking
+    fetched_artifact = run.use_artifact(artifact_or_name = name)  
 
-# Download artifact. Returns path to downloaded contents
-downloaded_path = fetched_artifact.download()  
+    # Download artifact. Returns path to downloaded contents
+    downloaded_path = fetched_artifact.download()  
 ```
 </details>
 

--- a/models/registry/download_use_artifact.mdx
+++ b/models/registry/download_use_artifact.mdx
@@ -27,7 +27,7 @@ Replace the values within the curly braces `{}` with the name of the registry, c
 Specify `model` or `dataset` to link an artifact version to the core Model registry or the core Dataset registry, respectively.
 </Note>
 
-Use the `wandb.init.use_artifact` method to access the artifact and download its contents once you have the path of the linked artifact. The proceeding code snippet shows how to use and download an artifact linked to the W&B Registry. Ensure to replace values within `<>` with your own:
+Use the `wandb.init.use_artifact` method to access the artifact and download its contents once you have the path of the linked artifact. The following code snippet shows how to use and download an artifact linked to the W&B Registry. Ensure to replace values within `<>` with your own:
 
 ```python
 import wandb
@@ -63,7 +63,7 @@ artifact = api.artifact(name = artifact_name)
 <details>
 <summary>Example: Use and download an artifact linked to the W&B Registry</summary>
 
-The proceeding code example shows how a user can download an artifact linked to a collection called `phi3-finetuned` in the **Fine-tuned Models** registry. The alias of the artifact version is set to `production`.
+The following code example shows how a user can download an artifact linked to a collection called `phi3-finetuned` in the **Fine-tuned Models** registry. The alias of the artifact version is set to `production`.
 
 ```python
 import wandb

--- a/models/registry/link_version.mdx
+++ b/models/registry/link_version.mdx
@@ -212,16 +212,14 @@ You can confirm the name of your team by:
 #### Log from a team entity
 1. Specify the team as the entity when you initialize a run with [`wandb.init()`](/models/ref/python/functions/init). If you do not specify the `entity` when you initialize a run, the run uses your default entity which may or may not be your team entity.
 
-  ```python 
-  import wandb   
+    ```python 
+    import wandb   
 
-  run = wandb.init(
-    entity='<team_entity>', 
-    project='<project_name>'
-    )
-  ```
+    with wandb.init(entity='<team_entity>', project='<project_name>') as run:
+        # Log your artifact here
+    ```
 
-2. Log the artifact to the run either with run.log_artifact or by creating an Artifact object and then adding files to it with:
+2. Log the artifact to the run either with `wandb.Run.log_artifact()` or by creating an Artifact object and then adding files to it with:
 
     ```python
     artifact = wandb.Artifact(name="<artifact_name>", type="<type>")

--- a/models/registry/model_registry.mdx
+++ b/models/registry/model_registry.mdx
@@ -41,19 +41,17 @@ import wandb
 import random
 
 # Start a new W&B run
-run = wandb.init(project="models_quickstart")
+with wandb.init(project="models_quickstart") as run:
 
-# Simulate logging model metrics
-run.log({"acc": random.random()})
+  # Simulate logging model metrics
+  run.log({"acc": random.random()})
 
-# Create a simulated model file
-with open("my_model.h5", "w") as f:
-    f.write("Model: " + str(random.random()))
+  # Create a simulated model file
+  with open("my_model.h5", "w") as f:
+      f.write("Model: " + str(random.random()))
 
-# Log and link the model to the Model Registry
-run.link_model(path="./my_model.h5", registered_model_name="MNIST")
-
-run.finish()
+  # Log and link the model to the Model Registry
+  run.link_model(path="./my_model.h5", registered_model_name="MNIST")
 ```
 
 4. **Connect model transitions to CI/CD workflows**: transition candidate models through workflow stages and [automate downstream actions](/models/automations/) with webhooks.

--- a/models/registry/model_registry/consume-models.mdx
+++ b/models/registry/model_registry/consume-models.mdx
@@ -18,10 +18,10 @@ Replace values within `<>` with your own:
 import wandb
 
 # Initialize a run
-run = wandb.init(project="<project>", entity="<entity>")
+with wandb.init(project="<project>", entity="<entity>") as run:
 
-# Access and download model. Returns path to downloaded artifact
-downloaded_model_path = run.use_model(name="<your-model-name>")
+    # Access and download model. Returns path to downloaded artifact
+    downloaded_model_path = run.use_model(name="<your-model-name>")
 ```
 
 Reference a model version with one of following formats listed:
@@ -46,10 +46,9 @@ alias = "latest"  # semantic nickname or identifier for the model version
 model_artifact_name = "fine-tuned-model"
 
 # Initialize a run
-run = wandb.init()
-# Access and download model. Returns path to downloaded artifact
-
-downloaded_model_path = run.use_model(name=f"{entity/project/model_artifact_name}:{alias}")
+with wandb.init() as run:
+    # Access and download model. Returns path to downloaded artifact
+    downloaded_model_path = run.use_model(name=f"{entity/project/model_artifact_name}:{alias}")
 ```
 </details>
 
@@ -67,10 +66,11 @@ Use the W&B Registry to track, organize and consume model artifacts. For more in
 Replace values within `<>` with your own:
 ```python
 import wandb
+
 # Initialize a run
-run = wandb.init(project="<project>", entity="<entity>")
-# Access and download model. Returns path to downloaded artifact
-downloaded_model_path = run.use_model(name="<your-model-name>")
+with wandb.init(project="<project>", entity="<entity>") as run:
+    # Access and download model. Returns path to downloaded artifact
+    downloaded_model_path = run.use_model(name="<your-model-name>")
 ```
 Reference a model version with one of following formats listed:
 

--- a/models/registry/organize-with-tags.mdx
+++ b/models/registry/organize-with-tags.mdx
@@ -171,13 +171,13 @@ REGISTRY_NAME = "<registry_name>"
 COLLECTION_NAME = "<collection_name>"
 VERSION = "<artifact_version>"
 
-run = wandb.init(entity = "<entity>", project="<project>")
+with wandb.init(entity = "<entity>", project="<project>") as run:
 
-artifact_name = f"{ORG_NAME}/wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}:v{VERSION}"
+    artifact_name = f"{ORG_NAME}/wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}:v{VERSION}"
 
-artifact = run.use_artifact(artifact_or_name = artifact_name)
-artifact.tags = ["tag2"] # Provide one or more tags in a list
-artifact.save()
+    artifact = run.use_artifact(artifact_or_name = artifact_name)
+    artifact.tags = ["tag2"] # Provide one or more tags in a list
+    artifact.save()
 ```
 </Tab>
 </Tabs>
@@ -265,12 +265,12 @@ REGISTRY_NAME = "<registry_name>"
 COLLECTION_NAME = "<collection_name>"
 VERSION = "<artifact_version>"
 
-run = wandb.init(entity = "<entity>", project="<project>")
+with wandb.init(entity = "<entity>", project="<project>") as run:
 
-artifact_name = f"{ORG_NAME}/wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}:v{VERSION}"
+    artifact_name = f"{ORG_NAME}/wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}:v{VERSION}"
 
-artifact = run.use_artifact(artifact_or_name = artifact_name)
-print(artifact.tags)
+    artifact = run.use_artifact(artifact_or_name = artifact_name)
+    print(artifact.tags)
 ```
 </Tab>
 </Tabs>

--- a/models/registry/organize-with-tags.mdx
+++ b/models/registry/organize-with-tags.mdx
@@ -61,7 +61,7 @@ collection.save()
 
 Update a tag programmatically by reassigning or by mutating the `tags` attribute. W&B recommends, and it is good Python practice, that you reassign the `tags` attribute instead of in-place mutation.
 
-For example, the proceeding code snippet shows common ways to update a list with reassignment. For brevity, we continue the code example from the [Add a tag to a collection section](#add-a-tag-to-a-collection): 
+For example, the following code snippet shows common ways to update a list with reassignment. For brevity, we continue the code example from the [Add a tag to a collection section](#add-a-tag-to-a-collection): 
 
 ```python
 collection.tags = [*collection.tags, "new-tag", "other-tag"]
@@ -143,7 +143,7 @@ Like other artifacts, you can fetch an artifact from W&B without creating a run 
 Copy and paste an appropriate code cells below to add or modify an artifact version's tag. Replace the values in `<>` with your own.
 
 
-The proceeding code snippet shows how to fetch an artifact and add a tag without creating a new run:
+The following code snippet shows how to fetch an artifact and add a tag without creating a new run:
 ```python title="Add a tag to an artifact version without creating a new run"
 import wandb
 
@@ -161,7 +161,7 @@ artifact.save()
 ```
 
 
-The proceeding code snippet shows how to fetch an artifact and add a tag by creating a new run:
+The following code snippet shows how to fetch an artifact and add a tag by creating a new run:
 
 ```python title="Add a tag to an artifact version during a run"
 import wandb
@@ -189,7 +189,7 @@ with wandb.init(entity = "<entity>", project="<project>") as run:
 
 Update a tag programmatically by reassigning or by mutating the `tags` attribute. W&B recommends, and it is good Python practice, that you reassign the `tags` attribute instead of in-place mutation.
 
-For example, the proceeding code snippet shows common ways to update a list with reassignment. For brevity, we continue the code example from the [Add a tag to an artifact version section](#add-a-tag-to-an-artifact-version): 
+For example, the following code snippet shows common ways to update a list with reassignment. For brevity, we continue the code example from the [Add a tag to an artifact version section](#add-a-tag-to-an-artifact-version): 
 
 ```python
 artifact.tags = [*artifact.tags, "new-tag", "other-tag"]
@@ -237,7 +237,7 @@ Like other artifacts, you can fetch an artifact from W&B without creating a run 
 
 Copy and paste an appropriate code cells below to add or modify an artifact version's tag. Replace the values in `<>` with your own.
 
-The proceeding code snippet shows how to fetch and view an artifact version's tags without creating a new run:
+The following code snippet shows how to fetch and view an artifact version's tags without creating a new run:
 
 ```python title="Add a tag to an artifact version without creating a new run"
 import wandb
@@ -255,7 +255,7 @@ print(artifact.tags)
 ```
 
 
-The proceeding code snippet shows how to fetch and view artifact version's tags by creating a new run:
+The following code snippet shows how to fetch and view artifact version's tags by creating a new run:
 
 ```python title="Add a tag to an artifact version during a run"
 import wandb

--- a/models/registry/registry_cards.mdx
+++ b/models/registry/registry_cards.mdx
@@ -47,7 +47,7 @@ Specify the collection's type for the `type_name` parameter and the collection's
 wandb-registry-{REGISTRY_NAME}/{COLLECTION_NAME}
 ```
 
-Copy and paste the proceeding code snippet into your Python script or notebook. Replace values enclosed in angle brackets (`<>`) with your own.
+Copy and paste the following code snippet into your Python script or notebook. Replace values enclosed in angle brackets (`<>`) with your own.
 
 ```python
 import wandb

--- a/models/registry/search_registry.mdx
+++ b/models/registry/search_registry.mdx
@@ -32,7 +32,7 @@ The following table lists query names you can use based on the type of item you 
 | collections | `name`, `tag`, `description`, `created_at`, `updated_at` |
 | versions | `tag`, `alias`, `created_at`, `updated_at`, `metadata` |
 
-The proceeding code examples demonstrate some common search scenarios. 
+The following code examples demonstrate some common search scenarios. 
 
 To use the `wandb.Api().registries()` method, first import the W&B Python SDK ([`wandb`](/models/ref/python/)) library:
 ```python

--- a/models/runs.mdx
+++ b/models/runs.mdx
@@ -214,7 +214,8 @@ You can specify your own run ID by passing the `id` parameter to the [`wandb.ini
 ```python 
 import wandb
 
-run = wandb.init(entity="<project>", project="<project>", id="<run-id>")
+with wandb.init(entity="<project>", project="<project>", id="<run-id>") as run:
+    # Your code here
 ```
 
 You can use a run's unique ID to directly navigate to the run's overview page in the W&B App. The proceeding cell shows the URL path for a specific run:

--- a/models/runs.mdx
+++ b/models/runs.mdx
@@ -63,7 +63,7 @@ The URL W&B returns in the terminal to redirects you to the run's workspace in t
     <img src="/images/runs/single-run-call.png" alt="Single run workspace"  />
 </Frame>
 
-Logging a metrics at a single point of time might not be that useful. A more realistic example in the case of training discriminative models is to log metrics at regular intervals. For example, consider the proceeding code snippet:
+Logging a metrics at a single point of time might not be that useful. A more realistic example in the case of training discriminative models is to log metrics at regular intervals. For example, consider the following code snippet:
 
 ```python
 import wandb
@@ -120,7 +120,7 @@ As another example, during a [sweep](/models/sweeps/), W&B explores a hyperparam
 
 ## Initialize a W&B Run
 
-Initialize a W&B Run with [`wandb.init()`](/models/ref/python/functions/init). The proceeding code snippet shows how to import the W&B Python SDK and initialize a run. 
+Initialize a W&B Run with [`wandb.init()`](/models/ref/python/functions/init). The following code snippet shows how to import the W&B Python SDK and initialize a run. 
 
 Ensure to replace values enclosed in angle brackets (`< >`) with your own values:
 

--- a/models/runs/alert.mdx
+++ b/models/runs/alert.mdx
@@ -60,8 +60,8 @@ Add `run.alert()` to your code (either in a Notebook or Python script) wherever 
 ```python
 import wandb
 
-run = wandb.init()
-run.alert(title="High Loss", text="Loss is increasing rapidly")
+with wandb.init() as run:
+    run.alert(title="High Loss", text="Loss is increasing rapidly")
 ```
 
 ### 3. Test the configuration
@@ -76,15 +76,15 @@ This simple alert sends a warning when accuracy falls below a threshold. In this
 import wandb
 from wandb import AlertLevel
 
-run = wandb.init()
+with wandb.init() as run:
 
-if acc < threshold:
-    run.alert(
-        title="Low accuracy",
-        text=f"Accuracy {acc} is below the acceptable threshold {threshold}",
-        level=AlertLevel.WARN,
-        wait_duration=300,
-    )
+    if acc < threshold:
+        run.alert(
+            title="Low accuracy",
+            text=f"Accuracy {acc} is below the acceptable threshold {threshold}",
+            level=AlertLevel.WARN,
+            wait_duration=300,
+        )
 ```
 
 

--- a/models/runs/forking.mdx
+++ b/models/runs/forking.mdx
@@ -35,6 +35,7 @@ forked_run = wandb.init(
     entity="your_entity_name",
     fork_from=f"{original_run.id}?_step=200",
 )
+forked_run.finish()
 ```
 
 ## Continue from a forked run

--- a/models/runs/resuming.mdx
+++ b/models/runs/resuming.mdx
@@ -6,8 +6,7 @@ title: Resume a run
 Specify how a run should behave in the event that run stops or crashes. To resume or enable a run to automatically resume, you will need to specify the unique run ID associated with that run for the `id` parameter:
 
 ```python
-run = wandb.init(entity="<entity>", \ 
-        project="<project>", id="<run ID>", resume="<resume>")
+with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="<resume>") as run:
 ```
 
 <Note>
@@ -41,8 +40,7 @@ If a run is stopped, crashes, or fails, you can resume it using the same run ID.
 The following code snippet shows how to accomplish this with the W&B Python SDK:
 
 ```python
-run = wandb.init(entity="<entity>", \ 
-        project="<project>", id="<run ID>", resume="must")
+with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="must") as run:
 ```
 
 <Warning>
@@ -60,8 +58,8 @@ Set the `resume` parameter to `"allow"` (`resume="allow"`) when you initialize a
 ```python
 import wandb
 
-run = wandb.init(entity="<entity>", \ 
-        project="<project>", id="<run ID>", resume="allow")
+with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="allow") as run:
+        # Your training code here
 ```
 
 
@@ -75,8 +73,8 @@ The following code snippet shows how to specify a W&B run ID with the Python SDK
 Replace values enclosed within `<>` with your own:
 
 ```python
-run = wandb.init(entity="<entity>", \ 
-        project="<project>", id="<run ID>", resume="<resume>")
+with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="<resume>") as run:
+        # Your training code here
 ```
 </Tab>
 <Tab title="Shell script">
@@ -118,8 +116,8 @@ Automatically requeue interrupted [sweep](/models/sweeps/) runs. This is particu
 Use the [`mark_preempting`](/models/ref/python/experiments/run#mark_preempting) function to automatically requeue interrupted sweep runs. For example:
 
 ```python
-run = wandb.init()  # Initialize a run
-run.mark_preempting()
+with wandb.init() as run:
+    run.mark_preempting()
 ```
 The following table outlines how W&B handles runs based on the exit status of the a sweep run.
 

--- a/models/runs/tags.mdx
+++ b/models/runs/tags.mdx
@@ -19,11 +19,12 @@ You can add tags to a run when it is created:
 ```python
 import wandb
 
-run = wandb.init(
+with wandb.init(
   entity="entity",
   project="<project-name>",
   tags=["tag1", "tag2"]
-)
+) as run:
+    # Your training code here
 ```
 
 You can also update the tags after you initialize a run. For example, the proceeding code snippet shows how to update a tag if a particular metrics crosses a pre-defined threshold:
@@ -31,25 +32,20 @@ You can also update the tags after you initialize a run. For example, the procee
 ```python
 import wandb
 
-run = wandb.init(
-  entity="entity", 
-  project="capsules", 
-  tags=["debug"]
-  )
+with wandb.init(entity="entity", project="capsules", tags=["debug"]) as run:
 
-# python logic to train model
-
-if current_loss < threshold:
-    run.tags = run.tags + ("release_candidate",)
+  # python logic to train model
+  if current_loss < threshold:
+      run.tags = run.tags + ("release_candidate",)
 ```
 </Tab>
 <Tab title="Public API">
 After you create a run, you can update tags using [the Public API](/models/track/public-api-guide/). For example:
 
 ```python
-run = wandb.Api().run("{entity}/{project}/{run-id}")
-run.tags.append("tag1")  # you can choose tags based on run data here
-run.update()
+with wandb.Api().run("{entity}/{project}/{run-id}") as run:
+  run.tags.append("tag1")  # you can choose tags based on run data here
+  run.update()
 ```
 </Tab>
 <Tab title="Project page">

--- a/models/runs/tags.mdx
+++ b/models/runs/tags.mdx
@@ -27,7 +27,7 @@ with wandb.init(
     # Your training code here
 ```
 
-You can also update the tags after you initialize a run. For example, the proceeding code snippet shows how to update a tag if a particular metrics crosses a pre-defined threshold:
+You can also update the tags after you initialize a run. For example, the following code snippet shows how to update a tag if a particular metrics crosses a pre-defined threshold:
 
 ```python
 import wandb

--- a/models/support/resolve_permission_errors_when_logging_wandb_entity.mdx
+++ b/models/support/resolve_permission_errors_when_logging_wandb_entity.mdx
@@ -10,9 +10,8 @@ To resolve permission errors when logging a run to a W&B entity, follow these st
   ```python
   import wandb
 
-  run = wandb.init(entity="your_entity", project="your_project")
-  run.log({'example_metric': 1})
-  run.finish()
+  with wandb.init(entity="your_entity", project="your_project") as run:
+      run.log({'example_metric': 1})
   ```
 - **Set API key**: Use the `WANDB_API_KEY` environment variable:
   ```bash

--- a/models/support/resume_parameter.mdx
+++ b/models/support/resume_parameter.mdx
@@ -5,5 +5,6 @@ title: How do I use the resume parameter when resuming a run in W&B?
 To use the `resume` parameter in W&B , set the `resume` argument in `wandb.init()` with `entity`, `project`, and `id` specified. The `resume` argument accepts values of `"must"` or `"allow"`. 
 
   ```python
-  run = wandb.init(entity="your-entity", project="your-project", id="your-run-id", resume="must")
+  with  wandb.init(entity="your-entity", project="your-project", id="your-run-id", resume="must") as run:
+      # Your training code here
   ```

--- a/models/support/why_are_steps_missing_from_a_csv_metric_export.mdx
+++ b/models/support/why_are_steps_missing_from_a_csv_metric_export.mdx
@@ -8,8 +8,8 @@ Export limits can prevent the entire run history from being exported as a CSV or
 import wandb
 import pandas as pd
 
-run = wandb.init()
-artifact = run.use_artifact('<entity>/<project>/<run-id>-history:v0', type='wandb-history')
-artifact_dir = artifact.download()
-df = pd.read_parquet('<path to .parquet file>')
+with wandb.init() as run:
+    artifact = run.use_artifact('<entity>/<project>/<run-id>-history:v0', type='wandb-history')
+    artifact_dir = artifact.download()
+    df = pd.read_parquet('<path to .parquet file>')
 ```

--- a/models/sweeps/define-sweep-configuration.mdx
+++ b/models/sweeps/define-sweep-configuration.mdx
@@ -21,7 +21,7 @@ Both sweep configuration format options (YAML and Python dictionary) utilize key
 Use top-level keys within your sweep configuration to define qualities of your sweep search such as the name of the sweep ([`name`](./sweep-config-keys) key), the parameters to search through ([`parameters`](./sweep-config-keys#parameters) key), the methodology to search the parameter space ([`method`](./sweep-config-keys#method) key), and more. 
 
 
-For example, the proceeding code snippets show the same sweep configuration defined within a YAML file and within a Python dictionary. Within the sweep configuration there are five top level keys specified: `program`, `name`, `method`, `metric` and `parameters`. 
+For example, the following code snippets show the same sweep configuration defined within a YAML file and within a Python dictionary. Within the sweep configuration there are five top level keys specified: `program`, `name`, `method`, `metric` and `parameters`. 
 
 
 <Tabs>
@@ -50,7 +50,7 @@ parameters:
 <Tab title="Python script or notebook">
 Define a sweep in a Python dictionary data structure if you define training algorithm in a Python script or notebook. 
 
-The proceeding code snippet stores a sweep configuration in a variable named `sweep_configuration`:
+The following code snippet stores a sweep configuration in a variable named `sweep_configuration`:
 
 ```python title="train.py"
 sweep_configuration = {
@@ -225,7 +225,7 @@ parameters:
    3. Specify one or more values to explore. The value (or values) should be inline with the distribution key.  
       1. (Optional) Use an additional parameters key under the top level parameter name to delineate a nested parameter. */}
 
-{/* For example, the proceeding code snippets show a sweep config both in a YAML config file and a Python script. */}
+{/* For example, the following code snippets show a sweep config both in a YAML config file and a Python script. */}
 
 
 <Warning>

--- a/models/sweeps/define-sweep-configuration.mdx
+++ b/models/sweeps/define-sweep-configuration.mdx
@@ -235,7 +235,8 @@ As an example, suppose you have `train.py` script that initializes a run with a 
 
 ```python
 def main():
-    run = wandb.init(config={"nested_param": {"manual_key": 1}})
+    with  wandb.init(config={"nested_param": {"manual_key": 1}}) as run:
+        # Your training code here
 ```
 
 Your sweep configuration defines nested parameters under a top-level `"parameters"` key:

--- a/models/sweeps/initialize-sweeps.mdx
+++ b/models/sweeps/initialize-sweeps.mdx
@@ -40,7 +40,7 @@ The [`wandb.sweep()`](/models/ref/python/functions/sweep) function returns the s
 <Tab title="CLI">
 Use the W&B CLI to initialize a sweep. Provide the name of your configuration file. Optionally provide the name of the project for the `project` flag. If the project is not specified, the W&B Run is put in an "Uncategorized" project.
 
-Use the [`wandb sweep`](/models/ref/cli/wandb-sweep) command to initialize a sweep. The proceeding code example initializes a sweep for a `sweeps_demo` project and uses a `config.yaml` file for the configuration.
+Use the [`wandb sweep`](/models/ref/cli/wandb-sweep) command to initialize a sweep. The following code example initializes a sweep for a `sweeps_demo` project and uses a `config.yaml` file for the configuration.
 
 ```bash
 wandb sweep --project sweeps_demo config.yaml

--- a/models/sweeps/parallelize-agents.mdx
+++ b/models/sweeps/parallelize-agents.mdx
@@ -51,7 +51,7 @@ Terminal 1
 CUDA_VISIBLE_DEVICES=0 wandb agent sweep_ID
 ```
 
-Open a second terminal window. Set `CUDA_VISIBLE_DEVICES` to `1` (`CUDA_VISIBLE_DEVICES=1`). Paste the same W&B Sweep ID for the `sweep_ID` mentioned in the proceeding code snippet:
+Open a second terminal window. Set `CUDA_VISIBLE_DEVICES` to `1` (`CUDA_VISIBLE_DEVICES=1`). Paste the same W&B Sweep ID for the `sweep_ID` mentioned in the following code snippet:
 
 Terminal 2
 

--- a/models/sweeps/start-sweep-agents.mdx
+++ b/models/sweeps/start-sweep-agents.mdx
@@ -20,7 +20,7 @@ Where:
 
 Provide the name of the function the W&B Sweep will execute if you start a W&B Sweep agent within a Jupyter Notebook or Python script.
 
-The proceeding code snippets demonstrate how to start an agent with W&B. We assume you already have a configuration file and you have already initialized a W&B Sweep. For more information about how to define a configuration file, see [Define sweep configuration](/models/sweeps/define-sweep-configuration/).
+The following code snippets demonstrate how to start an agent with W&B. We assume you already have a configuration file and you have already initialized a W&B Sweep. For more information about how to define a configuration file, see [Define sweep configuration](/models/sweeps/define-sweep-configuration/).
 
 <Tabs>
 <Tab title="CLI">

--- a/models/tables.mdx
+++ b/models/tables.mdx
@@ -39,9 +39,9 @@ Log a table with a few lines of code:
 ```python
 import wandb
 
-run = wandb.init(project="table-test")
-my_table = wandb.Table(columns=["a", "b"], data=[["a1", "b1"], ["a2", "b2"]])
-run.log({"Table Name": my_table})
+with wandb.init(project="table-test") as run:
+    my_table = wandb.Table(columns=["a", "b"], data=[["a1", "b1"], ["a2", "b2"]])
+    run.log({"Table Name": my_table})
 ```
 
 ## How to get started

--- a/models/track/config.mdx
+++ b/models/track/config.mdx
@@ -31,7 +31,7 @@ The following sections outline different common scenarios of how to define your 
 ### Set the configuration at initialization
 Pass a dictionary at the beginning of your script when you call the `wandb.init()` API to generate a background process to sync and log data as a W&B Run.
 
-The proceeding code snippet demonstrates how to define a Python dictionary with configuration values and how to pass that dictionary as an argument when you initialize a W&B Run.
+The following code snippet demonstrates how to define a Python dictionary with configuration values and how to pass that dictionary as an argument when you initialize a W&B Run.
 
 ```python
 import wandb
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     main(args)
 ```
 ### Set the configuration throughout your script
-You can add more parameters to your config object throughout your script. The proceeding code snippet demonstrates how to add new key-value pairs to your config object:
+You can add more parameters to your config object throughout your script. The following code snippet demonstrates how to add new key-value pairs to your config object:
 
 ```python
 import wandb

--- a/models/track/limits.mdx
+++ b/models/track/limits.mdx
@@ -53,22 +53,20 @@ If your workspace suddenly slows down, check whether recent runs have unintentio
 
 ### Value width
 
-Limit the size of a single logged value to under 1 MB and the total size of a single `run.log` call to under 25 MB. This limit does not apply to `wandb.Media` types like `wandb.Image`, `wandb.Audio`, etc.
+Limit the size of a single logged value to under 1 MB and the total size of a single `wandb.Run.log()` call to under 25 MB. This limit does not apply to `wandb.Media` types like `wandb.Image`, `wandb.Audio`, etc.
 
 ```python
 import wandb
 
-run = wandb.init(project="wide-values")
+with wandb.init(project="wide-values") as run:
 
-# not recommended
-run.log({"wide_key": range(10000000)})
+    # not recommended
+    run.log({"wide_key": range(10000000)})
 
-# not recommended
-with open("large_file.json", "r") as f:
-    large_data = json.load(f)
-    run.log(large_data)
-
-run.finish()
+    # not recommended
+    with open("large_file.json", "r") as f:
+        large_data = json.load(f)
+        run.log(large_data)
 ```
 
 Wide values can affect the plot load times for all metrics in the run, not just the metric with the wide values.

--- a/models/track/log/log-models.mdx
+++ b/models/track/log/log-models.mdx
@@ -132,7 +132,7 @@ The [use_model](/models/ref/python/experiments/run#use_model) function returns t
 
 <summary>Example: Download and use a logged model</summary>
 
-For example, in the proceeding code snippet a user called the `use_model` API. They specified the name of the model artifact they want to fetch and they also provided a version/alias. They then stored the path that is returned from the API to the `downloaded_model_path` variable.
+For example, in the following code snippet a user called the `use_model` API. They specified the name of the model artifact they want to fetch and they also provided a version/alias. They then stored the path that is returned from the API to the `downloaded_model_path` variable.
 
 ```python
 import wandb
@@ -167,7 +167,7 @@ Use the [Registry](/models/registry/) to organize your best models by task, mana
 
 A *Registered Model* is a collection or folder of linked model versions in the [Model Registry](/models/registry/model_registry/). Registered models typically represent candidate models for a single modeling use case or task. 
 
-The proceeding code snippet shows how to link a model with the [`link_model`](/models/ref/python/experiments/run#link_model) API. Ensure to replace other the values enclosed in `<>` with your own:
+The following code snippet shows how to link a model with the [`link_model`](/models/ref/python/experiments/run#link_model) API. Ensure to replace other the values enclosed in `<>` with your own:
 
 ```python
 import wandb
@@ -188,7 +188,7 @@ For example, suppose you have an existing registered model named "Fine-Tuned-Rev
 
 <summary>Example: Log and link a model to the W&B Model Registry</summary>
 
-For example, the proceeding code snippet logs model files and links the model to a registered model name `"Fine-Tuned-Review-Autocompletion"`. 
+For example, the following code snippet logs model files and links the model to a registered model name `"Fine-Tuned-Review-Autocompletion"`. 
 
 To do this, a user calls the `wandb.Run.link_model()`. When they call the `wandb.Run.link_model()`, W&B provides a local filepath that points the content of the model (`path`) and W&B provides a name for the registered model to link it to (`registered_model_name`). 
 

--- a/models/track/log/log-models.mdx
+++ b/models/track/log/log-models.mdx
@@ -33,16 +33,16 @@ Ensure to replace values enclosed in `<>` with your own.
 import wandb
 
 # Initialize a W&B run
-run = wandb.init(project="<your-project>", entity="<your-entity>")
+with wandb.init(project="<your-project>", entity="<your-entity>") as run:
 
-# Log the model
-run.log_model(path="<path-to-model>", name="<name>")
+    # Log the model
+    run.log_model(path="<path-to-model>", name="<name>")
 ```
 
 Optionally provide a name for the model artifact for the `name` parameter. If `name` is not specified, W&B will use the basename of the input path prepended with the run ID as the name. 
 
 <Note>
-Keep track of the `name` that you, or W&B assigns, to the model. You will need the name of the model to retrieve the model path with the [`use_model`](/models/ref/python/experiments/run#use_model) method.
+Keep track of the `name` that you, or W&B assigns, to the model. You will need the name of the model to retrieve the model path with the [`wandb.Run.use_model()`](/models/ref/python/experiments/run#use_model) method.
 </Note>
 
 See [`log_model`](/models/ref/python/experiments/run#log_model) in the API Reference for parameters.
@@ -60,41 +60,40 @@ from tensorflow.keras import layers
 config = {"optimizer": "adam", "loss": "categorical_crossentropy"}
 
 # Initialize a W&B run
-run = wandb.init(entity="charlie", project="mnist-experiments", config=config)
+with wandb.init(entity="charlie", project="mnist-experiments", config=config) as run:
 
-# Hyperparameters
-loss = run.config["loss"]
-optimizer = run.config["optimizer"]
-metrics = ["accuracy"]
-num_classes = 10
-input_shape = (28, 28, 1)
+    # Hyperparameters
+    loss = run.config["loss"]
+    optimizer = run.config["optimizer"]
+    metrics = ["accuracy"]
+    num_classes = 10
+    input_shape = (28, 28, 1)
 
-# Training algorithm
-model = keras.Sequential(
-    [
-        layers.Input(shape=input_shape),
-        layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
-        layers.MaxPooling2D(pool_size=(2, 2)),
-        layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
-        layers.MaxPooling2D(pool_size=(2, 2)),
-        layers.Flatten(),
-        layers.Dropout(0.5),
-        layers.Dense(num_classes, activation="softmax"),
-    ]
-)
+    # Training algorithm
+    model = keras.Sequential(
+        [
+            layers.Input(shape=input_shape),
+            layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
+            layers.MaxPooling2D(pool_size=(2, 2)),
+            layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
+            layers.MaxPooling2D(pool_size=(2, 2)),
+            layers.Flatten(),
+            layers.Dropout(0.5),
+            layers.Dense(num_classes, activation="softmax"),
+        ]
+    )
 
-# Configure the model for training
-model.compile(loss=loss, optimizer=optimizer, metrics=metrics)
+    # Configure the model for training
+    model.compile(loss=loss, optimizer=optimizer, metrics=metrics)
 
-# Save model
-model_filename = "model.h5"
-local_filepath = "./"
-full_path = os.path.join(local_filepath, model_filename)
-model.save(filepath=full_path)
+    # Save model
+    model_filename = "model.h5"
+    local_filepath = "./"
+    full_path = os.path.join(local_filepath, model_filename)
+    model.save(filepath=full_path)
 
-# Log the model to the W&B run
-run.log_model(path=full_path, name="MNIST")
-run.finish()
+    # Log the model to the W&B run
+    run.log_model(path=full_path, name="MNIST")
 ```
 
 When the user called `log_model`, a model artifact named `MNIST` was created and the file `model.h5` was added to the model artifact. Your terminal or notebook will print information of where to find information about the run the model was logged to.
@@ -121,10 +120,10 @@ Ensure to replace other the values enclosed in `<>` with your own:
 import wandb
 
 # Initialize a run
-run = wandb.init(project="<your-project>", entity="<your-entity>")
+with wandb.init(project="<your-project>", entity="<your-entity>") as run:
 
-# Access and download model. Returns path to downloaded artifact
-downloaded_model_path = run.use_model(name="<your-model-name>")
+    # Access and download model. Returns path to downloaded artifact
+    downloaded_model_path = run.use_model(name="<your-model-name>")
 ```
 
 The [use_model](/models/ref/python/experiments/run#use_model) function returns the path of downloaded model files. Keep track of this path if you want to link this model later. In the preceding code snippet, the returned path is stored in a variable called `downloaded_model_path`.
@@ -144,9 +143,9 @@ alias = "latest"  # semantic nickname or identifier for the model version
 model_artifact_name = "fine-tuned-model"
 
 # Initialize a run
-run = wandb.init(project=project, entity=entity)
-# Access and download model. Returns path to downloaded artifact
-downloaded_model_path = run.use_model(name = f"{model_artifact_name}:{alias}") 
+with wandb.init(project=project, entity=entity) as run:
+    # Access and download model. Returns path to downloaded artifact
+    downloaded_model_path = run.use_model(name = f"{model_artifact_name}:{alias}") 
 ```
 </details>
 
@@ -173,12 +172,12 @@ The proceeding code snippet shows how to link a model with the [`link_model`](/m
 ```python
 import wandb
 
-run = wandb.init(entity="<your-entity>", project="<your-project>")
-run.link_model(path="<path-to-model>", registered_model_name="<registered-model-name>")
-run.finish()
+with wandb.init(entity="<your-entity>", project="<your-project>") as run:
+    # Link the model to the W&B Model Registry
+    run.link_model(path="<path-to-model>", registered_model_name="<registered-model-name>")
 ```
 
-See [`link_model`](/models/ref/python/experiments/run#link_model) in the API Reference guide for optional parameters.
+See [`wandb.Run.link_model()`](/models/ref/python/experiments/run#link_model) in the API Reference guide for optional parameters.
 
 If the `registered-model-name` matches the name of a registered model that already exists within the Model Registry, the model will be linked to that registered model. If no such registered model exists, a new one will be created and the model will be the first one linked. 
 
@@ -191,7 +190,7 @@ For example, suppose you have an existing registered model named "Fine-Tuned-Rev
 
 For example, the proceeding code snippet logs model files and links the model to a registered model name `"Fine-Tuned-Review-Autocompletion"`. 
 
-To do this, a user calls the `link_model` API. When they call the API, they provide a local filepath that points the content of the model (`path`) and they provide a name for the registered model to link it to (`registered_model_name`). 
+To do this, a user calls the `wandb.Run.link_model()`. When they call the `wandb.Run.link_model()`, W&B provides a local filepath that points the content of the model (`path`) and W&B provides a name for the registered model to link it to (`registered_model_name`). 
 
 ```python
 import wandb
@@ -199,9 +198,8 @@ import wandb
 path = "/local/dir/model.pt"
 registered_model_name = "Fine-Tuned-Review-Autocompletion"
 
-run = wandb.init(project="llm-evaluation", entity="noa")
-run.link_model(path=path, registered_model_name=registered_model_name)
-run.finish()
+with wandb.init(project="llm-evaluation", entity="<your-entity>") as run:
+    run.link_model(path=path, registered_model_name=registered_model_name)
 ```
 
 <Note>

--- a/models/track/log/log-tables.mdx
+++ b/models/track/log/log-tables.mdx
@@ -107,10 +107,10 @@ with wandb.init(project="my_project") as run:
     )
 
     # Initialize the Run
-    run = wandb.init()
+    with wandb.init() as run:
 
-    # Log the updated table to W&B
-    run.log({table_name: best_checkpt_table})
+        # Log the updated table to W&B
+        run.log({table_name: best_checkpt_table})
 ```
 
 ## Retrieve data

--- a/models/track/log/log-tables.mdx
+++ b/models/track/log/log-tables.mdx
@@ -20,7 +20,7 @@ Use the `wandb.Table` constructor in one of two ways:
 
 1. **List of Rows:**
 
-   Log named columns and rows of data. For example the proceeding code snippet generates a table with two rows and three columns:
+   Log named columns and rows of data. For example the following code snippet generates a table with two rows and three columns:
 
    ```python
    wandb.Table(columns=["a", "b", "c"], data=[["1a", "1b", "1c"], ["2a", "2b", "2c"]])
@@ -190,7 +190,7 @@ You can join tables you have locally constructed or tables you have retrieved fr
 
 To join two Tables you have logged previously in an artifact context, fetch them from the artifact and join the result into a new Table. 
 
-For example, the proceeding code example demonstrates how to read one Table of original songs called `'original_songs'` and another Table of synthesized versions of the same songs called `'synth_songs'`. The code joins the two tables on `"song_id"`, and uploads the resulting table as a new W&B Table:
+For example, the following code example demonstrates how to read one Table of original songs called `'original_songs'` and another Table of synthesized versions of the same songs called `'synth_songs'`. The code joins the two tables on `"song_id"`, and uploads the resulting table as a new W&B Table:
 
 ```python
 import wandb

--- a/models/track/log/working-with-csv.mdx
+++ b/models/track/log/working-with-csv.mdx
@@ -11,7 +11,7 @@ Use the W&B Python Library to log a CSV file and visualize it in a [W&B Dashboar
 
 We suggest you utilize W&B Artifacts to make it easier to re-use the contents of the CSV file easier to use.
 
-1. To get started, first import your CSV file. In the proceeding code snippet, replace the `iris.csv` filename with the name of your CSV filename:
+1. To get started, first import your CSV file. In the following code snippet, replace the `iris.csv` filename with the name of your CSV filename:
 
 ```python
 import wandb
@@ -112,7 +112,7 @@ In some cases, you might have your experiment details in a CSV file. Common deta
 | ...          | ...              | ...                                              | ...           | ...        | ...             | ...           |                                       |
 | Experiment N | mnist-X-layers   | NOTES                                            | ...           | ...        | ...             | ...           | \[..., ...]                           |
 
-W&B can take CSV files of experiments and convert it into a W&B Experiment Run. The proceeding code snippets and code script demonstrates how to import and log your CSV file of experiments:
+W&B can take CSV files of experiments and convert it into a W&B Experiment Run. The following code snippets and code script demonstrates how to import and log your CSV file of experiments:
 
 1. To get started, first read in your CSV file and convert it into a Pandas DataFrame. Replace `"experiments.csv"` with the name of your CSV file:
 

--- a/models/track/log/working-with-csv.mdx
+++ b/models/track/log/working-with-csv.mdx
@@ -45,13 +45,13 @@ For more information about W&B Artifacts, see the [Artifacts chapter](/models/ar
 
 ```python
 # Start a W&B run to log data
-run = wandb.init(project="tables-walkthrough")
+with wandb.init(project="tables-walkthrough") as run:
 
-# Log the table to visualize with a run...
-run.log({"iris": iris_table})
+    # Log the table to visualize with a run...
+    run.log({"iris": iris_table})
 
-# and Log as an Artifact to increase the available row limit!
-run.log_artifact(iris_table_artifact)
+    # and Log as an Artifact to increase the available row limit!
+    run.log_artifact(iris_table_artifact)
 ```
 
 The `wandb.init()` API spawns a new background process to log data to a Run, and it synchronizes data to wandb.ai (by default). View live visualizations on your W&B Workspace Dashboard. The following image demonstrates the output of the code snippet demonstration.
@@ -82,16 +82,13 @@ iris_table_artifact.add(iris_table, "iris_table")
 iris_table_artifact.add_file("iris.csv")
 
 # Start a W&B run to log data
-run = wandb.init(project="tables-walkthrough")
+with wandb.init(project="tables-walkthrough") as run:
 
-# Log the table to visualize with a run...
-run.log({"iris": iris_table})
+    # Log the table to visualize with a run...
+    run.log({"iris": iris_table})
 
-# and Log as an Artifact to increase the available row limit!
-run.log_artifact(iris_table_artifact)
-
-# Finish the run (useful in notebooks)
-run.finish()
+    # and Log as an Artifact to increase the available row limit!
+    run.log_artifact(iris_table_artifact)
 ```
 
 ## Import and log your CSV of Experiments
@@ -158,9 +155,9 @@ for i, row in loaded_experiment_df.iterrows():
 2. Next, start a new W&B Run to track and log to W&B with [`wandb.init()`](/models/ref/python/functions/init):
 
     ```python
-    run = wandb.init(
+    with wandb.init(
         project=PROJECT_NAME, name=run_name, tags=tags, notes=notes, config=config
-    )
+    ) as run:
     ```
 
 As an experiment runs, you might want to log every instance of your metrics so they are available to view, query, and analyze with W&B. Use the [`run.log()`](/models/ref/python/experiments/run/#method-runlog) command to accomplish this:
@@ -209,17 +206,16 @@ for i, row in loaded_experiment_df.iterrows():
     for summary_col in SUMMARY_COLS:
         summaries[summary_col] = row[summary_col]
 
-    run = wandb.init(
+    with  wandb.init(
         project=PROJECT_NAME, name=run_name, tags=tags, notes=notes, config=config
-    )
+    ) as run:
 
-    for key, val in metrics.items():
-        if isinstance(val, list):
-            for _val in val:
-                run.log({key: _val})
-        else:
-            run.log({key: val})
+        for key, val in metrics.items():
+            if isinstance(val, list):
+                for _val in val:
+                    run.log({key: _val})
+            else:
+                run.log({key: val})
 
-    run.summary.update(summaries)
-    run.finish()
+        run.summary.update(summaries)
 ```

--- a/models/track/public-api-guide.mdx
+++ b/models/track/public-api-guide.mdx
@@ -451,10 +451,10 @@ The snippet below would find the system resource consumptions and then, save the
 ```python
 import wandb
 
-run = wandb.Api().run("<entity>/<project>/<run_id>")
+with wandb.Api().run("<entity>/<project>/<run_id>") as run:
 
-system_metrics = run.history(stream="events")
-system_metrics.to_csv("sys_metrics.csv")
+    system_metrics = run.history(stream="events")
+    system_metrics.to_csv("sys_metrics.csv")
 ```
 
 ### Get unsampled metric data

--- a/models/track/reproduce_experiments.mdx
+++ b/models/track/reproduce_experiments.mdx
@@ -35,7 +35,7 @@ Clone the GitHub repository your teammate used when creating the experiment. To 
     ```bash
     git clone https://github.com/your-repo.git && cd your-repo
     ```
-4. Copy and paste the **Git state** field into your terminal. The Git state is a set of Git commands that checks out the exact commit that your teammate used to create the experiment. Replace values specified in the proceeding code snippet with your own:
+4. Copy and paste the **Git state** field into your terminal. The Git state is a set of Git commands that checks out the exact commit that your teammate used to create the experiment. Replace values specified in the following code snippet with your own:
     ```bash
     git checkout -b "<run-name>" 0123456789012345678901234567890123456789
     ```


### PR DESCRIPTION
## Description

I have no idea why there are so many `run = wandb.init()` examples still out there. maybe it was lost in the migration? Unclear. 

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
