### PR TITLE
updating Plots page to style standards-DOCS-1710

### DIFF
--- a/models/track/log/plots.mdx
+++ b/models/track/log/plots.mdx
@@ -9,7 +9,7 @@ In W&B Models, methods in `wandb.plot` let you track charts with `wandb.Run.log(
 
 To create a W&B chart:
 1. Create a `wandb.Table` object and add the data you want to visualize.
-1. Generate a plot using a `wandb.plot` helper function.
+1. Generate a plot using one of the W&B's built-in [helper functions](/models/ref/python/custom-charts)
 1. Log the plot with `run.log()`.
 
 The following basic charts can be used to construct basic visualizations of metrics and results.

--- a/models/track/log/plots.mdx
+++ b/models/track/log/plots.mdx
@@ -10,7 +10,7 @@ In W&B Models, methods in `wandb.plot` let you track charts with `wandb.Run.log(
 To create a W&B chart:
 1. Create a `wandb.Table` object and add the data you want to visualize.
 1. Generate a plot using one of the W&B's built-in [helper functions](/models/ref/python/custom-charts)
-1. Log the plot with `run.log()`.
+1. Log the plot with `wandb.Run.log()`.
 
 The following basic charts can be used to construct basic visualizations of metrics and results.
 

--- a/models/track/log/plots.mdx
+++ b/models/track/log/plots.mdx
@@ -8,7 +8,7 @@ In W&B Models, methods in `wandb.plot` let you track charts with `wandb.Run.log(
 ### Basic charts
 
 To create a W&B chart:
-1. Create a `wandb.Table` containing the data you want to visualize.
+1. Create a `wandb.Table` object and add the data you want to visualize.
 1. Generate a plot using a `wandb.plot` helper function.
 1. Log the plot with `run.log()`.
 

--- a/models/track/log/plots.mdx
+++ b/models/track/log/plots.mdx
@@ -3,15 +3,20 @@ description: Create and track plots from machine learning experiments.
 title: Create and track plots from experiments
 ---
 
-Using the methods in `wandb.plot`, you can track charts with `wandb.Run.log()`, including charts that change over time during training. To learn more about our custom charting framework, check out the [custom charts walkthrough](/models/app/features/custom-charts/walkthrough/).
+In W&B Models, methods in `wandb.plot` let you track charts with `wandb.Run.log()`, including charts that change over time during training. To learn more about the custom charting framework, see the [custom charts walkthrough](/models/app/features/custom-charts/walkthrough/).
 
 ### Basic charts
 
-These simple charts make it easy to construct basic visualizations of metrics and results.
+To create a W&B chart:
+1. Create a `wandb.Table` containing the data you want to visualize.
+1. Generate a plot using a `wandb.plot` helper function.
+1. Log the plot with `run.log()`.
+
+The following basic charts can be used to construct basic visualizations of metrics and results.
 
 <Tabs>
 <Tab title="Line">
-Log a custom line plot—a list of connected and ordered points on arbitrary axes.
+Log a custom line plot, a list of connected and ordered points on arbitrary axes.
 
 ```python
 import wandb
@@ -22,7 +27,7 @@ with wandb.init() as run:
     run.log(
         {
             "my_custom_plot_id": wandb.plot.line(
-                table, "x", "y", title="Custom Y vs X Line Plot"
+                table, "x", "y", title="Custom Y versus X line plot"
             )
         }
     )
@@ -34,12 +39,12 @@ You can use this to log curves on any two dimensions. If you're plotting two lis
     <img src="/images/track/line_plot.png" alt="Custom line plot"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Custom-Line-Plots--VmlldzoyNjk5NTA)
+For more information, see the [Creating Custom Line Plots With W&B](https://wandb.ai/wandb/plots/reports/Custom-Line-Plots--VmlldzoyNjk5NTA) report.
 
 [Run the code](https://tiny.cc/custom-charts)
 </Tab>
 <Tab title="Scatter">
-Log a custom scatter plot—a list of points (x, y) on a pair of arbitrary axes x and y.
+Log a custom scatter plot, a list of points (x, y) on a pair of arbitrary axes x and y.
 
 ```python
 import wandb
@@ -56,12 +61,12 @@ You can use this to log scatter points on any two dimensions. If you're plotting
     <img src="/images/track/demo_scatter_plot.png" alt="Custom scatter plot"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Custom-Scatter-Plots--VmlldzoyNjk5NDQ)
+For more information, see the [Creating Custom Scatter Plots With W&B](https://wandb.ai/wandb/plots/reports/Custom-Scatter-Plots--VmlldzoyNjk5NDQ) report.
 
 [Run the code](https://tiny.cc/custom-charts)
 </Tab>
 <Tab title="Bar">
-Log a custom bar chart—a list of labeled values as bars—natively in a few lines:
+Log a custom bar chart (a list of labeled values as bars) natively in a few lines:
 
 ```python
 import wandb
@@ -71,11 +76,11 @@ with wandb.init() as run:
     table = wandb.Table(data=data, columns=["label", "value"])
     run.log(
         {
-        "my_bar_chart_id": wandb.plot.bar(
-            table, "label", "value", title="Custom Bar Chart"
-        )
-    }
-)
+            "my_bar_chart_id": wandb.plot.bar(
+                table, "label", "value", title="Custom bar chart"
+            )
+        }
+    )
 ```
 
 You can use this to log arbitrary bar charts. The number of labels and values in the lists must match exactly. Each data point must have both.
@@ -84,12 +89,12 @@ You can use this to log arbitrary bar charts. The number of labels and values in
     <img src="/images/track/basic_charts_bar.png" alt="Custom bar chart"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Custom-Bar-Charts--VmlldzoyNzExNzk)
+For more information, see the [Custom Bar Charts](https://wandb.ai/wandb/plots/reports/Custom-Bar-Charts--VmlldzoyNzExNzk) report.
 
 [Run the code](https://tiny.cc/custom-charts)
 </Tab>
 <Tab title="Histogram">
-Log a custom histogram—sort a list of values into bins by count/frequency of occurrence—natively in a few lines. Let's say I have a list of prediction confidence scores (`scores`) and want to visualize their distribution:
+Log a custom histogram (sort a list of values into bins by count or frequency of occurrence) natively in a few lines. If you have a list of prediction confidence scores (`scores`), you can visualize the distribution like this:
 
 ```python
 import wandb
@@ -106,7 +111,7 @@ You can use this to log arbitrary histograms. Note that `data` is a list of list
     <img src="/images/track/demo_custom_chart_histogram.png" alt="Custom histogram"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Custom-Histograms--VmlldzoyNzE0NzM)
+For more information, see the [Creating Custom Histograms With W&B](https://wandb.ai/wandb/plots/reports/Custom-Histograms--VmlldzoyNzE0NzM) report.
 
 [Run the code](https://tiny.cc/custom-charts)
 </Tab>
@@ -115,18 +120,19 @@ Plot multiple lines, or multiple different lists of x-y coordinate pairs, on one
 
 ```python
 import wandb
+
 with wandb.init() as run:
     run.log(
         {
             "my_custom_id": wandb.plot.line_series(
                 xs=[0, 1, 2, 3, 4],
                 ys=[[10, 20, 30, 40, 50], [0.5, 11, 72, 3, 41]],
-            keys=["metric Y", "metric Z"],
-            title="Two Random Metrics",
-            xname="x units",
-        )
-    }
-)
+                keys=["metric Y", "metric Z"],
+                title="Two Random Metrics",
+                xname="x units",
+            )
+        }
+    )
 ```
 
 Note that the number of x and y points must match exactly. You can supply one list of x values to match multiple lists of y values, or a separate list of x values for each list of y values.
@@ -135,7 +141,7 @@ Note that the number of x and y points must match exactly. You can supply one li
     <img src="/images/track/basic_charts_histogram.png" alt="Multi-line plot"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Custom-Multi-Line-Plots--VmlldzozOTMwMjU)
+For more information, see the [Custom Multi-Line Plots](https://wandb.ai/wandb/plots/reports/Custom-Multi-Line-Plots--VmlldzozOTMwMjU) report.
 </Tab>
 </Tabs>
 
@@ -152,8 +158,8 @@ Create a [Precision-Recall curve](https://scikit-learn.org/stable/modules/genera
 ```python
 import wandb
 with wandb.init() as run:
-    # ground_truth is a list of true labels, predictions is a list of predicted scores
-    # e.g. ground_truth = [0, 1, 1, 0], predictions = [0.1, 0.4, 0.35, 0.8]
+    # ground_truth is a list of true labels, predictions is a list of predicted scores.
+    # For example ground_truth = [0, 1, 1, 0], predictions = [0.1, 0.4, 0.35, 0.8]
     ground_truth = [0, 1, 1, 0]
     predictions = [0.1, 0.4, 0.35, 0.8]
     run.log({"pr": wandb.plot.pr_curve(ground_truth, predictions)})
@@ -161,16 +167,16 @@ with wandb.init() as run:
 
 You can log this whenever your code has access to:
 
-* a model's predicted scores (`predictions`) on a set of examples
-* the corresponding ground truth labels (`ground_truth`) for those examples
-* (optionally) a list of the labels/class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, etc.)
-* (optionally) a subset (still in list format) of the labels to visualize in the plot
+* A model's predicted scores (`predictions`) on a set of examples.
+* The corresponding ground truth labels (`ground_truth`) for those examples.
+* (Optional) A list of the labels or class names. For example, `labels=["cat", "dog", "bird"]`, if label index 0 means cat, 1 means dog, 2 means bird.
+* (Optional) A subset (still in list format) of the labels to visualize in the plot.
 
 <Frame>
     <img src="/images/track/model_eval_charts_precision_recall.png" alt="Precision-recall curve"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Plot-Precision-Recall-Curves--VmlldzoyNjk1ODY)
+For more information, see the [Plot Precision Recall Curves With W&B](https://wandb.ai/wandb/plots/reports/Plot-Precision-Recall-Curves--VmlldzoyNjk1ODY) report.
 
 [Run the code](https://colab.research.google.com/drive/1mS8ogA3LcZWOXchfJoMrboW3opY1A8BY?usp=sharing)
 </Tab>
@@ -181,8 +187,8 @@ Create an [ROC curve](https://scikit-learn.org/stable/modules/generated/sklearn.
 import wandb
 
 with wandb.init() as run:
-    # ground_truth is a list of true labels, predictions is a list of predicted scores
-    # e.g. ground_truth = [0, 1, 1, 0], predictions = [0.1, 0.4, 0.35, 0.8]
+    # ground_truth is a list of true labels, predictions is a list of predicted scores.
+    # For example ground_truth = [0, 1, 1, 0], predictions = [0.1, 0.4, 0.35, 0.8]
     ground_truth = [0, 1, 1, 0]
     predictions = [0.1, 0.4, 0.35, 0.8]
     run.log({"roc": wandb.plot.roc_curve(ground_truth, predictions)})
@@ -190,16 +196,16 @@ with wandb.init() as run:
 
 You can log this whenever your code has access to:
 
-* a model's predicted scores (`predictions`) on a set of examples
-* the corresponding ground truth labels (`ground_truth`) for those examples
-* (optionally) a list of the labels/ class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, etc.)
-* (optionally) a subset (still in list format) of these labels to visualize on the plot
+* A model's predicted scores (`predictions`) on a set of examples.
+* The corresponding ground truth labels (`ground_truth`) for those examples.
+* (Optional) A list of the labels or class names. For example, `labels=["cat", "dog", "bird"]`, if label index 0 means cat, 1 means dog, 2 means bird.
+* (Optional) A subset (still in list format) of these labels to visualize on the plot.
 
 <Frame>
     <img src="/images/track/demo_custom_chart_roc_curve.png" alt="ROC curve"  />
 </Frame>
 
-[See in the app](https://wandb.ai/wandb/plots/reports/Plot-ROC-Curves--VmlldzoyNjk3MDE)
+For more information, see the [Plot ROC Curves With W&B](https://wandb.ai/wandb/plots/reports/Plot-ROC-Curves--VmlldzoyNjk3MDE) report.
 
 [Run the code](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Plot_ROC_Curves_with_W%26B.ipynb)
 </Tab>
@@ -219,17 +225,17 @@ with wandb.init() as run:
 
 You can log this wherever your code has access to:
 
-* a model's predicted labels on a set of examples (`preds`) or the normalized probability scores (`probs`). The probabilities must have the shape (number of examples, number of classes). You can supply either probabilities or predictions but not both.
-* the corresponding ground truth labels for those examples (`y_true`)
-* a full list of the labels/class names as strings of `class_names`. Examples: `class_names=["cat", "dog", "bird"]` if index 0 is `cat`, 1 is `dog`, 2 is `bird`.
+* A model's predicted labels on a set of examples (`preds`) or the normalized probability scores (`probs`). The probabilities must have the shape (number of examples, number of classes). You can supply either probabilities or predictions but not both.
+* The corresponding ground truth labels for those examples (`y_true`).
+* A full list of the labels or class names as strings in `class_names`. For example, `class_names=["cat", "dog", "bird"]`, if index 0 is `cat`, 1 is `dog`, 2 is `bird`.
 
 <Frame>
     <img src="/images/experiments/confusion_matrix.png" alt="Confusion matrix"  />
 </Frame>
 
-​[See in the app](https://wandb.ai/wandb/plots/reports/Confusion-Matrix--VmlldzozMDg1NTM)​
+For more information, see the [Confusion Matrix: Usage and Examples](https://wandb.ai/wandb/plots/reports/Confusion-Matrix--VmlldzozMDg1NTM) report.
 
-​[Run the code](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Log_a_Confusion_Matrix_with_W%26B.ipynb)
+[Run the code](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb-log/Log_a_Confusion_Matrix_with_W%26B.ipynb)
 </Tab>
 </Tabs>
 
@@ -240,15 +246,15 @@ For full customization, tweak a built-in [Custom Chart preset](/models/app/featu
 
 ```python
 import wandb
-# Create a table with the columns to plot
+# Create a table with the columns to plot.
 table = wandb.Table(data=data, columns=["step", "height"])
 
-# Map from the table's columns to the chart's fields
+# Map from the table's columns to the chart's fields.
 fields = {"x": "step", "value": "height"}
 
-# Use the table to populate the new custom chart preset
-# To use your own saved chart preset, change the vega_spec_name
-# To edit the title, change the string_fields
+# Use the table to populate the new custom chart preset.
+# To use your own saved chart preset, change the vega_spec_name.
+# To edit the title, change the string_fields.
 my_custom_chart = wandb.plot_table(
     vega_spec_name="carey/new_chart",
     data_table=table,
@@ -257,7 +263,7 @@ my_custom_chart = wandb.plot_table(
 )
 
 with wandb.init() as run:
-    # Log the custom chart
+    # Log the custom chart.
     run.log({"my_custom_chart": my_custom_chart})
 ```
 
@@ -272,19 +278,19 @@ import wandb
 import matplotlib.pyplot as plt
 
 with wandb.init() as run:
-    # Create a simple matplotlib plot
+    # Create a simple matplotlib plot.
     plt.figure()
     plt.plot([1, 2, 3, 4])
     plt.ylabel("some interesting numbers")
-    
-    # Log the plot to W&B
+
+    # Log the plot to W&B.
     run.log({"chart": plt})
 ```
 
 Just pass a `matplotlib` plot or figure object to `wandb.Run.log()`. By default we'll convert the plot into a [Plotly](https://plot.ly/) plot. If you'd rather log the plot as an image, you can pass the plot into `wandb.Image`. We also accept Plotly charts directly.
 
 <Note>
-If you’re getting an error “You attempted to log an empty plot” then you can store the figure separately from the plot with `fig = plt.figure()` and then log `fig` in your call to `wandb.Run.log()`.
+If you get an error like "You attempted to log an empty plot", store the figure separately from the plot with `fig = plt.figure()` and then log `fig` in your call to `wandb.Run.log()`.
 </Note>
 
 ### Log custom HTML to W&B Tables
@@ -293,39 +299,39 @@ W&B supports logging interactive charts from Plotly and Bokeh as HTML and adding
 
 #### Log Plotly figures to Tables as HTML
 
-You can log interactive Plotly charts to wandb Tables by converting them to HTML.
+You can log interactive Plotly charts to W&B Tables by converting them to HTML.
 
 ```python
 import wandb
 import plotly.express as px
 
-# Initialize a new run
+# Initialize a new run.
 with wandb.init(project="log-plotly-fig-tables", name="plotly_html") as run:
 
-    # Create a table
+    # Create a table.
     table = wandb.Table(columns=["plotly_figure"])
 
-    # Create path for Plotly figure
+    # Create path for Plotly figure.
     path_to_plotly_html = "./plotly_figure.html"
 
-    # Example Plotly figure
+    # Example Plotly figure.
     fig = px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])
 
-    # Write Plotly figure to HTML
+    # Write Plotly figure to HTML.
     # Set auto_play to False prevents animated Plotly charts
-    # from playing in the table automatically
+    # from playing in the table automatically.
     fig.write_html(path_to_plotly_html, auto_play=False)
 
-    # Add Plotly figure as HTML file into Table
+    # Add Plotly figure as HTML file into Table.
     table.add_data(wandb.Html(path_to_plotly_html))
 
-    # Log Table
+    # Log table.
     run.log({"test_table": table})
 ```
 
 #### Log Bokeh figures to Tables as HTML
 
-You can log interactive Bokeh charts to wandb Tables by converting them to HTML.
+You can log interactive Bokeh charts to W&B Tables by converting them to HTML.
 
 ```python
 from scipy.signal import spectrogram


### PR DESCRIPTION
## Description

Cleaned up style and clarity.

Normally i don't like touching code in code examples unless i test, but two differnet models said the indentation was off on those so i elected to believe?
Also of note, all the 'see in app' links didn't take you to the app - they took you to a report, so i changed those. 
## Testing
- [x ] Local build succeeds without errors (`mint dev`)
- [x ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed


## Related issues

- Fixes DOCS-1710

