### PR TITLE
Fix error 'the argument '--format <FORMAT>' cannot be used multiple times

### DIFF
--- a/.github/workflows/linkcheck-pr.yml
+++ b/.github/workflows/linkcheck-pr.yml
@@ -15,8 +15,8 @@ jobs:
     if: |
       github.event.deployment_status.state == 'success' && 
       github.event.deployment.environment == 'staging' &&
-      contains(github.event.deployment_status.creator.login, 'mintlify' &&
-      contains(github.event.deployment_status.environment_url, 'mintlify'))
+      contains(github.event.deployment_status.creator.login, 'mintlify') &&
+      contains(github.event.deployment_status.environment_url, 'mintlify')
     steps:
       # check URLs with Lychee
       - uses: actions/checkout@v4
@@ -25,7 +25,8 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--threads 5 --max-retries 5 --retry-wait-time 2 -f markdown --include '^https?://' --include '^http?://' --base-url='$PREVIEW_URL' '$PREVIEW_URL'"
+          args: "--threads 5 --max-retries 5 --retry-wait-time 2 --include '^https?://' --include '^http?://' --base-url='$PREVIEW_URL' '$PREVIEW_URL'"
+          format: markdown
           fail: false
         env:
           # to be used in case rate limits are surpassed

--- a/.github/workflows/linkcheck-prod.yml
+++ b/.github/workflows/linkcheck-prod.yml
@@ -18,7 +18,9 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--threads 5 --max-retries 5 --retry-wait-time 2 -f markdown --output=./lychee-report.md --include '^https?://' --include '^http?://' --base-url='http://docs.wandb.ai' 'http://docs.wandb.ai'"
+          args: "--threads 5 --max-retries 5 --retry-wait-time 2 --include '^https?://' --include '^http?://' --base-url='http://docs.wandb.ai' 'http://docs.wandb.ai'"
+          output: ./lychee-report.md
+          format: markdown
           fail: false
         env:
           # to be used in case rate limits are surpassed
@@ -28,6 +30,6 @@ jobs:
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
-          title: Fix broken linksin docs.wandb.ai
+          title: Fix broken links in docs.wandb.ai
           content-filepath: ./lychee-report.md
           labels: report, automated issue


### PR DESCRIPTION
## Description

Fix error 'the argument '--format <FORMAT>' cannot be used multiple times

Discovered when I tried to run the new prod action for the first time https://github.com/wandb/docs/actions/runs/19181268747/job/54838396428
