### PR TITLE
Add K2.5 and GLM 5 to available models page

### DIFF
--- a/inference/models.mdx
+++ b/inference/models.mdx
@@ -9,27 +9,29 @@ W&B Inference provides access to several open-source foundation models. Each mod
 
 ## Model catalog
 
-| Model | Model ID (for API usage) | Type | Context Window | Parameters | Description |
-|-------|--------------------------|------|----------------|------------|-------------|
-| DeepSeek R1-0528 | `deepseek-ai/DeepSeek-R1-0528` | Text | 161K | 37B-680B (Active-Total) | Optimized for precise reasoning tasks including complex coding, math, and structured document analysis |
-| DeepSeek V3-0324 | `deepseek-ai/DeepSeek-V3-0324` | Text | 161K | 37B-680B (Active-Total) | Robust Mixture-of-Experts model tailored for high-complexity language processing and comprehensive document analysis |
-| DeepSeek V3.1 | `deepseek-ai/DeepSeek-V3.1` | Text | 128K | 37B-671B (Active-Total) | A large hybrid model that supports both thinking and non-thinking modes via prompt templates |
-| Meta Llama 3.1 8B | `meta-llama/Llama-3.1-8B-Instruct` | Text | 128K | 8B (Total) | Efficient conversational model optimized for responsive multilingual chatbot interactions |
-| Meta Llama 3.1 70B | `meta-llama/Llama-3.1-70B-Instruct` | Text | 128K | 70B (Total) | Efficient conversational model optimized for responsive multilingual chatbot interactions |
-| Meta Llama 3.3 70B | `meta-llama/Llama-3.3-70B-Instruct` | Text | 128K | 70B (Total) | Multilingual model excelling in conversational tasks, detailed instruction-following, and coding |
-| Meta Llama 4 Scout | `meta-llama/Llama-4-Scout-17B-16E-Instruct` | Text, Vision | 64K | 17B-109B (Active-Total) | Multi-modal model integrating text and image understanding, ideal for visual tasks and combined analysis |
-| Microsoft Phi 4 Mini 3.8B | `microsoft/Phi-4-mini-instruct` | Text | 128K | 3.8B (Active-Total) | Compact, efficient model ideal for fast responses in resource-constrained environments |
-| Moonshot AI Kimi K2 | `moonshotai/Kimi-K2-Instruct` | Text | 128K | 32B-1T (Active-Total) | Mixture-of-Experts model optimized for complex tool use, reasoning, and code synthesis |
-| Moonshot AI Kimi K2 Instruct 0905 | `moonshotai/Kimi-K2-Instruct-0905` | Text | 262K | 32B-1T | Latest version of Kimi K2 mixture-of-experts language model, featuring 32 billion activated parameters and a total of 1 trillion parameters |
-| OpenAI GPT OSS 20B | `openai/gpt-oss-20b` | Text | 131K | 3.6B-20B (Active-Total) | Lower latency Mixture-of-Experts model trained on OpenAI's Harmony response format with reasoning capabilities |
-| OpenAI GPT OSS 120B	| `openai/gpt-oss-120b` | Text | 131K | 5.1B-117B (Active-Total) | Efficient Mixture-of-Experts model designed for high-reasoning, agentic and general-purpose use cases |
-| OpenPipe Qwen3 14B Instruct | `OpenPipe/Qwen3-14B-Instruct` | Text | 32.8K | 14.8B (Active-Total) | An efficient multilingual, dense, instruction-tuned model, optimized by OpenPipe for building agents with finetuning. |
-| Qwen2.5 14B Instruct | `Qwen/Qwen2.5-14B-Instruct` | Text | 32.8K | 14.7B-14.7B (Active-Total) | Dense multilingual instruction-tuned model with tool-use and structured output support | 
-| Qwen3 235B A22B Thinking-2507 | `Qwen/Qwen3-235B-A22B-Thinking-2507` | Text | 262K | 22B-235B (Active-Total) | High-performance Mixture-of-Experts model optimized for structured reasoning, math, and long-form generation |
-| Qwen3 235B A22B-2507 | `Qwen/Qwen3-235B-A22B-Instruct-2507` | Text | 262K | 22B-235B (Active-Total) | Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning |
-| Qwen3 30B A3B Instruct | `Qwen/Qwen3-30B-A3B-Instruct-2507` | Text | 262K | 3.3B Active (30.5B Total) | Qwen3-30B-A3B-Instruct-2507 is a 30.5B MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding. |
-| Qwen3 Coder 480B A35B | `Qwen/Qwen3-Coder-480B-A35B-Instruct` | Text | 262K | 35B-480B (Active-Total) | Mixture-of-Experts model optimized for coding tasks such as function calling, tooling use, and long-context reasoning |
-| Z.AI GLM 4.5 | `zai-org/GLM-4.5` | Text | 131K | 32B-355B (Active-Total) | Mixture-of-Experts model with user-controllable thinking/non-thinking modes for reasoning, code, and agents |
+{/* takeru inference-models - This table is automatically generated, do not edit manually. */}
+| Model                             | Model ID (for API usage)                    | Type         | Context Window | Parameters                | Description                                                                                                                                  |
+| --------------------------------- | ------------------------------------------- | ------------ | -------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| DeepSeek R1-0528                  | `deepseek-ai/DeepSeek-R1-0528`              | Text         | 161K           | 37B-680B (Active-Total)   | Optimized for precise reasoning tasks including complex coding, math, and structured document analysis.                                      |
+| DeepSeek V3-0324                  | `deepseek-ai/DeepSeek-V3-0324`              | Text         | 161K           | 37B-680B (Active-Total)   | Robust Mixture-of-Experts model tailored for high-complexity language processing and comprehensive document analysis.                        |
+| DeepSeek V3.1                     | `deepseek-ai/DeepSeek-V3.1`                 | Text         | 161K           | 37B-671B (Active-Total)   | A large hybrid model that supports both thinking and non-thinking modes via prompt templates.                                                |
+| Meta Llama 3.1 70B                | `meta-llama/Llama-3.1-70B-Instruct`         | Text         | 128K           | 70B (Total)               | Efficient conversational model optimized for responsive multilingual chatbot interactions.                                                   |
+| Meta Llama 3.1 8B                 | `meta-llama/Llama-3.1-8B-Instruct`          | Text         | 128K           | 8B (Total)                | Efficient conversational model optimized for responsive multilingual chatbot interactions.                                                   |
+| Meta Llama 3.3 70B                | `meta-llama/Llama-3.3-70B-Instruct`         | Text         | 128K           | 70B (Total)               | Multilingual model excelling in conversational tasks, detailed instruction-following, and coding.                                            |
+| Meta Llama 4 Scout                | `meta-llama/Llama-4-Scout-17B-16E-Instruct` | Text, Vision | 64K            | 17B-109B (Active-Total)   | Multimodal model integrating text and image understanding, ideal for visual tasks and combined analysis.                                     |
+| Microsoft Phi 4 Mini 3.8B         | `microsoft/Phi-4-mini-instruct`             | Text         | 128K           | 3.8B (Total)              | Compact, efficient model ideal for fast responses in resource-constrained environments.                                                      |
+| Moonshot AI Kimi K2               | `moonshotai/Kimi-K2-Instruct`               | Text         | 131K           | 32B-1T (Active-Total)     | Mixture-of-Experts model optimized for complex tool use, reasoning, and code synthesis.                                                      |
+| Moonshot AI Kimi K2 Instruct 0905 | `moonshotai/Kimi-K2-Instruct-0905`          | Text         | 262K           | 32B-1T (Active-Total)     | Latest version of Kimi K2 mixture-of-experts language model, featuring 32 billion activated parameters and a total of 1 trillion parameters. |
+| Moonshot AI Kimi K2.5             | `moonshotai/Kimi-K2.5`                      | Text, Vision | 262K           | 32B-1T (Active-Total)     | Kimi K2.5 is a multimodal Mixture-of-Experts language model featuring 32 billion activated parameters and a total of 1 trillion parameters.  |
+| OpenAI GPT OSS 120B               | `openai/gpt-oss-120b`                       | Text         | 131K           | 5.1B-117B (Active-Total)  | Efficient Mixture-of-Experts model designed for high-reasoning, agentic and general-purpose use cases.                                       |
+| OpenAI GPT OSS 20B                | `openai/gpt-oss-20b`                        | Text         | 131K           | 3.6B-20B (Active-Total)   | Lower latency Mixture-of-Experts model trained on OpenAI's Harmony response format with reasoning capabilities.                              |
+| OpenPipe Qwen3 14B Instruct       | `OpenPipe/Qwen3-14B-Instruct`               | Text         | 32.8K          | 14.8B (Total)             | An efficient multilingual, dense, instruction-tuned model, optimized by OpenPipe for building agents with finetuning.                        |
+| Qwen3 235B A22B Thinking-2507     | `Qwen/Qwen3-235B-A22B-Thinking-2507`        | Text         | 262K           | 22B-235B (Active-Total)   | High-performance Mixture-of-Experts model optimized for structured reasoning, math, and long-form generation.                                |
+| Qwen3 235B A22B-2507              | `Qwen/Qwen3-235B-A22B-Instruct-2507`        | Text         | 262K           | 22B-235B (Active-Total)   | Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning.                                        |
+| Qwen3 30B A3B                     | `Qwen/Qwen3-30B-A3B-Instruct-2507`          | Text         | 262K           | 3.3B-30.5B (Active-Total) | Qwen3-30B-A3B-Instruct-2507 is a 30.5B MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding.          |
+| Qwen3 Coder 480B A35B             | `Qwen/Qwen3-Coder-480B-A35B-Instruct`       | Text         | 262K           | 35B-480B (Active-Total)   | Mixture-of-Experts model optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning.                  |
+| Z.AI GLM 4.5                      | `zai-org/GLM-4.5`                           | Text         | 131K           | 32B-355B (Active-Total)   | Mixture-of-Experts model with user-controllable thinking/non-thinking modes for strong reasoning, code generation, and agent alignment.      |
+| Z.AI GLM 5                        | `zai-org/GLM-5-FP8`                         | Text         | 203K           | 40B-744B (Active-Total)   | Mixture-of-Experts model for long-horizon agentic tasks with strong performance on reasoning and coding.                                     |
 
 ## Using model IDs
 
@@ -46,4 +48,4 @@ response = client.chat.completions.create(
 
 - Check [usage limits and pricing](/inference/usage-limits/) for each model
 - See [API reference](/inference/api-reference/) for how to use these models
-- Try models in the [W&B Playground](/inference/ui-guide/) 
+- Try models in the [W&B Playground](/inference/ui-guide/)


### PR DESCRIPTION
## Description

The actual key change here is the line:
`{/* takeru inference-models - This table is automatically generated, do not edit manually. */}`

which is used by upcoming automated tooling to automatically keep this table in sync with our catalog data.

The content changes are the addition of two rows for models we are launching, Moonshot AI Kimi K2.5 and Z.AI GLM 5.

The other changes are a result of the automated formatting. The script automatically adjusts the padding in the cells for alignment. A thing to note if doing a visual before/after comparison is that the program made some different choices about how to alphabetize e.g. it puts `OpenAI GPT OSS 120B` ahead of `OpenAI GPT OSS 20B`. We can revisit this, but I'd like to prioritize getting this out, and the automation is going to make all our lives a little easier.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
