### PR TITLE
Imgur redirect fixes

### DIFF
--- a/weave/cookbooks/source/Intro_to_Weave_Hello_Eval.ipynb
+++ b/weave/cookbooks/source/Intro_to_Weave_Hello_Eval.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Introduction to Evaluations\n",
         "\n",
-        "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        "<img src=\"https://cdn.prod.website-files.com/62ba1fb86485b6d5029975c4/69b1b3d9c77f6e5294374be1_Endorsed_primary_goldblack.png\" width=\"400\" alt=\"Weights & Biases\" />\n",
         "\n",
         "Weave is a toolkit for developing AI-powered applications.\n",
         "\n",

--- a/weave/cookbooks/source/Intro_to_Weave_Hello_Trace.ipynb
+++ b/weave/cookbooks/source/Intro_to_Weave_Hello_Trace.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Introduction to Traces\n",
         "\n",
-        "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        "<img src=\"https://cdn.prod.website-files.com/62ba1fb86485b6d5029975c4/69b1b3d9c77f6e5294374be1_Endorsed_primary_goldblack.png\" width=\"400\" alt=\"Weights & Biases\" />\n",
         "\n",
         "Weave is a toolkit for developing AI-powered applications.\n",
         "\n",


### PR DESCRIPTION
## Description
Resolves [DOCS-1953](https://wandb.atlassian.net/browse/DOCS-1953). Fixes weird Imgur logo redirects in a couple of Weave cookbooks.


[DOCS-1953]: https://wandb.atlassian.net/browse/DOCS-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ