### PR TITLE
style: black text for Mintlify announcement banner

### DIFF
--- a/table-styling.css
+++ b/table-styling.css
@@ -66,3 +66,6 @@ table tr:not(:last-child) td {
 .dark table tr:not(:last-child) td {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
+#banner > div > p, #banner > div > p > a, #banner > div, #banner > button > svg, .lucide-x {
+  color: black !important;
+}


### PR DESCRIPTION
## Description

Adds CSS overrides in `table-styling.css` so the Mintlify announcement banner (`#banner`) uses black text and icons for paragraph copy, links, the banner container, the close button SVG, and `.lucide-x`. This improves contrast when the banner uses a light background.

## Testing

- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)

Reviewers can verify visually that banner text and the close control are readable on the current banner styling.

Made with [Cursor](https://cursor.com)

<img width="1322" height="455" alt="image" src="https://github.com/user-attachments/assets/4cbb69dd-2ad0-446f-85d2-159a541b811f" />
