### PR TITLE
Reduce the links on the homepage to be onboarding only

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -22,7 +22,6 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
         • <a href="/models/">Introduction</a><br/>
         • <a href="/models/quickstart/">Quickstart</a><br/>
         • <a href="https://www.youtube.com/watch?v=tHAFujRhZLA">YouTube Tutorial</a><br/>
-        • <a href="https://wandb.ai/site/courses/101/">Online Course</a>
     </ProductCard>
 
     <ProductCard
@@ -37,8 +36,6 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
         • <a href="/weave/">Introduction</a><br/>
         • <a href="/weave/quickstart">Quickstart</a><br/>
         • <a href="https://www.youtube.com/watch?v=IQcGGNLN3zo">YouTube Demo</a><br/>
-        • <a href="/weave/guides/tools/playground/">Try the Playground</a><br/>
-        • <a href="/weave/guides/tools/weave-in-workspaces">Use Weave in your W&B runs</a>
     </ProductCard>
     
     <ProductCard
@@ -51,8 +48,6 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
         <br/>
         <br/>
         • <a href="/inference/">Introduction</a><br/>
-        • <a href="/inference/models/">Available Models</a><br/>
-        • <a href="/inference/api-reference/">API Reference</a><br/>
         • <a href="https://wandb.ai/inference">Try in Playground</a>
     </ProductCard>
 
@@ -66,9 +61,7 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
         <br/>
         <br/>
         • <a href="/training/">Introduction</a><br/>
-        • <a href="/training/prerequisites/">Prerequisites</a><br/>
-        • <a href="/training/serverless-rl/">Serverless RL</a><br/>
-        • <a href="/training/api-reference/">API Reference</a>
+        • <a href="/training/prerequisites/">Quickstart</a><br/>
     </ProductCard>
 </div>
 </HomeWrapper>


### PR DESCRIPTION
Goals:
- Create a more "scannable" experience
- For the flagship products (Models, Weave) allow three links, and for the others allow two. 
- Focus only on onboarding, do not attempt to recreate the TOC or "promote" new functionality with high-vis links.

Rather than overwhelm the user with 19 links, we're down to 10. 
