### PR TITLE
[DOCS-1880] Add max concurrent client #s for distributed training

### DIFF
--- a/models/track/log/distributed-training.mdx
+++ b/models/track/log/distributed-training.mdx
@@ -10,11 +10,15 @@ During a distributed training experiment, you train a model using multiple machi
    * Track each process separately using one run per process. You can optionally group them together in the W&B App UI.
    * Track all processes to a single run.
 
-<Note>
-Each concurrent connection takes compute, memory, and network resources. W&B recommends that you limit the maximum number of concurrent client connections as appropriate for your workload and that you monitor resource usage over time. W&B has tested with a hard limit of 300 concurrent client connections in **Dedicated Cloud**.
+<Tip>
+**Concurrent connections**
 
-In **Multi-tenant Cloud** organizations, keep in mind that client connections for distributed training are subject to [rate limits](/models/track/limits#rate-limits). Users on [Teams and Enterprise plans](https://wandb.ai/site/pricing) receive higher rate limits than those on the Free plan.
-</Note>
+Each concurrent connection takes compute, memory, and network resources. Even empty client connections that don't log metrics regularly push system metric updates, leading to slower performance when loading charts.
+
+W&B recommends that you limit the maximum number of concurrent client connections as appropriate for your workload and that you monitor resource usage over time. W&B has tested with a hard limit of 300 concurrent client connections in **Dedicated Cloud**.
+
+In **Multi-tenant Cloud** organizations, client connections for distributed training are subject to the same [rate limits](/models/track/limits#rate-limits) as regular training runs. Users on [Teams and Enterprise plans](https://wandb.ai/site/pricing) receive higher rate limits than those on the Free plan.
+</Tip>
 
 {/* The proceeding examples demonstrate how to track metrics with W&B using PyTorch DDP on two GPUs on a single machine. [PyTorch DDP](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) (`DistributedDataParallel` in`torch.nn`) is a popular library for distributed training. The basic principles apply to any distributed training setup, but the details of implementation may differ.
 

--- a/models/track/log/distributed-training.mdx
+++ b/models/track/log/distributed-training.mdx
@@ -10,6 +10,12 @@ During a distributed training experiment, you train a model using multiple machi
    * Track each process separately using one run per process. You can optionally group them together in the W&B App UI.
    * Track all processes to a single run.
 
+<Note>
+Each concurrent connection takes compute, memory, and network resources. W&B recommends that you limit the maximum number of concurrent client connections as appropriate for your workload and that you monitor resource usage over time. W&B has tested with a hard limit of 300 concurrent client connections in **Dedicated Cloud**.
+
+In **Multi-tenant Cloud** organizations, keep in mind that client connections for distributed training are subject to [rate limits](/models/track/limits#rate-limits). Users on [Teams and Enterprise plans](https://wandb.ai/site/pricing) receive higher rate limits than those on the Free plan.
+</Note>
+
 {/* The proceeding examples demonstrate how to track metrics with W&B using PyTorch DDP on two GPUs on a single machine. [PyTorch DDP](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) (`DistributedDataParallel` in`torch.nn`) is a popular library for distributed training. The basic principles apply to any distributed training setup, but the details of implementation may differ.
 
 <Note>


### PR DESCRIPTION
## Description
[DOCS-1880] Add max concurrent client #s for distributed training

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed


[DOCS-1880]: https://wandb.atlassian.net/browse/DOCS-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ