### PR TITLE
Remove redundant breadcrumb from Training API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1127,9 +1127,6 @@
               },
               {
                 "group": "API Reference",
-                "pages": [
-                  "training/api-reference"
-                ],
                 "openapi": {
                   "source": "training/api-reference/openapi.json",
                   "directory": "training/api-reference"


### PR DESCRIPTION
## Description

Training API was defined manually instead of the OpenAPI way, and this was creating an extra "API Reference" breadcrumb in reference pages. This aligns Training with how Weave handles its OpenAPI reference.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

