### PR TITLE
[DOCS-1870] Document keyboard shortcuts to minimize/restore the Runs selector

### DIFF
--- a/models/app/features/panels.mdx
+++ b/models/app/features/panels.mdx
@@ -63,7 +63,11 @@ To view a panel in full-screen mode:
     </Frame>
 1. When you [share the panel](#share-a-panel) while viewing it in full-screen mode, the resulting link opens in full-screen mode automatically.
 
-To get back to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page. To navigate through a section's panels without exiting full-screen mode, use either the **Previous** and **Next** buttons below the panel or the left and right arrow keys.
+- To get back to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page.
+- To navigate through a section's panels without exiting full-screen mode, use either the **Previous** and **Next** buttons below the panel or the left and right arrow keys.
+- To reclaim more space for the panel, minimize the run selector with **Cmd+.** (macOS) or **Ctrl+.** (Windows/Linux).
+
+See [Keyboard shortcuts](/models/app/keyboard-shortcuts) for details.
 
 ## Add panels
 

--- a/models/app/keyboard-shortcuts.mdx
+++ b/models/app/keyboard-shortcuts.mdx
@@ -25,6 +25,7 @@ These keyboard shortcuts work in the W&B App.
 |----------|-------------|
 | **Tab** | Navigate between interactive elements. |
 | **Cmd+J** (macOS) / **Ctrl+J** (Windows/Linux) | Switch between the Workspaces and Runs tabs in the project sidebar. |
+| **Cmd+.** (macOS) / **Ctrl+.** (Windows/Linux) | Minimize or restore the Runs selector sidebar to reclaim screen space. |
 | **Cmd+K** (macOS) / **Ctrl+K** (Windows/Linux) | Open the quick search dialog to search across projects, runs, and other resources. |
 | **Esc** | Throughout the W&B App, exit full-screen panel views, close settings drawers, dismiss the quick search dialog, close an editor, or dismiss other overlays. |
 
@@ -47,9 +48,9 @@ These keyboard shortcuts work in the W&B App.
 
 ## Notes
 
-- Most keyboard shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux
+- Most keyboard shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux.
 - The W&B App implements custom handling for some browser default shortcuts.
-- Some shortcuts are context-sensitive and only work in specific areas of the application
+- Some shortcuts are context-sensitive and only work in specific areas of the application.
 
 </Tab>
 <Tab title="LEET">

--- a/models/track/project-page.mdx
+++ b/models/track/project-page.mdx
@@ -72,6 +72,7 @@ A project's *workspace* gives you a personal sandbox to compare experiments. Use
 * **Group**: select a config column to dynamically group your runs, for example by architecture. Grouping makes plots show up with a line along the mean value, and a shaded region for the variance of points on the graph.
 * **Sort**: pick a value to sort your runs by, for example runs with the lowest loss or highest accuracy. Sorting will affect which runs show up on the graphs.
 * **Expand button**: expand the sidebar into the full table
+* **Minimize**: press **Cmd+.** (macOS) or **Ctrl+.** (Windows/Linux) to collapse or restore the Runs selector. See [Keyboard shortcuts](/models/app/keyboard-shortcuts) for details.
 * **Run count**: the number in parentheses at the top is the total number of runs in the project. The number (N visualized) is the number of runs that have the eye turned on and are available to be visualized in each plot. In the example below, the graphs are only showing the first 10 of 183 runs. Edit a graph to increase the max number of runs visible.
 
 If you pin, hide, or change the order of columns in the [Runs tab](#runs-tab), the Runs sidebar reflects these customizations.


### PR DESCRIPTION
## Description
[DOCS-1870] Document keyboard shortcuts to minimize/restore the Runs selector

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed


[DOCS-1870]: https://wandb.atlassian.net/browse/DOCS-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ