### PR TITLE
WEAVE: client.flush() and client.finish()

### DIFF
--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -155,7 +155,7 @@ To prevent data loss in worker processes, you must ensure that background upload
 These methods have different purposes:
 
 - `weave.flush()`: Simple, silent flushing. Recommended when Weave is integrated into worker processes or CI environments.
-- `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. We recommend using this with interactive scripts.
+- `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. Recommended for interactive scripts or notebooks.
 
 Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.
 The following example demonstrates `client.finish()`:

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -149,7 +149,7 @@ ulimit -n 65536
 
 ## Trace data loss in worker processes
 
-Weave performs network uploads in background threads to minimize impact on your application's performance. However, when using worker processes like Celery, multiprocessing, or other task queue systems, the worker process may exit before background threads finish uploading traces, causing trace data to be lost.
+Weave uploads trace data in background threads to minimize impact on your application's performance. However, when using a multiprocessing or task queue system or a worker processes like Celery, trace data will be lost if the worker process exits before background threads finish uploading traces.
 To prevent data loss in worker processes, call `client.flush()` or `client.finish()` before the worker task completes. This ensures all background uploads complete before the process exits.
 
 **Available methods:**

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -110,16 +110,9 @@ The following two methods should be used together in order to improve performanc
 
 ### Flushing
 
-When running evaluations with large datasets, you may experience a long period of time before program execution completes while the dataset is being uploaded in background threads. This generally occurs when main thread execution finishes before background cleanup is complete.
+When running evaluations with large datasets, you may experience a long period of time before program execution, while the dataset is being uploaded in background threads. This generally occurs when main thread execution finished before background cleanup is complete. Calling `client.flush()` will force all background tasks to be processed in the main thread, ensuring parallel processing during main thread execution. This can improve performance when user code completes before data has been uploaded to the server.
 
-Weave performs network uploads in background threads to minimize impact on your application's performance. Calling `client.flush()` or `client.finish()` will force all background tasks to be processed, ensuring parallel processing during main thread execution. This can improve performance when user code completes before data has been uploaded to the server.
-
-**Available methods:**
-
-- `client.flush()`: Simple, silent flushing (recommended for CI environments)
-- `client.finish()`: Includes progress feedback with a progress bar or status callbacks (useful for interactive scripts)
-
-**Example:**
+Example:
 
 ```python lines
 client = weave.init("fast-upload")

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -158,7 +158,7 @@ To prevent data loss in worker processes, call `client.flush()` or `client.finis
 - `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. We recommend using this with interactive scripts.
 
 Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.
-The following example demonstrates how to use `client.finish()` to ensure all traces are uploaded before tasks complete:
+The following example demonstrates `client.finish()`:
 
 ```python lines
 from celery import Celery

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -154,7 +154,7 @@ To prevent data loss in worker processes, you must ensure that background upload
 
 These methods have different purposes:
 
-- `weave.flush()`: Simple, silent flushing. We recommend this for when Weave is integrated into worker processes and CI environments.
+- `weave.flush()`: Simple, silent flushing. Recommended when Weave is integrated into worker processes or CI environments.
 - `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. We recommend using this with interactive scripts.
 
 Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -110,9 +110,16 @@ The following two methods should be used together in order to improve performanc
 
 ### Flushing
 
-When running evaluations with large datasets, you may experience a long period of time before program execution, while the dataset is being uploaded in background threads. This generally occurs when main thread execution finished before background cleanup is complete. Calling `client.flush()` will force all background tasks to be processed in the main thread, ensuring parallel processing during main thread execution. This can improve performance when user code completes before data has been uploaded to the server.
+When running evaluations with large datasets, you may experience a long period of time before program execution completes while the dataset is being uploaded in background threads. This generally occurs when main thread execution finishes before background cleanup is complete.
 
-Example:
+Weave performs network uploads in background threads to minimize impact on your application's performance. Calling `client.flush()` or `client.finish()` will force all background tasks to be processed, ensuring parallel processing during main thread execution. This can improve performance when user code completes before data has been uploaded to the server.
+
+**Available methods:**
+
+- `client.flush()`: Simple, silent flushing (recommended for CI environments)
+- `client.finish()`: Includes progress feedback with a progress bar or status callbacks (useful for interactive scripts)
+
+**Example:**
 
 ```python lines
 client = weave.init("fast-upload")
@@ -145,4 +152,65 @@ To resolve this issue, increase the system limit for open files to `65,536` usin
 
 ```bash
 ulimit -n 65536
+```
+
+## Trace data loss in worker processes
+
+Weave performs network uploads in background threads to minimize impact on your application's performance. However, when using worker processes like Celery, multiprocessing, or other task queue systems, the worker process may exit before background threads finish uploading traces, causing trace data to be lost.
+
+To prevent data loss in worker processes, call `client.flush()` or `client.finish()` before the worker task completes. This ensures all background uploads complete before the process exits.
+
+**Available methods:**
+
+- `client.flush()`: Simple, silent flushing. (recommended for worker processes and CI environments)
+- `client.finish()`: Includes progress feedback with a progress bar or status callbacks (useful for interactive scripts)
+
+Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.
+
+The following example demonstrates how to use `client.finish()` to ensure all traces are uploaded before tasks complete:
+
+```python lines
+from celery import Celery
+import weave
+
+app = Celery('tasks')
+
+@app.task
+def process_task(input_data):
+    client = weave.init("your-team-name/your-project-name")
+    
+    try:
+        # Your task logic that creates traces
+        result = your_processing_function(input_data)
+        
+        # Ensure all traces are uploaded before task completes
+        client.finish()
+        
+        return result
+    finally:
+        pass
+```
+
+The following example demonstrates how to use `client.flush()` with a multiprocessing application:
+
+```python lines
+import multiprocessing
+import weave
+
+def worker_function(data):
+    client = weave.init("your-team-name/your-project-name")
+    
+    try:
+        # Your processing logic
+        result = process_data(data)
+        
+        # Flush before worker process exits
+        client.flush()
+        return result
+    finally:
+        pass
+
+if __name__ == '__main__':
+    with multiprocessing.Pool() as pool:
+        results = pool.map(worker_function, data_list)
 ```

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -160,7 +160,7 @@ These methods have different purposes:
 Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.
 The following example demonstrates `client.finish()`:
 
-```python lines
+```python lines {15}
 from celery import Celery
 import weave
 
@@ -184,10 +184,10 @@ def process_task(input_data):
 
 You can also use the `with` context manager to automatically call `weave.finish()` on exit:
 
-```python lines
+```python lines {1}
 with weave.init("your-team-name/your-project-name") as client:
     result = your_processing_function(input_data)
-    # Automatically calls finish() on exit
+
     return result
 ```
 

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -152,7 +152,7 @@ ulimit -n 65536
 Weave uploads trace data in background threads to minimize impact on your application's performance. However, when using a multiprocessing or task queue system or a worker processes like Celery, trace data will be lost if the worker process exits before background threads finish uploading traces.
 To prevent data loss in worker processes, you must ensure that background uploads complete by calling `client.flush()` or `client.finish()` before the worker task completes.
 
-**Available methods:**
+These methods have different purposes:
 
 - `weave.flush()`: Simple, silent flushing. We recommend this for when Weave is integrated into worker processes and CI environments.
 - `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. We recommend using this with interactive scripts.

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -182,4 +182,13 @@ def process_task(input_data):
         pass
 ```
 
+You can also use the `with` context manager to automatically call `weave.finish()` on exit:
+
+```python lines
+with weave.init("your-team-name/your-project-name") as client:
+    result = your_processing_function(input_data)
+    # Automatically calls finish() on exit
+    return result
+```
+
 You can also improve the performance of your application using `weave.flush()`. See [Flushing](#flushing) for more information.

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -150,6 +150,7 @@ ulimit -n 65536
 ## Trace data loss in worker processes
 
 Weave uploads trace data in background threads to minimize impact on your application's performance. However, when using a multiprocessing or task queue system or a worker processes like Celery, trace data will be lost if the worker process exits before background threads finish uploading traces.
+
 To prevent data loss in worker processes, you must ensure that background uploads complete by calling `client.flush()` or `client.finish()` before the worker task completes.
 
 These methods have different purposes:

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -150,7 +150,7 @@ ulimit -n 65536
 ## Trace data loss in worker processes
 
 Weave uploads trace data in background threads to minimize impact on your application's performance. However, when using a multiprocessing or task queue system or a worker processes like Celery, trace data will be lost if the worker process exits before background threads finish uploading traces.
-To prevent data loss in worker processes, call `client.flush()` or `client.finish()` before the worker task completes. This ensures all background uploads complete before the process exits.
+To prevent data loss in worker processes, you must ensure that background uploads complete by calling `client.flush()` or `client.finish()` before the worker task completes.
 
 **Available methods:**
 

--- a/weave/guides/troubleshooting.mdx
+++ b/weave/guides/troubleshooting.mdx
@@ -150,16 +150,14 @@ ulimit -n 65536
 ## Trace data loss in worker processes
 
 Weave performs network uploads in background threads to minimize impact on your application's performance. However, when using worker processes like Celery, multiprocessing, or other task queue systems, the worker process may exit before background threads finish uploading traces, causing trace data to be lost.
-
 To prevent data loss in worker processes, call `client.flush()` or `client.finish()` before the worker task completes. This ensures all background uploads complete before the process exits.
 
 **Available methods:**
 
-- `client.flush()`: Simple, silent flushing. (recommended for worker processes and CI environments)
-- `client.finish()`: Includes progress feedback with a progress bar or status callbacks (useful for interactive scripts)
+- `weave.flush()`: Simple, silent flushing. We recommend this for when Weave is integrated into worker processes and CI environments.
+- `weave.finish()`: Includes progress feedback with a progress bar or status callbacks. We recommend using this with interactive scripts.
 
 Both methods block until all background uploads complete, ensuring no trace data is lost when the worker process exits.
-
 The following example demonstrates how to use `client.finish()` to ensure all traces are uploaded before tasks complete:
 
 ```python lines
@@ -170,40 +168,18 @@ app = Celery('tasks')
 
 @app.task
 def process_task(input_data):
-    client = weave.init("your-team-name/your-project-name")
+    weave.init("your-team-name/your-project-name")
     
     try:
         # Your task logic that creates traces
         result = your_processing_function(input_data)
         
         # Ensure all traces are uploaded before task completes
-        client.finish()
+        weave.finish()
         
         return result
     finally:
         pass
 ```
 
-The following example demonstrates how to use `client.flush()` with a multiprocessing application:
-
-```python lines
-import multiprocessing
-import weave
-
-def worker_function(data):
-    client = weave.init("your-team-name/your-project-name")
-    
-    try:
-        # Your processing logic
-        result = process_data(data)
-        
-        # Flush before worker process exits
-        client.flush()
-        return result
-    finally:
-        pass
-
-if __name__ == '__main__':
-    with multiprocessing.Pool() as pool:
-        results = pool.map(worker_function, data_list)
-```
+You can also improve the performance of your application using `weave.flush()`. See [Flushing](#flushing) for more information.


### PR DESCRIPTION
## Description
Resolves DOCS-1508. Adds a section on how to use client.finish() and client.flushing() to avoid data loss.