### PR TITLE
[Weave] TypeScript coverage for evals pt. 2

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -805,7 +805,8 @@
                       "weave/guides/evaluation/weave_local_scorers",
                       "weave/guides/evaluation/evaluation_logger",
                       "weave/guides/core-types/leaderboards",
-                      "weave/guides/tools/attributes"
+                      "weave/guides/tools/attributes",
+                      "weave/guides/tools/column-mapping"
                     ]
                   },
                   {

--- a/weave/guides/core-types/datasets.mdx
+++ b/weave/guides/core-types/datasets.mdx
@@ -161,7 +161,9 @@ Select a tab to see Python and TypeScript-specific code.
 
   </Tab>
   <Tab title="TypeScript">
-   This feature is not currently available in TypeScript.  Stay tuned!
+  ```plaintext
+   This feature is not currently available in TypeScript yet.
+   ```
   </Tab>
 </Tabs>
 
@@ -183,9 +185,9 @@ You can create, edit, and delete `Dataset`s in the UI.
 
 6. In the **Dataset name** field, enter a name for your dataset. Options to **Configure dataset fields**  appear.
 
-    :::important
+    <Note>
     Dataset names must start with a letter or number and can only contain letters, numbers, hyphens, and underscores.
-    :::
+    </Note>
 
 7. (Optional) In **Configure dataset fields**, select the fields from your calls to include in the dataset.  
     - You can customize the column names for each selected field.
@@ -308,6 +310,8 @@ You can create, edit, and delete `Dataset`s in the UI.
 
   </Tab>
   <Tab title="TypeScript">
-   This feature is not currently available in TypeScript.  Stay tuned!
+  ```plaintext
+   This feature is not currently available in TypeScript yet.
+   ```
   </Tab>
 </Tabs>

--- a/weave/guides/core-types/leaderboards.mdx
+++ b/weave/guides/core-types/leaderboards.mdx
@@ -10,6 +10,9 @@ Leaderboards are ideal for:
 - Tracking model performance regressions
 - Coordinating shared evaluation workflows
 
+<Note>
+Leaderboard creation is only available for the Weave UI and Weave Python SDK. TypeScript users can create and manage leaderboards using the [Weave UI](#using-the-ui).
+</Note>
 
 ## Create a Leaderboard
 

--- a/weave/guides/evaluation/builtin_scorers.mdx
+++ b/weave/guides/evaluation/builtin_scorers.mdx
@@ -3,448 +3,447 @@ title: "Use builtin scorers"
 description: "Use Weave's predefined scorers for evaluating your AI applications"
 ---
 
-<Tabs>
-  <Tab title="Python">
-    **Installation**
+Weave offers several predefined scorers for evaluating your AI applications, such as [Hallucination detection](#hallucinationfreescorer) and  [Summarization quality](#summarizationscorer). These can be helpful for quickly defining an evaluation and scoring your application's outputs.
 
-    To use Weave's predefined scorers you need to install some additional dependencies:
+<Note>
+Local scorers are only available for the Weave Python SDK. They are not yet available for the Weave TypeScript SDK yet.
 
-    ```bash
-    pip install weave[scorers]
-    ```
+To use Weave scorers in TypeScript, see [function-based scorers](/weave/guides/evaluation/scorers#function-based-scorers).
+</Note>
 
-    **LLM-evaluators**
-    Update Feb 2025: The pre-defined scorers that leverage LLMs now automatically integrate with litellm.
-    You no longer need to pass an LLM client; just set the `model_id`. 
-    See the supported models [here](https://docs.litellm.ai/docs/providers).
+## Installation
 
-    ## `HallucinationFreeScorer`
+To use Weave's predefined scorers you need to install some additional dependencies:
 
-    This scorer checks if your AI system's output includes any hallucinations based on the input data.
+```bash
+pip install weave[scorers]
+```
 
-    ```python lines
-    from weave.scorers import HallucinationFreeScorer
+**LLM-evaluators**
+Update Feb 2025: The pre-defined scorers that leverage LLMs now automatically integrate with litellm.
+You no longer need to pass an LLM client; just set the `model_id`. 
+See the supported models [here](https://docs.litellm.ai/docs/providers).
 
-    scorer = HallucinationFreeScorer()
-    ```
+## `HallucinationFreeScorer`
 
-    **Customization:**
+This scorer checks if your AI system's output includes any hallucinations based on the input data.
 
-    - Customize the `system_prompt` and `user_prompt` fields of the scorer to define what "hallucination" means for you.
+```python lines
+from weave.scorers import HallucinationFreeScorer
 
-    **Notes:**
+scorer = HallucinationFreeScorer()
+```
 
-    - The `score` method expects an input column named `context`. If your dataset uses a different name, [use the `column_map` attribute](#use-column-mapping) to map `context` to the dataset column.
+**Customization:**
 
-    Here you have an example in the context of an evaluation:
+- Customize the `system_prompt` and `user_prompt` fields of the scorer to define what "hallucination" means for you.
 
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import HallucinationFreeScorer
+**Notes:**
 
-    # Initialize scorer with a column mapping if needed.
-    hallucination_scorer = HallucinationFreeScorer(
-        model_id="openai/gpt-4o", # or any other model supported by litellm
-        column_map={"context": "input", "output": "other_col"}
-    )
+- The `score` method expects an input column named `context`. If your dataset uses a different name, [use the `column_map` attribute](#use-column-mapping) to map `context` to the dataset column.
 
-    # Create dataset
-    dataset = [
-        {"input": "John likes various types of cheese."},
-        {"input": "Pepe likes various types of cheese."},
-    ]
+Here you have an example in the context of an evaluation:
 
+```python lines
+import asyncio
+import weave
+from weave.scorers import HallucinationFreeScorer
+
+# Initialize scorer with a column mapping if needed.
+hallucination_scorer = HallucinationFreeScorer(
+    model_id="openai/gpt-4o", # or any other model supported by litellm
+    column_map={"context": "input", "output": "other_col"}
+)
+
+# Create dataset
+dataset = [
+    {"input": "John likes various types of cheese."},
+    {"input": "Pepe likes various types of cheese."},
+]
+
+@weave.op
+def model(input: str) -> str:
+    return "The person's favorite cheese is cheddar."
+
+# Run evaluation
+evaluation = weave.Evaluation(
+    dataset=dataset,
+    scorers=[hallucination_scorer],
+)
+result = asyncio.run(evaluation.evaluate(model))
+print(result)
+# Example output:
+# {'HallucinationFreeScorer': {'has_hallucination': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
+```
+
+---
+
+## `SummarizationScorer`
+
+Use an LLM to compare a summary to the original text and evaluate the quality of the summary.
+
+```python lines
+from weave.scorers import SummarizationScorer
+
+scorer = SummarizationScorer(
+    model_id="openai/gpt-4o"  # or any other model supported by litellm
+)
+```
+
+**How It Works:**
+
+This scorer evaluates summaries in two ways:
+
+1. **Entity Density:** Checks the ratio of unique entities (like names, places, or things) mentioned in the summary to the total word count in the summary in order to estimate the "information density" of the summary. Uses an LLM to extract the entities. Similar to how entity density is used in the Chain of Density paper, https://arxiv.org/abs/2309.04269
+2. **Quality Grading:** An LLM evaluator grades the summary as `poor`, `ok`, or `excellent`. These grades are then mapped to scores (0.0 for poor, 0.5 for ok, and 1.0 for excellent) for aggregate performance evaluation.
+
+**Customization:**
+
+- Adjust `summarization_evaluation_system_prompt` and `summarization_evaluation_prompt` to tailor the evaluation process.
+
+**Notes:**
+
+- The scorer uses litellm internally.
+- The `score` method expects the original text (the one being summarized) to be present in the `input` column. [Use `column_map`](#use-column-mapping) if your dataset uses a different name.
+
+Here you have an example usage in the context of an evaluation:
+
+```python lines
+import asyncio
+import weave
+from weave.scorers import SummarizationScorer
+
+class SummarizationModel(weave.Model):
+    @weave.op()
+    async def predict(self, input: str) -> str:
+        return "This is a summary of the input text."
+
+# Initialize scorer
+summarization_scorer = SummarizationScorer(
+    model_id="openai/gpt-4o"  # or any other model supported by litellm
+)
+# Create dataset
+dataset = [
+    {"input": "The quick brown fox jumps over the lazy dog."},
+    {"input": "Artificial Intelligence is revolutionizing various industries."}
+]
+# Run evaluation
+evaluation = weave.Evaluation(dataset=dataset, scorers=[summarization_scorer])
+results = asyncio.run(evaluation.evaluate(SummarizationModel()))
+print(results)
+# Example output:
+# {'SummarizationScorer': {'is_entity_dense': {'true_count': 0, 'true_fraction': 0.0}, 'summarization_eval_score': {'mean': 0.0}, 'entity_density': {'mean': 0.0}}, 'model_latency': {'mean': ...}}
+```
+
+---
+
+## `OpenAIModerationScorer`
+
+The `OpenAIModerationScorer` uses OpenAI's Moderation API to check if the AI system's output contains disallowed content, such as hate speech or explicit material.
+
+```python lines
+from weave.scorers import OpenAIModerationScorer
+
+scorer = OpenAIModerationScorer()
+```
+
+**How It Works:**
+
+- Sends the AI's output to the OpenAI Moderation endpoint and returns a structured response indicating if the content is flagged.
+
+**Notes:**
+Here is an example in the context of an evaluation:
+
+```python lines
+import asyncio
+import weave
+from weave.scorers import OpenAIModerationScorer
+
+class MyModel(weave.Model):
     @weave.op
-    def model(input: str) -> str:
-        return "The person's favorite cheese is cheddar."
+    async def predict(self, input: str) -> str:
+        return input
+
+# Initialize scorer
+moderation_scorer = OpenAIModerationScorer()
+
+# Create dataset
+dataset = [
+    {"input": "I love puppies and kittens!"},
+    {"input": "I hate everyone and want to hurt them."}
+]
+
+# Run evaluation
+evaluation = weave.Evaluation(dataset=dataset, scorers=[moderation_scorer])
+results = asyncio.run(evaluation.evaluate(MyModel()))
+print(results)
+# Example output:
+# {'OpenAIModerationScorer': {'flagged': {'true_count': 1, 'true_fraction': 0.5}, 'categories': {'violence': {'true_count': 1, 'true_fraction': 1.0}}}, 'model_latency': {'mean': ...}}
+```
+
+---
+
+## `EmbeddingSimilarityScorer`
+
+The `EmbeddingSimilarityScorer` computes the cosine similarity between the embeddings of the AI system's output and a target text from your dataset. It is useful for measuring how similar the AI's output is to a reference text.
+
+```python lines
+from weave.scorers import EmbeddingSimilarityScorer
+
+similarity_scorer = EmbeddingSimilarityScorer(
+    model_id="openai/text-embedding-3-small",  # or any other model supported by litellm
+    threshold=0.4  # the cosine similarity threshold
+)
+```
+
+**Parameters:**
+
+- `threshold` (float): The minimum cosine similarity score (between -1 and 1) needed to consider the two texts similar (defaults to `0.5`).
+
+**Example Usage:**
+
+The following example uses `EmbeddingSimilarityScorer` in the context of an evaluation:
+
+```python lines
+import asyncio
+import weave
+from weave.scorers import EmbeddingSimilarityScorer
+
+# Initialize scorer
+similarity_scorer = EmbeddingSimilarityScorer(
+    model_id="openai/text-embedding-3-small",  # or any other model supported by litellm
+    threshold=0.7
+)
+# Create dataset
+dataset = [
+    {
+        "input": "He's name is John",
+        "target": "John likes various types of cheese.",
+    },
+    {
+        "input": "He's name is Pepe.",
+        "target": "Pepe likes various types of cheese.",
+    },
+]
+# Define model
+@weave.op
+def model(input: str) -> str:
+    return "John likes various types of cheese."
+
+# Run evaluation
+evaluation = weave.Evaluation(
+    dataset=dataset,
+    scorers=[similarity_scorer],
+)
+result = asyncio.run(evaluation.evaluate(model))
+print(result)
+# Example output:
+# {'EmbeddingSimilarityScorer': {'is_similar': {'true_count': 1, 'true_fraction': 0.5}, 'similarity_score': {'mean': 0.844851403}}, 'model_latency': {'mean': ...}}
+```
+
+---
+
+## `ValidJSONScorer`
 
-    # Run evaluation
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[hallucination_scorer],
-    )
-    result = asyncio.run(evaluation.evaluate(model))
-    print(result)
-    # Example output:
-    # {'HallucinationFreeScorer': {'has_hallucination': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
-    ```
+The `ValidJSONScorer` checks whether the AI system's output is valid JSON. This scorer is useful when you expect the output to be in JSON format and need to verify its validity.
 
-    ---
+```python lines
+from weave.scorers import ValidJSONScorer
 
-    ## `SummarizationScorer`
+json_scorer = ValidJSONScorer()
+```
 
-    Use an LLM to compare a summary to the original text and evaluate the quality of the summary.
+Here is an example in the context of an evaluation:
 
-    ```python lines
-    from weave.scorers import SummarizationScorer
+```python lines
+import asyncio
+import weave
+from weave.scorers import ValidJSONScorer
 
-    scorer = SummarizationScorer(
-        model_id="openai/gpt-4o"  # or any other model supported by litellm
-    )
-    ```
+class JSONModel(weave.Model):
+    @weave.op()
+    async def predict(self, input: str) -> str:
+        # This is a placeholder.
+        # In a real scenario, this would generate JSON.
+        return '{"key": "value"}'
 
-    **How It Works:**
+model = JSONModel()
+json_scorer = ValidJSONScorer()
 
-    This scorer evaluates summaries in two ways:
+dataset = [
+    {"input": "Generate a JSON object with a key and value"},
+    {"input": "Create an invalid JSON"}
+]
 
-    1. **Entity Density:** Checks the ratio of unique entities (like names, places, or things) mentioned in the summary to the total word count in the summary in order to estimate the "information density" of the summary. Uses an LLM to extract the entities. Similar to how entity density is used in the Chain of Density paper, https://arxiv.org/abs/2309.04269
-    2. **Quality Grading:** An LLM evaluator grades the summary as `poor`, `ok`, or `excellent`. These grades are then mapped to scores (0.0 for poor, 0.5 for ok, and 1.0 for excellent) for aggregate performance evaluation.
+evaluation = weave.Evaluation(dataset=dataset, scorers=[json_scorer])
+results = asyncio.run(evaluation.evaluate(model))
+print(results)
+# Example output:
+# {'ValidJSONScorer': {'json_valid': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
+```
 
-    **Customization:**
+---
 
-    - Adjust `summarization_evaluation_system_prompt` and `summarization_evaluation_prompt` to tailor the evaluation process.
+## `ValidXMLScorer`
 
-    **Notes:**
+The `ValidXMLScorer` checks whether the AI system's output is valid XML. It is useful when expecting XML-formatted outputs.
 
-    - The scorer uses litellm internally.
-    - The `score` method expects the original text (the one being summarized) to be present in the `input` column. [Use `column_map`](#use-column-mapping) if your dataset uses a different name.
+```python lines
+from weave.scorers import ValidXMLScorer
 
-    Here you have an example usage in the context of an evaluation:
+xml_scorer = ValidXMLScorer()
+```
 
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import SummarizationScorer
+Here is an example in the context of an evaluation:
 
-    class SummarizationModel(weave.Model):
-        @weave.op()
-        async def predict(self, input: str) -> str:
-            return "This is a summary of the input text."
+```python lines
+import asyncio
+import weave
+from weave.scorers import ValidXMLScorer
 
-    # Initialize scorer
-    summarization_scorer = SummarizationScorer(
-        model_id="openai/gpt-4o"  # or any other model supported by litellm
-    )
-    # Create dataset
-    dataset = [
-        {"input": "The quick brown fox jumps over the lazy dog."},
-        {"input": "Artificial Intelligence is revolutionizing various industries."}
-    ]
-    # Run evaluation
-    evaluation = weave.Evaluation(dataset=dataset, scorers=[summarization_scorer])
-    results = asyncio.run(evaluation.evaluate(SummarizationModel()))
-    print(results)
-    # Example output:
-    # {'SummarizationScorer': {'is_entity_dense': {'true_count': 0, 'true_fraction': 0.0}, 'summarization_eval_score': {'mean': 0.0}, 'entity_density': {'mean': 0.0}}, 'model_latency': {'mean': ...}}
-    ```
-
-    ---
-
-    ## `OpenAIModerationScorer`
-
-    The `OpenAIModerationScorer` uses OpenAI's Moderation API to check if the AI system's output contains disallowed content, such as hate speech or explicit material.
-
-    ```python lines
-    from weave.scorers import OpenAIModerationScorer
-
-    scorer = OpenAIModerationScorer()
-    ```
-
-    **How It Works:**
-
-    - Sends the AI's output to the OpenAI Moderation endpoint and returns a structured response indicating if the content is flagged.
+class XMLModel(weave.Model):
+    @weave.op()
+    async def predict(self, input: str) -> str:
+        # This is a placeholder. In a real scenario, this would generate XML.
+        return '<root><element>value</element></root>'
 
-    **Notes:**
-    Here is an example in the context of an evaluation:
+model = XMLModel()
+xml_scorer = ValidXMLScorer()
 
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import OpenAIModerationScorer
+dataset = [
+    {"input": "Generate a valid XML with a root element"},
+    {"input": "Create an invalid XML"}
+]
 
-    class MyModel(weave.Model):
-        @weave.op
-        async def predict(self, input: str) -> str:
-            return input
-
-    # Initialize scorer
-    moderation_scorer = OpenAIModerationScorer()
-
-    # Create dataset
-    dataset = [
-        {"input": "I love puppies and kittens!"},
-        {"input": "I hate everyone and want to hurt them."}
-    ]
-
-    # Run evaluation
-    evaluation = weave.Evaluation(dataset=dataset, scorers=[moderation_scorer])
-    results = asyncio.run(evaluation.evaluate(MyModel()))
-    print(results)
-    # Example output:
-    # {'OpenAIModerationScorer': {'flagged': {'true_count': 1, 'true_fraction': 0.5}, 'categories': {'violence': {'true_count': 1, 'true_fraction': 1.0}}}, 'model_latency': {'mean': ...}}
-    ```
-
-    ---
-
-    ## `EmbeddingSimilarityScorer`
-
-    The `EmbeddingSimilarityScorer` computes the cosine similarity between the embeddings of the AI system's output and a target text from your dataset. It is useful for measuring how similar the AI's output is to a reference text.
-
-    ```python lines
-    from weave.scorers import EmbeddingSimilarityScorer
-
-    similarity_scorer = EmbeddingSimilarityScorer(
-        model_id="openai/text-embedding-3-small",  # or any other model supported by litellm
-        threshold=0.4  # the cosine similarity threshold
-    )
-    ```
-
-    **Parameters:**
-
-    - `threshold` (float): The minimum cosine similarity score (between -1 and 1) needed to consider the two texts similar (defaults to `0.5`).
-
-    **Example Usage:**
-
-    The following example uses `EmbeddingSimilarityScorer` in the context of an evaluation:
-
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import EmbeddingSimilarityScorer
-
-    # Initialize scorer
-    similarity_scorer = EmbeddingSimilarityScorer(
-        model_id="openai/text-embedding-3-small",  # or any other model supported by litellm
-        threshold=0.7
-    )
-    # Create dataset
-    dataset = [
-        {
-            "input": "He's name is John",
-            "target": "John likes various types of cheese.",
-        },
-        {
-            "input": "He's name is Pepe.",
-            "target": "Pepe likes various types of cheese.",
-        },
-    ]
-    # Define model
-    @weave.op
-    def model(input: str) -> str:
-        return "John likes various types of cheese."
-
-    # Run evaluation
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[similarity_scorer],
-    )
-    result = asyncio.run(evaluation.evaluate(model))
-    print(result)
-    # Example output:
-    # {'EmbeddingSimilarityScorer': {'is_similar': {'true_count': 1, 'true_fraction': 0.5}, 'similarity_score': {'mean': 0.844851403}}, 'model_latency': {'mean': ...}}
-    ```
-
-    ---
+evaluation = weave.Evaluation(dataset=dataset, scorers=[xml_scorer])
+results = asyncio.run(evaluation.evaluate(model))
+print(results)
+# Example output:
+# {'ValidXMLScorer': {'xml_valid': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
+```
 
-    ## `ValidJSONScorer`
+---
 
-    The `ValidJSONScorer` checks whether the AI system's output is valid JSON. This scorer is useful when you expect the output to be in JSON format and need to verify its validity.
+## `PydanticScorer`
 
-    ```python lines
-    from weave.scorers import ValidJSONScorer
+The `PydanticScorer` validates the AI system's output against a Pydantic model to ensure it adheres to a specified schema or data structure.
 
-    json_scorer = ValidJSONScorer()
-    ```
+```python lines
+from weave.scorers import PydanticScorer
+from pydantic import BaseModel
 
-    Here is an example in the context of an evaluation:
+class FinancialReport(BaseModel):
+    revenue: int
+    year: str
 
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import ValidJSONScorer
+pydantic_scorer = PydanticScorer(model=FinancialReport)
+```
 
-    class JSONModel(weave.Model):
-        @weave.op()
-        async def predict(self, input: str) -> str:
-            # This is a placeholder.
-            # In a real scenario, this would generate JSON.
-            return '{"key": "value"}'
+---
 
-    model = JSONModel()
-    json_scorer = ValidJSONScorer()
+## RAGAS - `ContextEntityRecallScorer`
 
-    dataset = [
-        {"input": "Generate a JSON object with a key and value"},
-        {"input": "Create an invalid JSON"}
-    ]
+The `ContextEntityRecallScorer` estimates context recall by extracting entities from both the AI system's output and the provided context, then computing the recall score. It is based on the [RAGAS](https://github.com/explodinggradients/ragas) evaluation library.
 
-    evaluation = weave.Evaluation(dataset=dataset, scorers=[json_scorer])
-    results = asyncio.run(evaluation.evaluate(model))
-    print(results)
-    # Example output:
-    # {'ValidJSONScorer': {'json_valid': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
-    ```
+```python lines
+from weave.scorers import ContextEntityRecallScorer
 
-    ---
+entity_recall_scorer = ContextEntityRecallScorer(
+    model_id="openai/gpt-4o"
+)
+```
 
-    ## `ValidXMLScorer`
+**How It Works:**
 
-    The `ValidXMLScorer` checks whether the AI system's output is valid XML. It is useful when expecting XML-formatted outputs.
+- Uses an LLM to extract unique entities from the output and context and calculates recall.
+- **Recall** indicates the proportion of important entities from the context that are captured in the output.
+- Returns a dictionary with the recall score.
 
-    ```python lines
-    from weave.scorers import ValidXMLScorer
+**Notes:**
 
-    xml_scorer = ValidXMLScorer()
-    ```
+- Expects a `context` column in your dataset. [Use the `column_map` attribute](#use-column-mapping) if the column name is different.
 
-    Here is an example in the context of an evaluation:
+---
 
-    ```python lines
-    import asyncio
-    import weave
-    from weave.scorers import ValidXMLScorer
+## RAGAS - `ContextRelevancyScorer`
 
-    class XMLModel(weave.Model):
-        @weave.op()
-        async def predict(self, input: str) -> str:
-            # This is a placeholder. In a real scenario, this would generate XML.
-            return '<root><element>value</element></root>'
+The `ContextRelevancyScorer` evaluates the relevancy of the provided context to the AI system's output. It is based on the [RAGAS](https://github.com/explodinggradients/ragas) evaluation library.
 
-    model = XMLModel()
-    xml_scorer = ValidXMLScorer()
+```python lines
+from weave.scorers import ContextRelevancyScorer
 
-    dataset = [
-        {"input": "Generate a valid XML with a root element"},
-        {"input": "Create an invalid XML"}
-    ]
+relevancy_scorer = ContextRelevancyScorer(
+    model_id="openai/gpt-4o",  # or any other model supported by litellm
+    relevancy_prompt="""
+Given the following question and context, rate the relevancy of the context to the question on a scale from 0 to 1.
 
-    evaluation = weave.Evaluation(dataset=dataset, scorers=[xml_scorer])
-    results = asyncio.run(evaluation.evaluate(model))
-    print(results)
-    # Example output:
-    # {'ValidXMLScorer': {'xml_valid': {'true_count': 2, 'true_fraction': 1.0}}, 'model_latency': {'mean': ...}}
-    ```
+Question: {question}
+Context: {context}
+Relevancy Score (0-1):
+"""
+)
+```
 
-    ---
+**How It Works:**
 
-    ## `PydanticScorer`
+- Uses an LLM to rate the relevancy of the context to the output on a scale from 0 to 1.
+- Returns a dictionary with the `relevancy_score`.
 
-    The `PydanticScorer` validates the AI system's output against a Pydantic model to ensure it adheres to a specified schema or data structure.
+**Notes:**
 
-    ```python lines
-    from weave.scorers import PydanticScorer
-    from pydantic import BaseModel
+- Expects a `context` column in your dataset. [Use the `column_map` attribute](#use-column-mapping) if the column name is different.
+- Customize the `relevancy_prompt` to define how relevancy is assessed.
 
-    class FinancialReport(BaseModel):
-        revenue: int
-        year: str
+Here is an example usage in the context of an evaluation:
 
-    pydantic_scorer = PydanticScorer(model=FinancialReport)
-    ```
+```python lines
+import asyncio
+from textwrap import dedent
+import weave
+from weave.scorers import ContextEntityRecallScorer, ContextRelevancyScorer
 
-    ---
+class RAGModel(weave.Model):
+    @weave.op()
+    async def predict(self, question: str) -> str:
+        "Retrieve relevant context"
+        return "Paris is the capital of France."
 
-    ## RAGAS - `ContextEntityRecallScorer`
-
-    The `ContextEntityRecallScorer` estimates context recall by extracting entities from both the AI system's output and the provided context, then computing the recall score. It is based on the [RAGAS](https://github.com/explodinggradients/ragas) evaluation library.
-
-    ```python lines
-    from weave.scorers import ContextEntityRecallScorer
-
-    entity_recall_scorer = ContextEntityRecallScorer(
-        model_id="openai/gpt-4o"
-    )
-    ```
-
-    **How It Works:**
-
-    - Uses an LLM to extract unique entities from the output and context and calculates recall.
-    - **Recall** indicates the proportion of important entities from the context that are captured in the output.
-    - Returns a dictionary with the recall score.
-
-    **Notes:**
-
-    - Expects a `context` column in your dataset. [Use the `column_map` attribute](#use-column-mapping) if the column name is different.
-
-    ---
-
-    ## RAGAS - `ContextRelevancyScorer`
-
-    The `ContextRelevancyScorer` evaluates the relevancy of the provided context to the AI system's output. It is based on the [RAGAS](https://github.com/explodinggradients/ragas) evaluation library.
-
-    ```python lines
-    from weave.scorers import ContextRelevancyScorer
-
-    relevancy_scorer = ContextRelevancyScorer(
-        model_id="openai/gpt-4o",  # or any other model supported by litellm
-        relevancy_prompt="""
+# Define prompts
+relevancy_prompt: str = dedent("""
     Given the following question and context, rate the relevancy of the context to the question on a scale from 0 to 1.
 
     Question: {question}
     Context: {context}
     Relevancy Score (0-1):
-    """
-    )
-    ```
+    """)
+# Initialize scorers
+entity_recall_scorer = ContextEntityRecallScorer()
+relevancy_scorer = ContextRelevancyScorer(relevancy_prompt=relevancy_prompt)
+# Create dataset
+dataset = [
+    {
+        "question": "What is the capital of France?",
+        "context": "Paris is the capital city of France."
+    },
+    {
+        "question": "Who wrote Romeo and Juliet?",
+        "context": "William Shakespeare wrote many famous plays."
+    }
+]
+# Run evaluation
+evaluation = weave.Evaluation(
+    dataset=dataset,
+    scorers=[entity_recall_scorer, relevancy_scorer]
+)
+results = asyncio.run(evaluation.evaluate(RAGModel()))
+print(results)
+# Example output:
+# {'ContextEntityRecallScorer': {'recall': {'mean': ...}}, 
+# 'ContextRelevancyScorer': {'relevancy_score': {'mean': ...}}, 
+# 'model_latency': {'mean': ...}}
+```
 
-    **How It Works:**
-
-    - Uses an LLM to rate the relevancy of the context to the output on a scale from 0 to 1.
-    - Returns a dictionary with the `relevancy_score`.
-
-    **Notes:**
-
-    - Expects a `context` column in your dataset. [Use the `column_map` attribute](#use-column-mapping) if the column name is different.
-    - Customize the `relevancy_prompt` to define how relevancy is assessed.
-
-    Here is an example usage in the context of an evaluation:
-
-    ```python lines
-    import asyncio
-    from textwrap import dedent
-    import weave
-    from weave.scorers import ContextEntityRecallScorer, ContextRelevancyScorer
-
-    class RAGModel(weave.Model):
-        @weave.op()
-        async def predict(self, question: str) -> str:
-            "Retrieve relevant context"
-            return "Paris is the capital of France."
-
-    # Define prompts
-    relevancy_prompt: str = dedent("""
-        Given the following question and context, rate the relevancy of the context to the question on a scale from 0 to 1.
-
-        Question: {question}
-        Context: {context}
-        Relevancy Score (0-1):
-        """)
-    # Initialize scorers
-    entity_recall_scorer = ContextEntityRecallScorer()
-    relevancy_scorer = ContextRelevancyScorer(relevancy_prompt=relevancy_prompt)
-    # Create dataset
-    dataset = [
-        {
-            "question": "What is the capital of France?",
-            "context": "Paris is the capital city of France."
-        },
-        {
-            "question": "Who wrote Romeo and Juliet?",
-            "context": "William Shakespeare wrote many famous plays."
-        }
-    ]
-    # Run evaluation
-    evaluation = weave.Evaluation(
-        dataset=dataset,
-        scorers=[entity_recall_scorer, relevancy_scorer]
-    )
-    results = asyncio.run(evaluation.evaluate(RAGModel()))
-    print(results)
-    # Example output:
-    # {'ContextEntityRecallScorer': {'recall': {'mean': ...}}, 
-    # 'ContextRelevancyScorer': {'relevancy_score': {'mean': ...}}, 
-    # 'model_latency': {'mean': ...}}
-    ```
-  </Tab>
-  <Tab title="TypeScript">
-    ```plaintext
-    This feature is not available in TypeScript yet.  Stay tuned!
-    ```
-  </Tab>
-</Tabs>
-
-**Note:** The built-in scorers were calibrated using OpenAI models (e.g. `openai/gpt-4o`, `openai/text-embedding-3-small`). If you wish to experiment with other providers, you can simply update the `model_id`. For example, to use an Anthropic model:
+**Note:** The built-in scorers were calibrated using OpenAI models, such as `openai/gpt-4o` and `openai/text-embedding-3-small`. If you want to experiment with other providers, you can update the `model_id` field to use a different model. For example, to use an Anthropic model:
 
 ```python lines
 from weave.scorers import SummarizationScorer
@@ -453,23 +452,4 @@ from weave.scorers import SummarizationScorer
 summarization_scorer = SummarizationScorer(
     model_id="anthropic/claude-3-5-sonnet-20240620"
 )
-```
-
-## Use column mapping
-
-You can use the `column_map` attribute to tell the scorer which dataset columns to use. The `column_map` attribute requires you to set the following keys:
-- `output`: Model prediction
-- `target`: Reference answer to compare with
-
-The following example maps the `output` and `target` columns to a dataset's `model_output` and `answer` columns, respectively:
-
-```python
-from weave.scorers import EmbeddingSimilarityScorer
-
-similarity_scorer = EmbeddingSimilarityScorer()
-
-similarity_scorer.column_map = {
-    "output": "model_output",  # The model's generated text
-    "target": "answer"        # The expected or reference response
-}
 ```

--- a/weave/guides/evaluation/evaluation_logger.mdx
+++ b/weave/guides/evaluation/evaluation_logger.mdx
@@ -20,10 +20,10 @@ The `EvaluationLogger` offers flexibility while the standard framework offers st
 ## Basic workflow
 
 1. _Initialize the logger:_ Create an instance of `EvaluationLogger`, optionally providing metadata about the `model` and `dataset`. Defaults will be used if omitted.
-    :::important Track token usage and cost
+    <Note>
     To capture token usage and cost for LLM calls (e.g. OpenAI), initialize `EvaluationLogger` before any LLM invocations**. 
     If you call your LLM first and then log predictions afterward, token and cost data are not captured.
-    :::
+    </Note>
 2. _Log predictions:_ Call `log_prediction` for each input/output pair from your system.
 3. _Log scores:_ Use the returned `ScoreLogger` to `log_score` for the prediction. Multiple scores per prediction are supported.
 4. _Finish prediction:_ Always call `finish()` after logging scores for a prediction to finalize it.
@@ -53,7 +53,7 @@ import weave
 from openai import OpenAI
 from weave import EvaluationLogger
 
-weave.init('my-project')
+weave.init('your-team/your-project')
 
 # Initialize EvaluationLogger BEFORE calling the model to ensure token tracking
 eval_logger = EvaluationLogger(
@@ -124,12 +124,11 @@ The fire-and-forget pattern is safe because `logSummary()` automatically waits f
 
 The following example evaluates model predictions with the fire-and-forget pattern. It sets up an evaluation logger, runs a simple model on three test samples, and then logs the prediction without using await:
 
-```typescript lines
-import weave from 'weave';
+```typescript lines {36,50}
+import weave, {EvaluationLogger} from 'weave';
 import OpenAI from 'openai';
-import {EvaluationLogger} from 'weave/evaluationLogger';
 
-await weave.init('my-project');
+await weave.init('your-team/your-project');
 
 // Initialize EvaluationLogger BEFORE calling the model to ensure token tracking
 const evalLogger = new EvaluationLogger({
@@ -138,7 +137,7 @@ const evalLogger = new EvaluationLogger({
   dataset: 'my_dataset'
 });
 
-// Example input data (this can be any data structure you want)
+// Example input data
 const evalSamples = [
   {inputs: {a: 1, b: 2}, expected: 3},
   {inputs: {a: 2, b: 3}, expected: 5},
@@ -152,7 +151,6 @@ const userModel = weave.op(async function userModel(a: number, b: number): Promi
     messages: [{role: 'user', content: `What is ${a}+${b}?`}],
     model: 'gpt-4o-mini'
   });
-  // Use the response in some way (here we just return a + b for simplicity)
   return a + b;
 });
 
@@ -175,7 +173,6 @@ for (const sample of evalSamples) {
 }
 
 // logSummary waits for all pending operations to complete internally
-// Weave auto-aggregates the 'correctness' scores logged above.
 const summaryStats = {subjective_overall_score: 0.8};
 await evalLogger.logSummary(summaryStats);
 
@@ -260,6 +257,63 @@ ev.log_summary({"avg_score": 1.0})
 ```
 
 This pattern ensures that all nested operations are tracked and attributed to the parent prediction, giving you accurate token usage and cost data in the Weave UI.
+</Tab>
+<Tab title="TypeScript">
+TypeScript doesn't have Python's `with` statement pattern for context managers. Instead, use the fire-and-forget pattern with explicit `finish()` calls.
+
+The following example logs a prediction, adds simple scores and an LLM judge score, then finalizes the prediction with `finish()`:
+
+```typescript lines {43}
+import weave from 'weave';
+import OpenAI from 'openai';
+import {EvaluationLogger} from 'weave/evaluationLogger';
+
+await weave.init('your-team/your-project');
+const oai = new OpenAI();
+
+// Initialize the logger
+const ev = new EvaluationLogger({
+  name: 'joke-eval',
+  model: 'gpt-4o-mini',
+  dataset: 'joke_dataset',
+});
+
+const userPrompt = 'Tell me a joke';
+
+// Get model output
+const result = await oai.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [{role: 'user', content: userPrompt}],
+});
+
+const modelOutput = result.choices[0].message.content;
+
+// Log prediction with output
+const pred = ev.logPrediction({user_prompt: userPrompt}, modelOutput);
+
+// Log simple scores
+pred.logScore('correctness', 1.0);
+pred.logScore('ambiguity', 0.3);
+
+// For LLM judge scores, make the call and log the result
+const judgeResult = await oai.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [
+    {role: 'system', content: 'Rate how funny the joke is from 1-5'},
+    {role: 'user', content: modelOutput || ''},
+  ],
+});
+pred.logScore('llm_judge', judgeResult.choices[0].message.content);
+
+// Explicitly call finish when done scoring
+pred.finish();
+
+await ev.logSummary({avg_score: 1.0});
+```
+
+<Note>
+While TypeScript doesn't have automatic cleanup with context managers, `logSummary()` automatically finishes any unfinished predictions before aggregating results. You can rely on this behavior if you prefer not to call `finish()` explicitly.
+</Note>
 </Tab>
 </Tabs>
 
@@ -400,6 +454,60 @@ for inputs in rich_media_dataset:
 ev.log_summary()
 ```
 </Tab>
+<Tab title="TypeScript">
+The TypeScript SDK supports logging images and audio using the `weaveImage` and `weaveAudio` functions. The following example loads image and audio files, processes them through a model, and logs the results with scores.
+
+```typescript lines
+import weave, {EvaluationLogger} from 'weave';
+import * as fs from 'fs';
+
+await weave.init('your-team/your-project');
+
+// Load images and audio from files
+const richMediaDataset = [
+  {
+    image: weave.weaveImage({data: fs.readFileSync('sample1.png')}),
+    audio: weave.weaveAudio({data: fs.readFileSync('sample1.wav')}),
+  },
+  {
+    image: weave.weaveImage({data: fs.readFileSync('sample2.png')}),
+    audio: weave.weaveAudio({data: fs.readFileSync('sample2.wav')}),
+  },
+];
+
+// Model that processes media and returns results
+const yourOutputGenerator = weave.op(
+  async (inputs: {image: any; audio: any}) => {
+    const result = Math.floor(Math.random() * 10);
+    return {
+      result,
+      image: inputs.image,
+      audio: inputs.audio,
+    };
+  },
+  {name: 'yourOutputGenerator'}
+);
+
+const ev = new EvaluationLogger({
+  name: 'rich-media-eval',
+  model: 'example_model',
+  dataset: 'example_dataset',
+});
+
+for (const inputs of richMediaDataset) {
+  const output = await yourOutputGenerator(inputs);
+
+  // Log prediction with rich media in both inputs and outputs
+  const pred = ev.logPrediction(inputs, output);
+  pred.logScore('greater_than_5_scorer', output.result > 5);
+  pred.logScore('greater_than_7_scorer', output.result > 7);
+  pred.finish();
+}
+
+await ev.logSummary();
+```
+
+</Tab>
 </Tabs>
 
 ### Log and compare multiple evaluations
@@ -453,7 +561,7 @@ import weave from 'weave';
 import {EvaluationLogger} from 'weave/evaluationLogger';
 import {WeaveObject} from 'weave/weaveObject';
 
-await weave.init('my-project');
+await weave.init('your-team/your-project');
 
 const models = [
   'model1',

--- a/weave/guides/evaluation/weave_local_scorers.mdx
+++ b/weave/guides/evaluation/weave_local_scorers.mdx
@@ -15,12 +15,13 @@ The model weights are publicly available in W&B Artifacts, and are automatically
 
 The object returned by these scorers contains a `passed` boolean attribute indicating whether the input text is safe or high quality, as well as a `metadata` attribute that contains more detail such as the raw score from the model.
 
-<Tip>
-While local scorers can be run on CPUs and GPUs, use GPUs for best performance.  
-</Tip>
+While you can run local scorers on CPUs, we recommend using GPUs for best performance.
 
-<Tabs>
-  <Tab title="Python">
+<Note>
+Local scorers are only available for the Weave Python SDK. They are not yet available for the Weave TypeScript SDK yet.
+
+To use Weave scorers in TypeScript, see [function-based scorers](/weave/guides/evaluation/scorers#function-based-scorers).
+</Note>
 
     ## Prerequisites
 
@@ -319,11 +320,3 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     print(f"Output contains PII: {not result.passed}")
     print(result)
     ```
-
-  </Tab>
-  <Tab title="TypeScript">
-    Weave local scorers are not available in TypeScript yet. Stay tuned!
-
-    To use Weave scorers in TypeScript, see [function-based scorers](/weave/guides/evaluation/scorers#function-based-scorers).
-  </Tab>
-</Tabs>

--- a/weave/guides/tools/column-mapping.mdx
+++ b/weave/guides/tools/column-mapping.mdx
@@ -1,0 +1,21 @@
+---
+title: "Map columns in datasets"
+description: "Map columns in datasets to different names. This helps you align the column names in your dataset with the column names expected by the scorer."
+---
+
+You can use the `column_map` attribute to tell the scorers which dataset columns to use. The `column_map` attribute requires you to set the following keys:
+- `output`: Model prediction
+- `target`: Reference answer to compare with
+
+The following example maps the `output` and `target` columns to a dataset's `model_output` and `answer` columns, respectively:
+
+```python
+from weave.scorers import EmbeddingSimilarityScorer
+
+similarity_scorer = EmbeddingSimilarityScorer()
+
+similarity_scorer.column_map = {
+    "output": "model_output",  # The model's generated text
+    "target": "answer"        # The expected or reference response
+}
+```

--- a/weave/guides/tools/column-mapping.mdx
+++ b/weave/guides/tools/column-mapping.mdx
@@ -3,19 +3,49 @@ title: "Map columns in datasets"
 description: "Map columns in datasets to different names. This helps you align the column names in your dataset with the column names expected by the scorer."
 ---
 
-You can use the `column_map` attribute to tell the scorers which dataset columns to use. The `column_map` attribute requires you to set the following keys:
-- `output`: Model prediction
-- `target`: Reference answer to compare with
 
-The following example maps the `output` and `target` columns to a dataset's `model_output` and `answer` columns, respectively:
+<Tabs>
+  <Tab title="Python">
+    In the Weave Python SDK, use the `column_map` attribute on a scorer to map its expected parameter names to your dataset's column names. The mapping format is `{scorer_parameter: dataset_column}`.
 
-```python
-from weave.scorers import EmbeddingSimilarityScorer
+    The following example maps the `output` and `target` parameters to a dataset's `model_output` and `answer` columns:
 
-similarity_scorer = EmbeddingSimilarityScorer()
+    ```python
+    from weave.scorers import EmbeddingSimilarityScorer
 
-similarity_scorer.column_map = {
-    "output": "model_output",  # The model's generated text
-    "target": "answer"        # The expected or reference response
-}
-```
+    similarity_scorer = EmbeddingSimilarityScorer()
+
+    similarity_scorer.column_map = {
+        "output": "model_output",  # The model's generated text
+        "target": "answer"         # The expected or reference response
+    }
+    ```
+
+    For more details on scorer column mapping, see [Mapping Column Names with `column_map`](../evaluation/scorers#mapping-column-names-with-column_map).
+  </Tab>
+  <Tab title="TypeScript">
+    In the Weave TypeScript SDK, column mapping is configured on the `Evaluation` object using the `columnMapping` option, not on individual scorers. The mapping format is `{scorer_key: dataset_column}`.
+
+    The following example maps `expectedOutputTimesTwo` (used by the scorer) to the `expected` column in the dataset:
+
+    ```typescript
+    import * as weave from 'weave';
+
+    const myScorer = weave.op(
+      ({modelOutput, datasetRow}) => {
+        return modelOutput * 2 === datasetRow.expectedOutputTimesTwo;
+      },
+      {name: 'myScorer'}
+    );
+
+    const myEval = new weave.Evaluation({
+      id: 'my-evaluation',
+      dataset: [{expected: 2}],
+      scorers: [myScorer],
+      columnMapping: {expectedOutputTimesTwo: 'expected'},
+    });
+    ```
+
+    For more details on TypeScript scorer arguments, see [Scorer Keyword Arguments](../evaluation/scorers#scorer-keyword-arguments).
+  </Tab>
+</Tabs>


### PR DESCRIPTION
## Description
This adds TypeScript examples to the Weave evaluation docs and calls out SDK gaps where applicable. The code examples have been tested and work.

This PR also breaks out column mapping into its own small doc.