### PR TITLE
Tutorials: Removed PyTorch tutorial

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -418,7 +418,6 @@
                           "models/integrations/mmf",
                           "models/integrations/paddledetection",
                           "models/integrations/paddleocr",
-                          "models/integrations/pytorch",
                           "models/integrations/lightning",
                           "models/integrations/ignite",
                           "models/integrations/skorch",
@@ -2304,6 +2303,10 @@
       "source": "/guides/integrations/:slug*",
       "destination": "/models/integrations/:slug*"
     },
+    {
+      "source": "/guides/integrations/pytorch",
+      "destination": "/models/integrations"
+    },    
     {
       "source": "/guides/launch/:slug*",
       "destination": "/platform/launch/:slug*"

--- a/models/track.mdx
+++ b/models/track.mdx
@@ -12,7 +12,7 @@ import { TryProductLink } from '/snippets/en/_includes/try-product-link.mdx';
 
 Track machine learning experiments with a few lines of code. You can then review the results in an [interactive dashboard](/models/track/workspaces/) or export your data to Python for programmatic access using our [Public API](/models/ref/python/public-api/). 
 
-Utilize W&B Integrations if you use popular frameworks such as [PyTorch](/models/integrations/pytorch), [Keras](/models/integrations/keras), or [Scikit](/models/integrations/scikit). See our [Integration guides](/models/integrations) for a full list of integrations and information on how to add W&B to your code.
+Utilize W&B Integrations if you use popular frameworks such as [Keras](/models/integrations/keras), or [Scikit](/models/integrations/scikit). See our [Integration guides](/models/integrations) for a full list of integrations and information on how to add W&B to your code.
 
 <Frame>
     <img src="/images/experiments/experiments_landing_page.png" alt="Experiments dashboard"  />

--- a/models/track/log.mdx
+++ b/models/track/log.mdx
@@ -58,7 +58,7 @@ With W&B, you can decide exactly what you want to log. The following lists some 
 * **Plots**: Use `wandb.plot()` with `wandb.Run.log()` to track charts. See [Log Plots](/models/track/log/plots/) for more information. 
 * **Tables**: Use `wandb.Table` to log data to visualize and query with W&B. See [Log Tables](/models/track/log/log-tables/) for more information.
 * **PyTorch gradients**: Add `wandb.Run.watch(model)` to see gradients of the weights as histograms in the UI.
-* **Configuration information**: Log hyperparameters, a link to your dataset, or the name of the architecture you're using as config parameters, passed in like this: `wandb.init(config=your_config_dictionary)`. See the [PyTorch Integrations](/models/integrations/pytorch) page for more information. 
+* **Configuration information**: Log hyperparameters, a link to your dataset, or the name of the architecture you're using as config parameters, passed in like this: `wandb.init(config=your_config_dictionary)`.
 * **Metrics**: Use `wandb.Run.log()` to see metrics from your model. If you log metrics like accuracy and loss from inside your training loop, you'll get live updating graphs in the UI.
 
 


### PR DESCRIPTION
## Description

This notebook needs moderate changes. As is, it doesn’t run locally (missing pip install libraries). It also uses global variables which we no longer advise. Because of the bad practices, I am removing this notebook for now. We can add it again once it is up to date.

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.
-->

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1790?issueKey=DOCS-1790&subProduct=jira-software

