### PR TITLE
Add 'platform/hosting/env-vars' to docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -151,7 +151,8 @@
                       "platform/hosting/data-security/private-connectivity",
                       "platform/hosting/data-security/data-encryption"
                     ]
-                  }
+                  },
+                  "platform/hosting/env-vars"
                 ]
               },
               {


### PR DESCRIPTION
## Description
Add 'platform/hosting/env-vars' to docs.json to try to improve its discoverability in the site search. This was a migration miss.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
