### PR TITLE
DOCS-1982 Update .mintignore to stop excluding .js and .css files

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -7,8 +7,9 @@ scripts/
 runbooks/
 
 # Top-level config and assets (not doc pages)
-/*.js
-/*.css
+# Note: Do not exclude .js or .css. Mintlify loads
+# these automatically if present in the content root.
+
 /*.yaml
 /*.toml
 /*.txt


### PR DESCRIPTION
## Description

Update .mintignore to stop excluding .js and .css files

Remove exclusion for .js and .css files in .mintignore to turn on the default behavior where Mintlify loads .js and .css files present in the site root automatically

Fixes DOCS-1982

## Testing
- [x] David confirms in local build
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

