### PR TITLE
Lychee quality-of-life improvements

### DIFF
--- a/.github/workflows/linkcheck-pr.yml
+++ b/.github/workflows/linkcheck-pr.yml
@@ -168,6 +168,35 @@ jobs:
             core.warning(`Unsupported event type: ${context.eventName}`);
             return null;
 
+      - name: Debug - Show lychee config being used
+        if: |
+          steps.pr-context.outputs.pr_closed != 'true' &&
+          ((github.event_name == 'pull_request' && 
+            github.event.pull_request.head.repo.fork == true && 
+            steps.fork-docs-check.outputs.any_changed == 'true') ||
+           (github.event_name == 'deployment_status' && 
+            steps.changed-files.outputs.any_changed == 'true') ||
+           github.event_name == 'workflow_dispatch')
+        run: |
+          echo "=== Lychee Configuration Debug ==="
+          echo "Working directory: $(pwd)"
+          echo "Git HEAD commit: $(git rev-parse HEAD)"
+          echo "Git branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached HEAD')"
+          echo ""
+          if [ -f "lychee.toml" ]; then
+            echo "✓ lychee.toml found in working directory"
+            echo "Last modified by commit: $(git log -1 --format='%H %ai %s' -- lychee.toml)"
+            echo ""
+            echo "=== Current verbosity setting ==="
+            grep "^verbose = " lychee.toml || echo "No verbose setting found"
+            echo ""
+            echo "=== Last 5 exclude patterns ==="
+            grep -A 25 "^exclude = " lychee.toml | tail -6
+          else
+            echo "✗ lychee.toml not found in working directory!"
+          fi
+          echo "=================================="
+
       - name: Link Checker
         id: lychee
         # Run if:
@@ -195,6 +224,7 @@ jobs:
           # Same-repo PRs: Wait for deployment and use preview URL
           # Fork PRs: Run immediately and check against production (no preview available)
           args: >-
+            --config lychee.toml
             --base-url ${{ steps.pr-context.outputs.deploy_url || 'https://docs.wandb.ai' }}
             ${{ steps.fork-docs-check.outputs.all_changed_files || steps.changed-files.outputs.all_changed_files || '.' }}
 

--- a/.github/workflows/linkcheck-prod.yml
+++ b/.github/workflows/linkcheck-prod.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           # Configuration is in lychee.toml
           # Check all URLs from sitemap
-          args: "urls.txt"
+          args: "--config lychee.toml urls.txt"
           output: ./lychee-report.md
           format: markdown
           fail: false

--- a/lychee.toml
+++ b/lychee.toml
@@ -36,7 +36,7 @@ include = [
 ]
 
 # Logging verbosity
-verbose = "info"
+verbose = "warn"
 
 # URL patterns to exclude from checking
 exclude = [
@@ -56,6 +56,7 @@ exclude = [
   # Third party URLs
   'https://auth0.com/docs',
   'https://cognito-idp.us-east-1.amazonaws.com',
+  'https://www.netapp.com',
   'https://portal.azure.com',
   'https://hhs.gov',
 


### PR DESCRIPTION
## Description
Lychee quality-of-life improvements
- Ignore netapp.com false positive
- Reduce verbosity to warn
- Add debug step to emit the effective Lychee config
- Explicitly pass --config and point to lychee.toml, which should pick up config changes in the same PRff

These changes were inspired by friction I encountered in #2113 where attempting to ignore netapp.com were ignored, as well as attempts to reduce the verbosity of the Lychee check. I think that after this PR merges, future config changes in scope of a PR will be picked up.

## Testing
N/A. This PR doesn't update Markdown, so most of the checks won't run.
