### PR TITLE
Weave: Fixes example links across Weave docs

### DIFF
--- a/ja/weave/guides/integrations/mcp.mdx
+++ b/ja/weave/guides/integrations/mcp.mdx
@@ -114,7 +114,7 @@ async with stdio_client(server_params) as (read, write):
 
 ## チュートリアル: `mcp_demo` の例
 
-[`mcp_example`](https://github.com/wandb/weave/tree/master/examples/mcp_demo) は、トレースのための Model Context Protocol (MCP) と Weave のインテグレーションを示しています。クライアントとサーバーの両方のコンポーネントを計測して、それらの相互作用の詳細なトレースをキャプチャする方法を紹介します。
+[`mcp_example`](https://github.com/wandb/docs/tree/main/weave/examples/mcp_demo) は、トレースのための Model Context Protocol (MCP) と Weave のインテグレーションを示しています。クライアントとサーバーの両方のコンポーネントを計測して、それらの相互作用の詳細なトレースをキャプチャする方法を紹介します。
 
 ### サンプルの実行
 

--- a/ko/weave/guides/integrations/mcp.mdx
+++ b/ko/weave/guides/integrations/mcp.mdx
@@ -113,7 +113,7 @@ async with stdio_client(server_params) as (read, write):
 
 ## 튜토리얼: `mcp_demo` 예시
 
-[`mcp_example`](https://github.com/wandb/weave/tree/master/examples/mcp_demo)은 트레이싱을 위한 Model Context Protocol (MCP)과 Weave 간의 인테그레이션을 보여줍니다. 클라이언트와 서버 구성 요소 모두를 인스트루먼트하여 상호작용의 상세한 트레이스를 캡처하는 방법을 보여줍니다.
+[`mcp_example`](https://github.com/wandb/docs/tree/main/weave/examples/mcp_demo)은 트레이싱을 위한 Model Context Protocol (MCP)과 Weave 간의 인테그레이션을 보여줍니다. 클라이언트와 서버 구성 요소 모두를 인스트루먼트하여 상호작용의 상세한 트레이스를 캡처하는 방법을 보여줍니다.
 
 ### 예시 실행하기
 

--- a/weave/cookbooks/pii.mdx
+++ b/weave/cookbooks/pii.mdx
@@ -136,7 +136,7 @@ weave.init(WEAVE_PROJECT)
 ```python lines
 import requests
 
-url = "https://raw.githubusercontent.com/wandb/weave/master/docs/notebooks/10_pii_data.json"
+url = "https://raw.githubusercontent.com/wandb/docs/main/weave/cookbooks/source/10_pii_data.json"
 response = requests.get(url)
 pii_data = response.json()
 

--- a/weave/guides/integrations/mcp.mdx
+++ b/weave/guides/integrations/mcp.mdx
@@ -118,11 +118,11 @@ The `mcp_demo` example demonstrates an integration between the Model Context Pro
 
 ### Run the example
 
-1. Clone the `weave` repository and navigate to the `mcp_demo` example:
+1. Clone the docs repository and navigate to the `mcp_demo` example:
 
    ```bash
-   git clone https://github.com/wandb/weave
-   cd weave/examples/mcp_demo
+   git clone https://github.com/wandb/docs
+   cd docs/weave/examples/mcp_demo
    ```
 
    The example includes two main files:


### PR DESCRIPTION
## Description
We used to link out to several pieces of example code that lived in the Weave repo. Those examples have since moved over here and I'm updating the links for them.