### PR TITLE
Improve MDX validation triggering, add mint broken-links at the end

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -18,6 +18,28 @@ cleanup() {
 # Trap to ensure cleanup
 trap cleanup EXIT INT TERM
 
+# Check if there are any MDX files in the changeset
+if [ -n "$GITHUB_BASE_REF" ]; then
+  # In a PR context, check changed files
+  echo "Checking for changed MDX files in PR..."
+  
+  # Get the list of changed files
+  CHANGED_MDX=$(git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD -- '*.mdx' 2>/dev/null | grep -E '\.mdx$' || true)
+  
+  if [ -z "$CHANGED_MDX" ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "NO MDX FILES CHANGED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "No MDX files found in this PR. Skipping validation."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 0
+  fi
+  
+  echo "Found changed MDX files:"
+  echo "$CHANGED_MDX" | sed 's/^/  /'
+  echo ""
+fi
+
 echo "Starting Mintlify validation..."
 echo ""
 echo "Running: mint dev --no-open (will run for ${PARSE_TIME}s to parse all files)"
@@ -54,4 +76,3 @@ else
   echo "No parsing errors detected by Mintlify"
   exit 0
 fi
-

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -46,7 +46,19 @@ echo "Running: mint dev --no-open (will run for ${PARSE_TIME}s to parse all file
 echo ""
 
 # Run mint dev with tee to force output writing, timeout after PARSE_TIME seconds
-timeout --preserve-status ${PARSE_TIME}s mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null || true
+# Use timeout if available (Linux), otherwise use gtimeout (macOS with coreutils), or perl as fallback
+if command -v timeout > /dev/null 2>&1; then
+  timeout --preserve-status ${PARSE_TIME}s mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null || true
+elif command -v gtimeout > /dev/null 2>&1; then
+  gtimeout --preserve-status ${PARSE_TIME}s mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null || true
+else
+  # Fallback: run mint dev in background and kill after PARSE_TIME
+  mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null &
+  PID=$!
+  sleep ${PARSE_TIME}
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+fi
 
 echo ""
 echo "✓ Mintlify finished parsing"
@@ -69,10 +81,28 @@ if grep -q "parsing error" "$LOGFILE"; then
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
   exit 1
-else
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "✅ MINTLIFY VALIDATION PASSED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "No parsing errors detected by Mintlify"
-  exit 0
 fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ MINTLIFY PARSING VALIDATION PASSED"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "No parsing errors detected by Mintlify"
+echo ""
+
+# Run broken links check
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "CHECKING FOR BROKEN LINKS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Running: mint broken-links"
+echo ""
+
+# Run mint broken-links - it will exit with non-zero if broken links are found
+mint broken-links
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ ALL VALIDATION CHECKS PASSED"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "- No parsing errors"
+echo "- No broken links"
+exit 0


### PR DESCRIPTION
## Description

- Move MDX file detection logic from action to script
  - Works around action hanging due to known issues with actions and file filtering (still exhibited in this PR, but merging this PR will fix it)
  - Succeeds quickly if no MDX files detected
- Add `mint broken-links` to the script
  - Adds coverage for broken-links checking in a fork PR
  - Clears the way to add MDX validation check to branch protection rules
  - Allows us to turn off the Mintlify-platform-initiated `link-rot` check completely

## Testing
- [x] Script works correctly when run locally
- [x] Action works correctly in a PR in my fork after the action is in my fork's `main`:
  - [x] Failing action due to MDX validity errors  https://github.com/mdlinville/docs/actions/runs/19977788568/job/57297962779?pr=55 
  - [x] Failing action due to broken links after fixing MDX validity errors https://github.com/mdlinville/docs/actions/runs/19977896301/job/57298298329?pr=55
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

