### PR TITLE
fixed config statement

### DIFF
--- a/models/tutorials/pytorch.mdx
+++ b/models/tutorials/pytorch.mdx
@@ -23,11 +23,15 @@ We show you how to integrate W&B with your PyTorch code to add experiment tracki
 # import the library
 import wandb
 
+# capture a dictionary of hyperparameters with config
+config = {
+    "learning_rate": 0.001,
+    "epochs": 100,
+    "batch_size": 128
+}
+
 # start a new experiment
-with wandb.init(project="new-sota-model") as run:
- 
-    # capture a dictionary of hyperparameters with config
-    run.config = {"learning_rate": 0.001, "epochs": 100, "batch_size": 128}
+with wandb.init(project="new-sota-model", config=config) as run:
 
     # set up model and data
     model, dataloader = get_model(), get_data()


### PR DESCRIPTION
## Description

Fix code snippet that incorrectly tries to assign value to `run.config`. Note that it's unclear where and why this code exists in the pytorch.mdx file. It is (supposedly) generated from this notebook: https://colab.research.google.com/github/wandb/examples/blob/master/colabs/pytorch/Simple_PyTorch_Integration.ipynb#scrollTo=tZkm1u_TYc6q .

## Related issues

- Fixes https://wandb.atlassian.net/browse/DOCS-1106

