### PR TITLE
Add .github and node_modules to .mintignore DOCS-1984

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -5,6 +5,8 @@
 # Repo and ops directories (not part of published docs)
 scripts/
 runbooks/
+node_modules/
+.github/
 
 # Top-level config and assets (not doc pages)
 # Note: Do not exclude .js or .css. Mintlify loads


### PR DESCRIPTION
## Description

Add .github and node_modules to .mintignore

See https://weightsandbiases.slack.com/archives/C092DCL5WGJ/p1773703227798779?thread_ts=1773693254.342689&cid=C092DCL5WGJ

Fixes DOCS-1984


## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

