### PR TITLE
Artifacts: Updated code snippets

### DIFF
--- a/models/artifacts/delete-artifacts.mdx
+++ b/models/artifacts/delete-artifacts.mdx
@@ -188,10 +188,10 @@ Artifacts with protected aliases have special deletion restrictions. [Protected 
 
 <Note>
 **Important considerations for protected aliases:**
-- Artifacts with protected aliases cannot be deleted by non-registry admins
-- Within a registry, registry admins can unlink protected artifact versions and delete collections/registries that contain protected aliases
+- Artifacts with protected aliases cannot be deleted by non-registry admins.
+- Within a registry, registry admins can unlink protected artifact versions and delete collections/registries that contain protected aliases.
 - For source artifacts: if a source artifact is linked to a registry with a protected alias, it cannot be deleted by any user
-- Registry admins can remove the protected aliases from source artifacts and then delete them
+- Registry admins can remove the protected aliases from source artifacts and then delete them.
 </Note>
 
 

--- a/models/artifacts/delete-artifacts.mdx
+++ b/models/artifacts/delete-artifacts.mdx
@@ -1,10 +1,10 @@
 ---
 description: Delete artifacts interactively with the App UI or programmatically with
-  the W&B SDK.
+  the W&B Python SDK.
 title: Delete an artifact
 ---
 
-Delete artifacts interactively with the App UI or programmatically with the W&B SDK. When you delete an artifact, W&B marks that artifact as a *soft-delete*. In other words, the artifact is marked for deletion but files are not immediately deleted from storage. 
+Delete artifacts interactively with the W&B App or programmatically with the W&B Python SDK. When you delete an artifact, W&B marks that artifact as a *soft-delete*. In other words, the artifact is marked for deletion but files are not immediately deleted from storage. 
 
 The contents of the artifact remain as a soft-delete, or pending deletion state, until a regularly run garbage collection process reviews all artifacts marked for deletion. The garbage collection process deletes associated files from storage if the artifact and its associated files are not used by a previous or subsequent artifact versions.
 
@@ -16,8 +16,8 @@ The following diagram illustrates the complete artifact garbage collection proce
 graph TB
     Start([Artifact Deletion Initiated]) --> DeleteMethod{Deletion Method}
     
-    DeleteMethod -->|UI| UIDelete[Delete via W&B App UI]
-    DeleteMethod -->|SDK| SDKDelete[Delete via W&B SDK]
+    DeleteMethod -->|UI| UIDelete[Delete via W&B App]
+    DeleteMethod -->|SDK| SDKDelete[Delete via W&B Python SDK]
     DeleteMethod -->|TTL| TTLDelete[TTL Policy Expires]
     
     UIDelete --> SoftDelete[Artifact Marked as<br/>'Soft Delete']
@@ -44,82 +44,145 @@ graph TB
     style End fill:#e0e0e0,stroke:#333,stroke-width:2px,color:#000
 ``` 
 
-The sections in this page describe how to delete specific artifact versions, how to delete an artifact collection, how to delete artifacts with and without aliases, and more. You can schedule when artifacts are deleted from W&B with TTL policies. For more information, see [Manage data retention with Artifact TTL policy](./ttl).
+You can schedule when artifacts are deleted from W&B with TTL policies. For more information, see [Manage data retention with Artifact TTL policy](./ttl).
 
 <Note>
-Artifacts that are scheduled for deletion with a TTL policy, deleted with the W&B SDK, or deleted with the W&B App UI are first soft-deleted. Artifacts that are soft deleted undergo garbage collection before they are hard-deleted.
+Artifacts deleted by a TTL policy, the W&B Python SDK, or the W&B App are first soft-deleted. Soft-deleted artifacts are then garbage-collected before they are permanently deleted.
 </Note>
 
 <Note>
-Deleting an entity, project, or artifact collection will also trigger the artifact deletion process described on this page. When deleting a run, if you choose to delete associated artifacts, those artifacts will follow the same soft-delete and garbage collection workflow.
+Deleting an entity, project, or artifact collection triggers the artifact deletion process described on this page. When you delete a run and choose to delete its associated artifacts, those artifacts follow the same soft-delete and garbage collection workflow.
 </Note>
 
-### Delete an artifact version
+## Delete an artifact version
 
+Delete an artifact version interactively with the W&B App or programmatically with the W&B Python SDK.
+
+<Tabs>
+<Tab title="W&B App" value="ui">
 To delete an artifact version:
 
-1. Select the name of the artifact. This will expand the artifact view and list all the artifact versions associated with that artifact.
-2. From the list of artifacts, select the artifact version you want to delete.
-3. On the right hand side of the workspace, select the kebab dropdown.
-4. Choose Delete.
+1. Navigate to the project that contains the artifact version you want to delete.
+2. Select the **Artifacts** tab.
+3. From the list of artifact types, select the type of artifact that contains the version you want to delete.
+4. Click the three horizontal dots (`...`) next to the artifact version you want to delete.
+5. From the dropdown, choose **Delete Version**.
 
-An artifact version can also be deleted programmatically via the [delete()](/models/ref/python/experiments/artifact#delete) method. See the examples below. 
+</Tab>
+<Tab title="W&B Python SDK" value="sdk">
 
-### Delete multiple artifact versions with aliases
-
-The following code example demonstrates how to delete artifacts that have aliases associated with them. Provide the entity, project name, and run ID that created the artifacts.
+Delete an artifact version programmatically with the [wandb.Artifact.delete()](/models/ref/python/experiments/artifact#delete) method. Provide the full name of the artifact. The full name consists of `<entity>/<project>/<artifact_name>:<version>`. Set the `delete_aliases` parameter to `True` to delete the artifact even if it has one or more aliases associated with it.
 
 ```python
 import wandb
 
-# Initialize W&B API
-api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
+api = wandb.Api()
 
-# Get the run by its path. Consists of <entity>/<project>/<run_path>
-run = api.run("entity/project/run_id")
+# Get the artifact by its path
+artifact = api.artifact("<entity>/<project>/<artifact_name>:<version>")
 
-for artifact in run.logged_artifacts():
-    artifact.delete()
+# Delete the artifact version along with any aliases
+artifact.delete(delete_aliases=True)
 ```
 
-Set the `delete_aliases` parameter to the boolean value, `True` to delete aliases if the artifact has one or more aliases.
+</Tab>
+</Tabs>
+
+## Delete multiple artifact versions
+
+The following code example shows how to delete multiple artifact versions. Provide the entity, project name, and run ID that created the artifact as arguments to `wandb.Api.run()`. This returns a run object that you can use to access all artifact versions created by that run. Next, iterate through the artifact versions and delete the ones that match your criteria.
+
+<Tip>
+Set the `delete_aliases` parameter to `True` (`wandb.Artifact.delete(delete_aliases=True)`) to delete an artifact version and any aliases associated with it.
+</Tip>
+
+Replace the `<entity>`, `<project>`, `<run_id>`, and `<artifact_name>` placeholders with your own values:
 
 ```python
 import wandb
 
 # Initialize W&B API
-api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
+api = wandb.Api()
 
-# Get the run by its path. Consists of <entity>/<project>/<run_path>
-run = api.run("entity/project/run_id")
+# Get the run by its path. Consists of <entity>/<project>/<run_id>
+run = api.run("<entity>/<project>/<run_id>")
 
+# Specify the artifact name to delete versions for
+artifact_name = "<artifact_name>"
+
+# Search and delete artifact versions with the specified name
 for artifact in run.logged_artifacts():
-    # Set delete_aliases=True in order to delete
-    # artifacts with one more aliases
-    artifact.delete(delete_aliases=True)
-```
-
-### Delete multiple artifact versions with a specific alias
-
-The following code demonstrates how to delete multiple artifact versions that have a specific alias. Provide the entity, project name, and run ID that created the artifacts. Replace the deletion logic with your own:
-
-```python
-import wandb
-
-# Initialize W&B API
-api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
-
-# Get the run by its path. Consists of <entity>/<project>/<run_path>
-run = api.run("entity/project/run_id")
-
-# Delete artifact ith alias 'v3' and 'v4
-for artifact_version in run.logged_artifacts():
-    # Replace with your own deletion logic.
-    if artifact_version.name[-2:] == "v3" or artifact_version.name[-2:] == "v4":
+    print(f"Found artifact: {artifact.name}") # Example name run_4dfbufgq_model:v0
+    # Grab only the artifact name without the version with split()
+    if artifact.name.split(":")[0] == artifact_name:
+        print(f"Deleting artifact version: {artifact.name}")
         artifact.delete(delete_aliases=True)
 ```
 
-### Protected aliases and deletion permissions
+## Delete multiple artifact versions with a specific alias
+
+The following code demonstrates how to delete multiple artifact versions that have a specific alias. 
+
+Replace the `<entity>`, `<project>`, `<run_id>`, `<artifact_name>`, and `<alias>` placeholders with your own values:
+
+```python
+import wandb
+
+# Initialize W&B API
+api = wandb.Api()
+
+# Get the run by its path. Consists of <entity>/<project>/<run_id>
+run = api.run("<entity>/<project>/<run_id>")
+
+# Specify the artifact name to delete versions for
+artifact_name = "<artifact_name>"
+
+# Specify the alias to filter artifact versions for deletion
+desired_alias = "<alias>"
+
+# Delete artifacts logged to run with alias 'v3' and 'v4
+for artifact in run.logged_artifacts():
+    print(f"Found artifact: {artifact.name}")
+    if (artifact.name.split(":")[0] == artifact_name) and (desired_alias in artifact.aliases):
+            artifact.delete(delete_aliases=True)
+```
+
+## Delete an artifact collection
+
+<Tabs>
+<Tab title="W&B App" value="ui">
+To delete an artifact collection:
+
+1. Navigate to the artifact collection you want to delete.
+3. Select the three horizontal dots (`...`) next to the artifact collection name.
+4. From the dropdown menu, select **Delete**.
+
+</Tab>
+<Tab title="W&B Python SDK" value="sdk">
+
+Delete artifact collection programmatically with the [wandb.Artifact.delete()](/models/ref/python/experiments/artifact#delete) method. 
+
+Provide the full path of the artifact collection to `wandb.Api.artifact_collection(name="")`. The full path consists of `<entity>/<project>/<artifact_collection_name>`.
+
+```python
+import wandb
+
+# Initialize W&B API
+api = wandb.Api()
+
+# Get the artifact collection by its path. Consists of
+# <entity>/<project>/<artifact_collection_name>
+collection = api.artifact_collection(
+    type_name = "<artifact_type>",
+    name = "<entity>/<project>/<artifact_collection_name>"
+)
+collection.delete()
+```
+
+</Tab>
+</Tabs>
+
+## Protected aliases and deletion permissions
 
 Artifacts with protected aliases have special deletion restrictions. [Protected aliases](/models/registry/aliases#protected-aliases) are aliases in the W&B Registry that registry admins can set to prevent unauthorized deletion.
 
@@ -131,50 +194,8 @@ Artifacts with protected aliases have special deletion restrictions. [Protected 
 - Registry admins can remove the protected aliases from source artifacts and then delete them
 </Note>
 
-### Delete all versions of an artifact that do not have an alias
 
-The following code snippet demonstrates how to delete all versions of an artifact that do not have an alias. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively. Replace the `<>` with the name of your artifact:
-
-```python
-import wandb
-
-# Initialize W&B API
-api = wandb.Api(overrides={"project": "project", "entity": "entity"})
-
-artifact_type, artifact_name = "<>"  # provide type and name
-
-for v in api.artifact_versions(artifact_type, artifact_name):
-    # Clean up versions that don't have an alias such as 'latest'.
-    # NOTE: You can put whatever deletion logic you want here.
-    if len(v.aliases) == 0:
-        v.delete()
-```
-
-### Delete an artifact collection
-
-To delete an artifact collection:
-
-1. Navigate to the artifact collection you want to delete and hover over it.
-3. Select the kebab dropdown next to the artifact collection name.
-4. Choose Delete.
-
-You can also delete artifact collection programmatically with the [delete()](/models/ref/python/experiments/artifact#delete) method. Provide the name of the project and entity for the `project` and `entity` keys in `wandb.Api`, respectively:
-
-```python
-import wandb
-
-# Initialize W&B API
-api = wandb.Api(overrides={"project": "project", "entity": "entity"})
-
-# Get the artifact collection by its path. Consists of
-# <entity>/<project>/<artifact_collection_name>
-collection = api.artifact_collection(
-    "<artifact_type>", "entity/project/artifact_collection_name"
-)
-collection.delete()
-```
-
-## How to enable garbage collection based on how W&B is hosted
+## Enable garbage collection based on how W&B is hosted
 Garbage collection is enabled by default if you use W&B's shared cloud. Based on how you host W&B, you might need to take additional steps to enable garbage collection, this includes:
 
 

--- a/models/artifacts/delete-artifacts.mdx
+++ b/models/artifacts/delete-artifacts.mdx
@@ -1,6 +1,6 @@
 ---
 description: Delete artifacts interactively with the App UI or programmatically with
-  the W&B SDK/
+  the W&B SDK.
 title: Delete an artifact
 ---
 
@@ -72,6 +72,10 @@ The following code example demonstrates how to delete artifacts that have aliase
 ```python
 import wandb
 
+# Initialize W&B API
+api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
+
+# Get the run by its path. Consists of <entity>/<project>/<run_path>
 run = api.run("entity/project/run_id")
 
 for artifact in run.logged_artifacts():
@@ -83,6 +87,10 @@ Set the `delete_aliases` parameter to the boolean value, `True` to delete aliase
 ```python
 import wandb
 
+# Initialize W&B API
+api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
+
+# Get the run by its path. Consists of <entity>/<project>/<run_path>
 run = api.run("entity/project/run_id")
 
 for artifact in run.logged_artifacts():
@@ -98,10 +106,14 @@ The following code demonstrates how to delete multiple artifact versions that ha
 ```python
 import wandb
 
-runs = api.run("entity/project_name/run_id")
+# Initialize W&B API
+api = wandb.Api(overrides={"project": "project_name", "entity": "entity"})
+
+# Get the run by its path. Consists of <entity>/<project>/<run_path>
+run = api.run("entity/project/run_id")
 
 # Delete artifact ith alias 'v3' and 'v4
-for artifact_version in runs.logged_artifacts():
+for artifact_version in run.logged_artifacts():
     # Replace with your own deletion logic.
     if artifact_version.name[-2:] == "v3" or artifact_version.name[-2:] == "v4":
         artifact.delete(delete_aliases=True)
@@ -126,11 +138,11 @@ The following code snippet demonstrates how to delete all versions of an artifac
 ```python
 import wandb
 
-# Provide your entity and a project name when you
-# use wandb.Api methods.
+# Initialize W&B API
 api = wandb.Api(overrides={"project": "project", "entity": "entity"})
 
 artifact_type, artifact_name = "<>"  # provide type and name
+
 for v in api.artifact_versions(artifact_type, artifact_name):
     # Clean up versions that don't have an alias such as 'latest'.
     # NOTE: You can put whatever deletion logic you want here.
@@ -151,9 +163,11 @@ You can also delete artifact collection programmatically with the [delete()](/mo
 ```python
 import wandb
 
-# Provide your entity and a project name when you
-# use wandb.Api methods.
+# Initialize W&B API
 api = wandb.Api(overrides={"project": "project", "entity": "entity"})
+
+# Get the artifact collection by its path. Consists of
+# <entity>/<project>/<artifact_collection_name>
 collection = api.artifact_collection(
     "<artifact_type>", "entity/project/artifact_collection_name"
 )


### PR DESCRIPTION
## Description

* This [code snippet](https://docs.wandb.ai/models/artifacts/delete-artifacts#delete-multiple-artifact-versions-with-a-specific-alias) doesn’t run if you copy and paste. It’s missing initializing the Public API.
* Updated the code snippets. It's no longer suggested we use `[wandb.Api.artifact_versions](https://docs.wandb.ai/models/ref/python/public-api/api#method-api-artifact_versions)()`.

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1278, https://wandb.atlassian.net/browse/DOCS-869

