### PR TITLE
Fix cli ref intro whitespace

### DIFF
--- a/models/ref/cli/wandb-beta/wandb-beta-sync.mdx
+++ b/models/ref/cli/wandb-beta/wandb-beta-sync.mdx
@@ -22,15 +22,21 @@ PATHS can include .wandb files, run directories containing .wandb files, and "wa
 
 For example, to sync all runs in a directory:
 
+```bash
 wandb beta sync ./wandb
+```
 
 To sync a specific run:
 
+```bash
 wandb beta sync ./wandb/run-20250813_124246-n67z9ude
+```
 
 Or equivalently:
 
+```bash
 wandb beta sync ./wandb/run-20250813_124246-n67z9ude/run-n67z9ude.wandb
+```
 
 ## Usage
 

--- a/scripts/cli-docs-generator.py
+++ b/scripts/cli-docs-generator.py
@@ -34,6 +34,7 @@ import sys
 import argparse
 import shutil
 import json
+import inspect
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Union
 import click
@@ -42,114 +43,89 @@ from click.core import Command, Group
 def clean_text(text: str) -> str:
     """Clean and format text for markdown.
     
-    Preserves indented code blocks (lines with 8+ spaces or relative indentation > 4) while
-    cleaning regular paragraph text. Handles Click docstrings where regular paragraphs
-    are indented with 4 spaces and code examples with 8+ spaces.
+    Uses inspect.cleandoc() to handle dedenting docstrings, then detects and converts
+    indented code blocks to fenced code blocks for Mintlify compatibility.
+    
+    Mintlify doesn't support implicit indented code blocks, so we convert them to
+    triple-backtick fenced blocks. Regular paragraphs are collapsed into single lines.
     """
     if not text:
         return ""
     
-    # First, normalize line endings and strip the whole text
-    text = text.strip()
-    
-    # Detect and remove common leading indentation (from Python docstrings)
-    lines = text.split('\n')
-    # Find minimum indentation of non-empty lines
-    indents = []
-    for line in lines:
-        if line.strip():  # Skip empty lines
-            # Count leading spaces
-            indent = len(line) - len(line.lstrip())
-            indents.append(indent)
-    
-    if indents:
-        min_indent = min(indents)
-        # Remove the common indentation from all lines
-        dedented_lines = []
-        for line in lines:
-            if line.strip():  # Non-empty lines
-                dedented_lines.append(line[min_indent:])
-            else:  # Empty lines
-                dedented_lines.append('')
-        text = '\n'.join(dedented_lines)
+    # Use inspect.cleandoc() to clean and dedent the docstring
+    # This handles common leading whitespace removal like most doc generators
+    text = inspect.cleandoc(text)
     
     # Split into paragraphs (separated by blank lines)
     paragraphs = re.split(r'\n\s*\n', text)
     
-    # Clean each paragraph
     cleaned_paragraphs = []
     for paragraph in paragraphs:
+        if not paragraph.strip():
+            continue
+        
         lines = paragraph.split('\n')
         
-        # Determine the minimum indentation within this paragraph
-        para_indents = []
-        for line in lines:
-            if line.strip():
-                indent = len(line) - len(line.lstrip())
-                para_indents.append(indent)
-        
-        if not para_indents:
-            continue
-            
-        para_min_indent = min(para_indents)
-        
-        # Code blocks have 8+ spaces OR relative indentation after removing paragraph base
-        # This handles Click docstrings where regular text has 4 spaces and code has 8
-        is_code_block = para_min_indent >= 8 or (
-            para_min_indent >= 4 and 
-            any(len(line) - len(line.lstrip()) >= para_min_indent + 4 
-                for line in lines if line.strip())
-        )
-        
-        # Special case: if minimum indentation is exactly 4 and all lines have exactly 4 or less,
-        # treat as regular text (this is Click's formatting for regular paragraphs)
-        if para_min_indent == 4 and all(
-            len(line) - len(line.lstrip()) <= 4 or not line.strip()
-            for line in lines
-        ):
-            is_code_block = False
+        # Detect if this paragraph is a code block
+        # After cleandoc(), code blocks still have relative indentation (4+ spaces)
+        is_code_block = _is_code_block(lines)
         
         if is_code_block:
-            # Code block: convert to fenced code block for Mintlify MDX
-            # Mintlify doesn't support indented code blocks, requires fenced blocks
-            code_lines = []
-            for line in lines:
-                if line.strip():
-                    # Remove all indentation from code lines
-                    code_lines.append(line.strip())
+            # Convert indented code block to fenced code block for Mintlify
+            code_lines = [line.strip() for line in lines if line.strip()]
             if code_lines:
-                # Wrap in triple backticks for fenced code block
                 fenced_block = '```bash\n' + '\n'.join(code_lines) + '\n```'
                 cleaned_paragraphs.append(fenced_block)
         else:
-            # Regular paragraph: dedent and collapse into single line
-            cleaned_lines = []
-            for line in lines:
-                # Strip all leading whitespace and clean
-                cleaned_line = re.sub(r'[ \t]+', ' ', line.strip())
-                if cleaned_line:
-                    cleaned_lines.append(cleaned_line)
-            if cleaned_lines:
-                cleaned_paragraphs.append(' '.join(cleaned_lines))
+            # Regular paragraph: collapse into single line
+            cleaned_text = ' '.join(line.strip() for line in lines if line.strip())
+            # Normalize whitespace
+            cleaned_text = re.sub(r'\s+', ' ', cleaned_text)
+            if cleaned_text:
+                cleaned_paragraphs.append(cleaned_text)
     
     # Join paragraphs with double newlines for markdown
-    text = '\n\n'.join(cleaned_paragraphs)
+    result = '\n\n'.join(cleaned_paragraphs)
     
     # Escape pipe characters for markdown tables
-    text = text.replace('|', '\\|')
-    return text
+    result = result.replace('|', '\\|')
+    return result
+
+
+def _is_code_block(lines: List[str]) -> bool:
+    """Detect if a paragraph is a code block based on indentation.
+    
+    After inspect.cleandoc(), code blocks still have relative indentation.
+    Code blocks typically have 4+ spaces of indentation for all lines.
+    """
+    if not lines:
+        return False
+    
+    non_empty_lines = [line for line in lines if line.strip()]
+    if not non_empty_lines:
+        return False
+    
+    # Check if all non-empty lines start with significant indentation (4+ spaces)
+    min_indent = min(len(line) - len(line.lstrip()) for line in non_empty_lines)
+    
+    # Code blocks have at least 4 spaces of indentation
+    # Regular text paragraphs have 0 spaces after cleandoc()
+    return min_indent >= 4
 
 def clean_text_for_table(text: str) -> str:
     """Clean text for use in markdown table cells.
     
-    Collapses all whitespace (including newlines) into single spaces,
+    Uses inspect.cleandoc() then collapses all whitespace into single spaces,
     suitable for inline table cell content.
     """
     if not text:
         return ""
     
-    # Strip and collapse all whitespace (spaces, tabs, newlines) into single spaces
-    text = re.sub(r'\s+', ' ', text.strip())
+    # Clean and dedent the text
+    text = inspect.cleandoc(text)
+    
+    # Collapse all whitespace (spaces, tabs, newlines) into single spaces
+    text = re.sub(r'\s+', ' ', text)
     
     # Escape pipe characters for markdown tables
     text = text.replace('|', '\\|')
@@ -157,33 +133,28 @@ def clean_text_for_table(text: str) -> str:
     return text
 
 def get_brief_description(text: str) -> str:
-    """Get just the first sentence or line for table display."""
+    """Get just the first sentence for table display.
+    
+    Extracts and returns the first sentence from the text, suitable for
+    brief descriptions in command tables.
+    """
     if not text:
         return "No description available"
     
-    # First clean the text but without escaping pipes yet
-    text = text.strip()
+    # Clean and dedent the text
+    text = inspect.cleandoc(text)
     
-    # Split into paragraphs
+    # Split into paragraphs and get the first one
     paragraphs = re.split(r'\n\s*\n', text)
-    if not paragraphs:
+    if not paragraphs or not paragraphs[0].strip():
         return "No description available"
     
-    # Get the first paragraph
-    first_para = paragraphs[0]
+    # Collapse the first paragraph into a single line
+    first_para = re.sub(r'\s+', ' ', paragraphs[0].strip())
     
-    # Clean up spaces in the first paragraph
-    first_para = re.sub(r'[ \t\n]+', ' ', first_para.strip())
-    
-    # Try to get just the first sentence
-    # Look for sentence endings
+    # Extract the first sentence
     sentence_match = re.match(r'^(.*?[.!?])\s', first_para + ' ')
-    if sentence_match:
-        first_sentence = sentence_match.group(1)
-    else:
-        # If no sentence ending found, take the whole first paragraph
-        # but limit to reasonable length
-        first_sentence = first_para
+    first_sentence = sentence_match.group(1) if sentence_match else first_para
     
     # Limit length for table display
     max_length = 150


### PR DESCRIPTION
## Description
Fix bug where CLI ref code blocks appear unstyled

This is happening because Mintlify doesn't support implicit code blocks
by indentation. This fix transforms them into code fences in the
generated references. The CLI code can't use code fences in the docstrings.

Fixes DOCS-1463

## Testing
- [x] Regenerated the refs with the fix
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

