### PR TITLE
Weave: audio and image mention for monitors

### DIFF
--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -3,9 +3,9 @@ title: "Set up monitors"
 description: "Passively score production traffic to surface trends and issues"
 ---
 
-Monitors use LLM judges to passively score production traffic to surface trends and issues in your LLM applications. For example, you can monitor your application's responses for correctness or helpfulness, or you can monitor user input to identify trends in what they're asking your agents about.
+Monitors use LLM judges to passively score production traffic to surface trends and issues in your LLM applications. For example, you can monitor your application's responses for correctness or helpfulness, or you can monitor user input to identify trends in what they're asking your agents about. Monitors automatically store all scoring results in Weave's database, allowing you to analyze historical trends and patterns.
 
-Monitors automatically store all scoring results in Weave's database, allowing you to analyze historical trends and patterns.
+You can monitor text, images, and audio in your application's input and output.
 
 Monitors require no code changes to your application. Set them up using the W&B Weave UI.
 


### PR DESCRIPTION
## Description
Adds a quick line of copy mentioning that you can use Weave monitors to monitor audio and images.
