### PR TITLE
Fix git cookbook links

### DIFF
--- a/weave/quickstart-inference.mdx
+++ b/weave/quickstart-inference.mdx
@@ -7,8 +7,8 @@ import { GitHubLink } from '/snippets/en/_includes/github-source-link.mdx';
 import WeaveQuickstartPrereqs from "/snippets/en/_includes/weave-quickstart-prereqs.mdx";
 
 <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/learn-weave-with-inference.ipynb" />
-<GitHubLink url="https://github.com/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/learn-weave-with-inference.ipynb" />
+<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/main/weave/cookbooks/source/learn-weave-with-inference.ipynb" />
+<GitHubLink url="https://github.com/wandb/docs/blob/weave/main/weave/cookbooks/source/learn-weave-with-inference.ipynb" />
 </div>
 
 This guide shows you how to use W&B Weave with [W&B Inference](https://docs.wandb.ai/inference/). Use W&B Inference, to build and trace LLM applications using live open-source models without setting up your own infrastructure or managing API keys from multiple providers. With your W&B API key, you can interact with [all models hosted by W&B Inference](https://docs.wandb.ai/inference/models/).

--- a/weave/quickstart.mdx
+++ b/weave/quickstart.mdx
@@ -9,8 +9,8 @@ import { GitHubLink } from '/snippets/en/_includes/github-source-link.mdx';
 import WeaveQuickstartPrereqs from "/snippets/en/_includes/weave-quickstart-prereqs.mdx";
 
 <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/traces-quickstart.ipynb" />
-<GitHubLink url="https://github.com/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/traces-quickstart.ipynb" />
+<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/main/weave/cookbooks/source/traces-quickstart.ipynb" />
+<GitHubLink url="https://github.com/wandb/docs/blob/weave/main/weave/cookbooks/source/traces-quickstart.ipynb" />
 </div>
 
 Learn how to track LLM calls with Weave by adding tracing to your code. This quickstart walks you through tracing a request to OpenAI and viewing the results in the Weave UI.

--- a/weave/tutorial-eval.mdx
+++ b/weave/tutorial-eval.mdx
@@ -8,8 +8,8 @@ import { GitHubLink } from '/snippets/en/_includes/github-source-link.mdx';
 import WeaveQuickstartPrereqs from "/snippets/en/_includes/weave-quickstart-prereqs.mdx";
 
 <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/build_an_evaluation_pipeline.ipynb" />
-<GitHubLink url="https://github.com/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/build_an_evaluation_pipeline.ipynb" />
+<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/main/weave/cookbooks/source/build_an_evaluation_pipeline.ipynb" />
+<GitHubLink url="https://github.com/wandb/docs/blob/weave/main/weave/cookbooks/source/build_an_evaluation_pipeline.ipynb" />
 </div>
 
 Evaluations help you iterate and improve your applications by testing them against a set of examples after you make changes. Weave provides first-class support for tracking evaluations with [`Model`](/weave/guides/core-types/models) and [`Evaluation`](/weave/guides/core-types/evaluations) classes. The APIs are designed with minimal assumptions, allowing flexibility for a wide array of use cases.

--- a/weave/tutorial-rag.mdx
+++ b/weave/tutorial-rag.mdx
@@ -8,8 +8,8 @@ import { GitHubLink } from '/snippets/en/_includes/github-source-link.mdx';
 import WeaveQuickstartPrereqs from "/snippets/en/_includes/weave-quickstart-prereqs.mdx";
 
 <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/evaluate_rag_applications.ipynb" />
-<GitHubLink url="https://github.com/wandb/docs/blob/weave/onboarding-revamp/weave/cookbooks/source/evaluate_rag_applications.ipynb" />
+<ColabLink url="https://colab.research.google.com/github/wandb/docs/blob/weave/main/weave/cookbooks/source/evaluate_rag_applications.ipynb" />
+<GitHubLink url="https://github.com/wandb/docs/blob/weave/main/weave/cookbooks/source/evaluate_rag_applications.ipynb" />
 </div>
 
 Retrieval Augmented Generation (RAG) is a common way of building Generative AI applications that have access to custom knowledge bases.


### PR DESCRIPTION
## Description
This fixes the links to the cookbooks to use `main` instead of the old onboarding branch.
