### PR TITLE
Clarify CoreWeave + W&B observability prerequisites (DOCS-1046)

### DIFF
--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -14,7 +14,7 @@ This page shows how to create, configure, and manage line plots in a [workspace]
 </Frame>
 
 <Tip>
-For [runs](/models/runs) that execute on [CoreWeave](https://coreweave.com) infrastructure, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For details, see [Visualize CoreWeave infrastructure alerts](/models/runs/infrastructure-alerts).
+For [runs](/models/runs) that execute on [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) clusters, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) can monitor your compute infrastructure when the integration is enabled. If an error occurs, W&B populates infrastructure information onto your run's plots in your project's workspace. For prerequisites and details, see [Visualize CoreWeave infrastructure alerts](/models/runs/infrastructure-alerts).
 </Tip>
 
 ## Add a line plot

--- a/models/runs/infrastructure-alerts.mdx
+++ b/models/runs/infrastructure-alerts.mdx
@@ -3,10 +3,21 @@ title: Visualize CoreWeave infrastructure alerts
 description: "View CoreWeave infrastructure alerts such as GPU failures and thermal violations on your W&B experiment run plots."
 ---
 
-Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. During a [W&B run](/models/runs), [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure.
+Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/docs/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
+
+## Prerequisites
+
+The following must be true for this integration to work end to end.
+
+| Prerequisite | Details |
+| --- | --- |
+| **CoreWeave platform** | Available only on [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/docs/products/cks) clusters. Not available on CoreWeave bare metal clusters or CoreWeave Classic. |
+| **SUNK (Slurm on Kubernetes)** | SUNK is deployed in a CKS cluster and ties into the observability systems built into CKS. Training jobs that run through SUNK on CKS therefore satisfy the cluster requirement above. See [About SUNK](https://docs.coreweave.com/products/sunk) in the CoreWeave documentation. |
+| **W&B Python SDK** | For training jobs, use the `wandb` package version **0.20.1** or later when you log a run. |
+| **W&B Server (Dedicated Cloud or Self-Managed)** | If using a W&B Dedicated Cloud or W&B Self-Managed deployment, use W&B Server version **0.73.0** or later. Set the `SERVER_FLAG_ENABLE_CORE_WEAVE_OBSERVABILITY` environment variable on the W&B app pod so the server can accept CoreWeave observability data. |
 
 <Note>
-This feature is in Preview and only available when training on a CoreWeave cluster. Contact your W&B representative for access.
+This feature is in Preview. Contact your W&B representative for access.
 </Note>
 
-If an error occurs, CoreWeave sends that information to W&B. W&B populates infrastructure information onto your run’s plots in your project’s workspace. CoreWeave attempts to automatically resolve some issues, and W&B surfaces that information in the run’s page.
+If an error occurs, CoreWeave sends that information to W&B. W&B populates infrastructure information onto your run's plots in your project's workspace. CoreWeave attempts to automatically resolve some issues, and W&B surfaces that information in the run's page.

--- a/models/runs/infrastructure-alerts.mdx
+++ b/models/runs/infrastructure-alerts.mdx
@@ -3,7 +3,11 @@ title: Visualize CoreWeave infrastructure alerts
 description: "View CoreWeave infrastructure alerts such as GPU failures and thermal violations on your W&B experiment run plots."
 ---
 
-Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
+Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
+
+<Note>
+This feature is in Preview. Contact your W&B representative for access.
+</Note>
 
 ## Prerequisites
 
@@ -12,11 +16,7 @@ The following must be true for this integration to work end-to-end.
 | Prerequisite | Details |
 | --- | --- |
 | **CoreWeave platform** | Available only on [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) clusters. Not available on CoreWeave bare metal clusters or CoreWeave Classic. Training jobs running through [SUNK](https://docs.coreweave.com/products/sunk) on CKS also satisfy this requirement. |
-| **W&B Python SDK** | For training jobs, use the `wandb` package version **0.20.1** or later when you log a run. |
-| **W&B Server (Dedicated Cloud or Self-Managed)** | If using a W&B Dedicated Cloud or W&B Self-Managed deployment, use W&B Server version **0.73.0** or later. Set the `SERVER_FLAG_ENABLE_CORE_WEAVE_OBSERVABILITY` environment variable on the W&B app pod so the server can accept CoreWeave observability data. |
-
-<Note>
-This feature is in Preview. Contact your W&B representative for access.
-</Note>
+| **W&B Python SDK** | For training jobs, use the `wandb` package version `0.20.1` or later when you log a run. |
+| **W&B Server (Dedicated Cloud or Self-Managed)** | If using a W&B Dedicated Cloud or W&B Self-Managed deployment, use W&B Server version `0.73.0` or later. Set the `SERVER_FLAG_ENABLE_CORE_WEAVE_OBSERVABILITY` environment variable on the W&B app pod so the server can accept CoreWeave observability data. |
 
 If an error occurs, CoreWeave sends that information to W&B. W&B populates infrastructure information onto your run's plots in your project's workspace. CoreWeave attempts to automatically resolve some issues, and W&B surfaces that information in the run's page.

--- a/models/runs/infrastructure-alerts.mdx
+++ b/models/runs/infrastructure-alerts.mdx
@@ -3,16 +3,15 @@ title: Visualize CoreWeave infrastructure alerts
 description: "View CoreWeave infrastructure alerts such as GPU failures and thermal violations on your W&B experiment run plots."
 ---
 
-Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/docs/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
+Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
 
 ## Prerequisites
 
-The following must be true for this integration to work end to end.
+The following must be true for this integration to work end-to-end.
 
 | Prerequisite | Details |
 | --- | --- |
-| **CoreWeave platform** | Available only on [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/docs/products/cks) clusters. Not available on CoreWeave bare metal clusters or CoreWeave Classic. |
-| **SUNK (Slurm on Kubernetes)** | SUNK is deployed in a CKS cluster and ties into the observability systems built into CKS. Training jobs that run through SUNK on CKS therefore satisfy the cluster requirement above. See [About SUNK](https://docs.coreweave.com/products/sunk) in the CoreWeave documentation. |
+| **CoreWeave platform** | Available only on [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) clusters. Not available on CoreWeave bare metal clusters or CoreWeave Classic. Training jobs running through [SUNK](https://docs.coreweave.com/products/sunk) on CKS also satisfy this requirement. |
 | **W&B Python SDK** | For training jobs, use the `wandb` package version **0.20.1** or later when you log a run. |
 | **W&B Server (Dedicated Cloud or Self-Managed)** | If using a W&B Dedicated Cloud or W&B Self-Managed deployment, use W&B Server version **0.73.0** or later. Set the `SERVER_FLAG_ENABLE_CORE_WEAVE_OBSERVABILITY` environment variable on the W&B app pod so the server can accept CoreWeave observability data. |
 

--- a/models/runs/infrastructure-alerts.mdx
+++ b/models/runs/infrastructure-alerts.mdx
@@ -3,7 +3,7 @@ title: Visualize CoreWeave infrastructure alerts
 description: "View CoreWeave infrastructure alerts such as GPU failures and thermal violations on your W&B experiment run plots."
 ---
 
-Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) cluster and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) monitors your compute infrastructure during a [W&B run](/models/runs).
+Observe infrastructure alerts such as GPU failures, thermal violations, and more during machine learning experiments you log to W&B. When you run on a supported [CoreWeave Kubernetes Service (CKS)](https://docs.coreweave.com/products/cks) cluster, enable this integration, and satisfy the prerequisites on this page, [CoreWeave Mission Control](https://www.coreweave.com/mission-control) can monitor your compute infrastructure during a [W&B run](/models/runs).
 
 <Note>
 This feature is in Preview. Contact your W&B representative for access.


### PR DESCRIPTION
## Summary

Updates the CoreWeave + W&B observability integration documentation to spell out prerequisites clearly.

## Changes

- **`models/runs/infrastructure-alerts.mdx`**: Add a prerequisites table covering CKS-only scope (not bare metal or CoreWeave Classic), SUNK on CKS, `wandb` 0.20.1+ for training jobs, and W&B server 0.73.0+ with `SERVER_FLAG_ENABLE_CORE_WEAVE_OBSERVABILITY` on the app pod for Dedicated Cloud and Self-Managed. Tighten the intro to match supported setups.
- **`models/app/features/panels/line-plot.mdx`**: Point the CoreWeave tip at CKS and the infrastructure alerts page for prerequisites.

## Tracking

Resolves WBDOCS-1046

Made with [Cursor](https://cursor.com)