### PR TITLE
docs(weave): add redact_pii_exclude_fields setting

### DIFF
--- a/weave/guides/tracking/redact-pii.mdx
+++ b/weave/guides/tracking/redact-pii.mdx
@@ -16,6 +16,7 @@ The Sensitive Data Protection feature introduces the following functionality to 
 - A `redact_pii` setting, which can be toggled on or off in the `weave.init` call to enable PII redaction.
 - Automatic redaction of [common entities](#entities-redacted-by-default) when `redact_pii = True`.
 - Customizable redaction fields using the configurable `redact_pii_fields` setting.
+- Exclude specific entities from redaction using the `redact_pii_exclude_fields` setting.
 
 ## Enable PII redaction
 
@@ -42,6 +43,14 @@ To get started with the Sensitive Data Protection feature in Weave, complete the
     ```
 
     For a full list of the entities that can be detected and redacted, see [PII entities supported by Presidio](https://microsoft.github.io/presidio/supported_entities/).
+
+4. (Optional) Exclude specific entities from redaction using the `redact_pii_exclude_fields` parameter. This is useful when you want to keep the default redaction but preserve certain entity types:
+
+    ```python lines
+    weave.init("my-project", settings={"redact_pii": True, "redact_pii_exclude_fields":["EMAIL_ADDRESS", "PERSON"]})
+    ```
+
+    In this example, all [default entities](#entities-redacted-by-default) are redacted except for `EMAIL_ADDRESS` and `PERSON`.
 
 ## Entities redacted by default
 

--- a/weave/guides/tracking/redact-pii.mdx
+++ b/weave/guides/tracking/redact-pii.mdx
@@ -44,13 +44,11 @@ To get started with the Sensitive Data Protection feature in Weave, complete the
 
     For a full list of the entities that can be detected and redacted, see [PII entities supported by Presidio](https://microsoft.github.io/presidio/supported_entities/).
 
-4. (Optional) Exclude specific entities from redaction using the `redact_pii_exclude_fields` parameter. This is useful when you want to keep the default redaction but preserve certain entity types:
+4. (Optional) Exclude specific entities from redaction using the `redact_pii_exclude_fields` parameter. This is useful when you want to keep the default redaction but preserve certain entity types. The following example demonstrates how to redact all [default entities](#entities-redacted-by-default) except `EMAIL_ADDRESS` and `PERSON`:
 
     ```python lines
     weave.init("my-project", settings={"redact_pii": True, "redact_pii_exclude_fields":["EMAIL_ADDRESS", "PERSON"]})
     ```
-
-    In this example, all [default entities](#entities-redacted-by-default) are redacted except for `EMAIL_ADDRESS` and `PERSON`.
 
 ## Entities redacted by default
 


### PR DESCRIPTION
## Summary
Documents the new `redact_pii_exclude_fields` setting that allows users to exclude specific PII entity types from redaction while keeping the defaults.

Related PR: https://github.com/wandb/weave/pull/5904
Ticket: https://wandb.atlassian.net/browse/WB-28728

🤖 Generated with [Claude Code](https://claude.com/claude-code)