### PR TITLE
Adding link to newly created Colab for this quickstart DOCS-1791

### DIFF
--- a/models/quickstart.mdx
+++ b/models/quickstart.mdx
@@ -4,6 +4,8 @@ title: W&B Quickstart
 ---
 
 import ApiKeyCreate from "/snippets/en/_includes/api-key-create.mdx";
+import { ColabLink } from '/snippets/en/_includes/colab-link.mdx';
+import { GitHubLink } from '/snippets/en/_includes/github-source-link.mdx';
 
 Install W&B to track, visualize, and manage machine learning experiments of any size.
 
@@ -16,6 +18,13 @@ Are you looking for information on W&B Weave? See the [Weave Python SDK quicksta
 To authenticate your machine with W&B, you need an API key.
 
 <ApiKeyCreate/>
+
+This quickstart is also available as a Colab notebook:
+
+<div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+<ColabLink url="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/run_quickstart.ipynb" />
+<GitHubLink url="https://github.com/wandb/examples/blob/master/colabs/intro/run_quickstart.ipynb" />
+</div>
 
 ## Install the `wandb` library and log in
 


### PR DESCRIPTION
## Description

This Colab was created during the last bug bash - but it took a long time to get it approved for that repo.

Now completing the doc change to link out to the Colab - followed an example I found in weave to use buttons.

For example:
## Testing
- [ x] Local build succeeds without errors (`mint dev`)
- [ x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed



## Related issues

- Fixes DOCS-1791

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/wb-21fd5541/wb-21fd5541/editor/add-colab-docs-1791?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->