### PR TITLE
docs: Update from DocEngine PR 20: feat: Shared navigation builder and generator hook; wandb i18n migration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3723,7 +3723,7 @@
     {
       "source": "/library/init",
       "destination": "/models/ref/python/functions/init"
-    },    
+    },
     {
       "source": "/models/app/pages/workspaces",
       "destination": "/models/app/features/cascade-settings"
@@ -3739,7 +3739,6 @@
     {
       "source": "/models/integrations/openai",
       "destination": "/models/integrations/openai-api"
-
     },
     {
       "source": "/models/tutorials",
@@ -3751,8 +3750,8 @@
     },
     {
       "source": "/models/tutorials/minikube_gpu",
-      "destination" : "/models/integrations"
-    },    
+      "destination": "/models/integrations"
+    },
     {
       "source": "/models/tutorials/monai_3d_segmentation",
       "destination": "/models/integrations"
@@ -3766,15 +3765,15 @@
       "destination": "/models/integrations/tensorflow"
     },
     {
-      "source" : "/models/tutorials/tensorflow_sweeps",
-      "destination": "/models/sweeps"
-    },    
-    {
-      "source" : "/models/tutorials/xgboost_sweeps",
+      "source": "/models/tutorials/tensorflow_sweeps",
       "destination": "/models/sweeps"
     },
     {
-      "source":"/models/tutorials/volcano",
+      "source": "/models/tutorials/xgboost_sweeps",
+      "destination": "/models/sweeps"
+    },
+    {
+      "source": "/models/tutorials/volcano",
       "destination": "/models/integrations"
     },
     {

--- a/models/support.mdx
+++ b/models/support.mdx
@@ -1,6 +1,10 @@
 ---
 title: Support
 ---
+{/*
+Built with DocEngine. Do not edit this MDX file directly. 
+Template: /sites/wandb-docs/templates/support.mdx.j2
+*/}
 
 import {Banner} from "/snippets/Banner.jsx";
 import ApiKeyFind from "/snippets/en/_includes/api-key-find.mdx";


### PR DESCRIPTION
This PR implements the MDX page updates caused by [DocEngine PR 20](https://github.com/coreweave/docengine/pull/20).

---
**Source PR (DocEngine)**
**Title**: feat: Shared navigation builder and generator hook; wandb i18n migration

**Description**:

## Summary

- **Navigation**: Add shared `app/core/navigation_builder.py` for Mintlify `docs.json` merge logic. Wire meta generators via `set_generator_runner(self)` so the navigation updater can use the runner’s output root and collect declarations. CoreWeave and wandb-docs navigation updaters use the shared builder (single nav root vs. `navigation.languages[]` for `en` only).
- **Docs**: Add `docs/generators/navigation_updater.md` describing the flow, declarations, and shared merge. Move plan docs under `docs/plans/` (future-plans, implemented-plans).
- **Wandb knowledgebase i18n**: One-off migration: remove `language` from knowledgebase YAMLs; all affected knowledgebase files updated.

## Changes

### Core

- **`app/core/navigation_builder.py`** (new): Shared helpers — `get_nav_root`, `navigate`, `get_existing_group_pages`, `update_navigation_group`, `update_dynamic_groups`, `add_single_to_path` — for a single nav root (CoreWeave: `config.navigation`; wandb: `config.navigation.languages[]` entry for `language == "en"`).
- **`app/core/generator_runner.py`**: Before running each generator, call `set_generator_runner(self)` when present so meta generators (e.g. navigation updater) can use `output_root` and discover other generators’ navigation declarations.

### Sites

- **CoreWeave**: `generators/navigation_updater.py` uses `navigation_builder` and `set_generator_runner`; `cpu_instance_pages`, `gpu_instance_pages`, `region_pages` aligned with declaration-based navigation.
- **Wandb**: `generators/navigation_updater.py` uses same flow with nav root = `languages[]` entry for `en`.

### Docs

- **`docs/generators/navigation_updater.md`** (new): Documents declaration-based flow, runner wiring, CoreWeave vs wandb nav root, shared merge behavior, and file formatting.
- Plan docs moved into `docs/plans/`: `NAVIGATION_ENHANCEMENT_PLAN.md` → `docs/plans/future-plans/`; `DRAFT_STATUS_PLAN.md`, `GITHUB_ACTION_CI_PLAN.md`, `IMPORTER_PLAN.md`, `WEB_UI_ENHANCEMENT_PLAN.md` → `docs/plans/implemented-plans/`.

### Scripts & data

- **`scripts/migrate_knowledgebase_i18n.py`**: Removes `language` and adds `title_ja`, `title_ko`, `body_ja`, `body_ko` (null) to all wandb knowledgebase YAMLs; run once from repo root.
- **`sites/wandb-docs/data/knowledgebase/*.yaml`**: Updated by the migration (schema-ready for future i18n).

## Testing

- Local build with navigation updater: ensure `docs.json` is merged correctly for CoreWeave and wandb-docs.
- No behavioral change to non-meta generators; navigation updater now requires `set_generator_runner` (runner always calls it for meta generators).

---

**Workflow run**: Run number 30 — [View build](https://github.com/coreweave/docengine/actions/runs/22368719306)
**Branch**: `4aa5bce00e268826ea993e914d00cc6522e4214d` — [View branch](https://github.com/coreweave/docengine/tree/4aa5bce00e268826ea993e914d00cc6522e4214d)

This PR contains **auto-generated** updates from DocEngine.

**Source**: `coreweave/docengine` @ `4aa5bce00e268826ea993e914d00cc6522e4214d`
**Trigger**: push | **Site**: `wandb-docs`

> [!IMPORTANT]
> Please review before merging. Do not assume it is safe!