### PR TITLE
[DOCS-1643] Scrub deprecated _runtime

### DIFF
--- a/models/track/public-api-guide.mdx
+++ b/models/track/public-api-guide.mdx
@@ -224,7 +224,6 @@ The following sections describe the different outputs for the above run object a
 
 ```python
 {
-    "_runtime": 4,
     "_step": 4,
     "_timestamp": 1644345412,
     "_wandb": {"runtime": 3},


### PR DESCRIPTION
## Description
Scrub a single mention of `_runtime`, which is deprecated and caused customer confusion.

Fixes DOCS-1643

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
