### PR TITLE
Release notes for SDK version 0.23.1

### DIFF
--- a/release-notes/sdk-releases.mdx
+++ b/release-notes/sdk-releases.mdx
@@ -34,7 +34,7 @@ This page includes release notes for the W&B Python SDK (`wandb` package). For W
 - Use explicitly provided API key in `wandb.init(settings=wandb.Settings(api_key="..."))` for login. Use the key from run when logging artifacts via `run.log_artifact`.
 - W&B LEET TUI correctly displays negative Y axis tick values and base/display units of certain system metrics.
 - Fixed a rare infinite loop in `console_capture.py`.
-- File upload/download now respects `WANDB_X_EXTRA_HTTP_HEADERS` except for [reference artifacts](https://docs.wandb.ai/models/artifacts/track-external-files).
+- File upload/download now respects `WANDB_X_EXTRA_HTTP_HEADERS` except for [reference artifacts](/models/artifacts/track-external-files).
 </Update>
 
 <Update label="v0.23.0" description="November 11, 2025">

--- a/release-notes/sdk-releases.mdx
+++ b/release-notes/sdk-releases.mdx
@@ -6,6 +6,37 @@ rss: true
 
 This page includes release notes for the W&B Python SDK (`wandb` package). For W&B Server, see [W&B Server release notes](/release-notes/server-releases).
 
+<Update label="v0.23.1" description="December 2, 2025">
+## Added
+
+- Regex support in metrics and run overview filters in W&B LEET TUI.
+- Chart inspection in W&B LEET TUI: right-click and drag to show (x, y) at the nearest data point; hold Alt for synchronized inspection across all visible charts.
+- The Automations API now supports creating and editing automations that trigger on run states.
+- The Automations API now supports basic zscore automation events.
+- Simplified the syntax for creating z-score metric automation triggers in the Automations API.
+- `beta_history_scan` method to `Run` objects for faster history scanning performance with `wandb.Api`.
+
+## Changed
+
+- `wandb.Api()` now raises a `UsageError` if `WANDB_IDENTITY_TOKEN_FILE` is set and an explicit API key is not provided. Previously, an explicit API key was required.
+
+## Deprecated
+
+- Anonymous mode is deprecated and will emit warnings. This deprecation includes the `anonymous` setting, the `WANDB_ANONYMOUS` environment variable, `wandb.init(anonymous=...)`, and commands `wandb login --anonymously` and `wandb.login(anonymous=...)`.
+
+## Fixed
+
+- `wandb.Image()` no longer prints a deprecation warning.
+- `Registry.description` and `ArtifactCollection.description` no longer reject empty strings.
+- Instantiating `Artifact` objects is now significantly faster.
+- `wandb.Run.save()` now falls back to hardlinks and, if needed, copying (downgrading the 'live' file policy to 'now', if applicable) when symlinks are disabled or unavailable (e.g., cross‑volume or no Developer Mode on Windows).
+- Artifact collection aliases are now fetched lazily on accessing `ArtifactCollection.aliases` instead of on instantiating `ArtifactCollection`, improving performance of `Api.artifact_collections()`, `Api.registries().collections()`, etc.
+- Use explicitly provided API key in `wandb.init(settings=wandb.Settings(api_key="..."))` for login. Use the key from run when logging artifacts via `run.log_artifact`.
+- W&B LEET TUI correctly displays negative Y axis tick values and base/display units of certain system metrics.
+- Fixed a rare infinite loop in `console_capture.py`.
+- File upload/download now respects `WANDB_X_EXTRA_HTTP_HEADERS` except for [reference artifacts](https://docs.wandb.ai/models/artifacts/track-external-files).
+</Update>
+
 <Update label="v0.23.0" description="November 11, 2025">
 ## Added
 


### PR DESCRIPTION
## Description
Add release notes for SDK v0.23.1 from wandb/wandb

_Minor_ adjustment to a few notes.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

