### PR TITLE
[DOCS-1875] Update baseline and pinned runs docs for max # of pins

### DIFF
--- a/models/runs/compare-runs.mdx
+++ b/models/runs/compare-runs.mdx
@@ -7,7 +7,7 @@ import PinRunsCondensed from '/snippets/en/_includes/pinned-and-baseline-runs/pi
 
 In a workspace with many runs, it can be difficult to keep track of your best performers, production models, failed experiments, or important reference points. The W&B App provides features to help organize and compare runs:
 
-- **Pinned runs**: Pin a maximum of 5 runs to keep them visible in the workspace and at the top of the runs list.
+- **Pinned runs**: Pin up to 6 runs to keep them visible in the workspace and at the top of the runs list. If you have a baseline run, you can pin up to 5 runs because the baseline uses a pinning slot.
 - **Baseline run**: Specify a baseline run as your reference point for comparisons. The baseline run is always visible in the workspace and at the top of the runs list. In line plots, the baseline appears with visually distinct styling to help with comparison.
 
 These features are particularly useful for:
@@ -60,16 +60,16 @@ Only one run can be the baseline at a time. To change which run is your baseline
 2. In the run selector or runs table, find the run you want to use as your new baseline.
 3. Click the action `...` menu, then select **Replace baseline**.
 
-The new run becomes the baseline. Depending on its configuration, the previous baseline run appears alongside other pinned or unpinned runs.
+The new run becomes the baseline. The previous baseline is automatically pinned if a pinning slot is available, so you can find it easily. To ensure the previous baseline is pinned, make sure you have a free pinning slot available before changing the baseline.
 
 ### Remove the baseline designation
 To remove the baseline designation:
 
 1. Navigate to your workspace.
-2. In the run selector or runs table, find the run you want to use as your new baseline.
+2. In the run selector or runs table, find the current baseline run.
 3. Click the action `...` menu, then select **Remove baseline**.
 
-Depending on its configuration, the previous baseline run appears alongside other pinned or unpinned runs.
+The previous baseline is automatically pinned if a pinning slot is available, so you can find it easily. To ensure the previous baseline is pinned, make sure you have a free pinning slot available before removing the baseline designation.
 
 ## Compare runs to the baseline
 The baseline run is always visible in line plots for metrics the run has logged. In line plots, lines for the baseline run appear bolder than other lines.

--- a/models/runs/compare-runs.mdx
+++ b/models/runs/compare-runs.mdx
@@ -7,7 +7,7 @@ import PinRunsCondensed from '/snippets/en/_includes/pinned-and-baseline-runs/pi
 
 In a workspace with many runs, it can be difficult to keep track of your best performers, production models, failed experiments, or important reference points. The W&B App provides features to help organize and compare runs:
 
-- **Pinned runs**: Pin up to 6 runs to keep them visible in the workspace and at the top of the runs list. If you have a baseline run, you can pin up to 5 runs because the baseline uses a pinning slot.
+- **Pinned runs**: Pin up to 6 runs to keep them visible in the workspace and at the top of the runs list. If you have a baseline run, you can pin up to 5 runs because the baseline is implicitly pinned.
 - **Baseline run**: Specify a baseline run as your reference point for comparisons. The baseline run is always visible in the workspace and at the top of the runs list. In line plots, the baseline appears with visually distinct styling to help with comparison.
 
 These features are particularly useful for:
@@ -58,7 +58,7 @@ Only one run can be the baseline at a time. To change which run is your baseline
 
 1. Navigate to your workspace.
 2. In the run selector or runs table, find the run you want to use as your new baseline.
-3. Click the action `...` menu, then select **Replace baseline**. <Note>If the menu item is disabled, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
+3. Click the action `...` menu, then select **Replace baseline**. <Note>If the menu item is inactive, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
 4. The new run becomes the baseline, and the previous baseline is automatically pinned so you can find it easily. Optionally, unpin it by clicking its pin icon.
 
 ### Remove the baseline designation
@@ -66,7 +66,7 @@ To remove the baseline designation:
 
 1. Navigate to your workspace.
 2. In the run selector or runs table, find the current baseline run.
-3. Click the action `...` menu, then select **Remove baseline**. <Note>If the menu item is disabled, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
+3. Click the action `...` menu, then select **Remove baseline**. <Note>If the menu item is inactive, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
 4. The previous baseline is automatically pinned so you can find it easily. Optionally, unpin it by clicking its pin icon.
 
 ## Compare runs to the baseline

--- a/models/runs/compare-runs.mdx
+++ b/models/runs/compare-runs.mdx
@@ -58,18 +58,16 @@ Only one run can be the baseline at a time. To change which run is your baseline
 
 1. Navigate to your workspace.
 2. In the run selector or runs table, find the run you want to use as your new baseline.
-3. Click the action `...` menu, then select **Replace baseline**.
-
-The new run becomes the baseline. The previous baseline is automatically pinned if a pinning slot is available, so you can find it easily. To ensure the previous baseline is pinned, make sure you have a free pinning slot available before changing the baseline.
+3. Click the action `...` menu, then select **Replace baseline**. <Note>If the menu item is disabled, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
+4. The new run becomes the baseline, and the previous baseline is automatically pinned so you can find it easily. Optionally, unpin it by clicking its pin icon.
 
 ### Remove the baseline designation
 To remove the baseline designation:
 
 1. Navigate to your workspace.
 2. In the run selector or runs table, find the current baseline run.
-3. Click the action `...` menu, then select **Remove baseline**.
-
-The previous baseline is automatically pinned if a pinning slot is available, so you can find it easily. To ensure the previous baseline is pinned, make sure you have a free pinning slot available before removing the baseline designation.
+3. Click the action `...` menu, then select **Remove baseline**. <Note>If the menu item is disabled, ensure that you have at least one pinning slot available. If necessary, unpin a pinned run by clicking the circular pin icon next to a pinned run.</Note>
+4. The previous baseline is automatically pinned so you can find it easily. Optionally, unpin it by clicking its pin icon.
 
 ## Compare runs to the baseline
 The baseline run is always visible in line plots for metrics the run has logged. In line plots, lines for the baseline run appear bolder than other lines.

--- a/snippets/en/_includes/pinned-and-baseline-runs/pin-runs-condensed.mdx
+++ b/snippets/en/_includes/pinned-and-baseline-runs/pin-runs-condensed.mdx
@@ -1,4 +1,4 @@
-Pin up to 5 runs to keep them easily accessible at the top of your workspace. Pinned runs remain visible regardless of sorting or filtering applied to other runs. Pinned runs appear at the top of the run selector with a circular pin icon, separated from other runs by a visual divider.
+Pin up to 6 runs to keep them easily accessible at the top of your workspace. If you have a baseline run, you can pin up to 5 runs because the baseline uses a pinning slot. Pinned runs remain visible regardless of sorting or filtering applied to other runs. Pinned runs appear at the top of the run selector with a circular pin icon, separated from other runs by a visual divider.
 
 To pin a run:
 

--- a/snippets/en/_includes/pinned-and-baseline-runs/pin-runs-condensed.mdx
+++ b/snippets/en/_includes/pinned-and-baseline-runs/pin-runs-condensed.mdx
@@ -1,4 +1,4 @@
-Pin up to 6 runs to keep them easily accessible at the top of your workspace. If you have a baseline run, you can pin up to 5 runs because the baseline uses a pinning slot. Pinned runs remain visible regardless of sorting or filtering applied to other runs. Pinned runs appear at the top of the run selector with a circular pin icon, separated from other runs by a visual divider.
+Pin up to 6 runs to keep them easily accessible at the top of your workspace. If you have a baseline run, you can pin up to 5 runs because the baseline is implicitly pinned. Pinned runs remain visible regardless of sorting or filtering applied to other runs. Pinned runs appear at the top of the run selector with a circular pin icon, separated from other runs by a visual divider.
 
 To pin a run:
 


### PR DESCRIPTION
[DOCS-1875] Update baseline and pinned runs docs for max # of pins
- Max of 6 pinned runs or 5 pinned + 1 baseline
- Previous baseline is pinned if possible when the baseline is changed or removed
- Make sure a pinning slot is available if you want the previous baseline to be pinned

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed



[DOCS-1875]: https://wandb.atlassian.net/browse/DOCS-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ