### PR TITLE
Feat/cli docs generator

### DIFF
--- a/scripts/cli-docs-generator.py
+++ b/scripts/cli-docs-generator.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+"""
+Generate Mintlify-compatible markdown documentation for W&B CLI commands.
+
+This script automatically generates reference documentation for the W&B CLI
+by introspecting the Click-based command structure. It creates properly
+formatted markdown files with Mintlify front matter for use in the documentation site.
+
+Note: Launch-only commands (launch, launch-agent, launch-sweep, scheduler) are generated 
+but excluded from the docs.json navigation (hidden from sidebar).
+
+Usage:
+    python scripts/cli-docs-generator.py          # Auto-overwrites existing docs (default)
+    python scripts/cli-docs-generator.py -i       # Interactive mode (prompts for confirmation)
+    python scripts/cli-docs-generator.py -o PATH  # Custom output directory
+    
+    Options:
+        -i, --interactive  Prompt for confirmation before overwriting
+        -o, --output       Custom output directory (default: models/ref/cli/)
+
+Output:
+    Generated documentation will be placed in: models/ref/cli/ (by default)
+    Navigation structure will be updated in: docs.json
+
+Requirements:
+    - wandb package must be installed (pip install wandb)
+    - Must be run from the project root directory
+
+"""
+
+import os
+import re
+import sys
+import argparse
+import shutil
+import json
+from pathlib import Path
+from typing import Dict, Any, List, Optional, Union
+import click
+from click.core import Command, Group
+
+def clean_text(text: str) -> str:
+    """Clean and format text for markdown."""
+    if not text:
+        return ""
+    
+    # First, normalize line endings and strip the whole text
+    text = text.strip()
+    
+    # Split into paragraphs (separated by blank lines)
+    paragraphs = re.split(r'\n\s*\n', text)
+    
+    # Clean each paragraph: remove extra spaces within lines, but keep paragraph structure
+    cleaned_paragraphs = []
+    for paragraph in paragraphs:
+        # Replace multiple spaces/tabs with single space, but keep newlines
+        lines = paragraph.split('\n')
+        cleaned_lines = []
+        for line in lines:
+            # Clean up spaces within the line
+            cleaned_line = re.sub(r'[ \t]+', ' ', line.strip())
+            if cleaned_line:  # Only add non-empty lines
+                cleaned_lines.append(cleaned_line)
+        if cleaned_lines:
+            cleaned_paragraphs.append(' '.join(cleaned_lines))
+    
+    # Join paragraphs with double newlines for markdown
+    text = '\n\n'.join(cleaned_paragraphs)
+    
+    # Escape pipe characters for markdown tables
+    text = text.replace('|', '\\|')
+    return text
+
+def get_brief_description(text: str) -> str:
+    """Get just the first sentence or line for table display."""
+    if not text:
+        return "No description available"
+    
+    # First clean the text but without escaping pipes yet
+    text = text.strip()
+    
+    # Split into paragraphs
+    paragraphs = re.split(r'\n\s*\n', text)
+    if not paragraphs:
+        return "No description available"
+    
+    # Get the first paragraph
+    first_para = paragraphs[0]
+    
+    # Clean up spaces in the first paragraph
+    first_para = re.sub(r'[ \t\n]+', ' ', first_para.strip())
+    
+    # Try to get just the first sentence
+    # Look for sentence endings
+    sentence_match = re.match(r'^(.*?[.!?])\s', first_para + ' ')
+    if sentence_match:
+        first_sentence = sentence_match.group(1)
+    else:
+        # If no sentence ending found, take the whole first paragraph
+        # but limit to reasonable length
+        first_sentence = first_para
+    
+    # Limit length for table display
+    max_length = 150
+    if len(first_sentence) > max_length:
+        first_sentence = first_sentence[:max_length-3] + "..."
+    
+    # Escape pipe characters for markdown tables
+    first_sentence = first_sentence.replace('|', '\\|')
+    
+    return first_sentence
+
+def get_param_info(param) -> Dict[str, Any]:
+    """Extract parameter information from a Click parameter."""
+    # Check if it's an Option or Argument
+    is_option = isinstance(param, click.Option)
+    
+    info = {
+        'name': param.name,
+        'opts': getattr(param, 'opts', []) or [],
+        'help': clean_text(getattr(param, 'help', '') or ''),
+        'type': str(param.type) if hasattr(param, 'type') else 'TEXT',
+        'required': getattr(param, 'required', False),
+        'default': getattr(param, 'default', None),
+        'multiple': getattr(param, 'multiple', False),
+    }
+    
+    # Format options string
+    if info['opts']:
+        info['opts_str'] = ', '.join(f'`{opt}`' for opt in info['opts'])
+    else:
+        info['opts_str'] = f'`{info["name"]}`'
+    
+    # Format default value
+    if info['default'] is not None and info['default'] != () and not callable(info['default']):
+        info['default_str'] = f" (default: {info['default']})"
+    else:
+        info['default_str'] = ""
+    
+    return info
+
+def extract_command_info(cmd: Command, parent_name: str = "") -> Dict[str, Any]:
+    """Extract information from a Click command."""
+    # Launch-only commands to exclude from docs.json navigation
+    LAUNCH_COMMANDS = {'launch', 'launch-agent', 'launch-sweep', 'scheduler'}
+    
+    # For the root command, use "wandb" as the name
+    name = cmd.name if cmd.name else "wandb"
+    full_name = f"{parent_name} {name}".strip() if parent_name else name
+    
+    info = {
+        'name': name,
+        'full_name': full_name,
+        'help': clean_text(cmd.help or cmd.short_help or ''),
+        'epilog': clean_text(cmd.epilog) if hasattr(cmd, 'epilog') and cmd.epilog else '',
+        'params': [],
+        'options': [],
+        'arguments': [],
+        'subcommands': {},
+        'is_group': isinstance(cmd, Group),
+        'is_launch_command': name in LAUNCH_COMMANDS,
+    }
+    
+    # Extract parameters
+    for param in cmd.params:
+        param_info = get_param_info(param)
+        if isinstance(param, click.Option):
+            info['options'].append(param_info)
+        elif isinstance(param, click.Argument):
+            info['arguments'].append(param_info)
+    
+    # Extract subcommands if it's a group
+    if isinstance(cmd, Group):
+        for name, subcmd in cmd.commands.items():
+            info['subcommands'][name] = extract_command_info(subcmd, full_name)
+    
+    return info
+
+def generate_markdown(cmd_info: Dict[str, Any], file_dir_path: str = "") -> str:
+    """Generate markdown content for a command.
+    
+    Args:
+        cmd_info: Command information dictionary
+        file_dir_path: Directory path where this file will be located (e.g., "wandb-artifact" for files in that dir)
+    """
+    lines = []
+    
+    # Mintlify front matter (simple, no Hugo properties)
+    lines.append("---")
+    # Fix title to show 'wandb' instead of 'cli'
+    title = cmd_info['full_name'].replace('cli', 'wandb')
+    lines.append(f"title: {title}")
+    lines.append("---")
+    lines.append("")
+    
+    # Command description
+    if cmd_info['help']:
+        lines.append(cmd_info['help'])
+        lines.append("")
+    
+    # Usage section
+    lines.append("## Usage")
+    lines.append("")
+    lines.append("```bash")
+    
+    # Fix usage to always show 'wandb' as the base command
+    if cmd_info['name'] in ['wandb', 'cli']:
+        usage = "wandb"
+    else:
+        usage = f"wandb {cmd_info['name']}"
+    
+    # Add arguments to usage
+    for arg in cmd_info['arguments']:
+        if arg['required']:
+            usage += f" {arg['name'].upper()}"
+        else:
+            usage += f" [{arg['name'].upper()}]"
+    
+    # Add [OPTIONS] if there are options
+    if cmd_info['options']:
+        usage += " [OPTIONS]"
+    
+    # Add subcommand placeholder if it's a group
+    if cmd_info['is_group'] and cmd_info['subcommands']:
+        usage += " COMMAND [ARGS]..."
+    
+    lines.append(usage)
+    lines.append("```")
+    lines.append("")
+    
+    # Arguments section
+    if cmd_info['arguments']:
+        lines.append("## Arguments")
+        lines.append("")
+        lines.append("| Argument | Description | Required |")
+        lines.append("| :--- | :--- | :--- |")
+        for arg in cmd_info['arguments']:
+            required = "Yes" if arg['required'] else "No"
+            desc = arg['help'] or "No description available"
+            lines.append(f"| `{arg['name'].upper()}` | {desc} | {required} |")
+        lines.append("")
+    
+    # Options section
+    if cmd_info['options']:
+        lines.append("## Options")
+        lines.append("")
+        lines.append("| Option | Description |")
+        lines.append("| :--- | :--- |")
+        for opt in cmd_info['options']:
+            desc = opt['help'] or "No description available"
+            if opt['default_str']:
+                desc += opt['default_str']
+            lines.append(f"| {opt['opts_str']} | {desc} |")
+        lines.append("")
+    
+    # Subcommands section
+    if cmd_info['is_group'] and cmd_info['subcommands']:
+        lines.append("## Commands")
+        lines.append("")
+        lines.append("| Command | Description |")
+        lines.append("| :--- | :--- |")
+        for name, subcmd_info in sorted(cmd_info['subcommands'].items()):
+            # Use brief description for table display
+            desc = get_brief_description(subcmd_info['help'] or "")
+            # For nested commands, we need to determine the correct reference path
+            # Get the full parent prefix from the full_name
+            parent_parts = cmd_info['full_name'].replace('cli', 'wandb').split()
+            parent_prefix = '-'.join(parent_parts)
+            # Subcommands are in a subdirectory named after the parent
+            # Build the full path including the directory this file is in
+            if file_dir_path:
+                full_path = f"/models/ref/cli/{file_dir_path}/{parent_prefix}/{parent_prefix}-{name}"
+            else:
+                full_path = f"/models/ref/cli/{parent_prefix}/{parent_prefix}-{name}"
+            lines.append(f"| [{name}]({full_path}) | {desc} |")
+        lines.append("")
+    
+    # Epilog section
+    if cmd_info['epilog']:
+        lines.append("## Additional Information")
+        lines.append("")
+        lines.append(cmd_info['epilog'])
+        lines.append("")
+    
+    return "\n".join(lines)
+
+def generate_index_markdown(cmd_info: Dict[str, Any], subcommands_only: bool = False, content_before: str = None, content_after: str = None, file_dir_path: str = "") -> str:
+    """Generate index markdown for a command group.
+    
+    Args:
+        cmd_info: Command information dictionary
+        subcommands_only: Whether this is a subcommand index page
+        content_before: Manual content to preserve before auto-generated content
+        content_after: Manual content to preserve after auto-generated content
+        file_dir_path: Directory path where this file will be located (e.g., "wandb-artifact" for files in that dir)
+    """
+    lines = []
+    
+    # Mintlify front matter (simple, no Hugo properties)
+    lines.append("---")
+    if subcommands_only:
+        # For subcommand index pages
+        title = f"{cmd_info['full_name']}".replace('cli', 'wandb')
+        lines.append(f"title: {title}")
+    else:
+        lines.append("title: CLI overview")
+        lines.append("description: Use the W&B Command Line Interface (CLI) to log in, run jobs, execute sweeps, and more using shell commands")
+    lines.append("---")
+    lines.append("")
+    
+    # Insert preserved manual content before auto-generated content
+    if content_before:
+        lines.append(content_before)
+        lines.append("")
+    
+    # Auto-generated marker start (for main CLI page only)
+    if not subcommands_only:
+        lines.append("{/* AUTO-GENERATED CONTENT STARTS HERE */}")
+        lines.append("{/* WARNING: Do not edit below this line. This content is auto-generated by scripts/cli-docs-generator.py */}")
+        lines.append("")
+    
+    # Description (only if no preserved content)
+    if not content_before and cmd_info['help']:
+        lines.append(cmd_info['help'])
+        lines.append("")
+    
+    # Usage section
+    lines.append("## Basic Usage" if content_before else "## Usage")
+    lines.append("")
+    lines.append("```bash")
+    # Always use 'wandb' as the base command
+    if cmd_info['name'] in ['wandb', 'cli']:
+        usage = "wandb"
+    else:
+        usage = cmd_info['full_name'].replace('cli', 'wandb')
+    if cmd_info['options']:
+        usage += " [OPTIONS]"
+    if cmd_info['is_group'] and cmd_info['subcommands']:
+        usage += " COMMAND [ARGS]..."
+    lines.append(usage)
+    lines.append("```")
+    lines.append("")
+    
+    # Options section (for main command)
+    if cmd_info['options']:
+        lines.append("## Options")
+        lines.append("")
+        lines.append("| Option | Description |")
+        lines.append("| :--- | :--- |")
+        for opt in cmd_info['options']:
+            desc = opt['help'] or "No description available"
+            if opt['default_str']:
+                desc += opt['default_str']
+            lines.append(f"| {opt['opts_str']} | {desc} |")
+        lines.append("")
+    
+    # Commands section
+    if cmd_info['is_group'] and cmd_info['subcommands']:
+        lines.append("## Commands")
+        lines.append("")
+        lines.append("| Command | Description |")
+        lines.append("| :--- | :--- |")
+        for name, subcmd_info in sorted(cmd_info['subcommands'].items()):
+            # Use brief description for table display
+            desc = get_brief_description(subcmd_info['help'] or "")
+            # Link to the command page using absolute Mintlify paths
+            if subcommands_only:
+                # Get the full parent prefix from the full_name
+                parent_parts = cmd_info['full_name'].replace('cli', 'wandb').split()
+                parent_prefix = '-'.join(parent_parts)
+                # Subcommands are in a subdirectory named after the parent command
+                # The subdirectory is named {parent_prefix} and contains files named {parent_prefix}-{name}
+                if file_dir_path:
+                    full_path = f"/models/ref/cli/{file_dir_path}/{parent_prefix}/{parent_prefix}-{name}"
+                else:
+                    full_path = f"/models/ref/cli/{parent_prefix}/{parent_prefix}-{name}"
+                lines.append(f"| [{name}]({full_path}) | {desc} |")
+            else:
+                # Top-level commands from main CLI page
+                lines.append(f"| [{name}](/models/ref/cli/wandb-{name}) | {desc} |")
+        lines.append("")
+    
+    # Auto-generated marker end and preserved content after
+    if not subcommands_only:
+        lines.append("{/* AUTO-GENERATED CONTENT ENDS HERE */}")
+        if content_after:
+            lines.append("{/* Manual content continues below */}")
+            lines.append("")
+            lines.append(content_after)
+    
+    return "\n".join(lines)
+
+def extract_manual_content(file_path: Path) -> tuple[Optional[str], Optional[str]]:
+    """Extract manually written content from existing cli.mdx file.
+    
+    Returns a tuple of (content_before, content_after) where:
+    - content_before: Content between front matter and auto-generated marker
+    - content_after: Content after the auto-generated section ends
+    Both can be None if the file doesn't exist or has no manual content.
+    """
+    if not file_path.exists():
+        return (None, None)
+    
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    # Find the end of front matter
+    if not content.startswith('---'):
+        return (None, None)
+    
+    # Find the second '---' that ends the front matter
+    front_matter_end = content.find('---', 3)
+    if front_matter_end == -1:
+        return (None, None)
+    
+    # Move past the closing --- and newline
+    content_start = front_matter_end + 3
+    while content_start < len(content) and content[content_start] in ['\n', '\r']:
+        content_start += 1
+    
+    # Find the auto-generated markers (JSX-style comments for MDX)
+    auto_gen_start_marker = "{/* AUTO-GENERATED CONTENT STARTS HERE */}"
+    auto_gen_end_marker = "{/* AUTO-GENERATED CONTENT ENDS HERE */}"
+    
+    auto_gen_start = content.find(auto_gen_start_marker)
+    auto_gen_end = content.find(auto_gen_end_marker)
+    
+    content_before = None
+    content_after = None
+    
+    if auto_gen_start == -1:
+        # No marker found, check if there's a "## Usage" or "## Basic Usage" section
+        usage_match = re.search(r'\n## (?:Basic )?Usage\n', content)
+        if usage_match:
+            # Content before Usage section is likely manual
+            content_before = content[content_start:usage_match.start()].strip()
+    else:
+        # Extract content between front matter and auto-generated marker
+        content_before = content[content_start:auto_gen_start].strip()
+        
+        # If we have an end marker, extract content after it
+        if auto_gen_end != -1:
+            # Find content after the end marker and following comment line
+            content_after_start = content.find('\n', auto_gen_end) + 1
+            # Skip the "Manual content continues below" comment if present
+            manual_comment = "{/* Manual content continues below */}"
+            if content[content_after_start:].strip().startswith(manual_comment):
+                content_after_start = content.find('\n', content_after_start + len(manual_comment)) + 1
+            
+            remaining = content[content_after_start:].strip()
+            if remaining:
+                content_after = remaining
+    
+    return (content_before, content_after)
+
+def write_command_docs(cmd_info: Dict[str, Any], output_dir: Path, parent_path: str = "", file_dir_path: str = ""):
+    """Write documentation files for a command and its subcommands.
+    
+    For Mintlify, the structure is:
+    - Root: cli.mdx (main index) in models/ref/
+    - Command groups: wandb-artifact.mdx (group file) + wandb-artifact/ (directory for subcommands)
+    - Simple commands: wandb-login.mdx (single file)
+    - Nested in directories: wandb-artifact/wandb-artifact-get.mdx
+    
+    Args:
+        cmd_info: Command information dictionary
+        output_dir: Base output directory for files
+        parent_path: Accumulated path prefix for file naming (e.g., "artifact-" for cache in artifact)
+        file_dir_path: Directory path where files are located relative to models/ref/cli/ (e.g., "wandb-artifact")
+    """
+    cmd_name = cmd_info['name']
+    
+    # Check if this is the root wandb command (either 'cli' or 'wandb' or None)
+    is_root = cmd_name in ['wandb', 'cli', None] and parent_path == ""
+    
+    if is_root:
+        # Main CLI index - Mintlify wants cli.mdx in models/ref/
+        index_path = output_dir.parent / "cli.mdx"
+        
+        # Extract any existing manual content before regenerating
+        content_before, content_after = extract_manual_content(index_path)
+        
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(index_path, 'w') as f:
+            f.write(generate_index_markdown(cmd_info, content_before=content_before, content_after=content_after, file_dir_path=""))
+        print(f"Generated: {index_path}")
+        if content_before or content_after:
+            print(f"  ✓ Preserved manual content")
+        
+        # Process top-level commands (alphabetically sorted)
+        for name, subcmd_info in sorted(cmd_info['subcommands'].items()):
+            write_command_docs(subcmd_info, output_dir, "", "")
+    else:
+        # Determine if this command has subcommands
+        has_subcommands = cmd_info['is_group'] and cmd_info['subcommands']
+        
+        if has_subcommands:
+            # For command groups, create BOTH a .mdx file AND a directory
+            # The .mdx file serves as the group page
+            cmd_file_name = f"wandb-{parent_path}{cmd_name}"
+            cmd_file_path = output_dir / f"{cmd_file_name}.mdx"
+            with open(cmd_file_path, 'w') as f:
+                f.write(generate_index_markdown(cmd_info, subcommands_only=True, file_dir_path=file_dir_path))
+            print(f"Generated: {cmd_file_path}")
+            
+            # Create the directory for subcommands
+            cmd_dir = output_dir / cmd_file_name
+            cmd_dir.mkdir(parents=True, exist_ok=True)
+            
+            # Calculate the new file_dir_path for subcommands (append this directory to the path)
+            if file_dir_path:
+                new_file_dir_path = f"{file_dir_path}/{cmd_file_name}"
+            else:
+                new_file_dir_path = cmd_file_name
+            
+            # Write individual subcommand files (alphabetically sorted)
+            for subcmd_name, subcmd_info in sorted(cmd_info['subcommands'].items()):
+                # Check if this subcommand also has subcommands
+                if subcmd_info['is_group'] and subcmd_info['subcommands']:
+                    # Handle nested command groups recursively
+                    write_command_docs(subcmd_info, cmd_dir, f"{parent_path}{cmd_name}-", new_file_dir_path)
+                else:
+                    # Write single subcommand file in the directory
+                    subcmd_path = cmd_dir / f"wandb-{parent_path}{cmd_name}-{subcmd_name}.mdx"
+                    with open(subcmd_path, 'w') as f:
+                        f.write(generate_markdown(subcmd_info, file_dir_path=new_file_dir_path))
+                    print(f"Generated: {subcmd_path}")
+        else:
+            # Write single command file
+            cmd_path = output_dir / f"wandb-{parent_path}{cmd_name}.mdx"
+            with open(cmd_path, 'w') as f:
+                f.write(generate_markdown(cmd_info, file_dir_path=file_dir_path))
+            print(f"Generated: {cmd_path}")
+
+def build_nav_structure(cmd_info: Dict[str, Any], parent_path: str = "") -> List[Union[str, Dict[str, Any]]]:
+    """Build navigation structure for docs.json, excluding launch commands.
+    
+    Returns a list of navigation items (either strings for simple pages or dicts for groups).
+    """
+    nav_items = []
+    
+    if not cmd_info['is_group'] or not cmd_info['subcommands']:
+        return nav_items
+    
+    for name, subcmd_info in sorted(cmd_info['subcommands'].items()):
+        # Skip launch commands in navigation
+        if subcmd_info.get('is_launch_command', False):
+            continue
+        
+        # Build the path for this command
+        if parent_path:
+            path = f"{parent_path}-{name}"
+        else:
+            path = f"wandb-{name}"
+        
+        if subcmd_info['is_group'] and subcmd_info['subcommands']:
+            # This is a group with subcommands
+            subpages = []
+            
+            # IMPORTANT: Include the group's own page first!
+            # This is the wandb-{name}.mdx file that serves as the group overview
+            subpages.append(f"models/ref/cli/{path}")
+            
+            # Recursively build subcommand navigation
+            for subname, subinfo in sorted(subcmd_info['subcommands'].items()):
+                # Skip launch commands
+                if subinfo.get('is_launch_command', False):
+                    continue
+                
+                subpath = f"{path}-{subname}"
+                
+                if subinfo['is_group'] and subinfo['subcommands']:
+                    # Nested group - needs its own page plus subpages
+                    nested_pages = []
+                    # Include the nested group's own page first
+                    nested_pages.append(f"models/ref/cli/{path}/{subpath}")
+                    # Then add its subcommands
+                    for nestedname, nestedinfo in sorted(subinfo['subcommands'].items()):
+                        if nestedinfo.get('is_launch_command', False):
+                            continue
+                        nested_pages.append(f"models/ref/cli/{path}/{subpath}/{subpath}-{nestedname}")
+                    
+                    if nested_pages:
+                        subpages.append({
+                            "group": f"{name} {subname}",
+                            "pages": nested_pages
+                        })
+                else:
+                    # Simple subcommand
+                    subpages.append(f"models/ref/cli/{path}/{subpath}")
+            
+            if subpages:
+                nav_items.append({
+                    "group": f"wandb {name}",
+                    "pages": subpages
+                })
+        else:
+            # Simple command
+            nav_items.append(f"models/ref/cli/{path}")
+    
+    return nav_items
+
+
+def update_docs_json(project_root: Path, nav_items: List[Union[str, Dict[str, Any]]]):
+    """Update docs.json with the new CLI navigation structure."""
+    docs_json_path = project_root / "docs.json"
+    
+    if not docs_json_path.exists():
+        print(f"❌ Error: docs.json not found at {docs_json_path}")
+        return False
+    
+    try:
+        with open(docs_json_path, 'r') as f:
+            docs_data = json.load(f)
+        
+        # Find the CLI section in the navigation
+        # It's nested under navigation -> pages -> (some models section) -> pages -> CLI group
+        found = False
+        
+        def find_and_update_cli(obj):
+            """Recursively find and update the CLI section."""
+            nonlocal found
+            
+            if isinstance(obj, dict):
+                if obj.get('group') == 'Command Line Interface (CLI)':
+                    # Found it! Update the pages
+                    obj['pages'] = ["models/ref/cli"] + nav_items
+                    found = True
+                    return True
+                
+                # Recurse into nested structures
+                for key, value in obj.items():
+                    if find_and_update_cli(value):
+                        return True
+            
+            elif isinstance(obj, list):
+                for item in obj:
+                    if find_and_update_cli(item):
+                        return True
+            
+            return False
+        
+        find_and_update_cli(docs_data)
+        
+        if not found:
+            print("⚠️  Warning: Could not find 'Command Line Interface (CLI)' section in docs.json")
+            return False
+        
+        # Write back to docs.json
+        with open(docs_json_path, 'w') as f:
+            json.dump(docs_data, f, indent=2)
+        
+        print(f"✅ Updated docs.json with CLI navigation (excluded launch commands)")
+        return True
+        
+    except json.JSONDecodeError as e:
+        print(f"❌ Error: Could not parse docs.json: {e}")
+        return False
+    except Exception as e:
+        print(f"❌ Error updating docs.json: {e}")
+        return False
+
+
+def main():
+    """Main function to generate CLI documentation."""
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description='Generate W&B CLI documentation')
+    parser.add_argument('-i', '--interactive', action='store_true',
+                        help='Prompt for confirmation before overwriting existing documentation')
+    parser.add_argument('-o', '--output', type=str, default=None,
+                        help='Custom output directory (default: models/ref/cli)')
+    args = parser.parse_args()
+    
+    # Get the script's parent directory (scripts/) and then go up to the project root
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+    
+    if args.output:
+        output_dir = Path(args.output)
+    else:
+        output_dir = project_root / "models" / "ref" / "cli"
+    
+    print("Generating W&B CLI documentation...")
+    print(f"Output directory: {output_dir}")
+    
+    # Warning about overwriting existing documentation (only in interactive mode)
+    if output_dir.exists() and any(output_dir.iterdir()):
+        # Check if cli.mdx has manual content (Mintlify structure)
+        index_path = output_dir.parent / "cli.mdx"
+        content_before, content_after = extract_manual_content(index_path)
+        has_manual_content = content_before is not None or content_after is not None
+        
+        if args.interactive:
+            print(f"⚠️  Warning: This will regenerate documentation in {output_dir}")
+            if has_manual_content:
+                print("   Note: Manual content in cli.mdx will be preserved.")
+            response = input("Continue? (y/N): ")
+            if response.lower() != 'y':
+                print("Aborted.")
+                sys.exit(0)
+        
+        # Clear directory selectively to remove any vestigial files from removed commands
+        print("Clearing existing documentation...")
+        files_removed = 0
+        dirs_removed = 0
+        for item in output_dir.iterdir():
+            if item.is_file():
+                item.unlink()
+                files_removed += 1
+            elif item.is_dir():
+                shutil.rmtree(item)
+                dirs_removed += 1
+        print(f"  Removed {files_removed} files and {dirs_removed} directories")
+    
+    # Create output directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        # Import W&B CLI - the cli module contains a Click group called 'cli'
+        from wandb.cli.cli import cli as wandb_cli
+        
+        # Extract command information
+        print("Extracting CLI structure...")
+        cli_info = extract_command_info(wandb_cli)
+        
+        # Generate documentation files
+        print("Generating markdown files...")
+        write_command_docs(cli_info, output_dir)
+        
+        print(f"\n✅ Documentation generated successfully in {output_dir}")
+        # Count both .mdx files in output_dir and the cli.mdx in parent
+        mdx_files = list(output_dir.rglob('*.mdx'))
+        cli_index = output_dir.parent / "cli.mdx"
+        if cli_index.exists():
+            mdx_files.append(cli_index)
+        print(f"Total files generated: {len(mdx_files)}")
+        
+        # Update docs.json with navigation structure
+        print("\nUpdating docs.json...")
+        nav_items = build_nav_structure(cli_info)
+        if update_docs_json(project_root, nav_items):
+            print("✅ Navigation structure updated (Launch commands excluded from TOC)")
+        else:
+            print("⚠️  Warning: Could not update docs.json navigation")
+        
+    except ImportError as e:
+        print(f"❌ Error: Could not import wandb CLI. Make sure wandb is installed.")
+        print(f"   Run: pip install wandb")
+        print(f"   Error details: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/snippets/en/_includes/cli/README.md
+++ b/snippets/en/_includes/cli/README.md
@@ -34,7 +34,7 @@ The CLI reference pages (`models/ref/cli/`) are auto-generated from the W&B CLI 
 
 To add introductory content for a command:
 
-1. Create a new file: `wandb-{command-name}.mdx`
+1. Create a new snippet with the correct naming: `wandb-{command-name}.mdx`.
 2. Write the intro content in MDX format (can include markdown, code blocks, etc.).
 3. In the generated CLI reference for the command, uncomment the lines to include and use the snippet. No need to regenerate all of the references.
 4. Next time the references are generated, the generator will automatically detect and include your snippet.

--- a/snippets/en/_includes/cli/README.md
+++ b/snippets/en/_includes/cli/README.md
@@ -1,0 +1,55 @@
+# CLI Reference Intro Snippets
+
+This directory contains introductory content for W&B CLI commands that gets included in the auto-generated CLI reference pages.
+
+## Purpose
+
+The CLI reference pages (`models/ref/cli/`) are auto-generated from the W&B CLI source code using `scripts/cli-docs-generator.py`. However, some commands benefit from additional context, examples, or explanations beyond what's in the CLI help text. This directory holds that supplementary content.
+
+## How It Works
+
+1. **Snippet files** are created here with the naming pattern: `wandb-{command}.mdx`
+   - Example: `wandb-login.mdx`, `wandb-sync.mdx`, `wandb-verify.mdx`
+   - For nested commands, use the full command with dashes: `wandb-artifact-get.mdx`
+
+2. **Generation script** automatically detects these snippets and:
+   - Adds an import statement at the top of the generated page
+   - Includes the snippet content right after the front matter, before the Usage section
+   - For pages without snippets, adds a commented-out template showing how to add one
+
+3. **Generated page structure**:
+   ```markdown
+   ---
+   title: wandb login
+   ---
+   import WandbLogin from "/snippets/en/_includes/cli/wandb-login.mdx";
+
+   <WandbLogin/>
+
+   ## Usage
+   [auto-generated content from CLI]
+   ```
+
+## Adding Intro Content for a Command
+
+To add introductory content for a command:
+
+1. Create a new file: `wandb-{command-name}.mdx`
+2. Write the intro content in MDX format (can include markdown, code blocks, etc.)
+3. Run the CLI docs generator: `python scripts/cli-docs-generator.py`
+4. The generator will automatically detect and include your snippet
+
+## Current Snippets
+
+- `wandb-docker-run.mdx` - Environment variables explanation
+- `wandb-docker.mdx` - Container usage examples
+- `wandb-login.mdx` - Authentication and server deployment details
+- `wandb-sync.mdx` - Synchronization examples
+- `wandb-verify.mdx` - Detailed list of verification checks
+
+## Guidelines
+
+- Keep content concise and focused on what users need to know before the command details
+- Use code blocks for examples
+- Avoid duplicating information that's already in the auto-generated command options/arguments
+- Test locally after adding a snippet to ensure it renders correctly

--- a/snippets/en/_includes/cli/README.md
+++ b/snippets/en/_includes/cli/README.md
@@ -35,17 +35,10 @@ The CLI reference pages (`models/ref/cli/`) are auto-generated from the W&B CLI 
 To add introductory content for a command:
 
 1. Create a new file: `wandb-{command-name}.mdx`
-2. Write the intro content in MDX format (can include markdown, code blocks, etc.)
-3. Run the CLI docs generator: `python scripts/cli-docs-generator.py`
-4. The generator will automatically detect and include your snippet
+2. Write the intro content in MDX format (can include markdown, code blocks, etc.).
+3. In the generated CLI reference for the command, uncomment the lines to include and use the snippet. No need to regenerate all of the references.
+4. Next time the references are generated, the generator will automatically detect and include your snippet.
 
-## Current Snippets
-
-- `wandb-docker-run.mdx` - Environment variables explanation
-- `wandb-docker.mdx` - Container usage examples
-- `wandb-login.mdx` - Authentication and server deployment details
-- `wandb-sync.mdx` - Synchronization examples
-- `wandb-verify.mdx` - Detailed list of verification checks
 
 ## Guidelines
 

--- a/snippets/en/_includes/cli/wandb-docker-run.mdx
+++ b/snippets/en/_includes/cli/wandb-docker-run.mdx
@@ -1,0 +1,5 @@
+Wrap `docker run` and adds WANDB_API_KEY and WANDB_DOCKER environment variables.
+
+This will also set the runtime to nvidia if the nvidia-docker executable is present on the system and --runtime wasn't set.
+
+See `docker run --help` for more details.

--- a/snippets/en/_includes/cli/wandb-docker.mdx
+++ b/snippets/en/_includes/cli/wandb-docker.mdx
@@ -1,0 +1,11 @@
+Run your code in a docker container.
+
+W&B docker lets you run your code in a docker image ensuring wandb is configured. It adds the WANDB_DOCKER and WANDB_API_KEY environment variables to your container and mounts the current directory in /app by default. You can pass additional args which will be added to `docker run` before the image name is declared, we'll choose a default image for you if one isn't passed:
+
+```sh
+wandb docker -v /mnt/dataset:/app/data
+wandb docker gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0 --jupyter
+wandb docker wandb/deepo:keras-gpu --no-tty --cmd "python train.py --epochs=5"
+```
+
+By default, we override the entrypoint to check for the existence of wandb and install it if not present. If you pass the --jupyter flag we will ensure jupyter is installed and start jupyter lab on port 8888. If we detect nvidia-docker on your system we will use the nvidia runtime. If you just want wandb to set environment variable to an existing docker run command, see the wandb docker-run command.

--- a/snippets/en/_includes/cli/wandb-login.mdx
+++ b/snippets/en/_includes/cli/wandb-login.mdx
@@ -1,0 +1,5 @@
+Verify and store your API key for authentication with W&B services.
+
+By default, only store credentials locally without verifying them with W&B. To verify credentials, set `--verify=True`.
+
+For server deployments (dedicated cloud or customer-managed instances), specify the host URL using the `--host` flag. You can also set environment variables `WANDB_BASE_URL` and `WANDB_API_KEY` instead of running the `login` command with host parameters.

--- a/snippets/en/_includes/cli/wandb-sync.mdx
+++ b/snippets/en/_includes/cli/wandb-sync.mdx
@@ -1,0 +1,11 @@
+Synchronize W&B run data to the cloud.
+
+If PATH is provided, sync runs found at the given path. If a path is not specified, search for `./wandb` first, then search for a `wandb/` subdirectory.
+
+To sync a specific run:
+
+wandb sync ./wandb/run-20250813_124246-n67z9ude
+
+Or equivalently:
+
+wandb sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb

--- a/snippets/en/_includes/cli/wandb-verify.mdx
+++ b/snippets/en/_includes/cli/wandb-verify.mdx
@@ -1,0 +1,21 @@
+Checks and verifies local instance of W&B. W&B checks for:
+
+Checks that the host is not `api.wandb.ai` (host check).
+
+Verifies if the user is logged in correctly using the provided API key (login check).
+
+Checks that requests are made over HTTPS (secure requests).
+
+Validates the CORS (Cross-Origin Resource Sharing) configuration of the object store (CORS configuration).
+
+Logs metrics, saves, and downloads files to check if runs are correctly recorded and accessible (run check).
+
+Saves and downloads artifacts to verify that the artifact storage and retrieval system is working as expected (artifact check).
+
+Tests the GraphQL endpoint by uploading a file to ensure it can handle signed URL uploads (GraphQL PUT check).
+
+Checks the ability to send large payloads through the proxy (large payload check).
+
+Verifies that the installed version of the W&B package is up-to-date and compatible with the server (W&B version check).
+
+Creates and executes a sweep to ensure that sweep functionality is working correctly (sweeps check).


### PR DESCRIPTION
## Description
Moved from #1643 and updated for Mintlify

This PR introduces an automated CLI documentation generator for the W&B CLI reference documentation. The new script introspects the W&B CLI structure and generates Hugo-compatible markdown documentation automatically.

## Changes

### New Script: `/scripts/cli-docs-generator.py`
A Python script that:
- Introspects the W&B CLI using the Click framework
- Generates structured markdown documentation with Hugo front matter
- Creates a hierarchical directory structure for nested commands
- Preserves formatting and paragraph breaks from original docstrings
- Auto-detects and preserves manually written intro material for a given generated page, now driven by Mintlify snippets for better reliability

### Key Features
- **Automatic Structure Discovery**: Extracts command hierarchy, options, arguments, and help text directly from the CLI code
- **Mintlify Integration**:
  - Generates proper front matter with `title`
  - Generates landing pages automatically
  - Updates TOC automatically
  - Auto-detects the SDK version and adds it to the CLI landing page, aligning with the Python ref behavior
  - Auto-detects and includes optional manually written intro material, now driven by snippets
- **Clean Output**: 
  - Brief descriptions in command tables (first sentence only)
  - Full descriptions preserved on individual command pages
  - Removed generic "Examples" sections that only showed `--help`
- **Robust File Management**: 
  - Clears entire output directory before regeneration to prevent vestigial files, without risk of losing manual intro material
  - Maintains consistent file naming (e.g., `wandb-artifact-cache-cleanup.md`)
- **User Control**:
  - Default: Auto-overwrites existing documentation
  - `-i/--interactive`: Prompts for confirmation before overwriting
  - `-o/--output`: Custom output directory option

### Documentation Updates
- Updated all 40 CLI documentation files with consistent formatting
- Added new command pages that were previously missing:
  - `wandb-local.md`
  - `wandb-off.md`
  - `wandb-on.md`
  - `wandb-projects.md`
  - `wandb-beta-leet.md`
- Moved existing intro content into snippets 
- Improved readability with preserved whitespace and paragraph breaks

## Usage

Run the script from the project root:
```bash
# Default: Auto-generate and overwrite
python scripts/cli-docs-generator.py

# Interactive mode (prompts before overwriting)
python scripts/cli-docs-generator.py -i

# Custom output directory
python scripts/cli-docs-generator.py -o /path/to/output
```

### Dependencies
- Depends on local install of `wandb` Python module being up to date.

## Benefits
- **Maintainability**: Documentation stays in sync with CLI implementation
- **Consistency**: All pages follow the same format and structure
- **Completeness**: Automatically discovers and documents all commands
- **Accuracy**: Documentation is extracted directly from the source code


## Testing
- [x] Testing in prior PR
- [x] Regenerated references to confirm a clean build and link check
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

