### PR TITLE
[WEAVE] Dataset reference correction

### DIFF
--- a/weave/reference/typescript-sdk/classes/Dataset.mdx
+++ b/weave/reference/typescript-sdk/classes/Dataset.mdx
@@ -14,7 +14,7 @@ Dataset object with easy saving and automatic versioning
 ```ts
 // Create a dataset
 const dataset = new Dataset({
-  id: 'grammar-dataset',
+  name: 'grammar-dataset',
   rows: [
     { id: '0', sentence: "He no likes ice cream.", correction: "He doesn't like ice cream." },
     { id: '1', sentence: "She goed to the store.", correction: "She went to the store." },


### PR DESCRIPTION
## Description
Resolves [DOCS-1721](https://wandb.atlassian.net/browse/DOCS-1721). This is a downstream fix that corrects the Dataset's `id` field to `name` for the Weave TS reference docs. Will fix upstream as well.

[DOCS-1721]: https://wandb.atlassian.net/browse/DOCS-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ