### PR TITLE
[DOCS-1792] Add Settings landing page to the nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -104,17 +104,19 @@
               {
                 "group": "Configure W&B",
                 "pages": [
-                  "platform/app/settings-page/user-settings",
-                  "platform/app/settings-page/billing-settings",
-                  "platform/app/settings-page/emails",
-                  "platform/app/settings-page/teams",
-                  "platform/app/settings-page/storage",
-                  "platform/app/settings-page/anon",
-                  "platform/secrets",
-                  "platform/hosting/privacy-settings",
-                  "platform/hosting/smtp",
-                  "platform/hosting/env-vars",
-                  "platform/hosting/enterprise-licenses",
+                  {
+                    "group": "Settings",
+                    "pages": [
+                      "platform/app/settings-page",
+                      "platform/app/settings-page/user-settings",
+                      "platform/app/settings-page/billing-settings",
+                      "platform/app/settings-page/emails",
+                      "platform/app/settings-page/teams",
+                      "platform/secrets",
+                      "platform/app/settings-page/storage",
+                      "platform/app/settings-page/anon"
+                    ]
+                  },
                   {
                     "group": "Identity and access management (IAM)",
                     "pages": [
@@ -1301,9 +1303,9 @@
                   "ja/platform/app/settings-page/billing-settings",
                   "ja/platform/app/settings-page/emails",
                   "ja/platform/app/settings-page/teams",
+                  "ja/platform/secrets",
                   "ja/platform/app/settings-page/storage",
                   "ja/platform/app/settings-page/anon",
-                  "ja/platform/secrets",
                   "ja/platform/hosting/privacy-settings",
                   "ja/platform/hosting/smtp",
                   "ja/platform/hosting/env-vars"
@@ -1820,9 +1822,9 @@
                   "ko/platform/app/settings-page/billing-settings/",
                   "ko/platform/app/settings-page/emails/",
                   "ko/platform/app/settings-page/teams/",
+                  "ko/platform/secrets",
                   "ko/platform/app/settings-page/storage/",
                   "ko/platform/app/settings-page/anon/",
-                  "ko/platform/secrets",
                   "ko/platform/hosting/privacy-settings",
                   "ko/platform/hosting/smtp",
                   "ko/platform/hosting/env-vars"

--- a/platform/app/settings-page.mdx
+++ b/platform/app/settings-page.mdx
@@ -2,6 +2,7 @@
 description: Use the Weights and Biases Settings Page to customize your individual
   user profile or team settings.
 title: Settings
+sidebarTitle: Overview
 ---
 
 Within your individual user account you can edit: your profile picture, display name, geography location, biography information, emails associated to your account, and manage alerts for runs. You can also use the settings page to link your GitHub repository and delete your account. For more information, see [User settings](/platform/app/settings-page/user-settings/).

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -1,6 +1,6 @@
 ---
 description: Overview of W&B secrets, how they work, and how to get started using them.
-title: Secrets
+title: Manage secrets
 ---
 
 W&B Secret Manager allows you to securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. W&B Secret Manager removes the need to add sensitive strings directly to your code or when configuring a webhook's header or [payload](/models/automations/).


### PR DESCRIPTION
## Description
[DOCS-1792] Add Settings landing page to the nav, add sidebar title "Overview"
Also move poorly-placed Secrets page into Settings right after Team Settings, change title to "Manage settings"

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed



[DOCS-1792]: https://wandb.atlassian.net/browse/DOCS-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ