### PR TITLE
Re-add RSS support to server release notes page

### DIFF
--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Supported W&B Server releases"
 sidebarTitle: "Supported releases"
+rss: true
 ---
 import EolReminder from '/snippets/en/_includes/release-notes-support-eol-reminder.mdx';
 


### PR DESCRIPTION
## Description
What it says on the tin. Somehow the RSS feed disappeared. The other release notes pages are not affected.

