### PR TITLE
Remove the huggingface integration guide link from the huggingface integration guide

### DIFF
--- a/models/integrations/huggingface.mdx
+++ b/models/integrations/huggingface.mdx
@@ -117,5 +117,4 @@ W&B saves a new run for each experiment. Here's the information that gets saved 
 - **System Metrics**: GPU and CPU utilization, memory, temperature etc.
 
 ## Learn more
-- [Hugging Face integration guide](/models/integrations/huggingface)
 - [Video walkthroughs on YouTube](http://wandb.me/youtube)


### PR DESCRIPTION
## Description

The huggingface integration guide contains a link to itself. This PR removes that link.
