### PR TITLE
QEL: Update landing page link

### DIFF
--- a/models/ref/query-panel.mdx
+++ b/models/ref/query-panel.mdx
@@ -6,7 +6,7 @@ Use the query expressions to select and aggregate data across runs and projects.
 Learn more about [query panels](/models/app/features/panels/query-panels/).
 
 <Tip>
-See the [Query Panel](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?access) W&B Report for an interactive examples.
+See the [Query Panel](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr) W&B Report for an interactive examples.
 </Tip>
 
 ## Data Types


### PR DESCRIPTION
Link to QEL Report was broken. It was missing a token in the path. This PR fixes that.