### PR TITLE
Fix spurious redirects for icons in cards

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -14,7 +14,7 @@ Choose the product for which you need documentation.
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
     <ProductCard
         title="W&B Models"
-        iconSrc="/icons/cropped-models.svg"
+        iconSrc="icons/cropped-models.svg"
         href="/models"
         subtitle="Develop AI models"
     >
@@ -29,7 +29,7 @@ Choose the product for which you need documentation.
 
     <ProductCard
         title="W&B Weave"
-        iconSrc="/icons/cropped-weave.svg"
+        iconSrc="icons/cropped-weave.svg"
         href="/weave"
         subtitle="Use AI models in your app"
     >   
@@ -45,7 +45,7 @@ Choose the product for which you need documentation.
     
     <ProductCard
         title="W&B Inference"
-        iconSrc="/icons/cropped-inference.svg"
+        iconSrc="icons/cropped-inference.svg"
         href="/inference/"
         subtitle="Access foundation models"
     >
@@ -60,7 +60,7 @@ Choose the product for which you need documentation.
 
     <ProductCard
         title="W&B Training"
-        iconSrc="/icons/cropped-training.svg"
+        iconSrc="icons/cropped-training.svg"
         href="/training/"
         subtitle="Post-train your models"
     >

--- a/ja.mdx
+++ b/ja.mdx
@@ -19,7 +19,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
     <ProductCard
         title="W&B Models"
-        iconSrc="/icons/Name=Models, Mode=Dark.svg"
+        iconSrc="icons/Name=Models, Mode=Dark.svg"
         href="/ja/models/"
         subtitle="AI モデルを開発する"
     >
@@ -37,7 +37,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Weave"
-        iconSrc="/icons/Name=Weave, Mode=Dark.svg"
+        iconSrc="icons/Name=Weave, Mode=Dark.svg"
         href="/weave"
         subtitle="アプリで AI モデルを利用する"
     >
@@ -55,7 +55,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Inference"
-        iconSrc="/icons/Name=Inference, Mode=Dark.svg"
+        iconSrc="icons/Name=Inference, Mode=Dark.svg"
         href="/inference/"
         subtitle="基盤モデルにアクセス"
     >
@@ -71,7 +71,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Training"
-        iconSrc="/icons/Name=Models, Mode=Dark.svg"
+        iconSrc="icons/Name=Models, Mode=Dark.svg"
         href="/training/"
         subtitle="モデルをポストトレーニング"
     >

--- a/ko.mdx
+++ b/ko.mdx
@@ -20,7 +20,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
     <ProductCard
         title="W&B Models"
-        iconSrc="/icons/Name=Models, Mode=Dark.svg"
+        iconSrc="icons/Name=Models, Mode=Dark.svg"
         href="/ko/models/"
         subtitle="AI 모델 개발"
     >
@@ -37,7 +37,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Weave"
-        iconSrc="/icons/Name=Weave, Mode=Dark.svg"
+        iconSrc="icons/Name=Weave, Mode=Dark.svg"
         href="/weave"
         subtitle="앱에서 AI 모델 사용"
     >
@@ -55,7 +55,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Inference"
-        iconSrc="/icons/Name=Inference, Mode=Dark.svg"
+        iconSrc="icons/Name=Inference, Mode=Dark.svg"
         href="/inference/"
         subtitle="파운데이션 모델 액세스"
     >
@@ -71,7 +71,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
 
     <ProductCard
         title="W&B Training"
-        iconSrc="/icons/Name=Models, Mode=Dark.svg"
+        iconSrc="icons/Name=Models, Mode=Dark.svg"
         href="/training/"
         subtitle="모델 포스트 트레이닝"
     >


### PR DESCRIPTION
## Description
Fix the spurious redirects seen in https://github.com/wandb/docs/actions/runs/19181542002/job/54839259052 by removing the leading `/` from `iconSrc` paths.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] Locally, the icons in the indexes still load
- [x] PR tests succeed
- [x] Specifically, the PR link checker [succeeds](https://github.com/wandb/docs/actions/runs/19182141423/job/54841198821?pr=1848) with no spurious redirects

