### PR TITLE
fix: Work around lazydocs inline code fence bug

### DIFF
--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -262,6 +262,12 @@ def generate_module_docs(module, module_name: str, src_root_path: str, version: 
     # These appear as standalone lines with just dashes (------) which break markdown parsing
     content = re.sub(r'\n\s*------+\s*\n', '\n\n', content)
     
+    # Fix lazydocs bug: inline code fences in Examples sections
+    # lazydocs incorrectly wraps text after colons (like "Basic usage:") with inline backticks
+    # Pattern: " text: ``` code```" should be "text:\n```python\ncode"
+    # This happens when lazydocs misapplies _RE_ARGSTART in Examples sections
+    content = re.sub(r'^ ([\w\s]+): ``` (.*?)```\n(    >>> )', r' \1:\n\n```python\n\2\n\3', content, flags=re.MULTILINE)
+    
     # Fix parameter lists that have been broken by lazydocs
     # Strategy: Parse all parameters into a structured format, then reconstruct them properly
     def fix_parameter_lists(text):


### PR DESCRIPTION
## Description

Lazydocs has a bug where it incorrectly wraps text after colons in Examples sections with inline backticks. This happens because the _RE_ARGSTART regex (line 36 in generation.py) is too greedy:

    _RE_ARGSTART = re.compile(r'^(.+):[ ]+(.{2,})$', re.IGNORECASE)

This matches ANY line with a colon, even in Examples sections where it shouldn't apply argument formatting. When it encounters:

    Basic usage:
    >>> import weave

It generates malformed MDX, which cause page-level parsing errors and breakage. 

    Basic usage: ``` import weave```

This commit adds a post-processing fix to detect and correct these malformed inline code fences, converting them to proper code blocks.

The underlying bug has been [reported](https://github.com/ml-tooling/lazydocs/issues/97) to Lazydocs.

## Testing
- [x] Locally, fix the parsing error by adding newlines manually
- [x] Locally, regenerate references and verify that the workaround works

