### PR TITLE
docs: Update from DocEngine PR 30

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -740,7 +740,6 @@
                       },
                       "weave/guides/tracking/trace-disable",
                       "weave/guides/tracking/costs",
-
                       "weave/guides/tools/saved-views",
                       "weave/guides/tools/comparison",
                       "weave/guides/tracking/trace-plots",


### PR DESCRIPTION
This PR implements the MDX page updates caused by [DocEngine PR 30](https://github.com/coreweave/docengine/pull/30).

> [!IMPORTANT]
> Please review before merging. Do not assume it is safe!
---
**Source PR (DocEngine)**
**Title**: feat: Replace terminal launching with in-process subprocess streaming

**Description**:

- Replace the macOS terminal-launching approach (AppleScript, Ghostty CLI, .command files) with in-process async subprocess management that streams output directly into the web UI
- Add ProcessManager (app/core/process_manager.py) for async subprocess lifecycle: start, stream stdout/stderr, stop gracefully, kill stale processes, and track exit codes
- Unify the UI pattern for both "Build a preview" (Step 1) and post-build steps terminal_command type) — same layout order (title → description → button → status → logfile), same color coding (green for success, red for error)
- Detect errors via non-zero exit codes; suppress post-build steps when the build itself fails
- Auto-detect and display localhost preview URLs as clickable links (new tab)
- Delete _launch_terminal_with_command (65 lines of per-terminal macOS detection logic) and remove unused tempfile/stat imports
- Add mint validate post-build step to registry.yaml
- Move PROCESS_MANAGER_PLAN.md from future-plans/ to implemented-plans/ and update CLAUDE.md, ARCHITECTURE.md, and USER_GUIDE.md to match

### Why

The previous approach opened external terminal windows via AppleScript or .command files, which triggered macOS Gatekeeper security prompts, required fragile per-terminal detection (iTerm, Ghostty, Terminal.app, Warp, Hyper), and gave users no visibility into command output from within the dashboard. Running subprocesses in-process eliminates all of these issues.

### Test plan

- [x] docengine build --site coreweave-public from CLI still works (sanity check)
- [x] Web dashboard: build a site → status shows spinner then green success, logfile is expandable
- [x] Web dashboard: introduce a build error → red error status, post-build steps not shown
- [x] Click Start on "Preview with Mintlify" → output streams, preview URL appears as clickable link
- [x] Click Stop → process terminates, status updates
- [x] Click Start on "Validate with Mintlify" → errors shown in red with "expand logfile" message
- [x] "Reload app" while a process is running → no orphan processes
- [x] open_vscode button still works
- [x] pytest tests/ -v — 29 tests pass

### Result

I have run the full test plan and all test are passing.

---

**Workflow run**: Run number 40 — [View build](https://github.com/coreweave/docengine/actions/runs/22688800330)
**Branch**: `75de6798b0752e32c13054cc7126c6654511bda5` — [View branch](https://github.com/coreweave/docengine/tree/75de6798b0752e32c13054cc7126c6654511bda5)

This PR contains **auto-generated** updates from DocEngine.

**Source**: `coreweave/docengine` @ `75de6798b0752e32c13054cc7126c6654511bda5`
**Trigger**: push | **Site**: `wandb-docs`