### PR TITLE
Fix Weave reference docs workflow to always base new branches on main

### DIFF
--- a/.github/workflows/generate-weave-reference-docs.yml
+++ b/.github/workflows/generate-weave-reference-docs.yml
@@ -133,6 +133,7 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        base: main
         commit-message: "chore: Update reference documentation (Weave ${{ steps.python-sdk.outputs.actual_version || steps.version.outputs.version }})"
         title: "Update Weave reference documentation (Weave ${{ steps.python-sdk.outputs.actual_version || steps.version.outputs.version }})"
         draft: true

--- a/.github/workflows/update-service-api.yml
+++ b/.github/workflows/update-service-api.yml
@@ -74,9 +74,10 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        base: main
         commit-message: "chore: Update Service API documentation"
         title: "Update Service API documentation"
-        draft: false
+        draft: true
         body: |
           This PR updates the Service API documentation based on the latest OpenAPI specification.
           

--- a/.github/workflows/update-training-api.yml
+++ b/.github/workflows/update-training-api.yml
@@ -72,9 +72,10 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        base: main
         commit-message: "chore: Update Training API documentation"
         title: "Update Training API documentation"
-        draft: false
+        draft: true
         body: |
           This PR updates the Training API documentation based on the latest OpenAPI specification.
           


### PR DESCRIPTION
The create-pull-request action was missing the 'base' parameter, which meant new branches weren't guaranteed to be created from the latest main. This caused update-reference-docs branches to be based on stale commits (e.g., 155 commits behind), resulting in corrupted docs.json missing integrations and other configuration.

Adding 'base: main' ensures each new PR branch is created fresh from the latest main commit.

## Description

Set the base branch in the Github action. Currently, the script is using an arbitrary commit as the base!
