### PR TITLE
[Weave] Adds self-managed URL to reference docs

### DIFF
--- a/weave/reference/service-api.mdx
+++ b/weave/reference/service-api.mdx
@@ -5,13 +5,13 @@ description: "Use the Weave Service API, which provides REST endpoints for progr
 
 ## Base URL
 
-For [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) and [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), use the following base URL:
+For [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) and [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), use the following base URL:
 
 ```
 https://trace.wandb.ai
 ```
 
-For [Self-Managed instances](/weave/guides/platform/weave-self-managed), use:
+For [W&B Self-Managed instances](/weave/guides/platform/weave-self-managed), use:
 
 ```
 https://<your-subdomain>.wandb.io/traces

--- a/weave/reference/service-api.mdx
+++ b/weave/reference/service-api.mdx
@@ -5,13 +5,13 @@ description: "Use the Weave Service API, which provides REST endpoints for progr
 
 ## Base URL
 
-For W&B Multi-tenant Cloud and Dedicated Cloud, use the following base URL:
+For [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) and [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), use the following base URL:
 
 ```
 https://trace.wandb.ai
 ```
 
-For Self-Managed instances, use:
+For [Self-Managed instances](/weave/guides/platform/weave-self-managed), use:
 
 ```
 https://<your-subdomain>.wandb.io/traces

--- a/weave/reference/service-api.mdx
+++ b/weave/reference/service-api.mdx
@@ -5,8 +5,16 @@ description: "Use the Weave Service API, which provides REST endpoints for progr
 
 ## Base URL
 
+For W&B Multi-tenant Cloud and Dedicated Cloud, use the following base URL:
+
 ```
 https://trace.wandb.ai
+```
+
+For Self-Managed instances, use:
+
+```
+https://<your-subdomain>.wandb.io/traces
 ```
 
 ## Authentication


### PR DESCRIPTION
## Description
Resolves DOCS-1072. Updates the Weave Service API reference overview page with the base URL for self-managed instances.