### PR TITLE
docs(weave): Fix invalid links in scorers documentation

### DIFF
--- a/weave/guides/evaluation/scorers.mdx
+++ b/weave/guides/evaluation/scorers.mdx
@@ -24,7 +24,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 <Tip>
 **Ready-to-Use Scorers**
-While this guide shows you how to create custom scorers, Weave comes with a variety of [predefined scorers](./builtin_scorers.mdx) and [local SLM scorers](./weave_local_scorers.mdx) that you can use right away, including:
+While this guide shows you how to create custom scorers, Weave comes with a variety of [predefined scorers](./builtin_scorers) and [local SLM scorers](./weave_local_scorers) that you can use right away, including:
 - [Hallucination detection](./builtin_scorers#hallucinationfreescorer)
 - [Summarization quality](./builtin_scorers#summarizationscorer)
 - [Embedding similarity](./builtin_scorers#embeddingsimilarityscorer)


### PR DESCRIPTION
## Description

Remove .mdx extension from internal links to builtin_scorers and weave_local_scorers pages to resolve 404 errors.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed