### PR TITLE
Exclude winogrande.allenai.org from link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -78,6 +78,7 @@ exclude = [
   '(http|https)://dspy-docs\.vercel\.app',
   # W&B Inference API base URL - returns 400 for GET without auth (expected)
   'https://api\.inference\.wandb\.ai/v1',
+  '(http|https)://winogrande\.allenai\.org',
   # WMDP site - connection closed / blocks crawlers
   '(http|https)://www\.wmdp\.ai',
   # YouTube embed URLs - often return 404/403 to crawlers but work in browser


### PR DESCRIPTION
## Description
Exclude winogrande.allenai.org from link checker

It blocks crawling and is coming up as a false positive

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
