### PR TITLE
[Weave] Fix typo in weave homepage

### DIFF
--- a/weave.mdx
+++ b/weave.mdx
@@ -7,7 +7,7 @@ mode: wide
 W&B Weave is an observability and evaluation platform that helps you track, evaluate, and improve your LLM application. With Weave, you can:
 
 * [Observe and debug](/weave/quickstart) your LLM application
-* [Evaluate](/weave/tutorial-eval) your application’s responses using LLM judges and customer scorers
+* [Evaluate](/weave/tutorial-eval) your application’s responses using LLM judges and custom scorers
 
 ## Get Started
 


### PR DESCRIPTION
I said "customer" instead of "custom" *facepalm*

## Description

<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
