### PR TITLE
Add redirect to cover /guides/hosting/setup/configuration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3655,6 +3655,10 @@
       "destination": "/models/:slug*"
     },
     {
+      "source": "/guides/hosting/setup/configuration",
+      "destination": "/platform/hosting/self-managed/requirements"
+    },
+    {
       "source": "/guides/hosting/:slug*",
       "destination": "/platform/hosting/:slug*"
     },


### PR DESCRIPTION
## Description
Add redirect to cover /guides/hosting/setup/configuration

This was broken well before our transition from Hugo to Mintlify, but the Wayback Machine never cached it so this is a best guess based on the docs on licensing.

Resolves DOCS-1983

## Testing
- [x] Redirect works locally
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
