### PR TITLE
Release notes for Server v0.78.1

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -16,6 +16,3 @@ runbooks/
 /package-lock.json
 /LICENSE
 /THIRD-PARTY-NOTICES.txt
-
-# exclude cursor:// protocol links from the internal link checker
-cursor://*

--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -13,9 +13,9 @@ This page includes release notes for supported releases of W&B Server.
 
 <Update label="v0.78.1" description="March 5, 2026">
 ## Fixes
-- Performance improvements and bug fixes for history reads from Parquet.
 - Fixed a bug where forking from a parent run that logged no data could fail.
 - Fixed a UI bug where the user's preference for light or dark mode was not used.
+- Performance improvements and bug fixes for history reads from Parquet.
 </Update>
 
 <Update label="v0.78.0" description="March 3, 2026">

--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -11,6 +11,13 @@ This page includes release notes for supported releases of W&B Server.
 
 <EolReminder/>
 
+<Update label="v0.78.1" description="March 5, 2026">
+## Fixes
+- Performance improvements and bug fixes for history reads from Parquet.
+- Fixed a bug where forking from a parent run that logged no data could fail.
+- Fixed a UI bug where the user's preference for light or dark mode was not used.
+</Update>
+
 <Update label="v0.78.0" description="March 3, 2026">
 
 W&B Server 0.78.0 strengthens security and access defaults, adds tools to compare experiments and control costs more efficiently, and more. For example:


### PR DESCRIPTION
## Description

Release notes for v0.78.1. All of these are high-pri customer-reported fixes.
Fixes DOCS-1957

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
