### PR TITLE
Fix the spec the Service API tooling downloads

### DIFF
--- a/.github/workflows/update-service-api.yml
+++ b/.github/workflows/update-service-api.yml
@@ -84,7 +84,7 @@ jobs:
           This PR updates the Service API documentation based on the latest OpenAPI specification.
           
           **Generated on**: ${{ steps.timestamp.outputs.timestamp }}
-          **OpenAPI spec source**: https://trace.wandb.ai/openapi.json
+          **OpenAPI spec source**: https://api.inference.wandb.ai/v1/openapi.json
           
           ### Changes
           - Synced latest OpenAPI specification from the Weave service

--- a/scripts/reference-generation/weave/README.md
+++ b/scripts/reference-generation/weave/README.md
@@ -21,7 +21,7 @@ The system generates three types of documentation:
 These scripts are intended for development/CI use only, not production environments:
 
 1. **Python Dependencies**: We use minimal dependencies (`requests` and `lazydocs`) with pinned versions
-2. **Network Access**: Scripts download from trusted sources (pypi.org, npm registry, trace.wandb.ai)
+2. **Network Access**: Scripts download from trusted sources (pypi.org, npm registry, api.inference.wandb.ai, trace.wandb.ai)
 3. **File System**: Scripts write only to the local `weave/` directory structure
 4. **No Sensitive Data**: Scripts don't handle authentication or sensitive information
 
@@ -163,7 +163,7 @@ Then navigate to the reference documentation sections to verify the output.
 The Service API documentation uses a multi-step process:
 
 1. **`sync_openapi_spec.py`**:
-   - Downloads the latest OpenAPI spec from https://trace.wandb.ai/openapi.json
+   - Downloads the latest OpenAPI spec (GitHub first, then https://api.inference.wandb.ai/v1/openapi.json)
    - Compares with local copy to detect changes
    - Saves to `weave/reference/service-api/openapi.json`
    - Can switch between local and remote spec in docs.json

--- a/scripts/reference-generation/weave/sync_openapi_spec.py
+++ b/scripts/reference-generation/weave/sync_openapi_spec.py
@@ -18,17 +18,21 @@ import sys
 from typing import Optional, Tuple
 
 # Remote OpenAPI spec URL
+# We fetch the spec from the Inference API (api.inference.wandb.ai/v1) so that the full
+# Inference APIs are included (e.g. OpenRouter models), instead of the filtered set
+# exposed via trace.wandb.ai/inference/v1.
 # Primary: GitHub raw URL (if available in wandb/core repo - more stable, version-controlled)
-# Fallback: Live service URL (may change frequently)
+# Fallback: Live Inference API URL
 GITHUB_SPEC_URL = "https://raw.githubusercontent.com/wandb/core/master/services/weave-trace/openapi.json"
-LIVE_SPEC_URL = "https://trace.wandb.ai/openapi.json"
+LIVE_SPEC_URL = "https://api.inference.wandb.ai/v1/openapi.json"
 REMOTE_SPEC_URL = GITHUB_SPEC_URL  # Try GitHub first, fallback to live service in fetch_remote_spec
 
 
-def fetch_remote_spec(url: str = None) -> dict:
+def fetch_remote_spec(url: str = None) -> Optional[dict]:
     """Fetch the OpenAPI spec from the remote service.
     
-    Tries GitHub first (more stable), falls back to live service if GitHub fails.
+    Tries GitHub first (more stable), falls back to live Inference API
+    (api.inference.wandb.ai/v1) if GitHub fails.
     For private repos, uses GITHUB_TOKEN or GITHUB_PAT from environment if available.
     """
     if url is None:
@@ -47,11 +51,12 @@ def fetch_remote_spec(url: str = None) -> dict:
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
-            if response.status_code == 404 and not github_token:
-                print(f"  ⚠ GitHub spec not available (404 - may require authentication for private repo): {e}")
+            err_msg = str(e)
+            if not github_token and "404" in err_msg:
+                print(f"  GitHub spec not available (404 - may require authentication for private repo): {e}")
             else:
-                print(f"  ⚠ GitHub spec not available: {e}")
-            print(f"  Falling back to live service: {LIVE_SPEC_URL}...")
+                print(f"  GitHub spec not available: {e}")
+            print(f"  Falling back to Inference API: {LIVE_SPEC_URL}...")
             url = LIVE_SPEC_URL
     
     print(f"  Fetching remote spec from {url}...")
@@ -60,7 +65,7 @@ def fetch_remote_spec(url: str = None) -> dict:
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e:
-        print(f"  ✗ Failed to fetch remote spec: {e}")
+        print(f"  Failed to fetch remote spec: {e}")
         return None
 
 

--- a/scripts/reference-generation/weave/update_service_api_landing.py
+++ b/scripts/reference-generation/weave/update_service_api_landing.py
@@ -22,9 +22,10 @@ def fetch_openapi_spec() -> dict:
         with open(local_spec, 'r') as f:
             return json.load(f)
     
-    # Fallback to remote
-    print("  Fetching remote OpenAPI spec from https://trace.wandb.ai/openapi.json")
-    response = requests.get("https://trace.wandb.ai/openapi.json")
+    # Fallback to remote (Inference API)
+    fallback_url = "https://api.inference.wandb.ai/v1/openapi.json"
+    print(f"  Fetching remote OpenAPI spec from {fallback_url}")
+    response = requests.get(fallback_url)
     response.raise_for_status()
     return response.json()
 

--- a/weave/reference/service-api/openapi.json
+++ b/weave/reference/service-api/openapi.json
@@ -1937,6 +1937,117 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "Annotation Queues"
+        ],
+        "summary": "Annotation Queue Delete",
+        "description": "Delete (soft-delete) an annotation queue.",
+        "operationId": "annotation_queue_delete_annotation_queues__queue_id__delete",
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Annotation Queues"
+        ],
+        "summary": "Annotation Queue Update",
+        "description": "Update an annotation queue's metadata (name, description, scorer_refs).",
+        "operationId": "annotation_queue_update_annotation_queues__queue_id__put",
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueUpdateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/annotation_queues/{queue_id}/items": {
@@ -5225,6 +5336,19 @@
         "title": "AnnotationQueueCreateRes",
         "description": "Response from creating an annotation queue."
       },
+      "AnnotationQueueDeleteRes": {
+        "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/AnnotationQueueSchema"
+          }
+        },
+        "type": "object",
+        "required": [
+          "queue"
+        ],
+        "title": "AnnotationQueueDeleteRes",
+        "description": "Response from deleting an annotation queue."
+      },
       "AnnotationQueueItemProgressUpdateBody": {
         "properties": {
           "project_id": {
@@ -5689,6 +5813,85 @@
         ],
         "title": "AnnotationQueueStatsSchema",
         "description": "Statistics for a single annotation queue."
+      },
+      "AnnotationQueueUpdateBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": [
+              "entity/project"
+            ]
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "examples": [
+              "Updated Queue Name"
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "examples": [
+              "Updated description"
+            ]
+          },
+          "scorer_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorer Refs",
+            "examples": [
+              [
+                "weave:///entity/project/scorer/error_severity:abc123",
+                "weave:///entity/project/scorer/resolution_quality:def456"
+              ]
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "project_id"
+        ],
+        "title": "AnnotationQueueUpdateBody",
+        "description": "Request body for updating an annotation queue (queue_id comes from path).\n\nAll fields except project_id are optional - only provided fields will be updated."
+      },
+      "AnnotationQueueUpdateRes": {
+        "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/AnnotationQueueSchema"
+          }
+        },
+        "type": "object",
+        "required": [
+          "queue"
+        ],
+        "title": "AnnotationQueueUpdateRes",
+        "description": "Response from updating an annotation queue."
       },
       "AnnotationQueuesQueryReq": {
         "properties": {
@@ -7021,6 +7224,13 @@
             },
             "type": "object",
             "title": "Call Usage"
+          },
+          "unfinished_call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Unfinished Call Ids"
           }
         },
         "type": "object",
@@ -7345,6 +7555,18 @@
             ],
             "title": "Template Vars",
             "description": "Dictionary of template variables to substitute in prompt messages. Variables in messages like '{variable_name}' will be replaced with the corresponding values. Applied to both prompt messages (if prompt is provided) and regular messages."
+          },
+          "vertex_credentials": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vertex Credentials",
+            "description": "JSON string of Vertex AI service account credentials. When provided for vertex_ai models (e.g. vertex_ai/gemini-2.5-pro), used for authentication instead of api_key. Not persisted in trace storage."
           }
         },
         "type": "object",
@@ -11631,6 +11853,18 @@
             },
             "type": "array",
             "title": "Datacenters"
+          },
+          "deprecation_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deprecation Date",
+            "description": "Date when the model is deprecated (YYYY-MM-DD). Omitted from output if not set."
           }
         },
         "type": "object",
@@ -12874,6 +13108,13 @@
             },
             "type": "object",
             "title": "Call Usage"
+          },
+          "unfinished_call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Unfinished Call Ids"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Description
- Update the tooling for the service API to fetch the spec from https://api.inference.wandb.ai/v1/ instead of https://trace.wandb.ai/inference/v1/
- Use the tooling to fetch the spec

Ref: [Slack thread](https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1772479371731189)

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
