### PR TITLE
docs: Update from DocEngine PR 53

### DIFF
--- a/support/inference/articles/api-error-code-401-authentication-failed.mdx
+++ b/support/inference/articles/api-error-code-401-authentication-failed.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 401 error with the message "Authentication failed" means your authentication credentials are incorrect or your W&B project entity and/or name are incorrect.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-402-you-exceeded-your-cur.mdx
+++ b/support/inference/articles/api-error-code-402-you-exceeded-your-cur.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 402 error with the message "You exceeded your current quota, please check your plan and billing details" means you've run out of credits or reached your monthly spending cap.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-403-country-region-or-ter.mdx
+++ b/support/inference/articles/api-error-code-403-country-region-or-ter.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 403 error with the message "Country, region, or territory not supported" means you're accessing W&B Inference from an unsupported location.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-403-the-inference-gateway.mdx
+++ b/support/inference/articles/api-error-code-403-the-inference-gateway.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 403 error with the message "The inference gateway is not enabled for your organization" means your organization doesn't have the inference gateway enabled, which is required to use W&B Inference.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-429-concurrency-limit-rea.mdx
+++ b/support/inference/articles/api-error-code-429-concurrency-limit-rea.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 429 error with the message "Concurrency limit reached for requests" means you're sending too many concurrent requests to the W&B Inference API.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-500-the-server-had-an-err.mdx
+++ b/support/inference/articles/api-error-code-500-the-server-had-an-err.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 500 error with the message "The server had an error while processing your request" indicates an internal server error on the W&B Inference side.
 
 ## Why this happens

--- a/support/inference/articles/api-error-code-503-the-engine-is-current.mdx
+++ b/support/inference/articles/api-error-code-503-the-engine-is-current.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 503 error with the message "The engine is currently overloaded, please try again later" means the W&B Inference server is experiencing high traffic and cannot process your request right now.
 
 ## Why this happens

--- a/support/inference/index.mdx
+++ b/support/inference/index.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_product_index.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index"  horizontal />
-
 ## Browse by category
 
 <Card title="Administrator" href="/support/inference/tags/administrator" arrow="true">

--- a/support/inference/tags/administrator.mdx
+++ b/support/inference/tags/administrator.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="API error code 403 - The inference gateway is not enabled for your organization" href="/support/inference/articles/api-error-code-403-the-inference-gateway" arrow="true" horizontal>
   A 403 error with the message "The inference gateway is not e ...
 </Card>

--- a/support/inference/tags/authentication-access.mdx
+++ b/support/inference/tags/authentication-access.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="API error code 401 - Authentication failed" href="/support/inference/articles/api-error-code-401-authentication-failed" arrow="true" horizontal>
   A 401 error with the message "Authentication failed" means y ...
 </Card>

--- a/support/inference/tags/billing.mdx
+++ b/support/inference/tags/billing.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>
   A 402 error with the message "You exceeded your current quot ...
 </Card>

--- a/support/inference/tags/quotas-rate-limits.mdx
+++ b/support/inference/tags/quotas-rate-limits.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>
   A 402 error with the message "You exceeded your current quot ...
 </Card>

--- a/support/inference/tags/server-errors.mdx
+++ b/support/inference/tags/server-errors.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="API error code 500 - The server had an error while processing your request" href="/support/inference/articles/api-error-code-500-the-server-had-an-err" arrow="true" horizontal>
   A 500 error with the message "The server had an error while  ...
 </Card>

--- a/support/models/articles/adding-multiple-authors-to-a-report.mdx
+++ b/support/models/articles/adding-multiple-authors-to-a-report.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Accurately credit all contributors in your report by adding multiple authors.
 
 To add multiple authors, click on the **+** icon next to the name of the author. This will open a drop-down menu with all the users who have access to the report. Select the users you want to add as authors.

--- a/support/models/articles/best-practices-to-organize-hyperparamete.mdx
+++ b/support/models/articles/best-practices-to-organize-hyperparamete.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Set unique tags with `wandb.init(tags='your_tag')`. This allows efficient filtering of project runs by selecting the corresponding tag in a Project Page's Runs Table. 
 
 For more information on `wandb.init()`, see the [`wandb.init()` reference](/models/ref/python/functions/init).

--- a/support/models/articles/can-i-get-an-academic-plan-as-a-student.mdx
+++ b/support/models/articles/can-i-get-an-academic-plan-as-a-student.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Students can apply for an academic plan by following these steps:
 
 - Visit [the Pricing page on the wandb.com](https://wandb.ai/site/pricing).

--- a/support/models/articles/can-i-group-runs-without-using-the-group.mdx
+++ b/support/models/articles/can-i-group-runs-without-using-the-group.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Yes, you can also use tags or custom metadata to categorize runs. That can be done using the `Group` button which is available in the Workspace and Runs views of the project.
 
 ---

--- a/support/models/articles/can-i-just-log-metrics-no-code-or-datase.mdx
+++ b/support/models/articles/can-i-just-log-metrics-no-code-or-datase.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 By default, W&B does not log dataset examples. By default, W&B logs code and system metrics.
 
 Two methods exist to turn off code logging with environment variables:

--- a/support/models/articles/can-i-just-set-the-run-name-to-the-run-i.mdx
+++ b/support/models/articles/can-i-just-set-the-run-name-to-the-run-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Yes. To overwrite the run name with the run ID, use the following code snippet:
 
 ```python

--- a/support/models/articles/can-i-log-metrics-on-two-different-time-.mdx
+++ b/support/models/articles/can-i-log-metrics-on-two-different-time-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 For example, I want to log training accuracy per batch and validation accuracy per epoch.
 
 Yes, log indices like `batch` and `epoch` alongside your metrics. Use `wandb.Run.log()({'train_accuracy': 0.9, 'batch': 200})` in one step and `wandb.Run.log()({'val_accuracy': 0.8, 'epoch': 4})` in another. In the UI, set the desired value as the x-axis for each chart. To set a default x-axis for a specific index, use [Run.define_metric()](/models/ref/python/experiments/run#define_metric). For the example provided, use the following code:

--- a/support/models/articles/can-i-rerun-a-grid-search.mdx
+++ b/support/models/articles/can-i-rerun-a-grid-search.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If a grid search completes but some W&B Runs need re-execution due to crashes, delete the specific W&B Runs to re-run. Then, select the **Resume** button on the [sweep control page](/models/sweeps/sweeps-ui). Start new W&B Sweep agents using the new Sweep ID.
 
 W&B Run parameter combinations that completed are not re-executed.

--- a/support/models/articles/can-i-run-wandb-offline.mdx
+++ b/support/models/articles/can-i-run-wandb-offline.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If training occurs on an offline machine, use the following steps to upload results to the servers:
 
 1. Set the environment variable `WANDB_MODE=offline` to save metrics locally without an internet connection.

--- a/support/models/articles/can-i-turn-off-wandb-when-testing-my-cod.mdx
+++ b/support/models/articles/can-i-turn-off-wandb-when-testing-my-cod.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use `wandb.init(mode="disabled")` or set `WANDB_MODE=disabled` to configure W&B as a no-operation (NOOP) for testing purposes.
 
 <Note>

--- a/support/models/articles/can-i-use-markdown-in-my-reports.mdx
+++ b/support/models/articles/can-i-use-markdown-in-my-reports.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Yes. Type "/mark" anywhere in the document and press enter to insert a Markdown block. This allows editing with Markdown as before.
 
 ---

--- a/support/models/articles/can-i-use-sweeps-and-sagemaker.mdx
+++ b/support/models/articles/can-i-use-sweeps-and-sagemaker.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To authenticate W&B, complete the following steps: create a `requirements.txt` file if using a built-in Amazon SageMaker estimator. For details on authentication and setting up the `requirements.txt` file, refer to the [SageMaker integration](/models/integrations/sagemaker) guide.
 
 <Note>

--- a/support/models/articles/can-wb-team-members-see-my-data.mdx
+++ b/support/models/articles/can-wb-team-members-see-my-data.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Key engineers and support staff at W&B access logged values for debugging purposes with user permission. All data stores encrypt data at rest, and audit logs record access. For complete data security from W&B employees, license the Self-Managed solution to run a W&B server within your own infrastructure.
 
 ---

--- a/support/models/articles/can-we-flag-boolean-variables-as-hyperpa.mdx
+++ b/support/models/articles/can-we-flag-boolean-variables-as-hyperpa.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use the `${args_no_boolean_flags}` macro in the command section of the configuration to pass hyperparameters as boolean flags. This macro automatically includes boolean parameters as flags. If `param` is `True`, the command receives `--param`. If `param` is `False`, the flag is omitted.
 
 ---

--- a/support/models/articles/can-you-group-runs-by-tags.mdx
+++ b/support/models/articles/can-you-group-runs-by-tags.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A run can have multiple tags, so grouping by tags is not supported. Add a value to the [`config`](/models/track/config) object for these runs and group by this config value instead. This can be accomplished using [the API](/models/track/config#set-the-configuration-after-your-run-has-finished).
 
 ---

--- a/support/models/articles/can-you-use-wb-sweeps-with-cloud-infrast.mdx
+++ b/support/models/articles/can-you-use-wb-sweeps-with-cloud-infrast.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To publish the `sweep_id` so that any W&B Sweep agent can access it, implement a method for these agents to read and execute the `sweep_id`.
 
 For example, launch an Amazon EC2 instance and execute `wandb agent` on it. Use an SQS queue to broadcast the `sweep_id` to multiple EC2 instances. Each instance can then retrieve the `sweep_id` from the queue and initiate the process.

--- a/support/models/articles/do-environment-variables-overwrite-the-p.mdx
+++ b/support/models/articles/do-environment-variables-overwrite-the-p.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Arguments passed to `wandb.init` override environment variables. To set a default directory other than the system default when the environment variable isn't set, use `wandb.init(dir=os.getenv("WANDB_DIR", my_default_override))`.
 
 ---

--- a/support/models/articles/do-i-need-to-provide-values-for-all-hype.mdx
+++ b/support/models/articles/do-i-need-to-provide-values-for-all-hype.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Access hyperparameter names and values from the sweep configuration using `(run.config())`, which acts like a dictionary.
 
 For runs outside a sweep, set `wandb.Run.config()` values by passing a dictionary to the `config` argument in `wandb.init()`. In a sweep, any configuration supplied to `wandb.init()` serves as a default value, which the sweep can override.

--- a/support/models/articles/do-run-finished-alerts-work-in-notebooks.mdx
+++ b/support/models/articles/do-run-finished-alerts-work-in-notebooks.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 No. **Run Finished** alerts (activated with the **Run Finished** setting in User Settings) operate only with Python scripts and remain turned off in Jupyter Notebook environments to avoid notifications for each cell execution. 
 
 Use `run.alert()` in notebook environments instead.

--- a/support/models/articles/do-you-have-a-bug-bounty-program.mdx
+++ b/support/models/articles/do-you-have-a-bug-bounty-program.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Weights and Biases has a bug bounty program. Access the [W&B security portal](https://wandb.ai/site/security/) for details.
 
 ---

--- a/support/models/articles/does-logging-block-my-training.mdx
+++ b/support/models/articles/does-logging-block-my-training.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 "Is the logging function lazy? I don't want to depend on the network to send results to your servers while executing local operations."
 
 The `wandb.log` function writes a line to a local file and does not block network calls. When calling `wandb.init`, a new process starts on the same machine. This process listens for filesystem changes and communicates with the web service asynchronously, allowing local operations to continue uninterrupted.

--- a/support/models/articles/does-the-wb-client-support-python-2.mdx
+++ b/support/models/articles/does-the-wb-client-support-python-2.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The W&B client library supported both Python 2.7 and Python 3 through version 0.10. Support for Python 2.7 discontinued with version 0.11 due to Python 2's end of life. Running `pip install --upgrade wandb` on a Python 2.7 system installs only new releases of the 0.10.x series. Support for the 0.10.x series includes critical bug fixes and patches only. The last version of the 0.10.x series that supports Python 2.7 is 0.10.33.
 
 ---

--- a/support/models/articles/does-the-wb-client-support-python-35.mdx
+++ b/support/models/articles/does-the-wb-client-support-python-35.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The W&B client library supported Python 3.5 until version 0.11. Support for Python 3.5 ended with version 0.12, which aligns with its end of life. For more details, visit [version 0.12 release notes](https://github.com/wandb/wandb/releases/tag/v0.12.0).
 
 ---

--- a/support/models/articles/does-this-only-work-for-python.mdx
+++ b/support/models/articles/does-this-only-work-for-python.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The library supports Python 2.7 and later, as well as Python 3.6 and later. The architecture facilitates integration with other programming languages. For monitoring other languages, contact [contact@wandb.com](mailto:contact@wandb.com).
 
 ---

--- a/support/models/articles/does-wb-support-sso-for-multi-tenant.mdx
+++ b/support/models/articles/does-wb-support-sso-for-multi-tenant.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B supports Single Sign-On (SSO) for the Multi-tenant offering through Auth0. SSO integration is compatible with any OIDC-compliant identity provider, such as Okta or Azure AD. To configure an OIDC provider, follow these steps:
 
 * Create a Single Page Application (SPA) on the identity provider.

--- a/support/models/articles/does-wb-use-the-multiprocessing-library.mdx
+++ b/support/models/articles/does-wb-use-the-multiprocessing-library.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Yes, W&B uses the `multiprocessing` library. An error message like the following indicates a possible issue:
 
 ```

--- a/support/models/articles/does-your-tool-track-or-store-training-d.mdx
+++ b/support/models/articles/does-your-tool-track-or-store-training-d.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Pass a SHA or unique identifier to `wandb.Run.config.update(...)` to associate a dataset with a training run. W&B stores no data unless `wandb.Run.save()` is called with the local file name.
 
 ---

--- a/support/models/articles/embedding-reports.mdx
+++ b/support/models/articles/embedding-reports.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can share your report by embedding it. Click the **Share** button at the top right of your report, then copy the embedded code from the bottom of the pop-up window.
 
 <Frame>

--- a/support/models/articles/filter-and-delete-unwanted-reports.mdx
+++ b/support/models/articles/filter-and-delete-unwanted-reports.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use the search bar to filter the reports list. Select an unwanted report to delete it individually, or select all reports and click 'Delete Reports' to remove them from the project.
 
 <Frame>

--- a/support/models/articles/how-can-i-access-the-data-logged-to-my-r.mdx
+++ b/support/models/articles/how-can-i-access-the-data-logged-to-my-r.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The history object tracks metrics logged with `wandb.log`. Access the history object using the API:
 
 ```python

--- a/support/models/articles/how-can-i-be-removed-from-a-team.mdx
+++ b/support/models/articles/how-can-i-be-removed-from-a-team.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A team admin can [remove you from a team](/platform/app/settings-page/teams)  from the **Users** tab of the team settings.
 
 ---

--- a/support/models/articles/how-can-i-change-how-frequently-to-log-s.mdx
+++ b/support/models/articles/how-can-i-change-how-frequently-to-log-s.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To configure the frequency to log [system metrics](/models/ref/python/experiments/system-metrics), set `_stats_sampling_interval` to a number of seconds, expressed as a float. Default: `10.0`.
 
 ```python

--- a/support/models/articles/how-can-i-change-my-account-from-corpora.mdx
+++ b/support/models/articles/how-can-i-change-my-account-from-corpora.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To change an account from corporate to academic in W&B, follow these steps:
 
 1. **Link your academic email**:

--- a/support/models/articles/how-can-i-change-the-colors-of-each-run-.mdx
+++ b/support/models/articles/how-can-i-change-the-colors-of-each-run-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Changing the colors of individual runs within a group is not possible. All runs in the same group share a common color.
 
 ---

--- a/support/models/articles/how-can-i-change-the-directory-my-sweep-.mdx
+++ b/support/models/articles/how-can-i-change-the-directory-my-sweep-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Set the logging directory for W&B run data by configuring the environment variable `WANDB_DIR`. For example:
 
 ```python

--- a/support/models/articles/how-can-i-change-the-privacy-of-my-proje.mdx
+++ b/support/models/articles/how-can-i-change-the-privacy-of-my-proje.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To change a project's privacy (visibility):
 
 1. In the W&B App, from any page in the project, click **Overview** in the project sidebar.

--- a/support/models/articles/how-can-i-compare-images-or-media-across.mdx
+++ b/support/models/articles/how-can-i-compare-images-or-media-across.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Expand the image panel and use the step slider to navigate through images from different steps. This process facilitates comparison of a model's output changes during training.
 
 ---

--- a/support/models/articles/how-can-i-configure-the-name-of-the-run-.mdx
+++ b/support/models/articles/how-can-i-configure-the-name-of-the-run-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 At the beginning of the training script, call `wandb.init` with an experiment name. For example: `wandb.init(name="my_awesome_run")`.
 
 ---

--- a/support/models/articles/how-can-i-define-the-local-location-for-.mdx
+++ b/support/models/articles/how-can-i-define-the-local-location-for-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 - `WANDB_DIR=<path>` or `wandb.init(dir=<path>)`: Controls the location of the `wandb` folder created for your training script. Defaults to `./wandb`. This folder stores Run's data and logs
 - `WANDB_ARTIFACT_DIR=<path>` or `wandb.Artifact().download(root="<path>")`: Controls the location where artifacts are downloaded. Defaults to `./artifacts`
 - `WANDB_CACHE_DIR=<path>`: This is the location where artifacts are created and stored when you call `wandb.Artifact`. Defaults to `~/.cache/wandb`

--- a/support/models/articles/how-can-i-delete-multiple-runs-in-bulk-i.mdx
+++ b/support/models/articles/how-can-i-delete-multiple-runs-in-bulk-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use the [public API](/models/ref/python/public-api/api) to delete multiple runs in a single operation:
 
 ```python

--- a/support/models/articles/how-can-i-delete-my-user-account.mdx
+++ b/support/models/articles/how-can-i-delete-my-user-account.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Delete your user account by clicking **Delete account** in your [user settings](/platform/app/settings-page/user-settings#delete-your-account). Note that this action is irreversible and it takes effect immediately.
 
 ---

--- a/support/models/articles/how-can-i-disable-logging-of-system-metr.mdx
+++ b/support/models/articles/how-can-i-disable-logging-of-system-metr.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To disable logging of [system metrics](/models/ref/python/experiments/system-metrics), set `_disable_stats` to `True`:
 
 ```python

--- a/support/models/articles/how-can-i-fetch-these-version-ids-and-et.mdx
+++ b/support/models/articles/how-can-i-fetch-these-version-ids-and-et.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If an artifact reference is logged with W&B and versioning is enabled on the buckets, the version IDs appear in the Amazon S3 UI. To retrieve these version IDs and ETags in W&B, fetch the artifact and access the corresponding manifest entries. For example:
 
 ```python

--- a/support/models/articles/how-can-i-find-the-artifacts-logged-or-c.mdx
+++ b/support/models/articles/how-can-i-find-the-artifacts-logged-or-c.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B tracks artifacts logged by each run and those used by each run to construct an artifact graph. This graph is a bipartite, directed, acyclic graph with nodes representing runs and artifacts. An example can be viewed [here](https://wandb.ai/shawn/detectron2-11/artifacts/dataset/furniture-small-val/06d5ddd4deeb2a6ebdd5/graph) (click "Explode" to expand the graph).
 
 Use the Public API to navigate the graph programmatically, starting from either an artifact or a run.

--- a/support/models/articles/how-can-i-fix-an-error-like-attributeerr.mdx
+++ b/support/models/articles/how-can-i-fix-an-error-like-attributeerr.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If you encounter an error like `AttributeError: module 'wandb' has no attribute 'init'` or `AttributeError: module 'wandb' has no attribute 'login'` when importing `wandb` in Python, `wandb` is not installed or the installation is corrupted, but a `wandb` directory exists in the current working directory. To fix this error, uninstall `wandb`, delete the directory, then install `wandb`:
 
 ```bash

--- a/support/models/articles/how-can-i-log-a-metric-that-doesnt-chang.mdx
+++ b/support/models/articles/how-can-i-log-a-metric-that-doesnt-chang.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Using `run.log({'final_accuracy': 0.9})` updates the final accuracy correctly. By default, `run.log({'final_accuracy': <value>})` updates `run.settings['final_accuracy']`, which reflects the value in the runs table.
 
 ---

--- a/support/models/articles/how-can-i-log-additional-metrics-after-a.mdx
+++ b/support/models/articles/how-can-i-log-additional-metrics-after-a.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 There are several ways to manage experiments.
 
 For complex workflows, use multiple runs and set the group parameters in [`wandb.init()`](/models/track/create-an-experiment) to a unique value for all processes within a single experiment. The [**Runs** tab](/models/track/project-page#runs-tab) will group the table by group ID, ensuring that visualizations function properly. This approach enables concurrent experiments and training runs while logging results in one location.

--- a/support/models/articles/how-can-i-log-in-to-wb-server.mdx
+++ b/support/models/articles/how-can-i-log-in-to-wb-server.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Set the login URL by either of these methods:
 
 - Set the [environment variable](/models/track/environment-variables) `WANDB_BASE_URL` to the Server URL.

--- a/support/models/articles/how-can-i-organize-my-logged-charts-and-.mdx
+++ b/support/models/articles/how-can-i-organize-my-logged-charts-and-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The `/` character separates logged panels in the W&B UI. By default, the segment of the logged item's name before the `/` defines a group of panels known as a "Panel Section."
 
 ```python

--- a/support/models/articles/how-can-i-overwrite-the-logs-from-previo.mdx
+++ b/support/models/articles/how-can-i-overwrite-the-logs-from-previo.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To overwrite logs from previous steps, use [forking](/models/runs/forking) and [rewind](/models/runs/rewind).
 
 ---

--- a/support/models/articles/how-can-i-recover-deleted-runs.mdx
+++ b/support/models/articles/how-can-i-recover-deleted-runs.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To recover deleted runs, complete the following steps:
 
 - Navigate to the Project Overview page.

--- a/support/models/articles/how-can-i-regain-access-to-my-account-if.mdx
+++ b/support/models/articles/how-can-i-regain-access-to-my-account-if.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To regain access to an account when unable to receive a password reset email:
 
 1. **Check Spam or Junk Folders:** Ensure the email is not filtered there.

--- a/support/models/articles/how-can-i-remove-projects-from-a-team-sp.mdx
+++ b/support/models/articles/how-can-i-remove-projects-from-a-team-sp.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To remove projects from a team space without admin privileges, follow these options:
 
 - Request that a current admin remove the projects.

--- a/support/models/articles/how-can-i-resolve-login-issues-with-my-a.mdx
+++ b/support/models/articles/how-can-i-resolve-login-issues-with-my-a.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resolve login issues, follow these steps:
 
 - **Verify access**: Confirm you are using the correct email or username and check membership in relevant teams or projects.

--- a/support/models/articles/how-can-i-resolve-the-filestream-rate-li.mdx
+++ b/support/models/articles/how-can-i-resolve-the-filestream-rate-li.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resolve the "Filestream rate limit exceeded" error in W&B, follow these steps:
 
 **Optimize logging**:

--- a/support/models/articles/how-can-i-resume-a-sweep-using-python-co.mdx
+++ b/support/models/articles/how-can-i-resume-a-sweep-using-python-co.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resume a sweep, pass the `sweep_id` to the `wandb.agent()` function. 
 
 ```python

--- a/support/models/articles/how-can-i-rotate-or-revoke-access.mdx
+++ b/support/models/articles/how-can-i-rotate-or-revoke-access.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Personal and service account keys can be rotated or revoked. Create a new API key or service account user, then reconfigure scripts to use the new key. After reconfiguration, remove the old API key from your profile or team.
 
 ---

--- a/support/models/articles/how-can-i-save-the-git-commit-associated.mdx
+++ b/support/models/articles/how-can-i-save-the-git-commit-associated.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When `wandb.init` is invoked, the system automatically collects git information, including the remote repository link and the SHA of the latest commit. This information appears on the [run page](/models/runs/#view-logged-runs). Ensure the current working directory when executing the script is within a git-managed folder to view this information.
 
 The git commit and the command used to run the experiment remain visible to the user but are hidden from external users. In public projects, these details remain private.

--- a/support/models/articles/how-can-i-see-files-that-do-not-appear-i.mdx
+++ b/support/models/articles/how-can-i-see-files-that-do-not-appear-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The Files tab shows a maximum of 10,000 files. To download all files, use the [public API](/models/ref/python/public-api/api):
 
 ```python

--- a/support/models/articles/how-can-i-see-the-bytes-stored-bytes-tra.mdx
+++ b/support/models/articles/how-can-i-see-the-bytes-stored-bytes-tra.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 View the bytes stored, bytes tracked, and tracked hours for your organization within organization settings:
 
 1. Navigate to your organization's settings at `https://wandb.ai/account-settings/<organization-name>/settings`.

--- a/support/models/articles/how-can-i-send-run-alerts-to-microsoft-t.mdx
+++ b/support/models/articles/how-can-i-send-run-alerts-to-microsoft-t.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To receive W&B alerts in Teams, follow these steps:
 
 - **Set up an email address for your Teams channel.** Create an email address for the Teams channel where you want to receive alerts.

--- a/support/models/articles/how-can-i-use-wandb-with-multiprocessing.mdx
+++ b/support/models/articles/how-can-i-use-wandb-with-multiprocessing.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If a training program uses multiple processes, structure the program to avoid making wandb method calls from processes without `wandb.init()`. 
 
 Manage multiprocess training using these approaches:

--- a/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into.mdx
+++ b/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Direct integration of Plotly or Bokeh figures into tables is not supported. Instead, export the figures to HTML and include the HTML in the table. Below are examples demonstrating this with interactive Plotly and Bokeh charts.
 
 <Tabs>

--- a/support/models/articles/how-do-i-best-log-models-from-runs-in-a-.mdx
+++ b/support/models/articles/how-do-i-best-log-models-from-runs-in-a-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 One effective approach for logging models in a [sweep](/models/sweeps/) involves creating a model artifact for the sweep. Each version represents a different run from the sweep. Implement it as follows:
 
 ```python

--- a/support/models/articles/how-do-i-cancel-my-subscription.mdx
+++ b/support/models/articles/how-do-i-cancel-my-subscription.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 - Contact the support team (support@wandb.com).
 - Provide the organization name, email associated with the account, and username.
 

--- a/support/models/articles/how-do-i-change-my-billing-address.mdx
+++ b/support/models/articles/how-do-i-change-my-billing-address.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To change the billing address, contact the support team (support@wandb.com).
 
 ---

--- a/support/models/articles/how-do-i-deal-with-network-issues.mdx
+++ b/support/models/articles/how-do-i-deal-with-network-issues.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If you encounter SSL or network errors, such as `wandb: Network error (ConnectionError), entering retry loop`, use the following solutions:
 
 1. Upgrade the SSL certificate. On an Ubuntu server, run `update-ca-certificates`. A valid SSL certificate is essential for syncing training logs to mitigate security risks.

--- a/support/models/articles/how-do-i-delete-a-panel-grid.mdx
+++ b/support/models/articles/how-do-i-delete-a-panel-grid.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Select the panel grid and press delete or backspace. Click the drag handle in the top-right corner to select the panel grid.
 
 ---

--- a/support/models/articles/how-do-i-delete-a-team-from-my-account.mdx
+++ b/support/models/articles/how-do-i-delete-a-team-from-my-account.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To delete a team from an account:
 
 - Access team settings as an admin.

--- a/support/models/articles/how-do-i-delete-my-organization-account.mdx
+++ b/support/models/articles/how-do-i-delete-my-organization-account.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To delete an organization account, follow these steps, contact the support team (support@wandb.com).
 
 ---

--- a/support/models/articles/how-do-i-downgrade-my-subscription-plan.mdx
+++ b/support/models/articles/how-do-i-downgrade-my-subscription-plan.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To downgrade a subscription plan, contact the support team at support@wandb.com with your current plan details and the desired plan.
 
 ---

--- a/support/models/articles/how-do-i-enable-code-logging-with-sweeps.mdx
+++ b/support/models/articles/how-do-i-enable-code-logging-with-sweeps.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To enable code logging for sweeps, add `wandb.log_code()` after initializing the W&B Run. This action is necessary even when code logging is enabled in the W&B profile settings. For advanced code logging, refer to the [docs for `wandb.log_code()` here](/models/ref/python/experiments/run#log_code).
 
 ---

--- a/support/models/articles/how-do-i-export-a-list-of-users-from-my-.mdx
+++ b/support/models/articles/how-do-i-export-a-list-of-users-from-my-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To export a list of users from a W&B organization, an admin uses the SCIM API with the following code:
 
 ```python

--- a/support/models/articles/how-do-i-find-an-artifact-from-the-best-.mdx
+++ b/support/models/articles/how-do-i-find-an-artifact-from-the-best-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To retrieve artifacts from the best performing run in a sweep, use the following code:
 
 ```python

--- a/support/models/articles/how-do-i-find-my-api-key.mdx
+++ b/support/models/articles/how-do-i-find-my-api-key.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 import ApiKeyFind from "/snippets/en/_includes/api-key-find.mdx";
 
 <ApiKeyFind/>

--- a/support/models/articles/how-do-i-fix-invalid-authentication-401-.mdx
+++ b/support/models/articles/how-do-i-fix-invalid-authentication-401-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A 401 Invalid Authentication error means your API key is invalid or your W&B project entity/name is incorrect.
 
 ## Verify your API key

--- a/support/models/articles/how-do-i-fix-server-errors-500-503-with-.mdx
+++ b/support/models/articles/how-do-i-fix-server-errors-500-503-with-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Server errors indicate temporary issues with the W&B Inference service.
 
 ## Error types

--- a/support/models/articles/how-do-i-fix-the-error-resumemust-but-ru.mdx
+++ b/support/models/articles/how-do-i-fix-the-error-resumemust-but-ru.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If you encounter the error `resume='must' but run (<run_id>) doesn't exist`, the run you are attempting to resume does not exist within the project or entity. Ensure that you are logged in to the correct instance and that the project and entity are set:
 
 ```python

--- a/support/models/articles/how-do-i-fix-the-overflows-maximum-value.mdx
+++ b/support/models/articles/how-do-i-fix-the-overflows-maximum-value.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resolve this error, add `?workspace=clear` to the end of the URL and press Enter. This action directs you to a cleared version of the project page workspace.
 
 ---

--- a/support/models/articles/how-do-i-get-added-to-a-team-on-wb.mdx
+++ b/support/models/articles/how-do-i-get-added-to-a-team-on-wb.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To join a team, follow these steps:
 
 - Contact a team admin or someone with administrative privileges to request an invite.

--- a/support/models/articles/how-do-i-get-the-random-run-name-in-my-s.mdx
+++ b/support/models/articles/how-do-i-get-the-random-run-name-in-my-s.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Call a run object's `.save()` method to save the current run. Retrieve the name using the run object's `name` attribute.
 
 ---

--- a/support/models/articles/how-do-i-handle-the-failed-to-query-for-.mdx
+++ b/support/models/articles/how-do-i-handle-the-failed-to-query-for-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If you encounter the error message `"Failed to query for notebook name, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable,"` resolve it by setting the environment variable. Multiple methods accomplish this:
 
 <Tabs>

--- a/support/models/articles/how-do-i-insert-a-table.mdx
+++ b/support/models/articles/how-do-i-insert-a-table.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Tables remain the only feature from Markdown without a direct WYSIWYG equivalent. To add a table, insert a Markdown block and create the table inside it.
 
 ---

--- a/support/models/articles/how-do-i-install-the-wandb-python-librar.mdx
+++ b/support/models/articles/how-do-i-install-the-wandb-python-librar.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If an error occurs when installing `wandb` that states:
 
 ```

--- a/support/models/articles/how-do-i-kill-a-job-with-wandb.mdx
+++ b/support/models/articles/how-do-i-kill-a-job-with-wandb.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Press `Ctrl+D` on the keyboard to stop a script instrumented with W&B.
 
 ---

--- a/support/models/articles/how-do-i-launch-multiple-runs-from-one-s.mdx
+++ b/support/models/articles/how-do-i-launch-multiple-runs-from-one-s.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Finish previous runs before starting new runs to log multiple runs within
 a single script.
 

--- a/support/models/articles/how-do-i-log-a-list-of-values.mdx
+++ b/support/models/articles/how-do-i-log-a-list-of-values.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 These examples show logging losses a couple of different ways using [`wandb.Run.log()`](/models/ref/python/experiments/run/#method-runlog/).
 
 <Tabs>

--- a/support/models/articles/how-do-i-log-an-artifact-to-an-existing-.mdx
+++ b/support/models/articles/how-do-i-log-an-artifact-to-an-existing-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Occasionally, it is necessary to mark an artifact as the output of a previously logged run. In this case, reinitialize the old run and log new artifacts as follows:
 
 ```python

--- a/support/models/articles/how-do-i-log-runs-launched-by-continuous.mdx
+++ b/support/models/articles/how-do-i-log-runs-launched-by-continuous.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To launch automated tests or internal tools that log to W&B, create a **Service Account** on the team settings page. This action allows the use of a service API key for automated jobs, including those running through continuous integration. To attribute service account jobs to a specific user, set the `WANDB_USERNAME` or `WANDB_USER_EMAIL` environment variables.
 
 <Frame>

--- a/support/models/articles/how-do-i-log-to-the-right-wandb-user-on-.mdx
+++ b/support/models/articles/how-do-i-log-to-the-right-wandb-user-on-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When using a shared machine, ensure that runs log to the correct WandB account by setting the `WANDB_API_KEY` environment variable for authentication. If sourced in the environment, this variable provides the correct credentials upon login. Alternatively, set the environment variable directly in the script.
 
 Execute the command `export WANDB_API_KEY=X`, replacing X with your API key. Create an API key at [wandb.ai/settings](https://wandb.ai/settings).

--- a/support/models/articles/how-do-i-plot-multiple-lines-on-a-plot-w.mdx
+++ b/support/models/articles/how-do-i-plot-multiple-lines-on-a-plot-w.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Create a multi-line custom chart with `wandb.plot.line_series()`. Navigate to the [project page](/models/track/project-page) to view the line chart. To add a legend, include the `keys` argument in `wandb.plot.line_series()`. For example:
 
 ```python

--- a/support/models/articles/how-do-i-programmatically-access-the-hum.mdx
+++ b/support/models/articles/how-do-i-programmatically-access-the-hum.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The `.name` attribute of a [`wandb.Run`](/models/ref/python/experiments/run) is accessible as follows:
 
 ```python

--- a/support/models/articles/how-do-i-rename-a-project.mdx
+++ b/support/models/articles/how-do-i-rename-a-project.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To rename a project:
 
 - Navigate to the Project overview.

--- a/support/models/articles/how-do-i-renew-my-expired-license.mdx
+++ b/support/models/articles/how-do-i-renew-my-expired-license.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To renew an expired license, contact the support team at support@wandb.com for assistance with the renewal process and to receive a new license key.
 
 ---

--- a/support/models/articles/how-do-i-request-the-complete-deletion-o.mdx
+++ b/support/models/articles/how-do-i-request-the-complete-deletion-o.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To delete a W&B account, navigate to the **User settings** page, scroll to the bottom, and click the **Delete Account** button.
 
 ---

--- a/support/models/articles/how-do-i-resolve-a-run-initialization-ti.mdx
+++ b/support/models/articles/how-do-i-resolve-a-run-initialization-ti.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resolve a run initialization timeout error, follow these steps:
 
 - **Retry initialization**: Attempt to restart the run.

--- a/support/models/articles/how-do-i-resolve-permission-errors-when-.mdx
+++ b/support/models/articles/how-do-i-resolve-permission-errors-when-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To resolve permission errors when logging a run to a W&B entity, follow these steps:
 
 - **Verify entity and project names**: Ensure correct spelling and case sensitivity of the W&B entity and project names in your code.

--- a/support/models/articles/how-do-i-save-code.mdx
+++ b/support/models/articles/how-do-i-save-code.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use `save_code=True` in `wandb.init` to save the main script or notebook that launches the run. To save all code for a run, version the code with Artifacts. The following example demonstrates this process:
 
 ```python

--- a/support/models/articles/how-do-i-set-a-retention-or-expiration-p.mdx
+++ b/support/models/articles/how-do-i-set-a-retention-or-expiration-p.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To manage artifacts that contain sensitive data or to schedule the deletion of artifact versions, set a TTL (time-to-live) policy. For detailed instructions, refer to the [TTL guide](/models/artifacts/ttl).
 
 ---

--- a/support/models/articles/how-do-i-silence-wb-info-messages.mdx
+++ b/support/models/articles/how-do-i-silence-wb-info-messages.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To suppress log messages in your notebook such as this:
 
 ```

--- a/support/models/articles/how-do-i-stop-wandb-from-writing-to-my-t.mdx
+++ b/support/models/articles/how-do-i-stop-wandb-from-writing-to-my-t.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Set the environment variable [`WANDB_SILENT`](/models/track/environment-variables) to `true`.
 
 <Tabs>

--- a/support/models/articles/how-do-i-switch-between-accounts-on-the-.mdx
+++ b/support/models/articles/how-do-i-switch-between-accounts-on-the-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To manage two W&B accounts from the same machine, store both API keys in a file. Use the following code in your repositories to switch between keys securely, preventing secret keys from being checked into source control.
 
 ```python

--- a/support/models/articles/how-do-i-turn-off-logging.mdx
+++ b/support/models/articles/how-do-i-turn-off-logging.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The command `wandb offline` sets the environment variable `WANDB_MODE=offline`, preventing data from syncing to the remote W&B server. This action affects all projects, stopping the logging of data to W&B servers.
 
 To suppress warning messages, use the following code:

--- a/support/models/articles/how-do-i-use-custom-cli-commands-with-sw.mdx
+++ b/support/models/articles/how-do-i-use-custom-cli-commands-with-sw.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can use W&B Sweeps with custom CLI commands if training configuration passes command-line arguments.
 
 In the example below, the code snippet illustrates a bash terminal where a user trains a Python script named `train.py`, providing values that the script parses:

--- a/support/models/articles/how-do-i-use-the-resume-parameter-when-r.mdx
+++ b/support/models/articles/how-do-i-use-the-resume-parameter-when-r.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To use the `resume` parameter in W&B , set the `resume` argument in `wandb.init()` with `entity`, `project`, and `id` specified. The `resume` argument accepts values of `"must"` or `"allow"`. 
 
   ```python

--- a/support/models/articles/how-do-we-update-our-payment-method.mdx
+++ b/support/models/articles/how-do-we-update-our-payment-method.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To update your payment method, follow these steps:
 
 1. **Go to your profile page**: First, navigate to your user profile page.

--- a/support/models/articles/how-do-you-delete-a-custom-chart-preset.mdx
+++ b/support/models/articles/how-do-you-delete-a-custom-chart-preset.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Access the custom chart editor. Click on the currently selected chart type to open a menu displaying all presets. Hover over the preset to delete, then click the Trash icon.
 
 <Frame>

--- a/support/models/articles/how-do-you-show-a-step-slider-in-a-custo.mdx
+++ b/support/models/articles/how-do-you-show-a-step-slider-in-a-custo.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Enable this option on the “Other settings” page of the custom chart editor. Changing the query to use a `historyTable` instead of a `summaryTable` provides the option to “Show step selector” in the custom chart editor. This feature includes a slider for selecting the step.
 
 ---

--- a/support/models/articles/how-does-someone-without-an-account-see-.mdx
+++ b/support/models/articles/how-does-someone-without-an-account-see-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If someone runs the script with `anonymous="allow"`:
 
 1. **Auto-create temporary account**: W&B checks for a signed-in account. If none exists, W&B creates a new anonymous account and saves the API key for that session.

--- a/support/models/articles/how-does-wandb-stream-logs-and-writes-to.mdx
+++ b/support/models/articles/how-does-wandb-stream-logs-and-writes-to.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B queues events in memory and writes them to disk asynchronously to manage failures and support the `WANDB_MODE=offline` configuration, allowing synchronization after logging.
 
 In the terminal, observe the path to the local run directory. This directory includes a `.wandb` file, which serves as the datastore. For image logging, W&B stores images in the `media/images` subdirectory before uploading them to cloud storage.

--- a/support/models/articles/how-is-wb-different-from-tensorboard.mdx
+++ b/support/models/articles/how-is-wb-different-from-tensorboard.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B integrates with TensorBoard and improves experiment tracking tools. The founders created W&B to address common frustrations faced by TensorBoard users. Key improvements include:
 
 1. **Model Reproducibility**: W&B facilitates experimentation, exploration, and model reproduction. It captures metrics, hyperparameters, code versions, and saves model checkpoints to ensure reproducibility.

--- a/support/models/articles/how-many-runs-can-i-create-per-project.mdx
+++ b/support/models/articles/how-many-runs-can-i-create-per-project.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Limit each project to approximately 10,000 runs for optimal performance.
 
 ---

--- a/support/models/articles/how-much-storage-does-each-artifact-vers.mdx
+++ b/support/models/articles/how-much-storage-does-each-artifact-vers.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Only files that change between two artifact versions incur storage costs.
 
 <Frame>

--- a/support/models/articles/how-often-are-system-metrics-collected.mdx
+++ b/support/models/articles/how-often-are-system-metrics-collected.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Metrics collect by default every 10 seconds. For higher resolution metrics, email contact@wandb.com.
 
 ---

--- a/support/models/articles/how-should-i-run-sweeps-on-slurm.mdx
+++ b/support/models/articles/how-should-i-run-sweeps-on-slurm.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When using sweeps with the [SLURM scheduling system](https://slurm.schedmd.com/documentation.html), run `wandb agent --count 1 SWEEP_ID` in each scheduled job. This command executes a single training job and then exits, facilitating runtime predictions for resource requests while leveraging the parallelism of hyperparameter searches.
 
 ---

--- a/support/models/articles/how-to-get-multiple-charts-with-differen.mdx
+++ b/support/models/articles/how-to-get-multiple-charts-with-differen.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 With W&B Reports, follow these steps:
 
 1. Create multiple panel grids.

--- a/support/models/articles/i-converted-my-report-to-wysiwyg-but-wan.mdx
+++ b/support/models/articles/i-converted-my-report-to-wysiwyg-but-wan.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If the report conversion occurred through the message at the top, click the red "Revert" button to restore the prior state. Note that any changes made after conversion will be lost.
 
 If a single Markdown block was converted, use `cmd+z` to undo.

--- a/support/models/articles/i-didnt-name-my-run-where-is-the-run-nam.mdx
+++ b/support/models/articles/i-didnt-name-my-run-where-is-the-run-nam.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If a run is not explicitly named, W&B assigns a random name to identify it in your project. Examples of random names are `pleasant-flower-4` and `misunderstood-glade-2.
 
 ---

--- a/support/models/articles/if-i-am-the-admin-of-my-local-instance-h.mdx
+++ b/support/models/articles/if-i-am-the-admin-of-my-local-instance-h.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If you are the admin for your instance, review the [User Management](/platform/hosting/iam/access-management/manage-organization) section for instructions on adding users and creating teams.
 
 ---

--- a/support/models/articles/if-wandb-crashes-will-it-possibly-crash-.mdx
+++ b/support/models/articles/if-wandb-crashes-will-it-possibly-crash-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 It is critical to avoid interference with training runs. W&B operates in a separate process, ensuring that training continues even if W&B experiences a crash. In the event of an internet outage, W&B continually retries sending data to [wandb.ai](https://wandb.ai).
 
 ---

--- a/support/models/articles/incorporating-latex.mdx
+++ b/support/models/articles/incorporating-latex.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 LaTeX integrates seamlessly into reports. To add LaTeX, create a new report and begin typing in the rich text area to write notes and save custom visualizations and tables.
 
 On a new line, press `/` and navigate to the inline equations tab to insert LaTeX content.

--- a/support/models/articles/initstarterror-error-communicating-with-.mdx
+++ b/support/models/articles/initstarterror-error-communicating-with-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 This error indicates that the library encounters an issue launching the process that synchronizes data to the server.
 
 The following workarounds resolve the issue in specific environments:

--- a/support/models/articles/is-it-possible-to-add-the-same-service-a.mdx
+++ b/support/models/articles/is-it-possible-to-add-the-same-service-a.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A service account cannot be added to multiple teams in W&B. Each service account is tied to a specific team.
 
 ---

--- a/support/models/articles/is-it-possible-to-change-the-group-assig.mdx
+++ b/support/models/articles/is-it-possible-to-change-the-group-assig.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can change the group assigned to a completed run using the API. This feature does not appear in the web UI. Use the following code to update the group:
 
 ```python

--- a/support/models/articles/is-it-possible-to-change-the-username.mdx
+++ b/support/models/articles/is-it-possible-to-change-the-username.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Changing the username after account creation is not possible. Create a new account with the desired username instead.
 
 ---

--- a/support/models/articles/is-it-possible-to-create-a-new-account-w.mdx
+++ b/support/models/articles/is-it-possible-to-create-a-new-account-w.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A new account can use an email previously associated with a deleted account.
 
 ---

--- a/support/models/articles/is-it-possible-to-move-a-run-from-one-pr.mdx
+++ b/support/models/articles/is-it-possible-to-move-a-run-from-one-pr.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can move a run from one project to another by following these steps:
 
 - Navigate to the project page with the run to be moved.

--- a/support/models/articles/is-it-possible-to-plot-the-max-of-a-metr.mdx
+++ b/support/models/articles/is-it-possible-to-plot-the-max-of-a-metr.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Create a scatter plot of the metric. Open the **Edit** menu and select **Annotations**. From there, plot the running maximum of the values.
 
 ---

--- a/support/models/articles/is-it-possible-to-recover-an-artifact-af.mdx
+++ b/support/models/articles/is-it-possible-to-recover-an-artifact-af.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When deleting a run, a prompt asks whether to delete the associated artifacts. Choosing this option permanently removes the artifacts, making recovery impossible, even if the run itself is restored later.
 
 ---

--- a/support/models/articles/is-it-possible-to-save-metrics-offline-a.mdx
+++ b/support/models/articles/is-it-possible-to-save-metrics-offline-a.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 By default, `wandb.init` starts a process that syncs metrics in real time to the cloud. For offline use, set two environment variables to enable offline mode and sync later.
 
 Set the following environment variables:

--- a/support/models/articles/is-there-a-dark-mode.mdx
+++ b/support/models/articles/is-there-a-dark-mode.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Dark mode is in beta and not optimized for accessibility. To enable dark mode:
 
 1. Go to your [W&B account settings](https://wandb.ai/settings).

--- a/support/models/articles/is-there-a-monthly-subscription-option-f.mdx
+++ b/support/models/articles/is-there-a-monthly-subscription-option-f.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The Teams plan does not offer a monthly subscription option. This subscription is billed annually.
 
 ---

--- a/support/models/articles/is-there-a-way-to-add-extra-values-to-a-.mdx
+++ b/support/models/articles/is-there-a-way-to-add-extra-values-to-a-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Once a W&B Sweep starts, you cannot change the Sweep configuration. However, you can navigate to any table view, select runs using the checkboxes, and then choose the **Create sweep** menu option to generate a new Sweep configuration based on previous runs.
 
 ---

--- a/support/models/articles/is-there-a-way-to-add-more-seats.mdx
+++ b/support/models/articles/is-there-a-way-to-add-more-seats.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To add more seats to an account, follow these steps:
 
 - Contact the Account Executive or support team (support@wandb.com) for assistance.

--- a/support/models/articles/is-there-a-wb-outage.mdx
+++ b/support/models/articles/is-there-a-wb-outage.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Check if the W&B Multi-tenant Cloud at wandb.ai is experiencing an outage by visiting the [W&B status page](https://status.wandb.com).
 
 ---

--- a/support/models/articles/is-there-an-anaconda-package-for-weights.mdx
+++ b/support/models/articles/is-there-an-anaconda-package-for-weights.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 There is an anaconda package that is installable using either `pip` or `conda`. For `conda`, obtain the package from the [conda-forge](https://conda-forge.org) channel.
 
 <Tabs>

--- a/support/models/articles/my-report-is-running-slowly-after-the-ch.mdx
+++ b/support/models/articles/my-report-is-running-slowly-after-the-ch.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Performance issues may arise on older hardware or with very large reports. To mitigate this, collapse sections of the report that are not currently in use.
 
 ---

--- a/support/models/articles/my-report-looks-different-after-converti.mdx
+++ b/support/models/articles/my-report-looks-different-after-converti.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The goal is to maintain the original appearance after transitioning to WYSIWYG, but the conversion process is not flawless. If significant discrepancies arise, report them for evaluation. Users can revert to the previous state until the editing session concludes.
 
 ---

--- a/support/models/articles/my-runs-state-is-crashed-on-the-ui-but-i.mdx
+++ b/support/models/articles/my-runs-state-is-crashed-on-the-ui-but-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You likely lost connection to your machine during training. Recover data by running [`wandb sync [PATH_TO_RUN]`](/models/ref/cli/wandb-sync). The path to your run is a folder in your `wandb` directory that matches the Run ID of the ongoing run.
 
 ---

--- a/support/models/articles/on-a-local-instance-which-files-should-i.mdx
+++ b/support/models/articles/on-a-local-instance-which-files-should-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Check the `Debug Bundle`. An admin can retrieve it from the `/system-admin` page by selecting the W&B icon in the top right corner and then choosing `Debug Bundle`.
 
 <Frame>

--- a/support/models/articles/optimizing-multiple-metrics.mdx
+++ b/support/models/articles/optimizing-multiple-metrics.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To optimize multiple metrics in a single run, use a weighted sum of the individual metrics.
 
 ```python

--- a/support/models/articles/refreshing-data.mdx
+++ b/support/models/articles/refreshing-data.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Workspaces automatically load updated data. Auto-refresh does not apply to reports. Reload the page to refresh report data.
 
 ---

--- a/support/models/articles/upload-a-csv-to-a-report.mdx
+++ b/support/models/articles/upload-a-csv-to-a-report.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To upload a CSV to a report, use the `wandb.Table` format. Load the CSV in your Python script and log it as a `wandb.Table` object. This action renders the data as a table in the report.
 
 ---

--- a/support/models/articles/upload-an-image-to-a-report.mdx
+++ b/support/models/articles/upload-an-image-to-a-report.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Press `/` on a new line, scroll to the Image option, and drag and drop an image into the report.
 
 <Frame>

--- a/support/models/articles/using-artifacts-with-multiple-architectu.mdx
+++ b/support/models/articles/using-artifacts-with-multiple-architectu.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 There are various methods to version a model. Artifacts provide a tool for model versioning tailored to specific needs. A common approach for projects that explore multiple model architectures involves separating artifacts by architecture. Consider the following steps:
 
 1. Create a new artifact for each distinct model architecture. Use the `metadata` attribute of artifacts to provide detailed descriptions of the architecture, similar to the use of `config` for a run.

--- a/support/models/articles/what-are-features-that-are-not-available.mdx
+++ b/support/models/articles/what-are-features-that-are-not-available.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 * **No persistent data**: Runs save for 7 days in an anonymous account. Claim anonymous run data by saving it to a real account.
 
 <Frame>

--- a/support/models/articles/what-are-the-best-practices-for-handling.mdx
+++ b/support/models/articles/what-are-the-best-practices-for-handling.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Follow these best practices to handle W&B Inference errors gracefully and maintain reliable applications.
 
 ## 1. Always implement error handling

--- a/support/models/articles/what-does-wandbinit-do-to-my-training-pr.mdx
+++ b/support/models/articles/what-does-wandbinit-do-to-my-training-pr.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When `wandb.init()` runs in a training script, an API call creates a run object on the servers. A new process starts to stream and collect metrics, allowing the primary process to function normally. The script writes to local files while the separate process streams data to the servers, including system metrics. To turn off streaming, run `wandb off` from the training directory or set the `WANDB_MODE` environment variable to `offline`.
 
 ---

--- a/support/models/articles/what-formula-do-you-use-for-your-smoothi.mdx
+++ b/support/models/articles/what-formula-do-you-use-for-your-smoothi.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The exponential moving average formula aligns with the one used in TensorBoard. 
 
 Refer to this [explanation on Stack OverFlow](https://stackoverflow.com/questions/42281844/what-is-the-mathematics-behind-the-smoothing-parameter-in-tensorboards-scalar/75421930#75421930) for details on the equivalent Python implementation. The source code to TensorBoard's smoothing algorithm (as of this writing) can be found [here](https://github.com/tensorflow/tensorboard/blob/34877f15153e1a2087316b9952c931807a122aa7/tensorboard/components/vz_line_chart2/line-chart.ts#L699).

--- a/support/models/articles/what-happens-if-i-edit-my-python-files-w.mdx
+++ b/support/models/articles/what-happens-if-i-edit-my-python-files-w.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 While a sweep is running:
 - If the `train.py` script which the sweep uses changes, the sweep continues to use the original `train.py`
 - If files that the `train.py` script references change, such as helper functions in the `helper.py` script, the sweep begins to use the updated `helper.py`.

--- a/support/models/articles/what-happens-if-i-pass-a-class-attribute.mdx
+++ b/support/models/articles/what-happens-if-i-pass-a-class-attribute.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Avoid passing class attributes into `wandb.Run.log()`. Attributes may change before the network call executes. When storing metrics as class attributes, use a deep copy to ensure the logged metric matches the attribute's value at the time of the `wandb.Run.log()` call.
 
 ---

--- a/support/models/articles/what-happens-if-internet-connection-is-l.mdx
+++ b/support/models/articles/what-happens-if-internet-connection-is-l.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If the library cannot connect to the internet, it enters a retry loop and continues to attempt to stream metrics until the network is restored. The program continues to run during this time.
 
 To run on a machine without internet, set `WANDB_MODE=offline`. This configuration stores metrics locally on the hard drive. Later, call `wandb sync DIRECTORY` to stream the data to the server.

--- a/support/models/articles/what-happens-when-i-log-millions-of-step.mdx
+++ b/support/models/articles/what-happens-when-i-log-millions-of-step.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The number of points sent affects the loading time of graphs in the UI. For lines exceeding 1,000 points, the backend samples the data down to 1,000 points before sending it to the browser. This sampling is nondeterministic, resulting in different sampled points upon page refresh.
 
 Log fewer than 10,000 points per metric. Logging over 1 million points in a line significantly increases page load time. Explore strategies to minimize logging footprint without sacrificing accuracy in this [Colab](https://wandb.me/log-hf-colab). With more than 500 columns of config and summary metrics, only 500 display in the table.

--- a/support/models/articles/what-if-i-want-to-integrate-wb-into-my-p.mdx
+++ b/support/models/articles/what-if-i-want-to-integrate-wb-into-my-p.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B supports projects that log only scalars by allowing explicit specification of files or data for upload. Refer to this [example in PyTorch](https://wandb.me/pytorch-colab) that demonstrates logging without using images.
 
 ---

--- a/support/models/articles/what-if-i-want-to-log-some-metrics-on-ba.mdx
+++ b/support/models/articles/what-if-i-want-to-log-some-metrics-on-ba.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 To log specific metrics in each batch and standardize plots, log the desired x-axis values alongside the metrics. In the custom plots, click edit and select a custom x-axis.
 
 ```python

--- a/support/models/articles/what-is-a-service-account-and-why-is-it-.mdx
+++ b/support/models/articles/what-is-a-service-account-and-why-is-it-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A **service account** represents a non-human or machine identity, which can automate common tasks across teams and projects. Service accounts are ideal for CI/CD pipelines, automated training jobs, and other machine-to-machine workflows.
 
 Key benefits of service accounts:

--- a/support/models/articles/what-is-a-team-and-where-can-i-find-more.mdx
+++ b/support/models/articles/what-is-a-team-and-where-can-i-find-more.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 For additional information about teams, visit the [teams section](/platform/app/settings-page/teams).
 
 ---

--- a/support/models/articles/what-is-the-difference-between-log-and-s.mdx
+++ b/support/models/articles/what-is-the-difference-between-log-and-s.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The summary displays in the table, while the log saves all values for future plotting.
 
 For instance, call `run.log()` whenever accuracy changes. By default, `run.log()` updates the summary value unless set manually for that metric.

--- a/support/models/articles/what-is-the-difference-between-team-and-.mdx
+++ b/support/models/articles/what-is-the-difference-between-team-and-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A team serves as a collaborative workspace for users working on the same projects. An entity represents either a username or a team name. When logging runs in W&B, set the entity to a personal or team account using `wandb.init(entity="example-team")`.
 
 ---

--- a/support/models/articles/what-is-the-difference-between-team-and-_2.mdx
+++ b/support/models/articles/what-is-the-difference-between-team-and-_2.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A team serves as a collaborative workspace for users working on the same projects. An organization functions as a higher-level entity that can include multiple teams, often related to billing and account management.
 
 ---

--- a/support/models/articles/what-is-the-difference-between-wandbinit.mdx
+++ b/support/models/articles/what-is-the-difference-between-wandbinit.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 These modes are available:
 
 * `online` (default): The client sends data to the wandb server.

--- a/support/models/articles/what-is-the-est-runs-column.mdx
+++ b/support/models/articles/what-is-the-est-runs-column.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B provides an estimated number of Runs generated when creating a W&B Sweep with a discrete search space. This total reflects the cartesian product of the search space.
 
 For instance, consider the following search space:

--- a/support/models/articles/what-really-good-functionalities-are-hid.mdx
+++ b/support/models/articles/what-really-good-functionalities-are-hid.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Some functionalities are hidden under a feature flag in the **Beta Features** section of a team's settings.
 
 <Frame>

--- a/support/models/articles/what-type-of-roles-are-available-and-wha.mdx
+++ b/support/models/articles/what-type-of-roles-are-available-and-wha.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Visit the [Team roles and permissions](/platform/app/settings-page/teams#team-roles-and-permissions) page for an overview of the available roles and permissions.
 
 ---

--- a/support/models/articles/when-should-i-log-to-my-personal-entity-.mdx
+++ b/support/models/articles/when-should-i-log-to-my-personal-entity-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Personal Entities are unavailable for accounts created after May 21, 2024. W&B encourages all users to log new projects to a Team to enable sharing of results.
 
 ---

--- a/support/models/articles/where-are-artifacts-downloaded-and-how-c.mdx
+++ b/support/models/articles/where-are-artifacts-downloaded-and-how-c.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 By default, artifacts download to the `artifacts/` folder. To change the location:
 
 - Pass it to [`wandb.Artifact().download`](/models/ref/python/public-api/api):

--- a/support/models/articles/which-files-should-i-check-when-my-code-.mdx
+++ b/support/models/articles/which-files-should-i-check-when-my-code-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 For the affected run, check `debug.log` and `debug-internal.log` in `wandb/run-<date>_<time>-<run-id>/logs` in the directory where your code is running.
 
 ---

--- a/support/models/articles/who-can-create-a-team-who-can-add-or-del.mdx
+++ b/support/models/articles/who-can-create-a-team-who-can-add-or-del.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Refer to the link for details on roles and permissions: [Team Roles and Permissions](/platform/app/settings-page/teams#team-roles-and-permissions).
 
 ---

--- a/support/models/articles/who-can-edit-and-share-reports.mdx
+++ b/support/models/articles/who-can-edit-and-share-reports.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Reports created within an individual's private project remain visible only to that user. The user can share their project with a team or the public.
 
 In team projects, the administrator or the member who created the report can toggle permissions between edit and view access for other team members. Team members can share reports.

--- a/support/models/articles/who-has-access-to-my-artifacts.mdx
+++ b/support/models/articles/who-has-access-to-my-artifacts.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Artifacts inherit access permissions from their parent project:
 
 * In a private project, only team members can access artifacts.

--- a/support/models/articles/why-am-i-getting-insufficient-quota-erro.mdx
+++ b/support/models/articles/why-am-i-getting-insufficient-quota-erro.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Insufficient quota errors (402) occur when you do not have remaining credits in your plan.
 
 **Error:** "You exceeded your current quota, please check your plan and billing details"

--- a/support/models/articles/why-am-i-getting-rate-limit-errors-429-w.mdx
+++ b/support/models/articles/why-am-i-getting-rate-limit-errors-429-w.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Rate limit errors (429) occur when you exceed concurrency limits.
 
 **Error:** "Concurrency limit reached for requests"

--- a/support/models/articles/why-am-i-seeing-fewer-data-points-than-i.mdx
+++ b/support/models/articles/why-am-i-seeing-fewer-data-points-than-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When visualizing metrics against an X-axis other than `Step`, expect to see fewer data points. Metrics must log at the same `Step` to remain synchronized. Only metrics logged at the same `Step` are sampled while interpolating between samples.
 
 **Guidelines**

--- a/support/models/articles/why-are-steps-missing-from-a-csv-metric-.mdx
+++ b/support/models/articles/why-are-steps-missing-from-a-csv-metric-.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Export limits can prevent the entire run history from being exported as a CSV or using the `run.history` API. To access the complete run history, download the run history artifact using Parquet format:
 
 ```python

--- a/support/models/articles/why-cant-i-sort-or-filter-metrics-with-c.mdx
+++ b/support/models/articles/why-cant-i-sort-or-filter-metrics-with-c.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Metric names in W&B must follow GraphQL naming conventions to ensure they can be properly sorted and filtered in the UI.
 
 ## Valid metric names

--- a/support/models/articles/why-does-the-storage-meter-not-update-af.mdx
+++ b/support/models/articles/why-does-the-storage-meter-not-update-af.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 - The storage meter does not update immediately after deleting runs due to processing delays. 
 - The backend system requires time to synchronize and reflect changes in usage accurately. 
 - If the storage meter has not updated, wait for the changes to process.

--- a/support/models/articles/why-is-a-run-marked-crashed-in-wb-when-i.mdx
+++ b/support/models/articles/why-is-a-run-marked-crashed-in-wb-when-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 This indicates a connection problem. If the server loses internet access and data stops syncing to W&B, the system marks the run as crashed after a brief retry period.
 
 ---

--- a/support/models/articles/why-is-nothing-showing-up-in-my-graphs.mdx
+++ b/support/models/articles/why-is-nothing-showing-up-in-my-graphs.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If the message "No visualization data logged yet" appears, the script has not executed the first `wandb.log` call. This situation may occur if the run takes a long time to complete a step. To expedite data logging, log multiple times per epoch instead of only at the end.
 
 ---

--- a/support/models/articles/why-is-the-same-metric-appearing-more-th.mdx
+++ b/support/models/articles/why-is-the-same-metric-appearing-more-th.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When logging various data types under the same key, split them in the database. This results in multiple entries of the same metric name in the UI dropdown. The data types grouped are `number`, `string`, `bool`, `other` (primarily arrays), and any `wandb` data type such as `Histogram` or `Image`. Send only one type per key to prevent this issue.
 
 Metric names are case-insensitive. Avoid using names that differ only by case, such as `"My-Metric"` and `"my-metric"`.

--- a/support/models/articles/will-wandb-slow-down-my-training.mdx
+++ b/support/models/articles/will-wandb-slow-down-my-training.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 W&B has a minimal impact on training performance under normal usage conditions. Normal use includes logging at a rate of less than once per second and limiting data to a few megabytes per step. W&B operates in a separate process with non-blocking function calls, ensuring that brief network outages or intermittent disk read/write issues do not disrupt performance. Excessive logging of large amounts of data may lead to disk I/O issues. For further inquiries, contact support.
 
 ---

--- a/support/models/index.mdx
+++ b/support/models/index.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_product_index.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index"  horizontal />
-
 ## Featured articles
 
 <Card title="How can I configure the name of the run in my training code?" href="/support/models/articles/how-can-i-configure-the-name-of-the-run-" arrow="true" horizontal>

--- a/support/models/tags/academic.mdx
+++ b/support/models/tags/academic.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>
   Students can apply for an academic plan by following these s ...
 </Card>

--- a/support/models/tags/administrator.mdx
+++ b/support/models/tags/administrator.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>
   Students can apply for an academic plan by following these s ...
 </Card>

--- a/support/models/tags/alerts.mdx
+++ b/support/models/tags/alerts.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>
   No. Run Finished alerts (activated with the Run Finished set ...
 </Card>

--- a/support/models/tags/anonymous.mdx
+++ b/support/models/tags/anonymous.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How does someone without an account see run results?" href="/support/models/articles/how-does-someone-without-an-account-see-" arrow="true" horizontal>
   If someone runs the script with anonymous "allow" : 1. Auto- ...
 </Card>

--- a/support/models/tags/artifacts.mdx
+++ b/support/models/tags/artifacts.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I turn off wandb when testing my code?" href="/support/models/articles/can-i-turn-off-wandb-when-testing-my-cod" arrow="true" horizontal>
   Use wandb.init(mode "disabled") or set WANDB MODE disabled t ...
 </Card>

--- a/support/models/tags/aws.mdx
+++ b/support/models/tags/aws.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I use Sweeps and SageMaker?" href="/support/models/articles/can-i-use-sweeps-and-sagemaker" arrow="true" horizontal>
   To authenticate W B, complete the following steps: create a  ...
 </Card>

--- a/support/models/tags/billing.mdx
+++ b/support/models/tags/billing.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I change my billing address?" href="/support/models/articles/how-do-i-change-my-billing-address" arrow="true" horizontal>
   To change the billing address, contact the support team (sup ...
 </Card>

--- a/support/models/tags/charts.mdx
+++ b/support/models/tags/charts.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>
   Direct integration of Plotly or Bokeh figures into tables is ...
 </Card>

--- a/support/models/tags/connectivity.mdx
+++ b/support/models/tags/connectivity.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>
   To resolve the "Filestream rate limit exceeded" error in W B ...
 </Card>

--- a/support/models/tags/environment-variables.mdx
+++ b/support/models/tags/environment-variables.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I run wandb offline?" href="/support/models/articles/can-i-run-wandb-offline" arrow="true" horizontal>
   If training occurs on an offline machine, use the following  ...
 </Card>

--- a/support/models/tags/experiments.mdx
+++ b/support/models/tags/experiments.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I just set the run name to the run ID?" href="/support/models/articles/can-i-just-set-the-run-name-to-the-run-i" arrow="true" horizontal>
   Yes. To overwrite the run name with the run ID, use the foll ...
 </Card>

--- a/support/models/tags/hyperparameter.mdx
+++ b/support/models/tags/hyperparameter.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>
   Set unique tags with wandb.init(tags 'your tag') . This allo ...
 </Card>

--- a/support/models/tags/inference.mdx
+++ b/support/models/tags/inference.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I fix Invalid Authentication (401) errors with W&B Inference?" href="/support/models/articles/how-do-i-fix-invalid-authentication-401-" arrow="true" horizontal>
   A 401 Invalid Authentication error means your API key is inv ...
 </Card>

--- a/support/models/tags/logs.mdx
+++ b/support/models/tags/logs.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Does logging block my training?" href="/support/models/articles/does-logging-block-my-training" arrow="true" horizontal>
   "Is the logging function lazy? I don't want to depend on the ...
 </Card>

--- a/support/models/tags/metrics.mdx
+++ b/support/models/tags/metrics.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>
   By default, W B does not log dataset examples. By default, W ...
 </Card>

--- a/support/models/tags/notebooks.mdx
+++ b/support/models/tags/notebooks.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>
   No. Run Finished alerts (activated with the Run Finished set ...
 </Card>

--- a/support/models/tags/outage.mdx
+++ b/support/models/tags/outage.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>
   To resolve the "Filestream rate limit exceeded" error in W B ...
 </Card>

--- a/support/models/tags/privacy.mdx
+++ b/support/models/tags/privacy.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>
   Key engineers and support staff at W B access logged values  ...
 </Card>

--- a/support/models/tags/projects.mdx
+++ b/support/models/tags/projects.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I change the privacy of my project?" href="/support/models/articles/how-can-i-change-the-privacy-of-my-proje" arrow="true" horizontal>
   To change a project's privacy (visibility): 1. In the W B Ap ...
 </Card>

--- a/support/models/tags/python.mdx
+++ b/support/models/tags/python.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Does the W&B client support Python 2?" href="/support/models/articles/does-the-wb-client-support-python-2" arrow="true" horizontal>
   The W B client library supported both Python 2.7 and Python  ...
 </Card>

--- a/support/models/tags/reports.mdx
+++ b/support/models/tags/reports.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Adding multiple authors to a report" href="/support/models/articles/adding-multiple-authors-to-a-report" arrow="true" horizontal>
   Accurately credit all contributors in your report by adding  ...
 </Card>

--- a/support/models/tags/resuming.mdx
+++ b/support/models/tags/resuming.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I fix the error `resume='must' but run (<run_id>) doesn't exist`?" href="/support/models/articles/how-do-i-fix-the-error-resumemust-but-ru" arrow="true" horizontal>
   If you encounter the error resume 'must' but run ( run id )  ...
 </Card>

--- a/support/models/tags/run-crashes.mdx
+++ b/support/models/tags/run-crashes.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I fix an error like `AttributeError: module 'wandb' has no attribute ...`?" href="/support/models/articles/how-can-i-fix-an-error-like-attributeerr" arrow="true" horizontal>
   If you encounter an error like AttributeError: module 'wandb ...
 </Card>

--- a/support/models/tags/runs.mdx
+++ b/support/models/tags/runs.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>
   Set unique tags with wandb.init(tags 'your tag') . This allo ...
 </Card>

--- a/support/models/tags/security.mdx
+++ b/support/models/tags/security.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>
   Key engineers and support staff at W B access logged values  ...
 </Card>

--- a/support/models/tags/storage.mdx
+++ b/support/models/tags/storage.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How much storage does each artifact version use?" href="/support/models/articles/how-much-storage-does-each-artifact-vers" arrow="true" horizontal>
   Only files that change between two artifact versions incur s ...
 </Card>

--- a/support/models/tags/sweeps.mdx
+++ b/support/models/tags/sweeps.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>
   Set unique tags with wandb.init(tags 'your tag') . This allo ...
 </Card>

--- a/support/models/tags/tables.mdx
+++ b/support/models/tags/tables.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>
   Direct integration of Plotly or Bokeh figures into tables is ...
 </Card>

--- a/support/models/tags/team-management.mdx
+++ b/support/models/tags/team-management.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>
   By default, W B does not log dataset examples. By default, W ...
 </Card>

--- a/support/models/tags/tensorboard.mdx
+++ b/support/models/tags/tensorboard.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How is W&B different from TensorBoard?" href="/support/models/articles/how-is-wb-different-from-tensorboard" arrow="true" horizontal>
   W B integrates with TensorBoard and improves experiment trac ...
 </Card>

--- a/support/models/tags/user-management.mdx
+++ b/support/models/tags/user-management.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>
   Students can apply for an academic plan by following these s ...
 </Card>

--- a/support/models/tags/workspaces.mdx
+++ b/support/models/tags/workspaces.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Can I group runs without using the 'Group' feature?" href="/support/models/articles/can-i-group-runs-without-using-the-group" arrow="true" horizontal>
   Yes, you can also use tags or custom metadata to categorize  ...
 </Card>

--- a/support/models/tags/wysiwyg.mdx
+++ b/support/models/tags/wysiwyg.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I delete a panel grid?" href="/support/models/articles/how-do-i-delete-a-panel-grid" arrow="true" horizontal>
   Select the panel grid and press delete or backspace. Click t ...
 </Card>

--- a/support/weave/articles/how-can-i-disable-client-information-cap.mdx
+++ b/support/weave/articles/how-can-i-disable-client-information-cap.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can disable client information capture during Weave client initialization: `weave.init("entity/project", settings={"capture_client_info": False})`.
 
 ---

--- a/support/weave/articles/how-can-i-disable-code-capture.mdx
+++ b/support/weave/articles/how-can-i-disable-code-capture.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can disable code capture during Weave client initialization: `weave.init("entity/project", settings={"capture_code": False})`.
 You can also use the [environment variable](/weave/guides/core-types/env-vars) `WEAVE_CAPTURE_CODE=false`.
 

--- a/support/weave/articles/how-can-i-disable-system-information-cap.mdx
+++ b/support/weave/articles/how-can-i-disable-system-information-cap.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 You can disable system information capture during Weave client initialization: `weave.init("entity/project", settings={"capture_system_info": False})`.
 
 ---

--- a/support/weave/articles/how-do-i-render-markdown-in-the-ui.mdx
+++ b/support/weave/articles/how-do-i-render-markdown-in-the-ui.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Wrap your string with `weave.Markdown(...)` before saving, and use `weave.publish(...)` to store it. Weave uses the object’s type to determine rendering, and `weave.Markdown` maps to a known UI renderer.  The value will be shown as a formatted Markdown object in the UI. For a full code sample, see [Viewing calls](/weave/guides/tracking/tracing#viewing-calls).
 
 ---

--- a/support/weave/articles/how-do-i-render-python-datetime-values-i.mdx
+++ b/support/weave/articles/how-do-i-render-python-datetime-values-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Use Python’s `datetime.datetime` (with timezone info), and publish the object using `weave.publish(...)`. Weave recognizes this type and renders it as a timestamp.
 
 ---

--- a/support/weave/articles/how-is-weave-data-ingestion-calculated.mdx
+++ b/support/weave/articles/how-is-weave-data-ingestion-calculated.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 We define ingested bytes as bytes that we receive, process, and store on your behalf. This includes trace metadata, LLM inputs/outputs, and any other information you explicitly log to Weave, but does not include communication overhead (e.g., HTTP headers) or any other data that is not placed in long-term storage. We count bytes as "ingested" only once at the time they are received and stored.
 
 ---

--- a/support/weave/articles/long-eval-clean-up-times.mdx
+++ b/support/weave/articles/long-eval-clean-up-times.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The following two methods should be used together in order to improve performance when running evaluations with large datasets.
 
 ### Flushing

--- a/support/weave/articles/os-errors-too-many-open-files.mdx
+++ b/support/weave/articles/os-errors-too-many-open-files.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 ### `[Errno 24]: Too many open files`
 
 This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets. Weave uses `PIL` for image processing, which keeps file descriptors open for the duration of the program.

--- a/support/weave/articles/server-response-caching.mdx
+++ b/support/weave/articles/server-response-caching.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Weave provides server response caching to improve performance when making repeated queries or working with limited network bandwidth. While currently disabled by default, this feature is expected to become the default behavior in a future release.
 
 ### When to use caching

--- a/support/weave/articles/trace-data-is-truncated.mdx
+++ b/support/weave/articles/trace-data-is-truncated.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Sometimes, large trace data is partially cut off in the Weave UI. This problem occurs because default trace output is a raw, custom Python object that Weave doesn't know how to serialize.
 
 To ensure that large trace data isn't cut off, define a dictionary of strings to return all trace data.

--- a/support/weave/articles/trace-data-loss-in-worker-processes.mdx
+++ b/support/weave/articles/trace-data-loss-in-worker-processes.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 Weave uploads trace data in background threads to minimize impact on your application's performance. However, when using a multiprocessing or task queue system or a worker processes like Celery, trace data will be lost if the worker process exits before background threads finish uploading traces.
 
 To prevent data loss in worker processes, you must ensure that background uploads complete by calling `client.flush()` or `client.finish()` before the worker task completes.

--- a/support/weave/articles/trace-pages-load-slowly.mdx
+++ b/support/weave/articles/trace-pages-load-slowly.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 If trace pages are loading slowly, reduce the number of rows displayed to improve load time. The default value is `50`. You can either reduce the number of rows via the UI, or using query parameters.
 
 ### Adjust via the UI (recommended)

--- a/support/weave/articles/what-information-does-weave-capture-for.mdx
+++ b/support/weave/articles/what-information-does-weave-capture-for.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 A function can be designated as a Weave [Op](/weave/guides/tracking/ops) either manually through a decorator or automatically as part of an enabled integration. When an Op executes, Weave captures detailed information to support your analysis. Weave provides you with fine grained control over what is logged in case you would like something different than the default; see below for configuration examples.
 
 - **Code capture** - Weave captures a representation of the Op's source code. This includes inline comments as well as recursively capturing the value of variables or the source of non-Op functions that were called. Code capture allows you to see what your function was doing even if the change was not saved to your source control system. Code capture is used as part of Op versioning, allowing you to understand the evaluation of your code over time. If code capture is disabled, a hash value will be used instead.

--- a/support/weave/articles/what-is-pairwise-evaluation-and-how-do-i.mdx
+++ b/support/weave/articles/what-is-pairwise-evaluation-and-how-do-i.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 When [scoring](/weave/guides/evaluation/scorers) models in a Weave [evaluation](/weave/guides/core-types/evaluations), absolute value metrics (e.g. `9/10` for Model A and `8/10` for Model B) are typically harder to assign than relative ones (e.g. Model A performs better than Model B). _Pairwise evaluation_ allows you to compare the outputs of two models by ranking them relative to each other. This approach is particularly useful when you want to determine which model performs better for subjective tasks such as text generation, summarization, or question answering. With pairwise evaluation, you can obtain a relative preference ranking that reveals which model is best for specific inputs.
 
 <Warning>

--- a/support/weave/articles/will-weave-affect-my-function-s-executio.mdx
+++ b/support/weave/articles/will-weave-affect-my-function-s-executio.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_article.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 The overhead of Weave logging is typically negligible compared to making a call to an LLM.
 To minimize Weave's impact on the speed of your Op's execution, its network activity happens on a background thread.
 When your program is exiting it may appear to pause while any remaining enqueued data is logged.

--- a/support/weave/index.mdx
+++ b/support/weave/index.mdx
@@ -6,8 +6,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_product_index.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index"  horizontal />
-
 ## Browse by category
 
 <Card title="Client Info" href="/support/weave/tags/client-info" arrow="true">

--- a/support/weave/tags/client-info.mdx
+++ b/support/weave/tags/client-info.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I disable client information capture?" href="/support/weave/articles/how-can-i-disable-client-information-cap" arrow="true" horizontal>
   You can disable client information capture during Weave clie ...
 </Card>

--- a/support/weave/tags/code-capture.mdx
+++ b/support/weave/tags/code-capture.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I disable code capture?" href="/support/weave/articles/how-can-i-disable-code-capture" arrow="true" horizontal>
   You can disable code capture during Weave client initializat ...
 </Card>

--- a/support/weave/tags/data-capture.mdx
+++ b/support/weave/tags/data-capture.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How is Weave data ingestion calculated?" href="/support/weave/articles/how-is-weave-data-ingestion-calculated" arrow="true" horizontal>
   We define ingested bytes as bytes that we receive, process,  ...
 </Card>

--- a/support/weave/tags/evaluation.mdx
+++ b/support/weave/tags/evaluation.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>
   The following two methods should be used together in order t ...
 </Card>

--- a/support/weave/tags/performance.mdx
+++ b/support/weave/tags/performance.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>
   The following two methods should be used together in order t ...
 </Card>

--- a/support/weave/tags/system-info.mdx
+++ b/support/weave/tags/system-info.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How can I disable system information capture?" href="/support/weave/articles/how-can-i-disable-system-information-cap" arrow="true" horizontal>
   You can disable system information capture during Weave clie ...
 </Card>

--- a/support/weave/tags/trace-data.mdx
+++ b/support/weave/tags/trace-data.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="Trace data is truncated" href="/support/weave/articles/trace-data-is-truncated" arrow="true" horizontal>
   Sometimes, large trace data is partially cut off in the Weav ...
 </Card>

--- a/support/weave/tags/ui-rendering.mdx
+++ b/support/weave/tags/ui-rendering.mdx
@@ -7,8 +7,6 @@ Built with DocEngine. Do not edit this MDX file directly.
 Template: /sites/wandb-docs/templates/support_tag.mdx.j2
 */}
 
-<Card title="Return to Support Home" icon="arrow-left" href="/support/index" horizontal />
-
 <Card title="How do I render Markdown in the UI?" href="/support/weave/articles/how-do-i-render-markdown-in-the-ui" arrow="true" horizontal>
   Wrap your string with weave.Markdown(...) before saving, and ...
 </Card>


### PR DESCRIPTION
This PR implements the MDX page updates caused by [DocEngine PR 53](https://github.com/coreweave/docengine/pull/53).

> [!IMPORTANT]
> Please review before merging. Do not assume it is safe!
---
**Source PR (DocEngine)**
**Title**: Remove "Return to Support Home" links

**Description**:

Removes the "Return to Support Home" cards at top of KB pages

---

**Workflow run**: Run number 15 — [View build](https://github.com/coreweave/docengine/actions/runs/23219619025)
**Branch**: `39a00a2d99287e3c3e0b2d51a204bf7420ca0d2f` — [View branch](https://github.com/coreweave/docengine/tree/39a00a2d99287e3c3e0b2d51a204bf7420ca0d2f)

This PR contains **auto-generated** updates from DocEngine.

**Source**: `coreweave/docengine` @ `39a00a2d99287e3c3e0b2d51a204bf7420ca0d2f`
**Trigger**: push | **Site**: `wandb-docs`