### PR TITLE
Add newly launched models to LoRA support list

### DIFF
--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -110,6 +110,7 @@ model_name = f"wandb-artifact:///{WB_TEAM}/{WB_PROJECT}/your_trained_lora:latest
 Inference is currently configured for the following LLMs (exact strings must be used in `wandb.base_model`). More models coming soon:
 
 - `OpenPipe/Qwen3-14B-Instruct`
+- `Qwen/Qwen3-30B-A3B-Instruct-2507`
 - `Qwen/Qwen2.5-14B-Instruct`
 - `meta-llama/Llama-3.1-70B-Instruct`
 - `meta-llama/Llama-3.1-8B-Instruct`


### PR DESCRIPTION
## Description

The Qwen/Qwen3-30B-A3B-Instruct-2507 model launched with LoRA support. The model was added to some other pages but should be mentioned on this page too.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed


## Related issues
- Fixes https://wandb.atlassian.net/browse/DOCS-1884
