### PR TITLE
Try tab bottom border feature

### DIFF
--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -22,7 +22,7 @@ For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infr
 This section shows how to create a line plot for a single metric or multiple metrics.
 
 <Tabs>
-<Tab title="Single-metric line plot">
+<Tab title="Single-metric line plot" borderBottom="true">
 In an [automatic workspace](/models/app/features/panels#workspace-modes), a single-metric line plot is created automatically for each logged metric. Follow these steps to re-add a line plot that was deleted from an automatic workspace, or to add a line plot to a manual workspace.
 
 1. Navigate to your workspace.
@@ -39,7 +39,7 @@ Select the type of panel to add, such as a chart. The panel's configuration deta
 1. Optionally, customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section below, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
 1. Click **Apply**.
 </Tab>
-<Tab title="Multi-metric line plot">
+<Tab title="Multi-metric line plot" borderBottom="true">
 
 <Note>
 This feature is in preview, available by invitation only. To request enrollment, contact [support](mailto:support@wandb.com) or your AISE.

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -21,8 +21,8 @@ For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infr
 
 This section shows how to create a line plot for a single metric or multiple metrics.
 
-<Tabs>
-<Tab title="Single-metric line plot" borderBottom="true">
+<Tabs borderBottom="true">
+<Tab title="Single-metric line plot">
 In an [automatic workspace](/models/app/features/panels#workspace-modes), a single-metric line plot is created automatically for each logged metric. Follow these steps to re-add a line plot that was deleted from an automatic workspace, or to add a line plot to a manual workspace.
 
 1. Navigate to your workspace.
@@ -39,7 +39,7 @@ Select the type of panel to add, such as a chart. The panel's configuration deta
 1. Optionally, customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section below, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
 1. Click **Apply**.
 </Tab>
-<Tab title="Multi-metric line plot" borderBottom="true">
+<Tab title="Multi-metric line plot">
 
 <Note>
 This feature is in preview, available by invitation only. To request enrollment, contact [support](mailto:support@wandb.com) or your AISE.


### PR DESCRIPTION
## Description
Try tab bottom border feature recently released by Mintlify. See https://www.mintlify.com/docs/components/tabs#param-border-bottom.

Note that I am not currently seeing a visual difference with this turned on in a local build. Maybe the PR preview will show it.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

