### PR TITLE
fix typo for ingress config

### DIFF
--- a/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
+++ b/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
@@ -416,7 +416,7 @@ spec:
 
     ingress:
       annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: 0
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
       class: nginx
 ```
 


### PR DESCRIPTION
Adding missing speech marks that is required to be added to the airgapped installation CR ingress annotation
