### PR TITLE
Fix tripled docstrings in `wandb sync` CLI ref

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -832,10 +832,10 @@
                   {
                     "group": "Monitor and collect feedback",
                     "pages": [
-                          "weave/guides/tracking/feedback",
-                          "weave/guides/tracking/redact-pii",
-                          "weave/guides/evaluation/guardrails_and_monitors",
-                          "weave/guides/tracking/otel"
+                      "weave/guides/tracking/feedback",
+                      "weave/guides/tracking/redact-pii",
+                      "weave/guides/evaluation/guardrails_and_monitors",
+                      "weave/guides/tracking/otel"
                     ]
                   },
                   {
@@ -2493,8 +2493,8 @@
     },
     {
       "source": "/models/runs/multiple-runs-per-process",
-      "destination" : "/models/runs/initialize-run"
-    },    
+      "destination": "/models/runs/initialize-run"
+    },
     {
       "source": "/models/hosting/:slug*",
       "destination": "/platform/hosting/:slug*"

--- a/models/ref/cli/wandb-beta/wandb-beta-leet.mdx
+++ b/models/ref/cli/wandb-beta/wandb-beta-leet.mdx
@@ -5,12 +5,6 @@ import WandbBetaLeet from "/snippets/en/_includes/cli/wandb-beta-leet.mdx";
 
 <WandbBetaLeet/>
 
-Launch W&B LEET: the Lightweight Experiment Exploration Tool.
-
-LEET is a terminal UI for viewing a W&B run specified by an optional PATH.
-
-PATH can include a .wandb file or a run directory containing a .wandb file. If PATH is not provided, the command will look for the latest run.
-
 ## Usage
 
 ```bash

--- a/models/ref/cli/wandb-docker-run.mdx
+++ b/models/ref/cli/wandb-docker-run.mdx
@@ -5,12 +5,6 @@ import WandbDockerRun from "/snippets/en/_includes/cli/wandb-docker-run.mdx";
 
 <WandbDockerRun/>
 
-Wrap `docker run` and adds WANDB_API_KEY and WANDB_DOCKER environment variables.
-
-This will also set the runtime to nvidia if the nvidia-docker executable is present on the system and --runtime wasn't set.
-
-See `docker run --help` for more details.
-
 ## Usage
 
 ```bash

--- a/models/ref/cli/wandb-docker.mdx
+++ b/models/ref/cli/wandb-docker.mdx
@@ -5,14 +5,6 @@ import WandbDocker from "/snippets/en/_includes/cli/wandb-docker.mdx";
 
 <WandbDocker/>
 
-Run your code in a docker container.
-
-W&B docker lets you run your code in a docker image ensuring wandb is configured. It adds the WANDB_DOCKER and WANDB_API_KEY environment variables to your container and mounts the current directory in /app by default. You can pass additional args which will be added to `docker run` before the image name is declared, we'll choose a default image for you if one isn't passed:
-
-```sh wandb docker -v /mnt/dataset:/app/data wandb docker gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0 --jupyter wandb docker wandb/deepo:keras-gpu --no-tty --cmd "python train.py --epochs=5" ```
-
-By default, we override the entrypoint to check for the existence of wandb and install it if not present. If you pass the --jupyter flag we will ensure jupyter is installed and start jupyter lab on port 8888. If we detect nvidia-docker on your system we will use the nvidia runtime. If you just want wandb to set environment variable to an existing docker run command, see the wandb docker-run command.
-
 ## Usage
 
 ```bash

--- a/models/ref/cli/wandb-login.mdx
+++ b/models/ref/cli/wandb-login.mdx
@@ -5,12 +5,6 @@ import WandbLogin from "/snippets/en/_includes/cli/wandb-login.mdx";
 
 <WandbLogin/>
 
-Verify and store your API key for authentication with W&B services.
-
-By default, only store credentials locally without verifying them with W&B. To verify credentials, set `--verify=True`.
-
-For server deployments (dedicated cloud or customer-managed instances), specify the host URL using the `--host` flag. You can also set environment variables `WANDB_BASE_URL` and `WANDB_API_KEY` instead of running the `login` command with host parameters.
-
 ## Usage
 
 ```bash

--- a/models/ref/cli/wandb-sync.mdx
+++ b/models/ref/cli/wandb-sync.mdx
@@ -5,18 +5,6 @@ import WandbSync from "/snippets/en/_includes/cli/wandb-sync.mdx";
 
 <WandbSync/>
 
-Synchronize W&B run data to the cloud.
-
-If PATH is provided, sync runs found at the given path. If a path is not specified, search for `./wandb` first, then search for a `wandb/` subdirectory.
-
-To sync a specific run:
-
-wandb sync ./wandb/run-20250813_124246-n67z9ude
-
-Or equivalently:
-
-wandb sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
-
 ## Usage
 
 ```bash

--- a/models/ref/cli/wandb-verify.mdx
+++ b/models/ref/cli/wandb-verify.mdx
@@ -5,28 +5,6 @@ import WandbVerify from "/snippets/en/_includes/cli/wandb-verify.mdx";
 
 <WandbVerify/>
 
-Checks and verifies local instance of W&B. W&B checks for:
-
-Checks that the host is not `api.wandb.ai` (host check).
-
-Verifies if the user is logged in correctly using the provided API key (login check).
-
-Checks that requests are made over HTTPS (secure requests).
-
-Validates the CORS (Cross-Origin Resource Sharing) configuration of the object store (CORS configuration).
-
-Logs metrics, saves, and downloads files to check if runs are correctly recorded and accessible (run check).
-
-Saves and downloads artifacts to verify that the artifact storage and retrieval system is working as expected (artifact check).
-
-Tests the GraphQL endpoint by uploading a file to ensure it can handle signed URL uploads (GraphQL PUT check).
-
-Checks the ability to send large payloads through the proxy (large payload check).
-
-Verifies that the installed version of the W&B package is up-to-date and compatible with the server (W&B version check).
-
-Creates and executes a sweep to ensure that sweep functionality is working correctly (sweeps check).
-
 ## Usage
 
 ```bash

--- a/scripts/cli-docs-generator.py
+++ b/scripts/cli-docs-generator.py
@@ -242,11 +242,12 @@ def generate_markdown(cmd_info: Dict[str, Any], file_dir_path: str = "", project
         lines.append(f"  The snippet will be auto-detected on the next regeneration.")
         lines.append("*/}")
         lines.append("")
-    
-    # Command description from CLI (always shown, appears after any manual snippet content)
-    if cmd_info['help']:
-        lines.append(cmd_info['help'])
-        lines.append("")
+        
+        # Only add CLI help text when there's no snippet file
+        # (When a snippet exists, it should contain any necessary intro content)
+        if cmd_info['help']:
+            lines.append(cmd_info['help'])
+            lines.append("")
     
     # Usage section
     lines.append("## Usage")
@@ -367,7 +368,8 @@ def generate_index_markdown(cmd_info: Dict[str, Any], subcommands_only: bool = F
     snippet_path = project_root / "snippets/en/_includes/cli" / f"{command_name}.mdx" if project_root else None
     
     # Add snippet or template for manual content
-    if snippet_path and snippet_path.exists():
+    has_snippet = snippet_path and snippet_path.exists()
+    if has_snippet:
         # Add import and include the snippet
         # Convert command name to PascalCase for the component name
         component_name = ''.join(word.capitalize() for word in command_name.split('-'))
@@ -392,9 +394,9 @@ def generate_index_markdown(cmd_info: Dict[str, Any], subcommands_only: bool = F
         lines.append("*/}")
         lines.append("")
     
-    # Always show command description from CLI help (extracted from Python module)
-    # This appears after any manual snippet content
-    if cmd_info['help']:
+    # Only add CLI help text when there's no snippet file
+    # (When a snippet exists, it should contain any necessary intro content)
+    if not has_snippet and cmd_info['help']:
         lines.append(cmd_info['help'])
         lines.append("")
     


### PR DESCRIPTION
## Description
Fix tripled docstrings in `wandb sync` CLI ref

### The problem
The `wandb sync` command's docstrings were appearing 3 times on the documentation page because:
1. Once from the snippet file (`/snippets/en/_includes/cli/wandb-sync.mdx`) - included via `<WandbSync/>`
1. Once from the CLI extraction - the script was adding the help text from the command definition even when a snippet existed
1. The snippet itself could also contain the text, making it render a third time

Meanwhile, `wandb beta sync` didn't have this issue because it has no snippet file, so the CLI help text was only shown once (as intended).

The bug was introduced when I added the ability to load intro material from a snippet in the docs repo, to support `wandb beta leet`. It affects more commands than only `wandb sync`.

### The fix
This PR modifies the logic of two functions depending on whether there is a snippet file or not:
- `generate_markdown()` (lines 221-250)
- `generate_index_markdown()` (lines 370-401)

To test the fix, I regenerated the CLI refs with it in place. Duplicate intro material was removed from several CLI refs.

## Testing
- [x] Locally regenerated the refs with the fix in place (see the second commit in this PR)
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
