### PR TITLE
Add CAIOS acronym to secure storage connector documentation

### DIFF
--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -55,9 +55,9 @@ The following table shows the availability of BYOB at each scope for each W&B de
 
 | W&B deployment type        | Instance level   | Team level | Additional information |
 |----------------------------|------------------|------------|------------------------|
-| Dedicated Cloud            | &check;          | &check;    | Instance and team level BYOB are supported for CoreWeave AI Object Storage, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
-| Multi-tenant Cloud         | Not Applicable   | &check;<sup><a href="#footnote_1">1</a></sup> | Team level BYOB is supported for CoreWeave AI Object Storage, Amazon S3, and Google Cloud Storage. |
-| Self-Managed               | &check;          | &check;    | Instance and team level BYOB are supported for CoreWeave AI Object Storage, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
+| Dedicated Cloud            | &check;          | &check;    | Instance and team level BYOB are supported for CAIOS, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
+| Multi-tenant Cloud         | Not Applicable   | &check;<sup><a href="#footnote_1">1</a></sup> | Team level BYOB is supported for CAIOS, Amazon S3, and Google Cloud Storage. |
+| Self-Managed               | &check;          | &check;    | Instance and team level BYOB are supported for CAIOS, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
 
 <sup><a id="footnote_1">1</a>.</sup>Azure Blob Storage is not supported for team level BYOB on Multi-tenant Cloud.
 

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -45,7 +45,7 @@ For example, suppose you have a team called Kappa in your organization. Your org
 
 ### Availability matrix
 W&B can connect to the following storage providers:
-- [CoreWeave AI Object Storage](https://docs.coreweave.com/docs/products/storage/object-storage): High-performance, S3-compatible object storage service optimized for AI workloads.
+- [CoreWeave AI Object Storage (CAIOS)](https://docs.coreweave.com/docs/products/storage/object-storage): High-performance, S3-compatible object storage service optimized for AI workloads.
 - [Amazon S3](https://aws.amazon.com/s3/): Object storage service offering industry-leading scalability, data availability, security, and performance.
 - [Google Cloud Storage](https://cloud.google.com/storage): Managed service for storing unstructured data at scale.
 - [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs): Cloud-based object storage solution for storing massive amounts of unstructured data like text, binary data, images, videos, and logs.

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -459,7 +459,7 @@ Plan your storage bucket layout carefully. After you configure a storage bucket 
 ### Instance level BYOB
 
 <Note>
-For CoreWeave AI Object Storage at the instance level, contact [W&B support](mailto:support@wandb.com) instead of following these instructions. Self-service configuration is not yet supported.
+For CAIOS at the instance level, contact [W&B support](mailto:support@wandb.com) instead of following these instructions. Self-service configuration is not yet supported.
 </Note>
 
 For **Dedicated Cloud**: Share the bucket details with your W&B team, who will configure your Dedicated Cloud instance.

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -76,7 +76,7 @@ After [verifying availability](#availability-matrix), you are ready to provision
 - A CoreWeave account with CAIOS enabled and with permission to create buckets, API access keys, and secret keys.
 - Your W&B instance must be able to connect to CoreWeave network endpoints.
 
-For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/create-bucket) in the CoreWeave documentation.
+For details, see [Create a CAIOS bucket](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/create-bucket) in the CoreWeave documentation.
 
 1. <a id="coreweave-org-id"></a>**Multi-tenant Cloud**: Obtain your organization ID, which is required for your bucket policy.
     1. Log in to the [W&B App](https://wandb.ai/).

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -73,7 +73,7 @@ After [verifying availability](#availability-matrix), you are ready to provision
 - **Multi-tenant Cloud**, or
 - **Dedicated Cloud** v0.73.0 or above, or
 - **Self-Managed** v0.73.0 or above deployed with v0.33.14+ of the Helm chart
-- A CoreWeave account with AI Object Storage enabled and with permission to create buckets, API access keys, and secret keys.
+- A CoreWeave account with CAIOS enabled and with permission to create buckets, API access keys, and secret keys.
 - Your W&B instance must be able to connect to CoreWeave network endpoints.
 
 For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.coreweave.com/docs/products/storage/object-storage/how-to/create-bucket) in the CoreWeave documentation.

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -548,7 +548,7 @@ If W&B encounters errors accessing the bucket or detects invalid settings, an er
 </Tabs>
 
 ## Troubleshooting
-This section helps troubleshoot problems connecting to CoreWeave AI Object Storage.
+This section helps troubleshoot problems connecting to CAIOS.
 
 - **Connection errors**
   - Verify that your W&B instance can connect to CoreWeave network endpoints.


### PR DESCRIPTION
Added "(CAIOS)" acronym after the first mention of "CoreWeave AI Object Storage" and replaced subsequent occurrences with the acronym for better readability. This improves consistency and reduces repetition throughout the documentation.

Files changed:
- platform/hosting/data-security/secure-storage-connector.mdx

---

Created by Mintlify agent