### PR TITLE
docs: recommend aliases over version indices in prompt versioning

### DIFF
--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -37,7 +37,7 @@ weave:///<your-team-name>/<your-project-name>/object/<object_name>:<object_versi
 - _your-team-name_: W&B entity (username or team name)
 - _your-project-name_: W&B project
 - _object_name_: object name
-- _object_version_: either a version hash, a version index like `v0` or `v1`, or an alias like `:latest` or `:production`. All objects have the `:latest` alias. For stable references, prefer aliases or version hashes over version indices.
+- _object_version_: either a version hash, a version index like `v0` or `v1`, or an alias like `:latest` or `:production`. All objects have the `:latest` alias, which automatically points to the most recently published version.
 
 For example, a fully qualified Weave prompt URI looks like this:
 
@@ -52,7 +52,7 @@ To retrieve a prompt, create a reference to its name and version, then call `.ge
 You can construct refs with a few different styles:
 
 - `weave.ref(<name>)`: Retrieves the `:latest` version of a prompt. Requires calling `weave.init(...)`.
-- `weave.ref(<name>:<version_or_alias>)`:  Retrieves the specified version or alias of a prompt. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) or digest hashes over version indices (e.g. `v3`), which can shift.
+- `weave.ref(<name>:<alias_or_version>)`: Retrieves a prompt by alias, version hash, or version index. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) over version indices (e.g. `v3`), which can shift.
 - `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init(...)`.
 
 

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -64,8 +64,8 @@ To view versions of the prompt in the UI:
 
 You can organize prompt versions using aliases and tags. These labels help identify and reference specific versions.
 
-- An alias is a unique name that points to one prompt version at a time. It can be used to get a reference to the prompt it points to.
-- Tags are descriptive labels on a version. A version can have many tags. Use tags to organize and find versions in the UI and in code.
+- Alias: A unique name that resolves to a single prompt version. You can move an alias to point to a different version at any time, making it useful for stable references like production or staging.
+- Tag: A descriptive label attached to a version. A version can have multiple tags. Use tags to categorize and filter versions, such as reviewed or passed-eval.
 
 To set aliases and tags for your prompts in the UI:
 1. In the Weave project sidebar, click **Assets**. This opens the Assets page.
@@ -166,7 +166,7 @@ You can construct refs with a few different styles:
 
 - `weave.ref(<name>)`: Retrieves the `:latest` version of a prompt. Requires calling `weave.init(...)`.
 - `weave.ref(<name>:<alias_or_version>)`: Retrieves a prompt by alias, version hash, or version index. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) over version indices (e.g. `v3`), which can shift.
-- `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init`.
+- `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init(...)`.
 
 The following example loads the `support_prompt` prompt by its `production` alias:
 
@@ -180,7 +180,7 @@ prompt = weave.ref("support_prompt:production").get()
 
 ## Use prompt versions in production
 
-When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index or latest version. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
+When deploying prompts in production systems, use an [alias](#add-prompt-tags-and-aliases) like `production` rather than a version index or latest version. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
 
 Aliases are stable named pointers that always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
 

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -19,10 +19,6 @@ Weave automatically tracks every version of your prompts, creating a complete hi
 
 Each version is immutable. Once created, the contents of that version cannot be changed. If you update a prompt and publish it again, Weave creates a new version while preserving previous versions.
 
-:::warning
-Version indices like `v0`, `v1`, `v2` are computed from creation timestamps and are **not guaranteed to be stable**. In rare cases, re-publishing identical content can cause version indices to shift. Use [aliases](#prompt-tags-and-aliases) instead of version numbers to create stable references to specific prompt versions.
-:::
-
 Versioning enables you to:
 
 - Reproduce past experiments.
@@ -41,7 +37,7 @@ weave:///<your-team-name>/<your-project-name>/object/<object_name>:<object_versi
 - _your-team-name_: W&B entity (username or team name)
 - _your-project-name_: W&B project
 - _object_name_: object name
-- _object_version_: either a version hash, a string like `v0` or `v1`, or an alias like `:latest` or `:production`. All objects have the `:latest` alias. For stable references, prefer aliases or version hashes over version indices like `v0`.
+- _object_version_: either a version hash, a version index like `v0` or `v1`, or an alias like `:latest` or `:production`. All objects have the `:latest` alias. For stable references, prefer aliases or version hashes over version indices.
 
 For example, a fully qualified Weave prompt URI looks like this:
 

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -11,13 +11,13 @@ When you publish a prompt with `weave.publish`, W&B Weave creates an immutable v
 
 Prompts in Weave are stored as **versioned objects**. This allows you to safely iterate on prompts while ensuring that evaluations, experiments, and production systems can reference the exact prompt version they were run with.
 
-Prompt versions are accessed using Weave object references. This page explains how prompt versions are created, how to retrieve a specific version in code, and how to inspect and compare versions in the Weave UI.
+Prompt versions are accessed using Weave object references. This page explains how prompt versions are created, how to organize them with tags and aliases, how to retrieve a specific version in code, and how to use prompts in production.
 
 ## How prompt versions are created
 
-Weave automatically tracks every version of your prompts, creating a complete history of how your prompts evolve. This versioning system is crucial for prompt engineering workflows, allowing you to experiment safely, track what changes improved or hurt performance, and easily roll back to previous versions if needed. Each time you publish a prompt with the same name but different content, Weave creates a new version while preserving all previous versions.
+Weave automatically tracks every version of your prompts, creating a complete history of how your prompts evolve. This versioning system is crucial for prompt engineering workflows, allowing you to experiment safely, track what changes improved or hurt performance, and easily roll back to previous versions if needed.
 
-Each version is immutable. Once created, the contents of that version cannot be changed. If you update a prompt and publish it again, Weave creates a new version while preserving previous versions.
+Each version is immutable. Once created, the contents of that version cannot be changed. If you update a prompt and publish it again, Weave creates a new version while preserving all previous versions.
 
 Versioning enables you to:
 
@@ -45,53 +45,6 @@ For example, a fully qualified Weave prompt URI looks like this:
 weave:///your-team-name/your-project-name/object/support_prompt:production
 ```
 
-## Retrieve a prompt version in code
-
-To retrieve a prompt, create a reference to its name and version, then call `.get()` to load it. A ref points to a stored object; `.get()` fetches that object so you can use it in your application.
-
-You can construct refs with a few different styles:
-
-- `weave.ref(<name>)`: Retrieves the `:latest` version of a prompt. Requires calling `weave.init(...)`.
-- `weave.ref(<name>:<alias_or_version>)`: Retrieves a prompt by alias, version hash, or version index. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) over version indices (e.g. `v3`), which can shift.
-- `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init(...)`.
-
-
-
-The following example loads the `support_prompt` prompt by its `production` alias:
-
-```python lines
-import weave
-
-weave.init("your-team-name/your-project-name")
-
-prompt = weave.ref("support_prompt:production").get()
-```
-
-## Use prompt versions in production
-
-When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index or latest version. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
-
-Aliases are stable named pointers that always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
-
-Using an alias ensures that production behavior remains stable and predictable. When you're ready to promote a new version, move the alias and all consumers automatically pick up the change.
-
-A common workflow looks like this:
-
-1. Develop and test a new prompt version.
-2. Evaluate the new prompt against datasets or evaluation suites.
-3. Move the `production` alias to the new version with `client.set_aliases(new_ref, "production")`.
-
-```python lines
-import weave
-
-client = weave.init("your-team-name/your-project-name")
-
-# Load whatever version "production" currently points to
-prompt = weave.ref("my-prompt:production").get()
-```
-
-This approach allows teams to safely iterate on prompts without unexpectedly changing production behavior.
-
 ## <a id="view-prompts" aria-label="View and compare prompt versions"></a>View and compare prompt versions
 
 To view versions of the prompt in the UI:
@@ -103,7 +56,7 @@ To view versions of the prompt in the UI:
 
 ![UI of Prompt Assets, showing the versions of the selected prompt.](/weave/guides/core-types/imgs/prompt-object.png)
 
-5. (Optional) You can compare versions of prompts by clicking the checkboxes beside the listed prompts and then clicking the **Compare** button in the table toolbar. This allows you to see the diff between your prompts.
+1. (Optional) You can compare versions of prompts by clicking the checkboxes beside the listed prompts and then clicking the **Compare** button in the table toolbar. This allows you to see the diff between your prompts.
 
 ![The Compare prompts UI showing a diff between two different prompt versions.](/weave/guides/core-types/imgs/prompt-comparison.png)
 
@@ -130,7 +83,7 @@ Tags and aliases can also be managed in code, for tasks such as:
 - Pointing aliases at specific versions and resolving them to load prompts.
 - Adding, removing, or listing tags and aliases on versions.
 
-The following code example adds a prompt `my-prompt` to your project with three versions, each having various tags and aliases. Update `'your-team-name/your-project-name'` accordingly for your project.
+The following code example adds a prompt `my-prompt` to your project with various tags and aliases. Update `'your-team-name/your-project-name'` accordingly for your project.
 
 <CodeGroup>
 ```python Python lines
@@ -204,3 +157,39 @@ This feature is not available in the TypeScript SDK yet.
 ```
 </CodeGroup>
 When you run the example, Weave prints links to your objects in the Weave dashboard. Follow the links to see your prompts.
+
+## Retrieve a prompt version in code
+
+To retrieve a prompt, create a reference to its name and optionally a version, then call `.get()` to load it. A ref points to a stored object; `.get()` fetches that object so you can use it in your application.
+
+You can construct refs with a few different styles:
+
+- `weave.ref(<name>)`: Retrieves the `:latest` version of a prompt. Requires calling `weave.init(...)`.
+- `weave.ref(<name>:<alias_or_version>)`: Retrieves a prompt by alias, version hash, or version index. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) over version indices (e.g. `v3`), which can shift.
+- `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init`.
+
+The following example loads the `support_prompt` prompt by its `production` alias:
+
+```python lines
+import weave
+
+weave.init("your-team-name/your-project-name")
+
+prompt = weave.ref("support_prompt:production").get()
+```
+
+## Use prompt versions in production
+
+When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index or latest version. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
+
+Aliases are stable named pointers that always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
+
+Using an alias ensures that production behavior remains stable and predictable. When you're ready to promote a new version, move the alias and all consumers automatically pick up the change.
+
+A common workflow looks like this:
+
+1. Develop and test a new prompt version.
+2. Evaluate the new prompt against datasets or evaluation suites.
+3. Move the `production` alias to the new version with `client.set_aliases(new_ref, "production")`.
+
+This approach allows teams to safely iterate on prompts without unexpectedly changing production behavior.

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -64,8 +64,8 @@ To view versions of the prompt in the UI:
 
 You can organize prompt versions using aliases and tags. These labels help identify and reference specific versions.
 
-- Alias: A unique name that resolves to a single prompt version. You can move an alias to point to a different version at any time, making it useful for stable references like production or staging.
-- Tag: A descriptive label attached to a version. A version can have multiple tags. Use tags to categorize and filter versions, such as reviewed or passed-eval.
+- An alias is a unique name that points to one prompt version at a time. It can be used to get a reference to the prompt it points to.
+- Tags are descriptive labels on a version. A version can have many tags. Use tags to organize and find versions in the UI and in code.
 
 To set aliases and tags for your prompts in the UI:
 1. In the Weave project sidebar, click **Assets**. This opens the Assets page.

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -19,6 +19,10 @@ Weave automatically tracks every version of your prompts, creating a complete hi
 
 Each version is immutable. Once created, the contents of that version cannot be changed. If you update a prompt and publish it again, Weave creates a new version while preserving previous versions.
 
+:::warning
+Version indices like `v0`, `v1`, `v2` are computed from creation timestamps and are **not guaranteed to be stable**. In rare cases, re-publishing identical content can cause version indices to shift. Use [aliases](#prompt-tags-and-aliases) instead of version numbers to create stable references to specific prompt versions.
+:::
+
 Versioning enables you to:
 
 - Reproduce past experiments.
@@ -37,12 +41,12 @@ weave:///<your-team-name>/<your-project-name>/object/<object_name>:<object_versi
 - _your-team-name_: W&B entity (username or team name)
 - _your-project-name_: W&B project
 - _object_name_: object name
-- _object_version_: either a version hash, a string like `v0` or `v1`, or an alias like `:latest`. All objects have the `:latest` alias.
+- _object_version_: either a version hash, a string like `v0` or `v1`, or an alias like `:latest` or `:production`. All objects have the `:latest` alias. For stable references, prefer aliases or version hashes over version indices like `v0`.
 
 For example, a fully qualified Weave prompt URI looks like this:
 
 ```text
-weave:///your-team-name/your-project-name/object/support_prompt:v3
+weave:///your-team-name/your-project-name/object/support_prompt:production
 ```
 
 ## Retrieve a prompt version in code
@@ -52,31 +56,45 @@ To retrieve a prompt, create a reference to its name and version, then call `.ge
 You can construct refs with a few different styles:
 
 - `weave.ref(<name>)`: Retrieves the `:latest` version of a prompt. Requires calling `weave.init(...)`.
-- `weave.ref(<name>:<version>)`:  Retrieves the specified version of a prompt. Requires calling `weave.init(...)`.
+- `weave.ref(<name>:<version_or_alias>)`:  Retrieves the specified version or alias of a prompt. Requires calling `weave.init(...)`. Prefer aliases (e.g. `production`) or digest hashes over version indices (e.g. `v3`), which can shift.
 - `weave.ref(<fully_qualified_ref_uri>)`: Retrieves the prompt located at the specified [fully qualified ref URI](#construct-a-fully-qualified-ref-uri). Does not require calling `weave.init(...)`.
 
 
-The following example loads the `support_prompt:v3` version so you can use it in your application:
+
+The following example loads the `support_prompt` prompt by its `production` alias:
 
 ```python lines
 import weave
 
 weave.init("your-team-name/your-project-name")
 
-prompt = weave.ref("support_prompt:v3").get()
+prompt = weave.ref("support_prompt:production").get()
 ```
 
 ## Use prompt versions in production
 
-When deploying prompts in production systems, pin a specific prompt version rather than referencing the latest version. In your production application, load that version with `weave.ref(<name>:<version>).get()`.
+When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index like `v3`. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
 
-Pinning a version ensures that production behavior remains stable even if new prompt versions are published later.
+Aliases are stable named pointers — they always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
+
+Using an alias ensures that production behavior remains stable and predictable. When you're ready to promote a new version, move the alias — all consumers automatically pick up the change.
 
 A common workflow looks like this:
 
 1. Develop and test a new prompt version.
 2. Evaluate the new prompt against datasets or evaluation suites.
-3. Update the production system to reference the new version.
+3. Move the `production` alias to the new version with `client.set_aliases(new_ref, "production")`.
+
+```python lines
+import weave
+
+client = weave.init("your-team-name/your-project-name")
+
+# Load whatever version "production" currently points to
+prompt = weave.ref("my-prompt:production").get()
+
+response = chat_model.invoke(prompt.format(question=user_input))
+```
 
 This approach allows teams to safely iterate on prompts without unexpectedly changing production behavior.
 

--- a/weave/guides/core-types/prompts-version.mdx
+++ b/weave/guides/core-types/prompts-version.mdx
@@ -73,11 +73,11 @@ prompt = weave.ref("support_prompt:production").get()
 
 ## Use prompt versions in production
 
-When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index like `v3`. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
+When deploying prompts in production systems, use an [alias](#prompt-tags-and-aliases) like `production` rather than a version index or latest version. In your production application, load the prompt with `weave.ref(<name>:<alias>).get()`.
 
-Aliases are stable named pointers — they always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
+Aliases are stable named pointers that always resolve to the version you assigned them to. Version indices (`v0`, `v1`, ...) are computed from timestamps and can shift if the same content is re-published, so they are not safe to use as long-lived references.
 
-Using an alias ensures that production behavior remains stable and predictable. When you're ready to promote a new version, move the alias — all consumers automatically pick up the change.
+Using an alias ensures that production behavior remains stable and predictable. When you're ready to promote a new version, move the alias and all consumers automatically pick up the change.
 
 A common workflow looks like this:
 
@@ -92,8 +92,6 @@ client = weave.init("your-team-name/your-project-name")
 
 # Load whatever version "production" currently points to
 prompt = weave.ref("my-prompt:production").get()
-
-response = chat_model.invoke(prompt.format(question=user_input))
 ```
 
 This approach allows teams to safely iterate on prompts without unexpectedly changing production behavior.


### PR DESCRIPTION
## Summary
- Add warning callout that version indices (`v0`, `v1`, ...) are not guaranteed stable
- Update examples and guidance to recommend aliases (e.g. `production`) and digest hashes over version indices
- Rewrite "Use prompt versions in production" section to center on alias-based workflows

## Test plan
- [ ] Verify internal links (`#prompt-tags-and-aliases`) resolve correctly
- [ ] Confirm code examples render properly
- [ ] Review warning callout renders in Docusaurus