### PR TITLE
docs: Update from DocEngine PR 25

### DIFF
--- a/models/support.mdx
+++ b/models/support.mdx
@@ -306,7 +306,7 @@ For more information on `wandb.init()`, see the [`wandb.init()` reference](/mode
 <Update tags={["Security"]}>
 <Accordion title="Do you have a bug bounty program?">
 
-Weights and Biases has a bug bounty program. Access the [W&B security portal](https://wandb.ai/site/security/) for details.
+Weights and Biases has a bug bounty program. Access the [W&B security portal](https://security.wandb.ai/) for details.
 </Accordion>
 </Update>
 
@@ -1410,7 +1410,7 @@ unable to execute 'gcc': No such file or directory
 error: command 'gcc' failed with exit status 1
 ```
 
-Install `psutil` directly from a pre-built wheel. Determine your Python version and operating system at [https://pywharf.github.io/pywharf-pkg-repo/psutil/](https://pywharf.github.io/pywharf-pkg-repo/psutil/).
+Install `psutil` directly from a pre-built wheel. Determine your Python version and operating system at [https://pywharf.github.io/pywharf-pkg-repo/psutil](https://pywharf.github.io/pywharf-pkg-repo/psutil).
 
 For example, to install `psutil` on Python 3.8 in Linux:
 


### PR DESCRIPTION
This PR implements the MDX page updates caused by [DocEngine PR 25](https://github.com/coreweave/docengine/pull/25).

---
**Source PR (DocEngine)**
**Title**: feat: Allow DocEngine to use any preferred terminal

**Description**:

## Summary

Replace the hardcoded iTerm2 path check in `_launch_terminal_with_command()` with `$TERM_PROGRAM`-based terminal detection and per-terminal dispatch so the Mintlify preview (and other `terminal_command` post-build steps) open in the user's preferred terminal without unnecessary security prompts where possible.

- **Terminal.app** and **iTerm2**: AppleScript (`do script` / `write text`) — no file, no prompt.
- **Ghostty**: `open -na Ghostty --args -e bash -l -c "..."` — no file, no prompt.
- **Warp** and **Hyper**: `.command` temp file (no AppleScript dictionary or `-e` equivalent; a one-time security prompt may appear).
- **Unrecognized** or unset `$TERM_PROGRAM` (WezTerm, kitty, Alacritty, VS Code integrated terminal, etc.): fall back to Terminal.app via AppleScript.

## Changes

- **app/server.py**: Refactor `_launch_terminal_with_command()` to read `$TERM_PROGRAM`, then dispatch to AppleScript (Terminal.app / iTerm2), Ghostty CLI, or a temp `.command` file (Warp/Hyper). Add `stat` and `tempfile` imports.
- **docs/USER_GUIDE.md**: Update the post-build steps table and troubleshooting row to describe terminal detection and the Warp/Hyper security prompt.

## Testing

- [x] Launch DocEngine from Ghostty; run a `terminal_command` post-build step — opens in Ghostty with no security prompt.
- [x] Launch from Terminal.app — opens in Terminal.app.
- [x] Launch from iTerm2 — opens in a new iTerm2 window.
- [x] Launch from VS Code integrated terminal — falls back to Terminal.app.
- [x] Confirm USER_GUIDE post-build and troubleshooting text is accurate.

---

**Workflow run**: Run number 36 — [View build](https://github.com/coreweave/docengine/actions/runs/22641196676)
**Branch**: `ab2f2cc3167a2ecfaa22961344fbc0b0e5f4609d` — [View branch](https://github.com/coreweave/docengine/tree/ab2f2cc3167a2ecfaa22961344fbc0b0e5f4609d)

This PR contains **auto-generated** updates from DocEngine.

**Source**: `coreweave/docengine` @ `ab2f2cc3167a2ecfaa22961344fbc0b0e5f4609d`
**Trigger**: push | **Site**: `wandb-docs`

> [!IMPORTANT]
> Please review before merging. Do not assume it is safe!