### PR TITLE
Fix code formatting in Hydra integration docs

### DIFF
--- a/models/integrations/hydra.mdx
+++ b/models/integrations/hydra.mdx
@@ -77,8 +77,8 @@ command:
 
 Invoke the sweep:
 
-``` bash
-wandb sweep sweep.yaml` \
+```bash
+wandb sweep sweep.yaml \
 ```
 
 W&B automatically creates a sweep inside your project and returns a `wandb agent` command for you to run on each machine you want to run your sweep.

--- a/models/integrations/hydra.mdx
+++ b/models/integrations/hydra.mdx
@@ -78,7 +78,7 @@ command:
 Invoke the sweep:
 
 ```bash
-wandb sweep sweep.yaml \
+wandb sweep sweep.yaml
 ```
 
 W&B automatically creates a sweep inside your project and returns a `wandb agent` command for you to run on each machine you want to run your sweep.


### PR DESCRIPTION
Fixed a formatting issue in the Hydra integration documentation where there was an extra backtick after `sweep.yaml` that was breaking the code block display. Also corrected the code fence formatting by removing an extra space.

Files changed:
- models/integrations/hydra.mdx

---

Created by Mintlify agent