### PR TITLE
Runs: Re adds CW infrastructure paragraph

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -215,7 +215,8 @@
                           "models/runs/manage-runs",
                           "models/runs/run-colors",
                           "models/runs/color-code-runs",
-                          "models/runs/alert"
+                          "models/runs/alert",
+                          "models/runs/infrastructure-alerts"
                         ]
                       },
                       {

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -14,7 +14,7 @@ This page shows how to create, configure, and manage line plots in a [workspace]
 </Frame>
 
 <Tip>
-For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infrastructure, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For details, see [Visualize CoreWeave infrastructure alerts](/models/runs#visualize-coreweave-infrastructure-alerts).
+For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infrastructure, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For details, see [Visualize CoreWeave infrastructure alerts](/models/runs/infrastructure-alerts).
 </Tip>
 
 ## Add a line plot

--- a/models/runs/infrastructure-alerts.mdx
+++ b/models/runs/infrastructure-alerts.mdx
@@ -1,0 +1,12 @@
+---
+title: Visualize CoreWeave infrastructure alerts
+description: 
+---
+
+Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. During a [W&B run](/models/runs), [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure.
+
+<Note>
+This feature is in Preview and only available when training on a CoreWeave cluster. Contact your W&B representative for access.
+</Note>
+
+If an error occurs, CoreWeave sends that information to W&B. W&B populates infrastructure information onto your run’s plots in your project’s workspace. CoreWeave attempts to automatically resolve some issues, and W&B surfaces that information in the run’s page.


### PR DESCRIPTION
## Description

This was lost during the Run section rewrite + when it was moved from `models/app/*` to Runs section. 