### PR TITLE
Remove Sweeps UI page (DOCS-1218)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -268,7 +268,6 @@
                       "models/sweeps/useful-resources",
                       "models/sweeps/local-controller",
                       "models/sweeps/troubleshoot-sweeps",
-                      "models/sweeps/sweeps-ui",
                       "models/sweeps/existing-project"
                     ]
                   },
@@ -3891,6 +3890,14 @@
     },
     {
       "source": "/models/tutorials/xgboost_sweeps",
+      "destination": "/models/sweeps"
+    },
+    {
+      "source": "/models/sweeps/sweeps-ui",
+      "destination": "/models/sweeps"
+    },
+    {
+      "source": "/models/sweeps/sweeps-ui/",
       "destination": "/models/sweeps"
     },
     {

--- a/models/sweeps/existing-project.mdx
+++ b/models/sweeps/existing-project.mdx
@@ -21,7 +21,7 @@ Optionally explore the example appear in the W&B App UI dashboard.
 
 ## 2. Create a sweep
 
-From your project page, open the [Sweep tab](./sweeps-ui) in the project sidebar and select **Create Sweep**.
+From your project page, open the [Sweep tab](./visualize-sweep-results) in the project sidebar and select **Create Sweep**.
 
 <Frame>
     <img src="/images/sweeps/sweep1.png" alt="Sweep overview"  />

--- a/models/sweeps/sweep-config-keys.mdx
+++ b/models/sweeps/sweep-config-keys.mdx
@@ -83,7 +83,7 @@ Iterate over every combination of hyperparameter values. Grid search makes uninf
 Grid search executes forever if it is searching within in a continuous search space.
 
 #### Random search
-Choose a random, uninformed, set of hyperparameter values on each iteration based on a distribution. Random search runs forever unless you stop the process from the command line, within your python script, or [the W&B App](/models/sweeps/sweeps-ui/).
+Choose a random, uninformed, set of hyperparameter values on each iteration based on a distribution. Random search runs forever unless you stop the process from the command line, within your python script, or [the W&B App](/models/sweeps/visualize-sweep-results/).
 
 Specify the distribution space with the metric key if you choose random (`method: random`) search.
 
@@ -92,7 +92,7 @@ In contrast to [random](#random-search) and [grid](#grid-search) search, Bayesia
 
 {/* There are different Bayesian optimization methods. W&B uses a Gaussian process to model the relationship between hyperparameters and the model metric. For more information, see this paper. [LINK] */}
 
-Bayesian search runs forever unless you stop the process from the command line, within your python script, or [the W&B App](/models/sweeps/sweeps-ui/). 
+Bayesian search runs forever unless you stop the process from the command line, within your python script, or [the W&B App](/models/sweeps/visualize-sweep-results/). 
 
 ### Distribution options for random and Bayesian search
 Within the `parameter` key, nest the name of the hyperparameter. Next, specify the `distribution` key and specify a distribution for the value.

--- a/models/sweeps/sweeps-ui.mdx
+++ b/models/sweeps/sweeps-ui.mdx
@@ -1,6 +1,0 @@
----
-description: Describes the different components of the Sweeps UI.
-title: Sweeps UI
----
-
-The state (**State**), creation time (**Created**), the entity that started the sweep (**Creator**), the number of runs completed (**Run count**), and the time it took to compute the sweep (**Compute time**) are displayed in the Sweeps UI. The expected number of runs a sweep will create (**Est. Runs**) is provided when you do a grid search over a discrete search space. You can also click on a sweep to pause, resume, stop, or kill the sweep from the interface.

--- a/models/sweeps/visualize-sweep-results.mdx
+++ b/models/sweeps/visualize-sweep-results.mdx
@@ -5,6 +5,8 @@ title: Visualize sweep results
 
 Visualize the results of your W&B Sweeps with the W&B App. Navigate to the [W&B App](https://wandb.ai/home). Choose the project that you specified when you initialized a sweep. You will be redirected to your project [workspace](/models/track/workspaces/). Select the **Sweep icon** in the project sidebar (broom icon). From the Sweep UI, select the name of your Sweep from the list.
 
+The sweep list shows each sweep's state (**State**), creation time (**Created**), who started it (**Creator**), how many runs finished (**Run count**), and total **Compute time**. For a grid search over a discrete search space, W&B also shows **Est. Runs** (the expected number of runs). Open a sweep from the list to pause, resume, stop, or kill it from the app. For the same controls with the CLI, see [Manage sweeps](/models/sweeps/pause-resume-and-cancel-sweeps/).
+
 By default, W&B will automatically create a parallel coordinates plot, a parameter importance plot, and a scatter plot when you start a W&B Sweep job.
 
 <Frame>

--- a/support/models/articles/can-i-rerun-a-grid-search.mdx
+++ b/support/models/articles/can-i-rerun-a-grid-search.mdx
@@ -3,7 +3,7 @@ title: "Can I rerun a grid search?"
 keywords: ["Sweeps", "Hyperparameter", "Runs"]
 ---
 
-If a grid search completes but some W&B Runs need re-execution due to crashes, delete the specific W&B Runs to re-run. Then, select the **Resume** button on the [sweep control page](/models/sweeps/sweeps-ui). Start new W&B Sweep agents using the new Sweep ID.
+If a grid search completes but some W&B Runs need re-execution due to crashes, delete the specific W&B Runs to re-run. Then, select the **Resume** button on the [Sweep list in the W&B App](/models/sweeps/visualize-sweep-results). Start new W&B Sweep agents using the new Sweep ID.
 
 W&B Run parameter combinations that completed are not re-executed.
 


### PR DESCRIPTION
## Summary
Removes the standalone English **Sweeps UI** doc page and folds its useful content into **Visualize sweep results**. Adds a redirect from the old URL to the [Sweeps overview](https://docs.wandb.ai/models/sweeps).

## Changes
- Delete `models/sweeps/sweeps-ui.mdx` and remove it from English nav in `docs.json`
- Document sweep list columns and in-app pause / resume / stop / kill on `models/sweeps/visualize-sweep-results.mdx`, with a link to **Manage sweeps** for CLI parity
- Update internal links (`sweep-config-keys`, `existing-project`, support article) to point at visualize
- Redirect `/models/sweeps/sweeps-ui` and `/models/sweeps/sweeps-ui/` → `/models/sweeps`
- **Japanese and Korean** Sweeps UI pages and nav entries are unchanged (per team preference)

Resolves DOCS-1218

Made with [Cursor](https://cursor.com)