### PR TITLE
Use new mint validate command to detect parsing errors

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -28,6 +28,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mintlify-
       - name: Install Mintlify CLI
-        run: npm install -g mintlify
+        run: npm install -g mint
       - name: Validate MDX with Mintlify
         run: ./scripts/mdx-validation/validate-mdx-mintlify.sh

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 set -e
 
-LOGFILE="/tmp/mint-dev-$$.log"
-PARSE_TIME=45  # Give Mintlify time to log parsing errors
-PID=""
-
-# Cleanup function
-cleanup() {
-  if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
-    kill "$PID" 2>/dev/null || true
-    sleep 0.5
-    kill -9 "$PID" 2>/dev/null || true
-  fi
-  rm -f "$LOGFILE"
-}
-
-# Trap to ensure cleanup
-trap cleanup EXIT INT TERM
-
 # Check if there are any MDX files in the changeset
 if [ -n "$GITHUB_BASE_REF" ]; then
   # In a PR context, check changed files
@@ -40,53 +23,31 @@ if [ -n "$GITHUB_BASE_REF" ]; then
   echo ""
 fi
 
-echo "Starting Mintlify validation..."
-echo ""
-echo "Running: mint dev --no-open (will run for ${PARSE_TIME}s to parse all files)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "VALIDATING DOCUMENTATION BUILD"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Running: mint validate"
 echo ""
 
-# Run mint dev with tee to force output writing, timeout after PARSE_TIME seconds
-# Use timeout if available (Linux), otherwise use gtimeout (macOS with coreutils), or perl as fallback
-if command -v timeout > /dev/null 2>&1; then
-  timeout --preserve-status ${PARSE_TIME}s mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null || true
-elif command -v gtimeout > /dev/null 2>&1; then
-  gtimeout --preserve-status ${PARSE_TIME}s mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null || true
+# Run mint validate - exits with non-zero if there are any errors or warnings
+if mint validate; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "✅ MINTLIFY VALIDATION PASSED"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "No errors or warnings detected"
 else
-  # Fallback: run mint dev in background and kill after PARSE_TIME
-  mint dev --no-open 2>&1 | tee "$LOGFILE" > /dev/null &
-  PID=$!
-  sleep ${PARSE_TIME}
-  kill "$PID" 2>/dev/null || true
-  wait "$PID" 2>/dev/null || true
-fi
-
-echo ""
-echo "✓ Mintlify finished parsing"
-echo ""
-
-# Check for parsing errors
-if grep -q "parsing error" "$LOGFILE"; then
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "❌ MINTLIFY PARSING ERRORS DETECTED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
-  echo "Parsing errors found:"
-  echo ""
-  grep "parsing error" "$LOGFILE" | sed 's/^/  /'
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "💡 These are Mintlify parsing errors. Please fix them or"
-  echo "   file an issue if you believe they are incorrect:"
-  echo "   https://github.com/wandb/docs/issues/new"
+  echo "❌ MINTLIFY VALIDATION FAILED"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
+  echo "Errors or warnings were detected. Please fix them or"
+  echo "file an issue if you believe they are incorrect:"
+  echo "https://github.com/wandb/docs/issues/new"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   exit 1
 fi
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "✅ MINTLIFY PARSING VALIDATION PASSED"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "No parsing errors detected by Mintlify"
 echo ""
 
 # Run broken links check
@@ -110,10 +71,11 @@ else
   echo "Please fix the broken links reported above"
   exit 1
 fi
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "✅ ALL VALIDATION CHECKS PASSED"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "- No parsing errors"
+echo "- No validation errors or warnings"
 echo "- No broken links"
 exit 0


### PR DESCRIPTION
## Description
Add new [`mint validate`](https://www.mintlify.com/docs/installation#validate-documentation-build) command to validate-mdx CI check

This will replace brittle logic for running mint dev and then waiting for 45 seconds before checking the redirected logs for parsing errors. This logic runs in both fork PRs and non-fork PRs.

## Testing
- [x] Merged this PR change to my fork's `main`, then created a PR in my fork with intentional errors and observed the [failure](https://github.com/mdlinville/docs/actions/runs/21419377278/job/61675280816?pr=66), then fixed the errors and observed the [success](https://github.com/mdlinville/docs/actions/runs/21419466212/job/61675552441?pr=66).
- [x] PR tests succeed
