### PR TITLE
Add a note on another LoRA requirement

### DIFF
--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -85,6 +85,7 @@ You can add LoRAs to your W&B account and start using them with two methods:
 
     * The LoRA must have been trained using one of the models listed in the [Supported Base Models section](#supported-base-models).
     * A LoRA saved in PEFT format as a `lora` type artifact in your W&B account.
+    * The maximum supported rank is 16.
     * The LoRA must be stored in the `storage_region="coreweave-us"` for low latency.
     * When uploading, include the name of the base model you trained it on (for example, `meta-llama/Llama-3.1-8B-Instruct`). This ensures W&B can load it with the correct model.
   </Tab>


### PR DESCRIPTION
## Description

Internal Slack thread: https://weightsandbiases.slack.com/archives/C08RU04P36G/p1768599858877389

Our current configuration requires that LoRAs have rank less than or equal to 16. Noting this in the Key Requirements section.

<img width="697" height="367" alt="Screenshot 2026-01-21 at 3 17 18 PM" src="https://github.com/user-attachments/assets/68c4f260-ed16-414b-a420-d4cc070d880a" />

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed