### PR TITLE
Create redirect to solve /guides/models 404s, fix validate-mdx

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -1,8 +1,6 @@
 name: Validate MDX
 on:
   pull_request:
-    paths:
-      - '**.mdx'
 
 jobs:
   validate-mdx:

--- a/docs.json
+++ b/docs.json
@@ -2307,14 +2307,6 @@
       "source": "/getting-started/",
       "destination": "/get-started/"
     },
-        {
-      "source": "/guides/models/:slug*",
-      "destination": "/models/:slug*"
-    },
-    {
-      "source": "/guides/:slug*",
-      "destination": "/models/:slug*"
-    },
     {
       "source": "/guides/app/:slug*",
       "destination": "/models/app/:slug*"
@@ -2434,6 +2426,10 @@
     {
       "source": "/guides/training/:slug*",
       "destination": "/training/:slug*"
+    },
+    {
+      "source": "/guides/:slug*",
+      "destination": "/models/:slug*"
     },
     {
       "source": "/inference/response-settings",

--- a/docs.json
+++ b/docs.json
@@ -2307,6 +2307,10 @@
       "source": "/getting-started/",
       "destination": "/get-started/"
     },
+        {
+      "source": "/guides/models/:slug*",
+      "destination": "/models/:slug*"
+    },
     {
       "source": "/guides/:slug*",
       "destination": "/models/:slug*"

--- a/models/integrations.mdx
+++ b/models/integrations.mdx
@@ -15,7 +15,7 @@ If you're looking to integrate W&B with a library not listed here, see [Add W&B 
 
 Integrate W&B with popular machine learning frameworks:
 
-- [Catalyst](/models/integrations/catalyst/testsoetijsoietjsioetjiosetj)
+- [Catalyst](/models/integrations/catalyst)
 - [DeepChem](/models/integrations/deepchem)
 - [DSPy](/models/integrations/dspy)
 - [Keras](/models/integrations/keras)

--- a/models/integrations.mdx
+++ b/models/integrations.mdx
@@ -15,7 +15,7 @@ If you're looking to integrate W&B with a library not listed here, see [Add W&B 
 
 Integrate W&B with popular machine learning frameworks:
 
-- [Catalyst](/models/integrations/catalyst)
+- [Catalyst](/models/integrations/catalyst/testsoetijsoietjsioetjiosetj)
 - [DeepChem](/models/integrations/deepchem)
 - [DSPy](/models/integrations/dspy)
 - [Keras](/models/integrations/keras)

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -97,8 +97,19 @@ echo "Running: mint broken-links"
 echo ""
 
 # Run mint broken-links - it will exit with non-zero if broken links are found
-mint broken-links
-
+if mint broken-links; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "✅ NO BROKEN LINKS FOUND"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+else
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "❌ BROKEN LINKS DETECTED"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Please fix the broken links reported above"
+  exit 1
+fi
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "✅ ALL VALIDATION CHECKS PASSED"


### PR DESCRIPTION
The top 404 URL is /guides/models right now; this is because the general `/guides/:slug*` rule comes before all the other more specific rules, when it should run as the final catch-all rule when the more specific rules have not matched.

Meanwhile, this PR will not merge unless I remove the `path: **.mdx` filter on the `validate-mdx` since it is rqeuired, so that has been removed. Further, I can see re: the broken link check that it was scheduled to run but it never actually fails if a link is broken, so that is fixed too. 

TO MERGE: Upload a commit that fixes the broken link in `integration.mdx`, see that the broken link check now passes. And approve this PR. It will auto-merge once approved & the link is fixed.