### PR TITLE
Fix non-forked PR link check trigger

### DIFF
--- a/.github/workflows/linkcheck-pr.yml
+++ b/.github/workflows/linkcheck-pr.yml
@@ -10,9 +10,8 @@ on:
   deployment_status:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '**.md'
-      - '**.mdx'
+    # No paths filter - we check paths inside the job for fork PRs only
+    # This prevents "Skipped" status for same-repo PRs
 
 permissions:
   contents: read
@@ -25,8 +24,8 @@ jobs:
     
     # Run on:
     # 1. Manual trigger (workflow_dispatch)
-    # 2. Successful Mintlify deployment (for non-fork PRs)
-    # 3. PR events from forks only (since forks don't get Mintlify previews)
+    # 2. Successful Mintlify deployment (for same-repo PRs - waits for preview URL)
+    # 3. PR events from forks only (no Mintlify preview, checks against production)
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'deployment_status' && 
@@ -42,6 +41,24 @@ jobs:
         with:
           # Needed to diff base..head for the associated PR
           fetch-depth: 0
+
+      - name: Early exit if no docs changed (fork PRs only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        id: fork-docs-check
+        uses: tj-actions/changed-files@v47.0.1
+        with:
+          files: |
+            **/*.md
+            **/*.mdx
+
+      - name: Report no changes (fork PRs only)
+        if: |
+          github.event_name == 'pull_request' && 
+          github.event.pull_request.head.repo.fork == true && 
+          steps.fork-docs-check.outputs.any_changed != 'true'
+        run: |
+          echo "✓ No documentation files (.md/.mdx) changed in this fork PR."
+          echo "Link check not needed - exiting successfully."
 
       - name: Resolve PR and deployment URL
         id: pr-context
@@ -82,7 +99,15 @@ jobs:
 
       - name: Get changed documentation files
         id: changed-files
-        if: steps.pr-context.outputs.pr_number != '' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+        # Skip this for fork PRs with no doc changes (already checked above)
+        # For deployment_status and workflow_dispatch, always run
+        if: |
+          (github.event_name == 'pull_request' && 
+           github.event.pull_request.head.repo.fork == true && 
+           steps.fork-docs-check.outputs.any_changed == 'true') ||
+          (github.event_name == 'deployment_status' && 
+           steps.pr-context.outputs.pr_number != '') ||
+          github.event_name == 'workflow_dispatch'
         uses: tj-actions/changed-files@v47.0.1
         with:
           base_sha: ${{ steps.pr-context.outputs.base_sha || github.event.pull_request.base.sha }}
@@ -134,7 +159,17 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        if: steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+        # Run if:
+        # - Fork PR with doc changes
+        # - Deployment status event with doc changes  
+        # - Manual workflow dispatch
+        if: |
+          (github.event_name == 'pull_request' && 
+           github.event.pull_request.head.repo.fork == true && 
+           steps.fork-docs-check.outputs.any_changed == 'true') ||
+          (github.event_name == 'deployment_status' && 
+           steps.changed-files.outputs.any_changed == 'true') ||
+          github.event_name == 'workflow_dispatch'
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
@@ -145,14 +180,18 @@ jobs:
           # GitHub token for API rate limiting
           token: ${{ secrets.GITHUB_TOKEN }}
           # Use deployment URL (from Mintlify preview) or fallback to production
-          # Non-fork PRs wait for deployment and use preview URL
-          # Fork PRs run immediately and check against production (no preview available)
+          # Same-repo PRs: Wait for deployment and use preview URL
+          # Fork PRs: Run immediately and check against production (no preview available)
           args: >-
             --base-url ${{ steps.pr-context.outputs.deploy_url || 'https://docs.wandb.ai' }}
-            ${{ steps.changed-files.outputs.all_changed_files || '.' }}
+            ${{ steps.fork-docs-check.outputs.all_changed_files || steps.changed-files.outputs.all_changed_files || '.' }}
 
       - name: Comment on PR with results
-        if: steps.get-pr.outputs.pr_number && (steps.changed-files.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch')
+        # Comment if link checker ran
+        if: |
+          steps.get-pr.outputs.pr_number && 
+          (steps.lychee.conclusion == 'success' || 
+           steps.lychee.conclusion == 'failure')
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Description
- Currently becasue of the top-level  selector, the check is skipped on the first run in a PR. **This is mostly a cosmetic issue.**
- Fix the check so that in a non-fork PR, it waits for a successful Mintlify deploy event (which means there is a Mintlify preview URL), and only runs then. No more extraneous skipped runs. The paths are evaluated only for a fork PR, where we wouldn't have a preview to check otherwise.

## Testing
- [x] Tested the action in my fork to test the forked-PR logic (https://github.com/mdlinville/docs/actions/runs/21420961033/job/61680098995?pr=66)
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

