### PR TITLE
[DOCS-1896] Add individual writers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @wandb/docs-team
+# Required approvers. Last matching line wins
+# so they all need to be on a single line
+* @wandb/docs-team @johndmulhausen @ngrayluna @mdlinville @dbrian57


### PR DESCRIPTION
## Description
[DOCS-1896] Add individual writers to CODEOWNERS

- Mostly redundant since individual writers should also be team members, but somewhat self-documenting
- Works together with branch protection rules configured for `main`

[DOCS-1896]: https://wandb.atlassian.net/browse/DOCS-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ