### PR TITLE
[Weave] Tracing ToC changes DOCS 1972

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -723,11 +723,12 @@
                           "weave/guides/tracking/tracing",
                           "weave/guides/tracking/create-call",
                           "weave/guides/tracking/trace-tree",
+                          "weave/guides/tools/comparison",
                           "weave/guides/tracking/querying-calls"
                         ]
                       },
                       {
-                        "group": "Advanced tracing",
+                        "group": "Advanced Ops",
                         "pages": [
                           "weave/guides/tracking/trace-generator-func",
                           "weave/tutorial-tracing_2",
@@ -735,7 +736,8 @@
                           "weave/guides/tracking/ops",
                           "weave/guides/tools/attributes",
                           "weave/guides/core-types/media",
-                          "weave/guides/tracking/view-call"
+                          "weave/guides/tracking/view-call",
+                          "weave/guides/tracking/trace-disable"
                         ]
                       },
                       {
@@ -747,12 +749,11 @@
                           "weave/guides/tracking/set-call-display"
                         ]
                       },
-                      "weave/guides/tracking/trace-disable",
+
                       "weave/guides/tracking/costs",
                       "weave/guides/tools/saved-views",
-                      "weave/guides/tools/comparison",
+
                       "weave/guides/tracking/trace-plots",
-                      "weave/guides/tools/attributes",
                       "weave/guides/tracking/trace-to-run",
                       "weave/guides/tools/weave-in-workspaces"
                     ]

--- a/weave/guides/tracking/costs.mdx
+++ b/weave/guides/tracking/costs.mdx
@@ -1,7 +1,10 @@
 ---
-title: "Track costs"
+title: "Track custom costs"
 description: "Track and manage costs for LLM operations in Weave"
 ---
+W&B Weave automatically calculates the cost of each LLM call by tracking token usage and applying the pricing for the model used, allowing you to monitor and analyze application spend directly in your traces and evaluations.
+
+You can also track custom costs when you need different pricing, internal cost models, or costs for operations that Weave does not price automatically.
 
 ## Adding a custom cost
 

--- a/weave/guides/tracking/trace-tree.mdx
+++ b/weave/guides/tracking/trace-tree.mdx
@@ -18,7 +18,7 @@ To enter the Trace view:
 
 The Traces page is composed of three core panels:
 
-- **Left panel**: A sortable, paginated list of all trace runs for the project.
+- **Left panel**: A sortable, paginated list of all traces for the project.
   - This traces table includes additional data such as tokens, cost, and latency.
 - **Center panel**: Interactive trace view for a selected trace. The trace tree shows a hierarchy of all the methods tracked within the trace. 
   - The trace tree displays [ops](/weave/guides/tracking/ops#automatically-track-function-calls-using-ops), which are `@weave.op()`-decorated functions, that were called during the trace. 


### PR DESCRIPTION
## Description
Obtained follow-up feedback from Scott on the huge Basics page reordering.  some addressed in other tickets. this ticket addresses:
 

-remove duplicate ‘define and log attributes’
-move ‘disable trace’ to advanced
-change track costs title to track custom costs and add an introductory clause to explain that Weave automatically tracks costs.
-move Compare traces to Basics. 
-clean up sloppy ‘trace runs’ language on trace tree page.
-'Advanced tracing' renamed to ‘Advanced Ops’ to better declare it a bucket for specifically Op-related things, not anything advanced regarding tracing in general.  it already has 7 pages under it.  I don’t personally feel that just because we can organize ‘some’ things two levels deep doesn’t mean we have to organize ‘everything’ two levels deep.

## Testing
- [x ] Local build succeeds without errors (`mint dev`)
- [x ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed



## Related issues

- Fixes DOCS-1972
