### PR TITLE
[DOCS-1915] Consistency scrub for 'project sidebar' for the left panel in the W&B App

### DIFF
--- a/models/app/features/panels/code.mdx
+++ b/models/app/features/panels/code.mdx
@@ -56,7 +56,7 @@ W&B saves the history of code executed in your Jupyter notebook session. When yo
 
 
 1. Navigate to your project workspaces that contains your code.
-2. Select the **Artifacts** tab in the left navigation bar.
+2. Select the **Artifacts** tab in the project sidebar.
 3. Expand the **code** artifact.
 4. Select the **Files** tab.
 

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -167,7 +167,7 @@ with wandb.init() as run:
 
 1. Navigate to your workspace.
 1. Select the **Add panels** button in the top right corner of the page.
-1. From the left panel that appears, expand the Evaluation dropdown.
+1. From the drawer that appears, expand the Evaluation dropdown.
 1. Select **Run comparer**
 
 ## Change the colors of the lines

--- a/models/app/keyboard-shortcuts.mdx
+++ b/models/app/keyboard-shortcuts.mdx
@@ -24,7 +24,7 @@ These keyboard shortcuts work in the W&B App.
 | Shortcut | Description |
 |----------|-------------|
 | **Tab** | Navigate between interactive elements. |
-| **Cmd+J** (macOS) / **Ctrl+J** (Windows/Linux) | Switch between the Workspaces and Runs tabs in the sidebar. |
+| **Cmd+J** (macOS) / **Ctrl+J** (Windows/Linux) | Switch between the Workspaces and Runs tabs in the project sidebar. |
 | **Cmd+K** (macOS) / **Ctrl+K** (Windows/Linux) | Open the quick search dialog to search across projects, runs, and other resources. |
 | **Esc** | Throughout the W&B App, exit full-screen panel views, close settings drawers, dismiss the quick search dialog, close an editor, or dismiss other overlays. |
 

--- a/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
+++ b/models/artifacts/explore-and-traverse-an-artifact-graph.mdx
@@ -20,7 +20,7 @@ To view an artifact's lineage graph:
 
 1. Navigate to the W&B App.
 2. Select the project that contains the run or artifact you want to explore.
-3. Click on the **Artifacts** tab on the left sidebar.
+3. Click on the **Artifacts** tab in the project sidebar.
 4. Select the **Lineage** tab.
 
 <Frame>

--- a/models/artifacts/ttl.mdx
+++ b/models/artifacts/ttl.mdx
@@ -120,7 +120,7 @@ The preceding code example sets the TTL policy to two years.
 </Tab>
 <Tab title="W&B App">
 1. Navigate to your W&B project in the W&B App UI.
-2. Select the artifact icon on the left panel.
+2. Select the artifact icon in the project sidebar.
 3. From the list of artifacts, expand the artifact type you 
 4. Select on the artifact version you want to edit the TTL policy for.
 5. Click on the **Version** tab.
@@ -195,7 +195,7 @@ artifact.save()
 </Tab>
 <Tab title="W&B App">
 1. Navigate to your W&B project in the W&B App UI.
-2. Select the artifact icon on the left panel.
+2. Select the artifact icon in the project sidebar.
 3. From the list of artifacts, expand the artifact type you 
 4. Select on the artifact version you want to edit the TTL policy for.
 5. Click on the Version tab.
@@ -230,7 +230,7 @@ View a TTL policy for an artifact with the W&B App UI.
 
 1. Navigate to the [W&B App](https://wandb.ai).
 2. Go to your W&B Project.
-3. Within your project, select the Artifacts tab in the left sidebar.
+3. Within your project, select the Artifacts tab in the project sidebar.
 4. Click on a collection.
 
 Within the collection view you can see all of the artifacts in the selected collection. Within the `Time to Live` column you will see the TTL policy assigned to that artifact. 

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -67,7 +67,7 @@ A Registry admin can create automations in that registry. Registry automations a
 A W&B admin can create automations in a project.
 
 1. Log in to W&B and go to the project page.
-1. In the sidebar, click **Automations**, then click **Create automation**.
+1. In the project sidebar, click **Automations**, then click **Create automation**.
 
     Or, from a line plot in the workspace, you can quickly create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
     <Frame>

--- a/models/automations/view-automation-history.mdx
+++ b/models/automations/view-automation-history.mdx
@@ -22,7 +22,7 @@ Based on your use case, select the **Registry** or **Project** tab for detailed 
 
 <Tabs>
 <Tab title="Registry">
-1. Navigate to your registry by clicking on **Registry** in the left sidebar.
+1. Navigate to your registry by clicking on **Registry** in the project sidebar.
 1. Select your registry from the list.
 1. View the registry's automations in the **Automations** tab. Click the **Last execution** timestamp to view the execution history details. You can use the search bar to filter by automation name, and you can sort by the last triggered date to find recently executed automations.
 1. View the registry's automation executions in reverse chronological order in the **Automations history** tab, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
@@ -30,7 +30,7 @@ Based on your use case, select the **Registry** or **Project** tab for detailed 
 <Tip>If a collection has associated automation executions, the icon ![Collection automation execution symbol, a circle with a right-pointing arrow](/images/automations/collection-automation-execution-icon.png) displays, along with the number of associated executions.</Tip>
 </Tab>
 <Tab title="Project">
-1. Click the **Automations** tab in the left navigation. The project's automations display. Click the **Last execution** timestamp to view the execution history details. You can use the search bar to filter by automation name, and you can sort by the last triggered date to find recently executed automations.
+1. Click the **Automations** tab in the project sidebar. The project's automations display. Click the **Last execution** timestamp to view the execution history details. You can use the search bar to filter by automation name, and you can sort by the last triggered date to find recently executed automations.
 1. In the **History** tab, view all executions of the project's automations in reverse chronological order, starting with the most recent execution. Each execution's metadata displays, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
 </Tab>
 </Tabs>

--- a/models/launch/evaluate-hosted-model.mdx
+++ b/models/launch/evaluate-hosted-model.mdx
@@ -18,13 +18,13 @@ This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series
     - A **Hugging Face user access token**: Required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face Token** appears after selecting a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
     - To evaluate a model provided by [W&B Inference](/inference), an organization or team admin must create `WANDB_API_KEY` with any value. The secret is not actually used for authentication. 
 1. The model to evaluate must be available at a publicly accessible URL. An organization or team admin must create a team-scoped secret with the API key for authentication.
-1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the left navigation, click **Create new project**.
+1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the project sidebar, click **Create new project**.
 1. Review the documentation for a given benchmark to understand how it works and learn about specific requirements. For convenience, the [Available evaluation benchmarks](/models/launch/evaluations) reference includes relevant links.
 
 ## Evaluate your model
 Follow these steps to set up and launch an evaluation job:
 
-1. Log in to W&B, then click **Launch** in the left navigation. The **LLM Evaluation Jobs** page displays.
+1. Log in to W&B, then click **Launch** in the project sidebar. The **LLM Evaluation Jobs** page displays.
 1. Click **Evaluate hosted API model** to set up the evaluation.
 1. Select a destination project to save the evaluation results to.
 1. In the **Model** section, specify the base URL and model name to evaluate, and select the API key to use for authentication. Provide the model name in OpenAI-compatible format defined by the [AI Security Institute](https://inspect.aisi.org.uk/providers.html#openai-api). For example, specify an OpenAI mode in the following syntax: `openai/<model-name>`. For a comprehensive list of hosted model providers and models, see [AI Security Institute's model provider reference](https://inspect.aisi.org.uk/providers.html).

--- a/models/launch/evaluate-model-checkpoint.mdx
+++ b/models/launch/evaluate-model-checkpoint.mdx
@@ -9,21 +9,21 @@ import PreviewLink from '/snippets/en/_includes/llm-eval-jobs/preview.mdx';
 
 <PreviewLink />
 
-This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a model checkpoint in W&B Models, using infrastructure managed by CoreWeave. To evaluate a hosted API model served at a publicly-accessible URL, see [Evaluate an API-hosted model](/models/launch/evaluate-hosted-model) instead.
+This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a fine-tuned model in W&B Models, using infrastructure managed by CoreWeave. To evaluate a hosted API model served at a publicly-accessible URL, see [Evaluate an API-hosted model](/models/launch/evaluate-hosted-model) instead, or run a small benchmark against a public OpenAI model endpoint with a streamlined [Quickstart](/models/launch#quickstart).
 
 ## Prerequisites
 1. Review the [requirements and limitations](/models/launch#more-details) for LLM Evaluation Jobs.
 1. To run certain benchmarks, a team admin must add the required API keys as [team-scoped secrets](/platform/secrets#add-a-secret). Any team member can specify the secret when configuring an evaluation job. See [Evaluation model catalog](/models/launch/evaluations) for requirements.
     - An **OpenAPI API key**: Used by benchmarks that use OpenAI models for scoring. Required if the field **Scorer API key** appears after you select a benchmark. The secret must be named `OPENAI_API_KEY`.
     - A **Hugging Face user access token**: Required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face Token** appears after selecting a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
-1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the left navigation, click **Create new project**.
+1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the project sidebar, click **Create new project**.
 1. Package the model in VLLM-compatible format and save it as an artifact in W&B Models. An attempt to benchmark any other type of artifact will fail. For one approach, see [Example: Prepare a model](#example-prepare-your-model) at the end of this page.
 1. Review the documentation for a given benchmark to understand how it works and learn about specific requirements. For convenience, the [Available evaluation benchmarks](/models/launch/evaluations) reference includes relevant links.
 
 ## Evaluate your model
 Follow these steps to set up and launch an evaluation job:
 
-1. Log in to W&B, then click **Launch** in the left navigation. The **LLM Evaluation Jobs** page displays.
+1. Log in to W&B, then click **Launch** in the project sidebar. The **LLM Evaluation Jobs** page displays.
 1. Click **Evaluate model checkpoint** to set up the evaluation job.
 1. Select a destination project to save the evaluation results to.
 1. In the **Model artifact** section, specify the project, artifact, and version of the prepared model to evaluate.

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -83,7 +83,7 @@ with wandb.init(project="registry_quickstart") as run:
 
 W&B automatically creates a collection for you if the collection you specify in the returned run object's `wandb.Run.link_artifact(target_path = "")` method does not exist within the registry you specify.
 
-Continuing from the previous example, after you run the script, navigate to W&B Registry to view artifact versions that you and other members of your organization publish. Select **Registry** in the left sidebar below **Applications**. Select the `"Model"` registry. Within the registry, you should see the `"first-collection"` collection with your linked artifact version.
+Continuing from the previous example, after you run the script, navigate to W&B Registry to view artifact versions that you and other members of your organization publish. Select **Registry** in the project sidebar below **Applications**. Select the `"Model"` registry. Within the registry, you should see the `"first-collection"` collection with your linked artifact version.
 
 Once you link an artifact version to a collection within a registry, members of your organization can [view](/models/registry/lineage), [download](/models/registry/search_registry), [organize](/models/registry/organize-with-tags), and manage your artifact versions, create downstream automations, and more if they have the proper permissions.
 

--- a/models/registry/link_version.mdx
+++ b/models/registry/link_version.mdx
@@ -127,7 +127,7 @@ artifact.link(target_path = target_path)
 <Tab title="W&B Registry">
 1. Navigate to the W&B Registry.
     <Frame>
-    <img src="/images/registry/navigate_to_registry_app.png" alt="W&B Registry UI navigation"  />
+    <img src="/images/registry/navigate_to_registry_app.png" alt="W&B Registry UI with project sidebar"  />
     </Frame>
 2. Hover your mouse next to the name of the collection you want to link an artifact version to.
 3. Select the meatball menu icon (three horizontal dots) next to  **View details**.
@@ -141,7 +141,7 @@ artifact.link(target_path = target_path)
 </Tab>
 <Tab title="Artifact browser">
 1. Navigate to your project's artifact browser on the W&B App at: `https://wandb.ai/<entity>/<project>/artifacts`
-2. Select the Artifacts icon on the left sidebar.
+2. Select the Artifacts icon in the project sidebar.
 3. Click on the artifact version you want to link to your registry.
 4. Within the **Version overview** section, click the **Link to registry** button.
 5. From the modal that appears on the right of the screen, select an artifact from the **Select a register model** menu dropdown. 

--- a/models/runs/tags.mdx
+++ b/models/runs/tags.mdx
@@ -52,7 +52,7 @@ with wandb.Api().run("{entity}/{project}/{run-id}") as run:
 This method is best suited to tagging large numbers of runs with the same tag or tags.
 
 1. Navigate to your project workspace.
-2. Select **Runs** in the from the project sidebar.
+2. Select **Runs** from the project sidebar.
 3. Select one or more runs from the table.
 4. Once you select one or more runs, select the **Tag** button above the table.
 5. Type the tag you want to add and select the **Create new tag** checkbox to add the tag.
@@ -61,10 +61,9 @@ This method is best suited to tagging large numbers of runs with the same tag or
 This method is best suited to applying a tag or tags to a single run manually.
 
 1. Navigate to your project workspace.
-2. Select a run from the list of runs within your project's workspace.
-1. Select **Overview** from the project sidebar.
-2. Select the gray plus icon (**+**) button next to **Tags**.
-3. Type a tag you want to add and select **Add** below the text box to add a new tag.
+2. Click a run to open it. The run page opens with the **Overview** tab shown by default.
+3. Select the gray plus icon (**+**) button next to **Tags**.
+4. Type a tag you want to add and select **Add** below the text box to add a new tag.
 </Tab>
 </Tabs>
 

--- a/models/runs/view-logged-runs.mdx
+++ b/models/runs/view-logged-runs.mdx
@@ -55,15 +55,15 @@ To view a run locally in your terminal using the `wandb beta leet` terminal UI:
 
 LEET displays a three-panel interface:
 
-- **Left sidebar**: Run overview with environment variables, configuration, and summary statistics
+- **Left panel**: Run overview with environment variables, configuration, and summary statistics
 - **Center panel**: Metrics grid with Braille-style line charts showing your logged metrics
-- **Right sidebar**: System metrics including GPU/CPU/RAM utilization
+- **Right panel**: System metrics including GPU/CPU/RAM utilization
 
 Get started with these keyboard shortcuts:
 
 - `h` or `?` - View all keyboard shortcuts
 - `/` - Filter metrics by pattern
-- `[` / `]` - Toggle left/right sidebars
+- `[` / `]` - Toggle left/right panels
 - `n` / `N` - Navigate between metric pages
 - `q` / `CMD+C` - Quit
 

--- a/models/support.mdx
+++ b/models/support.mdx
@@ -1980,7 +1980,7 @@ with wandb.init() as run:
 
 To change a project's privacy (visibility):
 
-1. In the W&B App, from any page in the project, click **Overview** in the left navigation.
+1. In the W&B App, from any page in the project, click **Overview** in the project sidebar.
 1. At the top right, click **Edit**.
 1. Choose a new value for **Project visibility**:
 

--- a/models/sweeps/existing-project.mdx
+++ b/models/sweeps/existing-project.mdx
@@ -21,7 +21,7 @@ Optionally explore the example appear in the W&B App UI dashboard.
 
 ## 2. Create a sweep
 
-From your project page, open the [Sweep tab](./sweeps-ui) in the sidebar and select **Create Sweep**.
+From your project page, open the [Sweep tab](./sweeps-ui) in the project sidebar and select **Create Sweep**.
 
 <Frame>
     <img src="/images/sweeps/sweep1.png" alt="Sweep overview"  />

--- a/models/sweeps/visualize-sweep-results.mdx
+++ b/models/sweeps/visualize-sweep-results.mdx
@@ -3,12 +3,12 @@ description: Visualize the results of your W&B Sweeps with the W&B App UI.
 title: Visualize sweep results
 ---
 
-Visualize the results of your W&B Sweeps with the W&B App. Navigate to the [W&B App](https://wandb.ai/home). Choose the project that you specified when you initialized a sweep. You will be redirected to your project [workspace](/models/track/workspaces/). Select the **Sweep icon** on the left panel (broom icon). From the Sweep UI, select the name of your Sweep from the list.
+Visualize the results of your W&B Sweeps with the W&B App. Navigate to the [W&B App](https://wandb.ai/home). Choose the project that you specified when you initialized a sweep. You will be redirected to your project [workspace](/models/track/workspaces/). Select the **Sweep icon** in the project sidebar (broom icon). From the Sweep UI, select the name of your Sweep from the list.
 
 By default, W&B will automatically create a parallel coordinates plot, a parameter importance plot, and a scatter plot when you start a W&B Sweep job.
 
 <Frame>
-    <img src="/images/sweeps/navigation_sweeps_ui.gif" alt="Sweep UI navigation"  />
+    <img src="/images/sweeps/navigation_sweeps_ui.gif" alt="Sweep UI in project sidebar"  />
 </Frame>
 
 Parallel coordinates charts summarize the relationship between large numbers of hyperparameters and model metrics at a glance. For more information on parallel coordinates plots, see [Parallel coordinates](/models/app/features/panels/parallel-coordinates/).

--- a/models/tables/visualize-tables.mdx
+++ b/models/tables/visualize-tables.mdx
@@ -32,7 +32,7 @@ Compare two tables with a [merged view](#merged-view) or a [side-by-side view](#
 Follow these steps to compare two tables:
 
 1. Go to your project in the W&B App.
-2. Select the artifacts icon on the left panel.
+2. Select the artifacts icon in the project sidebar.
 2. Select an artifact version. 
 
 In the following image we demonstrate a model's predictions on MNIST validation data after each of five epochs ([view interactive example here](https://wandb.ai/stacey/mnist-viz/artifacts/predictions/baseline/d888bc05719667811b23/files/predictions.table.json)).

--- a/models/track/log/distributed-training.mdx
+++ b/models/track/log/distributed-training.mdx
@@ -142,7 +142,7 @@ For example, you could create the following saved views:
      - No filter
      - Useful for comprehensive monitoring
 
-To open a saved view, click **Workspaces** in the sidebar, then click the menu. Workspaces appear at the top of the list and saved views appear at the bottom.
+To open a saved view, click **Workspaces** in the project sidebar, then click the menu. Workspaces appear at the top of the list and saved views appear at the bottom.
 
 ### Track all processes to a single run
 
@@ -237,9 +237,9 @@ See the [Distributed Training with Shared Mode](https://wandb.ai/dimaduev/simple
 View console logs from multi node processes in the project that the run logs to:
 
 1. Navigate to the project that contains the run.
-2. Click on the **Runs** tab in the left sidebar.
+2. Click on the **Runs** tab in the project sidebar.
 3. Click on the run you want to view.
-4. Click on the **Logs** tab in the left sidebar.
+4. Click on the **Logs** tab in the project sidebar.
 
 You can filter console logs based on the labels you provide for `x_label` in the UI search bar located at the top of the console log page. For example, the following image shows which options are available to filter the console log by if values  `rank0`, `rank1`, `rank2`, `rank3`, `rank4`, `rank5`, and `rank6` are provided to `x_label`.` 
 

--- a/models/track/log/log-summary.mdx
+++ b/models/track/log/log-summary.mdx
@@ -77,10 +77,9 @@ View summary values in a run's **Overview** page or the project's runs table.
 <Tabs>
 <Tab title="Run Overview">
 1. Navigate to the W&B App.
-2. Select the **Workspace** tab.
-3. From the list of runs, click the name of the run that logged the summary values.
-4. Select the **Overview** tab.
-5. View the summary values in the **Summary** section.
+2. Select the **Workspace** tab from the project sidebar.
+3. Click the run that logged the summary values. The run page opens with the **Overview** tab shown by default.
+4. View the summary values in the **Summary** section.
 
 <Frame>
     <img src="/images/track/customize_summary.png" alt="Run overview"  />

--- a/models/track/project-page.mdx
+++ b/models/track/project-page.mdx
@@ -288,7 +288,7 @@ You can create a project in the W&B App or programmatically by specifying a proj
 In the W&B App, you can create a project from the **Projects** page or from a team's landing page.
 
 From the **Projects** page:
-1. Click the global navigation icon in the upper left. The navigation sidebar opens.
+1. Click the global navigation icon in the upper left. The project sidebar opens.
 1. In the **Projects** section of the navigation, click **View all** to open the project overview page.
 1. Click **Create new project**.
 1. Set **Team** to the name of the team that will own the project.
@@ -298,7 +298,7 @@ From the **Projects** page:
 1. Click **Create project**.
 
 From a team's landing page:
-1. Click the global navigation icon in the upper left. The navigation sidebar opens.
+1. Click the global navigation icon in the upper left. The project sidebar opens.
 1. In the **Teams** section of the navigation, click the name of a team to open its landing page.
 1. In the landing page, click **Create new project**.
 1. **Team** is automatically set to the team that owns the landing page you were viewing. If necessary, change the team.

--- a/models/track/reproduce_experiments.mdx
+++ b/models/track/reproduce_experiments.mdx
@@ -12,9 +12,8 @@ Before you reproduce an experiment, you need to make note of the:
 To reproduce an experiment:
 
 1. Navigate to the project where the run is logged to.
-2. Select the **Workspace** tab in the left sidebar.
-3. From the list of runs, select the run that you want to reproduce.
-4. Click **Overview**.
+2. Select the **Workspace** tab from the project sidebar.
+3. Click the run that you want to reproduce. The run page opens with the **Overview** tab shown by default.
 
 To continue, download the experiment's code at a given hash or clone the experiment's entire repository.
 
@@ -22,8 +21,8 @@ To continue, download the experiment's code at a given hash or clone the experim
 <Tab title="Download Python script or notebook">
 Download the experiment's Python script or notebook:
 
-1. In the **Command** field, make a note of the name of the script that created the experiment.
-2. Select the **Code** tab in the left navigation bar.
+1. On the **Overview** tab (shown by default), in the **Command** field, make a note of the name of the script that created the experiment.
+2. Select the **Code** tab on the run page.
 3. Click **Download** next to the file that corresponds to the script or notebook.
 </Tab>
 <Tab title="GitHub">
@@ -42,7 +41,7 @@ Clone the GitHub repository your teammate used when creating the experiment. To 
 </Tab>
 </Tabs>
 
-5. Select **Files** in the left navigation bar.
+5. On the run page, select the **Files** tab.
 6. Download the `requirements.txt` file and store it in your working directory. This directory should contain either the cloned GitHub repository or the downloaded Python script or notebook.
 7. (Recommended) Create a Python virtual environment.
 8. Install the requirements specified in the `requirements.txt` file.

--- a/platform/launch/add-job-to-queue.mdx
+++ b/platform/launch/add-job-to-queue.mdx
@@ -16,7 +16,7 @@ Add jobs to your queue interactively with the W&B App or programmatically with t
 Add a job to your queue programmatically with the W&B App.
 
 1. Navigate to your W&B Project Page.
-2. Select the **Jobs** icon on the left panel:
+2. Select the **Jobs** icon in the project sidebar:
   <Frame>
     <img src="/images/launch/project_jobs_tab_gs.png" alt="Project Jobs tab"  />
 </Frame>

--- a/platform/launch/sweeps-on-launch.mdx
+++ b/platform/launch/sweeps-on-launch.mdx
@@ -31,7 +31,7 @@ Before you create a sweep with W&B Launch, ensure that you first create a job to
 Create a sweep interactively with the W&B App.
 
 1. Navigate to your W&B project on the W&B App.  
-2. Select the sweeps icon on the left panel (broom image). 
+2. Select the sweeps icon in the project sidebar (broom image). 
 3. Next, select the **Create Sweep** button.
 4. Click the **Configure Launch** button.
 5. From the **Job** dropdown menu, select the name of your job and the job version you want to create a sweep from.


### PR DESCRIPTION
## Description
[DOCS-1915] Consistency scrub for 'project sidebar' for the left panel in the W&B App

- Fix some really outdated content about the Run details UI. The tabs like Charts, Overview, Code are in tabs at the top while viewing the run details, not in the project sidebar.
- Update details about the LEET TUI to avoid 'sidebar'
- Update details about workspace settings to call the right-hand flyouts drawers instead of sidebars or panels

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed


[DOCS-1915]: https://wandb.atlassian.net/browse/DOCS-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ