### PR TITLE
Fix generated Weave Python SDK landing page

### DIFF
--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -230,7 +230,10 @@ def generate_module_docs(module, module_name: str, src_root_path: str, version: 
                 continue
             
             obj = getattr(module, name)
-            if hasattr(obj, "__module__") and obj.__module__ != module_name:
+            
+            # For the root "weave" module, include re-exported items from submodules
+            # Otherwise, only include items that belong to this specific module
+            if module_name != "weave" and hasattr(obj, "__module__") and obj.__module__ != module_name:
                 continue
             
             sections.append(process_object(obj, generator, module_name))


### PR DESCRIPTION
## Description
The root weave module re-exports many classes and functions from submodules (e.g., Agent from weave.agent.agent). The doc generation script was filtering these out because their __module__ attribute didn't match 'weave', resulting in an empty landing page (8 lines instead of 3000+).

This fix updates the filtering logic to include all public members for the root 'weave' module while maintaining strict filtering for submodules.

Fixes the python-sdk.mdx being empty/deleted in generated PRs.

## Testing
- [x] Locally regenerated the landing page with this fix in place
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
