### PR TITLE
[Weave] Corrects syntax for source link URLs in Weave ref docs

### DIFF
--- a/.github/workflows/generate-weave-reference-docs.yml
+++ b/.github/workflows/generate-weave-reference-docs.yml
@@ -1,6 +1,10 @@
 name: Generate Weave references
 
 on:
+  # TODO: Remove push trigger after testing
+  push:
+    branches:
+      - weave/ref-source-link-fix
   workflow_dispatch:
     inputs:
       weave_version:

--- a/.github/workflows/generate-weave-reference-docs.yml
+++ b/.github/workflows/generate-weave-reference-docs.yml
@@ -1,10 +1,6 @@
 name: Generate Weave references
 
 on:
-  # TODO: Remove push trigger after testing
-  push:
-    branches:
-      - weave/ref-source-link-fix
   workflow_dispatch:
     inputs:
       weave_version:

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -166,8 +166,8 @@ def fix_code_fence_indentation(text: str) -> str:
 
 
 def convert_source_badges_to_buttons(content: str) -> str:
-    
-    # Convert source badge images to text-based buttons.
+
+    # Convert source badge images to text-based buttons
     pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
     
     replacement = r'<a href="\1" class="source-link">Source</a>'

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -166,13 +166,27 @@ def fix_code_fence_indentation(text: str) -> str:
 
 
 def convert_source_badges_to_buttons(content: str) -> str:
-
-    # Convert source badge images to text-based buttons.
-    pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
+    """Convert shields.io source badge images to text-based buttons.
     
+    This avoids Mintlify's image lightbox from triggering when clicking source links.
+    
+    Converts:
+        <a href="..."><img ... src="...badge/-source..." /></a>
+    To:
+        <a href="..." class="source-link">Source</a>
+    """
+    pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
     replacement = r'<a href="\1" class="source-link">Source</a>'
     
-    return re.sub(pattern, replacement, content)
+    # Debug: count matches before conversion
+    matches_before = len(re.findall(pattern, content))
+    result = re.sub(pattern, replacement, content)
+    matches_after = content.count('class="source-link"')
+    
+    if matches_before > 0:
+        print(f"      [DEBUG] Source badge conversion: {matches_before} badges found, converted to text buttons")
+    
+    return result
 
 
 def convert_docusaurus_to_mintlify(content: str, module_name: str) -> str:

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -199,7 +199,7 @@ description: "Python SDK reference for {module_name}"
 def generate_module_docs(module, module_name: str, src_root_path: str, version: str = "master") -> str:
     """Generate documentation for a single module."""
     # Use the specific version tag for source links
-    src_url = f"https://github.com/wandb/weave/blob/{version}"
+    src_url = f"https://github.com/wandb/weave/blob/v{version}"
     if version == "latest":
         src_url = "https://github.com/wandb/weave/blob/master"
     

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -166,19 +166,19 @@ def fix_code_fence_indentation(text: str) -> str:
 
 
 def convert_source_badges_to_buttons(content: str) -> str:
-    """Convert shields.io source badge images to text-based buttons.
+    """Convert shields.io source badge images to SourceLink components.
     
     This avoids Mintlify's image lightbox from triggering when clicking source links.
     
     Converts:
         <a href="..."><img ... src="...badge/-source..." ></a>
     To:
-        <a href="..." class="source-link">Source</a>
+        <SourceLink url="..." />
     """
     # Pattern matches both self-closing (/>) and non-self-closing (>) img tags
     # lazydocs generates non-self-closing tags: <img ... >
     pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/?>\s*</a>'
-    replacement = r'<a href="\1" class="source-link">Source</a>'
+    replacement = r'<SourceLink url="\1" />'
     return re.sub(pattern, replacement, content)
 
 
@@ -206,6 +206,8 @@ def convert_docusaurus_to_mintlify(content: str, module_name: str) -> str:
 title: "{title}"
 description: "Python SDK reference for {module_name}"
 ---
+
+import {{ SourceLink }} from '/snippets/en/_includes/source-link.mdx';
 
 """
         content = frontmatter + content

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -171,22 +171,15 @@ def convert_source_badges_to_buttons(content: str) -> str:
     This avoids Mintlify's image lightbox from triggering when clicking source links.
     
     Converts:
-        <a href="..."><img ... src="...badge/-source..." /></a>
+        <a href="..."><img ... src="...badge/-source..." ></a>
     To:
         <a href="..." class="source-link">Source</a>
     """
-    pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
+    # Pattern matches both self-closing (/>) and non-self-closing (>) img tags
+    # lazydocs generates non-self-closing tags: <img ... >
+    pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/?>\s*</a>'
     replacement = r'<a href="\1" class="source-link">Source</a>'
-    
-    # Debug: count matches before conversion
-    matches_before = len(re.findall(pattern, content))
-    result = re.sub(pattern, replacement, content)
-    matches_after = content.count('class="source-link"')
-    
-    if matches_before > 0:
-        print(f"      [DEBUG] Source badge conversion: {matches_before} badges found, converted to text buttons")
-    
-    return result
+    return re.sub(pattern, replacement, content)
 
 
 def convert_docusaurus_to_mintlify(content: str, module_name: str) -> str:

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -165,6 +165,16 @@ def fix_code_fence_indentation(text: str) -> str:
     return "\n".join(result_lines)
 
 
+def convert_source_badges_to_buttons(content: str) -> str:
+    
+    # Convert source badge images to text-based buttons.
+    pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
+    
+    replacement = r'<a href="\1" class="source-link">Source</a>'
+    
+    return re.sub(pattern, replacement, content)
+
+
 def convert_docusaurus_to_mintlify(content: str, module_name: str) -> str:
     """Convert Docusaurus markdown to Mintlify MDX format."""
     # Remove the sidebar_label frontmatter (Mintlify uses title)
@@ -370,6 +380,9 @@ def generate_module_docs(module, module_name: str, src_root_path: str, version: 
         return '\n'.join(fixed_lines)
     
     content = fix_parameter_lists(content)
+    
+    # Convert source badge images to text buttons (avoids Mintlify lightbox issue)
+    content = convert_source_badges_to_buttons(content)
     
     # Convert to Mintlify format
     content = convert_docusaurus_to_mintlify(content, module_name)

--- a/scripts/reference-generation/weave/generate_python_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_python_sdk_docs.py
@@ -167,7 +167,7 @@ def fix_code_fence_indentation(text: str) -> str:
 
 def convert_source_badges_to_buttons(content: str) -> str:
 
-    # Convert source badge images to text-based buttons
+    # Convert source badge images to text-based buttons.
     pattern = r'<a href="(https://github\.com/wandb/weave/blob/[^"]+)">\s*<img[^>]*src="https://img\.shields\.io/badge/-source[^"]*"[^>]*/>\s*</a>'
     
     replacement = r'<a href="\1" class="source-link">Source</a>'

--- a/snippets/button-links.css
+++ b/snippets/button-links.css
@@ -43,3 +43,35 @@
   background-color: rgba(39, 39, 42, 0.8);
   border-color: rgba(63, 63, 70, 1);
 }
+
+/* Compact source link for SDK reference docs */
+.source-link {
+  float: right;
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid rgba(230, 228, 224, 0.7);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgb(87, 85, 81);
+  background-color: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.source-link:hover {
+  background-color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(230, 228, 224, 1);
+  text-decoration: none;
+}
+
+.dark .source-link {
+  color: rgb(214, 211, 209);
+  background-color: rgba(39, 39, 42, 0.5);
+  border: 1px solid rgba(63, 63, 70, 0.7);
+}
+
+.dark .source-link:hover {
+  background-color: rgba(39, 39, 42, 0.8);
+  border-color: rgba(63, 63, 70, 1);
+}

--- a/snippets/en/_includes/source-link.mdx
+++ b/snippets/en/_includes/source-link.mdx
@@ -1,0 +1,10 @@
+export const SourceLink = ({ url }) => (
+  <a
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="source-link"
+  >
+    Source
+  </a>
+);


### PR DESCRIPTION
## Description
Currently, the links to the source code link that send readers to the code in the Weave SDK are 404ing. This hopefully corrects that. It also make the source links a button instead of an image that does a weird zoom animation.