### PR TITLE
[Weave] Corrects global_attributes field syntax

### DIFF
--- a/weave/guides/tools/attributes.mdx
+++ b/weave/guides/tools/attributes.mdx
@@ -8,7 +8,7 @@ Attributes in Weave allow you to attach custom metadata to your traces and evalu
 Weave provides two ways to add attributes:
 
 * **Per-call attributes**: Use the `weave.attributes()` to add metadata to specific operations or code blocks
-* **Global attributes**: Use the `global_attributes()` field to set attributes at initialization that apply to all traces and evaluations in your project
+* **Global attributes**: Use the `global_attributes` field to set attributes at initialization that apply to all traces and evaluations in your project
 
 You can view all attributes logged during traces and evaluation in the UI. You can then use them to filter and group data.
 


### PR DESCRIPTION
## Description
The PR corrects Weave global attributes field syntax.
