### PR TITLE
Test: MDX Validation GitHub Action

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -1,0 +1,18 @@
+name: Validate MDX
+on:
+  pull_request:
+    paths:
+      - '**.mdx'
+
+jobs:
+  validate-mdx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - name: Validate MDX syntax
+        run: npm run validate-mdx
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,21 @@
 {
+  "type": "module",
+  "scripts": {
+    "validate-mdx": "node scripts/validate-mdx.js"
+  },
   "dependencies": {
     "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@mdx-js/mdx": "^3.1.1",
+    "eslint": "^9.39.1",
+    "eslint-plugin-mdx": "^3.6.2",
+    "glob": "^11.0.3",
+    "remark-cli": "^12.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-lint": "^10.0.1",
+    "remark-mdx": "^3.1.1",
+    "remark-preset-lint-recommended": "^7.0.1"
   }
 }

--- a/scripts/validate-mdx.js
+++ b/scripts/validate-mdx.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { compile } from '@mdx-js/mdx';
+import { readFile } from 'fs/promises';
+import { glob } from 'glob';
+
+async function validateMDX(filePath) {
+  try {
+    const content = await readFile(filePath, 'utf8');
+    await compile(content, { filepath: filePath });
+    return { success: true, file: filePath };
+  } catch (error) {
+    return { 
+      success: false, 
+      file: filePath, 
+      error: error.message,
+      line: error.line,
+      column: error.column
+    };
+  }
+}
+
+async function main() {
+  const files = await glob('**/*.mdx', { 
+    ignore: ['node_modules/**', '.git/**'],
+    absolute: true
+  });
+  
+  console.log(`Validating ${files.length} MDX files...\n`);
+  
+  const results = await Promise.all(files.map(validateMDX));
+  const failures = results.filter(r => !r.success);
+  
+  if (failures.length > 0) {
+    console.error(`❌ Found ${failures.length} MDX parsing errors:\n`);
+    failures.forEach(({ file, error, line, column }) => {
+      const relativePath = file.replace(process.cwd() + '/', '');
+      console.error(`${relativePath}:${line}:${column}`);
+      console.error(`  ${error}\n`);
+    });
+    process.exit(1);
+  } else {
+    console.log(`✅ All ${files.length} MDX files are valid!`);
+  }
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Testing the new MDX validation action that catches parsing errors.

This PR should trigger the validation and show 3 MDX parsing errors:
- ko/models/track/project-page.mdx (unclosed <br> tag)
- weave/reference/typescript-sdk/classes/Evaluation.mdx (invalid character in tag)
- weave/reference/typescript-sdk/classes/Dataset.mdx (unclosed <R> tag)

The action should fail, demonstrating that it will catch these issues in future PRs.