### PR TITLE
Improves PR comments from KB nav workflow

### DIFF
--- a/.github/workflows/knowledgebase-nav.yml
+++ b/.github/workflows/knowledgebase-nav.yml
@@ -39,6 +39,13 @@
 # branch name does not exist on the upstream clone. Detached HEAD is fine
 # here since the auto-commit step is skipped for forks anyway.
 #
+# PR comment vs auto-commit
+# -------------------------
+# After this workflow pushes the chore commit below, GitHub starts a second
+# run (synchronize). That run would post the same navigation report again and
+# overwrite the comment from the run that mattered. We skip the PR comment
+# step when the checked-out HEAD is exactly that chore commit.
+#
 # ------------------------------------------------------------------
 
 name: Knowledgebase Nav
@@ -89,6 +96,20 @@ jobs:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork && github.event.pull_request.head.sha || github.head_ref) || github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
 
+      # Same message as git-auto-commit-action below (first line only).
+      - name: Detect chore-only navigation commit (skip PR comment on next run)
+        id: nav_commit
+        if: github.event_name == 'pull_request'
+        run: |
+          CHORE_SUBJECT="chore: regenerate support tag pages and docs.json navigation"
+          FIRST="$(git log -1 --pretty=%B | head -n1)"
+          if [ "${FIRST}" = "${CHORE_SUBJECT}" ]; then
+            echo "is_auto_nav_commit=true" >> "${GITHUB_OUTPUT}"
+            echo "HEAD is the auto-generated navigation commit; PR comment step will be skipped."
+          else
+            echo "is_auto_nav_commit=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
@@ -116,56 +137,56 @@ jobs:
         if: always()
         run: |
           if [ -s generator-warnings.log ]; then
-            echo "::warning::Knowledgebase Nav Generator produced warnings (see PR comment)"
+            echo "::warning::Knowledgebase Nav Generator produced warnings (see PR comment or job summary)"
             cat generator-warnings.log
           fi
 
-      # Creates, updates, or deletes a single PR comment identified by an
-      # HTML marker so repeated pushes do not pile up duplicate comments.
-      - name: Upsert generator warnings on PR
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      # Creates or updates a single PR comment identified by an HTML marker so
+      # repeated pushes do not pile up duplicate comments. Includes navigation
+      # counts from git diff and generator stderr (see scripts/knowledgebase-nav/pr_report.py).
+      - name: Upsert knowledgebase navigation report on PR
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && steps.nav_commit.outputs.is_auto_nav_commit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          MARKER="<!-- knowledgebase-nav-warnings -->"
+          MARKER="<!-- knowledgebase-nav-report -->"
 
-          # Find an existing comment with the marker.
+          python scripts/knowledgebase-nav/pr_report.py \
+            --repo-root . \
+            --warnings-file generator-warnings.log \
+            --run-url "${RUN_URL}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --include-marker \
+            > comment-body.md
+
           COMMENT_ID=$(gh api \
             "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --paginate -q ".[] | select(.body | contains(\"${MARKER}\")) | .id" \
           | head -n1)
 
-          if [ -s generator-warnings.log ]; then
-            {
-              echo "${MARKER}"
-              echo "### Knowledgebase Nav Generator warnings"
-              echo ""
-              echo '```'
-              cat generator-warnings.log
-              echo '```'
-              echo ""
-              echo "*From [workflow run](${RUN_URL})*"
-            } > comment-body.md
-
-            if [ -n "${COMMENT_ID}" ]; then
-              gh api \
-                "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-                -X PATCH -F "body=@comment-body.md"
-              echo "Updated existing warnings comment ${COMMENT_ID}"
-            else
-              gh pr comment "${PR_NUMBER}" --body-file comment-body.md
-              echo "Created new warnings comment"
-            fi
+          if [ -n "${COMMENT_ID}" ]; then
+            gh api \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -F "body=@comment-body.md"
+            echo "Updated existing knowledgebase navigation report comment ${COMMENT_ID}"
           else
-            if [ -n "${COMMENT_ID}" ]; then
-              gh api \
-                "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-                -X DELETE
-              echo "Deleted stale warnings comment ${COMMENT_ID} (no warnings this run)"
-            fi
+            gh pr comment "${PR_NUMBER}" --body-file comment-body.md
+            echo "Created new knowledgebase navigation report comment"
           fi
+
+      - name: Write knowledgebase navigation report to job summary
+        if: always() && github.event_name == 'workflow_dispatch'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python scripts/knowledgebase-nav/pr_report.py \
+            --repo-root . \
+            --warnings-file generator-warnings.log \
+            --run-url "${RUN_URL}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            >> "${GITHUB_STEP_SUMMARY}"
 
       # Surfaces an Actions notice when the commit step below is skipped.
       - name: Fork PR (no push to fork)

--- a/scripts/knowledgebase-nav/generate_tags.py
+++ b/scripts/knowledgebase-nav/generate_tags.py
@@ -820,6 +820,8 @@ def crawl_articles(repo_root: Path, product_slug: str) -> List[Dict[str, Any]]:
         - ``body_preview`` (str): Truncated plain-text preview of the body.
         - ``page_path`` (str): The URL path without leading slash
           (for example ``support/models/articles/my-article``).
+        - ``mdx_path`` (str): Repo-relative path to the MDX file using forward
+          slashes (for example ``support/models/articles/my-article.mdx``).
         - ``file_stem`` (str): The filename without extension
           (for example ``my-article``).
         - ``tag_links`` (list of dict): Badge link data for each keyword,
@@ -865,6 +867,8 @@ def crawl_articles(repo_root: Path, product_slug: str) -> List[Dict[str, Any]]:
             for kw in keywords
         ]
 
+        mdx_rel = mdx_file.relative_to(repo_root).as_posix()
+
         articles.append({
             "title": title,
             "title_attr": title.replace('"', "&quot;"),
@@ -872,6 +876,7 @@ def crawl_articles(repo_root: Path, product_slug: str) -> List[Dict[str, Any]]:
             "featured": bool(featured),
             "body_preview": body_preview,
             "page_path": f"support/{product_slug}/articles/{file_stem}",
+            "mdx_path": mdx_rel,
             "file_stem": file_stem,
             "tag_links": article_tag_links,
         })
@@ -924,6 +929,8 @@ def get_featured_articles(articles: List[Dict[str, Any]]) -> List[Dict[str, Any]
 def build_tag_index(
     articles: List[Dict[str, Any]],
     allowed_keywords: List[str],
+    *,
+    config_yaml_path: str = "scripts/knowledgebase-nav/config.yaml",
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Build a mapping from tag names to lists of articles that use that tag.
@@ -939,6 +946,9 @@ def build_tag_index(
         The article dictionaries for a single product.
     allowed_keywords : list of str
         The keywords recognized for this product (from config.yaml).
+    config_yaml_path : str, optional
+        Repo-relative path to the config file, shown in unknown-keyword
+        warnings. Defaults to ``scripts/knowledgebase-nav/config.yaml``.
 
     Returns
     -------
@@ -966,10 +976,10 @@ def build_tag_index(
         for keyword in article.get("keywords", []):
             # Warn on unknown keywords, but only once per keyword
             if keyword not in allowed_set and keyword not in warned_keywords:
+                source = article.get("mdx_path") or article.get("title", "?")
                 warnings.warn(
-                    f"Unknown keyword '{keyword}' used in article "
-                    f"'{article.get('title', '?')}'. Add it to config.yaml "
-                    f"to suppress this warning."
+                    f"Unknown keyword `{keyword}` used in `{source}`. "
+                    f"Add it to `{config_yaml_path}` to suppress this warning."
                 )
                 warned_keywords.add(keyword)
 
@@ -1608,6 +1618,13 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     config = load_config(config_path)
     products = config["products"]
 
+    try:
+        config_yaml_display = config_path.resolve().relative_to(
+            repo_root.resolve()
+        ).as_posix()
+    except ValueError:
+        config_yaml_display = config_path.as_posix()
+
     # Set up Jinja2 templates from the templates/ directory next to this script
     script_dir = Path(__file__).resolve().parent
     templates_dir = script_dir / "templates"
@@ -1638,7 +1655,11 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
         print(f"  Found {len(articles)} articles")
 
         # Phase 1b: Build the tag index
-        tag_index = build_tag_index(articles, allowed_keywords)
+        tag_index = build_tag_index(
+            articles,
+            allowed_keywords,
+            config_yaml_path=config_yaml_display,
+        )
         print(f"  Found {len(tag_index)} unique tags")
 
         # Phase 2: Generate tag pages and remove stale ones

--- a/scripts/knowledgebase-nav/pr_report.py
+++ b/scripts/knowledgebase-nav/pr_report.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""
+Knowledgebase navigation PR report
+===================================
+
+This script turns **what changed after** ``generate_tags.py`` runs into Markdown
+for humans. GitHub Actions either posts that Markdown on a pull request or
+writes it to the workflow **job summary** when you run the workflow by hand.
+
+Who should read this
+----------------------
+If you are new to Python, here is the map of this file:
+
+- **Imports** at the top pull in the standard library (``argparse``, ``re``,
+  ``subprocess``, and others). ``from __future__ import annotations`` lets us
+  write type hints like ``list[str]`` on older Python 3.9+ runtimes in some
+  setups; you can ignore it if you are learning the basics.
+- **Type hints** (for example ``path: str``, ``-> Optional[...]``) describe what
+  each function expects and returns. They help editors and ``mypy`` catch
+  mistakes; they do not change how the code runs at runtime.
+- **Functions** whose names start with a single underscore (``_is_article_path``)
+  are **private helpers** used only inside this file. Public functions have no
+  leading underscore.
+
+What this script does (high level)
+-----------------------------------
+1. After the generator edits files, CI runs ``git diff --name-status HEAD``.
+   That compares the **working tree** (files on disk) to **HEAD** (the latest
+   commit you checked out, for example the tip of a PR branch). Each line looks
+   like ``M\\tsupport/models/articles/foo.mdx`` where the first letter is the
+   **change type** (Modified, Added, Deleted, Renamed, and so on).
+2. We **parse** those lines and **count** how many paths fall into each bucket
+   (articles, tag pages, ``docs.json``, and others).
+3. We read **stderr** that was saved to ``generator-warnings.log`` and count
+   distinct **unknown keyword** warnings so tech writers see how many tags are
+   not in ``config.yaml`` yet.
+4. We **build Markdown** (plain text with ``#`` headings and bullet lists) and
+   print it to **stdout**. The workflow captures that output and posts it.
+
+This file is intentionally **standalone**: it does not import ``generate_tags.py``
+so you can test the reporting logic without running the full generator.
+
+See also
+--------
+- ``generate_tags.py`` for what actually edits support content.
+- ``.github/workflows/knowledgebase-nav.yml`` for when ``pr_report.py`` runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# Constants (shared with tests via REPORT_FALLBACK_BODY and REPORT_MARKER)
+# ---------------------------------------------------------------------------
+
+# GitHub issue comments are upserted by searching for this exact HTML comment.
+# The workflow finds an existing comment with this substring and PATCHes it,
+# or creates a new comment if none exists.
+REPORT_MARKER = "<!-- knowledgebase-nav-report -->"
+
+# Visible heading in PR comments and job summaries (sentence case per docs style).
+REPORT_TITLE = "## Knowledgebase navigation update"
+
+# Paragraph when there is nothing to report: no file changes vs HEAD,
+# no unknown-keyword warnings parsed from the log, and an empty warnings file.
+REPORT_FALLBACK_PARAGRAPH = (
+    "No updates to support articles, tag pages, product indexes or docs.json from this run."
+)
+
+# Full Markdown for the empty case: title plus fallback paragraph.
+REPORT_FALLBACK_BODY = f"{REPORT_TITLE}\n\n{REPORT_FALLBACK_PARAGRAPH}"
+
+# ``re.compile`` builds a reusable pattern. Parentheses in the pattern form a
+# **capture group**: ``findall`` returns only the text that matched inside the
+# backticks. This mirrors the f-string used in ``generate_tags.build_tag_index``.
+_UNKNOWN_KEYWORD_RE = re.compile(
+    r"Unknown keyword `([^`]+)`",
+)
+
+# GitHub Actions checks out the repo under a path like
+# ``/home/runner/work/<repo>/<repo>/``. Strip that prefix from messages so PR
+# comments show repo-relative paths when paths appear inside a warning body.
+_CI_WORKSPACE_PREFIX_RE = re.compile(r"/home/runner/work/[^/]+/[^/]+/")
+
+# Standard library warning line (see ``warnings._formatwarnmsg`` / default
+# ``formatwarning``): ``path:lineno: Category: message``.
+_WARNING_LINE_RE = re.compile(
+    r"^(.+?):(\d+):\s*([\w]+Warning):\s*(.+)$",
+)
+
+
+# ---------------------------------------------------------------------------
+# Formatting captured stderr for pull request comments
+# ---------------------------------------------------------------------------
+
+
+def normalize_ci_paths(text: str) -> str:
+    """Remove GitHub Actions workspace prefix from paths embedded in text."""
+    return _CI_WORKSPACE_PREFIX_RE.sub("", text)
+
+
+def format_warnings_for_display(warnings_text: str) -> str:
+    """
+    Turn raw stderr from the generator into short Markdown list items.
+
+    Python prints each warning as a line ``file:lineno: UserWarning: ...`` and
+    often a second indented line showing ``warnings.warn(``. Readers care about
+    the message, not the runner-specific absolute path or the scaffolding line.
+
+    Lines that match the standard warning pattern become ``- message`` bullets.
+    Continuation lines that only show ``warnings.warn(`` are skipped. Any other
+    non-empty lines are kept with CI paths stripped (rare).
+
+    Parameters
+    ----------
+    warnings_text
+        Full text read from ``generator-warnings.log``.
+
+    Returns
+    -------
+    str
+        Markdown bullet list, or empty string if ``warnings_text`` is blank.
+    """
+    if not warnings_text.strip():
+        return ""
+
+    out_lines: List[str] = []
+    for line in warnings_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        m = _WARNING_LINE_RE.match(line.rstrip())
+        if m:
+            msg = normalize_ci_paths(m.group(4).strip())
+            out_lines.append(f"- {msg}")
+            continue
+
+        # Skip indented continuation (for example ``  warnings.warn(``).
+        if line.startswith((" ", "\t")):
+            continue
+
+        out_lines.append(f"- {normalize_ci_paths(line.rstrip())}")
+
+    return "\n".join(out_lines).strip()
+
+
+# ---------------------------------------------------------------------------
+# Parsing ``git diff --name-status`` lines
+# ---------------------------------------------------------------------------
+
+
+def parse_name_status_line(line: str) -> Optional[Tuple[str, str, Optional[str]]]:
+    """
+    Parse one line produced by ``git diff --name-status``.
+
+    Git separates fields with **tab characters** (``\\t``), not spaces, so file
+    names with spaces stay intact.
+
+    Parameters
+    ----------
+    line
+        A single line of diff output, for example ``M\\tpath/to/file.mdx`` or a
+        three-field rename line.
+
+    Returns
+    -------
+    tuple or None
+        ``(status, first_path, second_path)``. For a rename or copy (status
+        starts with ``R`` or ``C``), ``second_path`` is the new location. For all
+        other statuses, ``second_path`` is ``None``. Returns ``None`` for blank
+        or malformed lines so callers can skip them safely.
+    """
+    line = line.rstrip("\n\r")
+    if not line.strip():
+        return None
+    parts = line.split("\t")
+    if len(parts) < 2:
+        return None
+    status = parts[0]
+    if status.startswith(("R", "C")):
+        if len(parts) < 3:
+            return None
+        return status, parts[1], parts[2]
+    return status, parts[1], None
+
+
+def _is_article_path(path: str) -> bool:
+    """True if ``path`` is ``support/<product>/articles/<name>.mdx``."""
+    parts = path.split("/")
+    return (
+        len(parts) == 4
+        and parts[0] == "support"
+        and parts[2] == "articles"
+        and parts[3].endswith(".mdx")
+    )
+
+
+def _is_tag_page_path(path: str) -> bool:
+    """True if ``path`` is ``support/<product>/tags/<slug>.mdx``."""
+    parts = path.split("/")
+    return (
+        len(parts) == 4
+        and parts[0] == "support"
+        and parts[2] == "tags"
+        and parts[3].endswith(".mdx")
+    )
+
+
+def _is_product_index_path(path: str) -> bool:
+    """
+    True if ``path`` is a product landing page: ``support/<product>.mdx``.
+
+    These live directly under ``support/``, not under ``articles/`` or
+    ``tags/``. Example: ``support/models.mdx``.
+    """
+    parts = path.split("/")
+    return len(parts) == 2 and parts[0] == "support" and parts[1].endswith(".mdx")
+
+
+def _is_root_support_mdx(path: str) -> bool:
+    """True if ``path`` is the repo-root ``support.mdx`` (the top-level hub)."""
+    return path == "support.mdx"
+
+
+def _is_docs_json(path: str) -> bool:
+    """True if ``path`` is the Mintlify navigation file at the repo root."""
+    return path == "docs.json"
+
+
+def _is_deleted_pages_scope(path: str) -> bool:
+    """
+    True if a **deleted** path should count toward the "pages deleted" bucket.
+
+    We include anything under ``support/`` plus ``docs.json``. We do not count
+    deletions only under ``scripts/knowledgebase-nav/`` in that bucket so the
+    report stays focused on reader-facing content.
+    """
+    return path == "docs.json" or path.startswith("support/")
+
+
+# ---------------------------------------------------------------------------
+# Turning diff lines into numeric buckets
+# ---------------------------------------------------------------------------
+
+
+def categorize_name_status_lines(lines: List[str]) -> Dict[str, int]:
+    """
+    Count how many files fall into each **report category** from diff lines.
+
+    Git status letters we care about:
+
+    - **M** modified: file existed and changed.
+    - **A** added: new file.
+    - **D** deleted: file removed.
+    - **R** / **C** rename or copy: Git emits the old and new paths. We treat
+      tag renames as "one keyword removed, one added" and **do not** also mark
+      them as "tag pages modified" (that label is for **M** on tag files only).
+
+    Parameters
+    ----------
+    lines
+        Complete lines from ``git diff --name-status HEAD`` (no shell splitting).
+
+    Returns
+    -------
+    dict
+        String keys (for example ``"articles_badges_updated"``) mapping to
+        non-negative integer counts. Every key is always present so callers can
+        loop or index without ``KeyError``.
+    """
+    buckets: Dict[str, int] = {
+        "articles_badges_updated": 0,
+        "tag_pages_modified": 0,
+        "product_index_pages": 0,
+        "support_mdx_root": 0,
+        "deleted_pages": 0,
+        "new_keywords_tag_pages": 0,
+        "keywords_no_longer_in_use": 0,
+        "docs_json": 0,
+    }
+
+    for raw in lines:
+        parsed = parse_name_status_line(raw)
+        if parsed is None:
+            continue
+        status, first, second = parsed
+        st = status[0]
+
+        if st in ("R", "C"):
+            old_p, new_p = first, second
+            assert new_p is not None
+            # Treat rename as remove old + add new for tag pages and deletions.
+            if _is_deleted_pages_scope(old_p):
+                buckets["deleted_pages"] += 1
+            if _is_tag_page_path(old_p):
+                buckets["keywords_no_longer_in_use"] += 1
+            if _is_tag_page_path(new_p):
+                buckets["new_keywords_tag_pages"] += 1
+            if _is_article_path(new_p):
+                buckets["articles_badges_updated"] += 1
+            elif _is_product_index_path(new_p):
+                buckets["product_index_pages"] += 1
+            # Tag renames are counted as new + removed keywords, not as "modified".
+            if _is_root_support_mdx(new_p):
+                buckets["support_mdx_root"] += 1
+            if _is_docs_json(new_p):
+                buckets["docs_json"] += 1
+            continue
+
+        path = first
+        if st == "D":
+            if _is_deleted_pages_scope(path):
+                buckets["deleted_pages"] += 1
+            if _is_tag_page_path(path):
+                buckets["keywords_no_longer_in_use"] += 1
+        elif st == "A":
+            if _is_tag_page_path(path):
+                buckets["new_keywords_tag_pages"] += 1
+            if _is_article_path(path):
+                buckets["articles_badges_updated"] += 1
+            elif _is_product_index_path(path):
+                buckets["product_index_pages"] += 1
+            if _is_root_support_mdx(path):
+                buckets["support_mdx_root"] += 1
+            if _is_docs_json(path):
+                buckets["docs_json"] += 1
+        elif st == "M":
+            if _is_article_path(path):
+                buckets["articles_badges_updated"] += 1
+            elif _is_tag_page_path(path):
+                buckets["tag_pages_modified"] += 1
+            elif _is_product_index_path(path):
+                buckets["product_index_pages"] += 1
+            if _is_root_support_mdx(path):
+                buckets["support_mdx_root"] += 1
+            if _is_docs_json(path):
+                buckets["docs_json"] += 1
+
+    return buckets
+
+
+def distinct_unknown_keywords_from_warnings(warnings_text: str) -> Set[str]:
+    """
+    Collect distinct keyword strings from "Unknown keyword" warning lines.
+
+    Expects ``generate_tags`` format: ``Unknown keyword `tag` used in ...``.
+
+    The generator may emit the same unknown tag for several articles; we count
+    **distinct** tags so the PR summary matches how many new ``config.yaml``
+    entries are needed.
+
+    Parameters
+    ----------
+    warnings_text
+        Full text of ``generator-warnings.log`` (or any string containing the
+        same warning format).
+
+    Returns
+    -------
+    set of str
+        Unique keyword strings, with no guaranteed ordering.
+    """
+    return set(_UNKNOWN_KEYWORD_RE.findall(warnings_text))
+
+
+# ---------------------------------------------------------------------------
+# Building Markdown for GitHub
+# ---------------------------------------------------------------------------
+
+
+def build_report_markdown(
+    buckets: Dict[str, int],
+    unknown_keywords: Set[str],
+    warnings_text: str,
+    run_url: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> str:
+    """
+    Build the Markdown body **without** the HTML comment marker.
+
+    If every bucket is zero, there are no unknown keywords, and the warnings
+    text is blank, returns ``REPORT_FALLBACK_BODY`` (``REPORT_TITLE`` plus
+    ``REPORT_FALLBACK_PARAGRAPH``).
+
+    Otherwise builds a short report starting with ``REPORT_TITLE``, then bullet
+    lines (counts only), optional "no categorized file changes" when warnings
+    exist but nothing matched our path rules, a fenced code block with the raw
+    warnings log if present, and an optional footer link when ``run_url`` is
+    set (with ``run_id`` in the link text when provided).
+
+    Parameters
+    ----------
+    buckets
+        Counts from :func:`categorize_name_status_lines`.
+    unknown_keywords
+        Distinct unknown tags from :func:`distinct_unknown_keywords_from_warnings`.
+    warnings_text
+        Raw stderr captured from the generator. The Generator warnings section
+        uses :func:`format_warnings_for_display` when it can parse standard
+        warning lines; otherwise it falls back to a fenced copy of the raw log.
+    run_url
+        If set, appended as a footer link to the Actions run.
+    run_id
+        GitHub Actions ``GITHUB_RUN_ID`` (same number as in ``/actions/runs/<id>``).
+        If set with ``run_url``, the link text is ``workflow run <id>`` so the
+        number is visible without hovering.
+
+    Returns
+    -------
+    str
+        Markdown suitable for a PR comment body or job summary (without marker).
+    """
+    lines_out: List[str] = []
+
+    uk_count = len(unknown_keywords)
+    if (
+        not any(buckets[k] > 0 for k in buckets)
+        and uk_count == 0
+        and not warnings_text.strip()
+    ):
+        return REPORT_FALLBACK_BODY
+
+    lines_out.append(REPORT_TITLE)
+    lines_out.append("")
+
+    added_bullet = False
+    if buckets["articles_badges_updated"] > 0:
+        n = buckets["articles_badges_updated"]
+        lines_out.append(
+            f"- Articles with Badges updated: {n} article{'s' if n != 1 else ''}."
+        )
+        added_bullet = True
+    if buckets["tag_pages_modified"] > 0:
+        n = buckets["tag_pages_modified"]
+        lines_out.append(
+            f"- Tag pages modified: {n} page{'s' if n != 1 else ''}."
+        )
+        added_bullet = True
+    if buckets["product_index_pages"] > 0:
+        n = buckets["product_index_pages"]
+        lines_out.append(
+            f"- Product index pages updated: {n} page{'s' if n != 1 else ''}."
+        )
+        added_bullet = True
+    if buckets["support_mdx_root"] > 0:
+        lines_out.append("- Root support.mdx updated.")
+        added_bullet = True
+    if buckets["deleted_pages"] > 0:
+        n = buckets["deleted_pages"]
+        lines_out.append(f"- Pages deleted: {n} page{'s' if n != 1 else ''}.")
+        added_bullet = True
+    if buckets["new_keywords_tag_pages"] > 0:
+        n = buckets["new_keywords_tag_pages"]
+        lines_out.append(
+            f"- New keywords (new tag pages): {n} keyword{'s' if n != 1 else ''}."
+        )
+        added_bullet = True
+    if buckets["keywords_no_longer_in_use"] > 0:
+        n = buckets["keywords_no_longer_in_use"]
+        lines_out.append(
+            f"- Keywords no longer in use (tag pages removed): {n} keyword{'s' if n != 1 else ''}."
+        )
+        added_bullet = True
+    if uk_count > 0:
+        lines_out.append(
+            f"- Keywords not on the allowed list: {uk_count} distinct keyword{'s' if uk_count != 1 else ''}."
+        )
+        added_bullet = True
+    if buckets["docs_json"] > 0:
+        lines_out.append("- docs.json updated.")
+        added_bullet = True
+
+    if not added_bullet and warnings_text.strip():
+        lines_out.append("- (No categorized file changes.)")
+
+    if warnings_text.strip():
+        lines_out.append("")
+        lines_out.append("### Generator warnings")
+        lines_out.append("")
+        formatted_warnings = format_warnings_for_display(warnings_text)
+        if formatted_warnings.strip():
+            lines_out.append(formatted_warnings)
+        else:
+            lines_out.append("```")
+            lines_out.append(warnings_text.rstrip("\n"))
+            lines_out.append("```")
+
+    if run_url:
+        lines_out.append("")
+        if run_id:
+            lines_out.append(f"*From [workflow run {run_id}]({run_url})*")
+        else:
+            lines_out.append(f"*From [workflow run]({run_url})*")
+
+    return "\n".join(lines_out)
+
+
+def format_pr_body(
+    inner_markdown: str,
+    *,
+    include_marker: bool = True,
+) -> str:
+    """
+    Optionally prefix the report with ``REPORT_MARKER`` for GitHub upserts.
+
+    The ``*`` before ``include_marker`` means **keyword-only**: callers must
+    pass ``include_marker=...`` by name, which keeps the optional flag obvious
+    at call sites and avoids mixing up argument order.
+
+    Parameters
+    ----------
+    inner_markdown
+        Output of :func:`build_report_markdown`.
+    include_marker
+        When ``True`` (default), prepend the HTML comment GitHub searches for.
+
+    Returns
+    -------
+    str
+        Text ready to POST or PATCH as an issue comment body.
+    """
+    if not include_marker:
+        return inner_markdown
+    return f"{REPORT_MARKER}\n\n{inner_markdown}"
+
+
+def git_diff_name_status_head(repo_root: Path) -> str:
+    """
+    Run ``git diff --name-status HEAD`` in ``repo_root`` and return stdout.
+
+    **HEAD** means the commit currently checked out. Uncommitted edits from the
+    generator show up as differences versus that commit.
+
+    Raises
+    ------
+    SystemExit
+        If Git returns a non-zero exit code (for example not a Git repository).
+
+    Returns
+    -------
+    str
+        Raw diff text, possibly empty if the working tree matches HEAD.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        sys.exit(result.returncode or 1)
+    return result.stdout
+
+
+def main() -> None:
+    """
+    Command-line entry point used by GitHub Actions and local debugging.
+
+    Reads flags, loads the warnings file if present, builds Markdown, prints to
+    **stdout** (the shell redirects that to a file in CI).
+    """
+    parser = argparse.ArgumentParser(
+        description="Build Knowledgebase Nav PR comment or job summary Markdown.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        required=True,
+        help="Repository root (contains .git).",
+    )
+    parser.add_argument(
+        "--warnings-file",
+        type=Path,
+        default=Path("generator-warnings.log"),
+        help="Path to captured stderr from generate_tags.py.",
+    )
+    parser.add_argument(
+        "--run-url",
+        default=None,
+        help="Link to the GitHub Actions workflow run (optional).",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help=(
+            "Workflow run id (GITHUB_RUN_ID) for the footer link text (optional)."
+        ),
+    )
+    parser.add_argument(
+        "--include-marker",
+        action="store_true",
+        help="Prefix output with the HTML marker for PR comment upserts.",
+    )
+    parser.add_argument(
+        "--diff-text",
+        type=str,
+        default=None,
+        help="For tests: use this text instead of running git diff.",
+    )
+    args = parser.parse_args()
+
+    if args.diff_text is not None:
+        diff_out = args.diff_text
+    else:
+        diff_out = git_diff_name_status_head(args.repo_root)
+
+    diff_lines = [ln for ln in diff_out.splitlines() if ln.strip()]
+    buckets = categorize_name_status_lines(diff_lines)
+
+    warnings_text = ""
+    if args.warnings_file.exists():
+        warnings_text = args.warnings_file.read_text(encoding="utf-8")
+
+    unknown_set = distinct_unknown_keywords_from_warnings(warnings_text)
+    inner = build_report_markdown(
+        buckets,
+        unknown_set,
+        warnings_text,
+        run_url=args.run_url,
+        run_id=args.run_id,
+    )
+    out = format_pr_body(inner, include_marker=args.include_marker)
+    sys.stdout.write(out)
+    if not out.endswith("\n"):
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
@@ -1,6 +1,7 @@
 ---
 title: {{ ("Support: " ~ product_name) | tojson_unicode }}
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
 ---
 
 {% if featured_articles %}

--- a/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
@@ -1,6 +1,6 @@
 ---
 title: {{ ("Support: " ~ product_name) | tojson_unicode }}
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 {% if featured_articles %}

--- a/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
@@ -2,6 +2,7 @@
 title: {{ tag | tojson_unicode }}
 tag: {{ articles | length | string | tojson_unicode }}
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 {% for article in articles %}

--- a/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
@@ -1,7 +1,7 @@
 ---
 title: {{ tag | tojson_unicode }}
 tag: {{ articles | length | string | tojson_unicode }}
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 {% for article in articles %}

--- a/scripts/knowledgebase-nav/tests/test_generate_tags.py
+++ b/scripts/knowledgebase-nav/tests/test_generate_tags.py
@@ -595,6 +595,7 @@ class TestCrawlArticles:
         assert article["keywords"] == ["Alpha", "Beta"]
         assert article["featured"] is True
         assert article["page_path"] == "support/widgets/articles/article-one"
+        assert article["mdx_path"] == "support/widgets/articles/article-one.mdx"
         assert article["file_stem"] == "article-one"
         assert isinstance(article["body_preview"], str)
         assert isinstance(article["tag_links"], list)
@@ -771,7 +772,11 @@ class TestBuildTagIndex:
         still appear in the index.  This prevents silent data loss.
         """
         articles = [
-            {"title": "A", "keywords": ["Unknown"]},
+            {
+                "title": "A",
+                "keywords": ["Unknown"],
+                "mdx_path": "support/widgets/articles/example.mdx",
+            },
         ]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -779,7 +784,9 @@ class TestBuildTagIndex:
 
             assert "Unknown" in index
             assert len(w) == 1
-            assert "Unknown keyword 'Unknown'" in str(w[0].message)
+            assert "Unknown keyword `Unknown`" in str(w[0].message)
+            assert "support/widgets/articles/example.mdx" in str(w[0].message)
+            assert "scripts/knowledgebase-nav/config.yaml" in str(w[0].message)
 
     def test_unknown_keyword_warned_only_once(self):
         """

--- a/scripts/knowledgebase-nav/tests/test_pr_report.py
+++ b/scripts/knowledgebase-nav/tests/test_pr_report.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for ``pr_report.py`` (Knowledgebase navigation PR report).
+
+What these tests do
+--------------------
+They check **pure functions**: parsing fake ``git diff`` lines, bucketing paths
+into counts, extracting unknown keywords from warning text, and building
+Markdown. No real Git repository is required for most tests.
+
+If you are new to **pytest**:
+
+- A file named ``test_*.py`` is discovered automatically.
+- A function named ``test_*`` is one test case.
+- ``assert`` compares values; if the comparison fails, pytest prints a clear
+  diff. There is no need to import a special ``assertEqual`` helper.
+
+How ``pr_report`` is imported
+-----------------------------
+The script ``pr_report.py`` lives in ``scripts/knowledgebase-nav/``, not in an
+installed Python package. The block below adds that directory to ``sys.path`` so
+``import pr_report`` works when pytest runs from the repo root. The
+``# noqa: E402`` comment tells the linter not to complain that imports are not
+at the very top of the file (they must come after ``sys.path`` is updated).
+
+Run with::
+
+    pytest scripts/knowledgebase-nav/tests/test_pr_report.py -v
+"""
+
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import the module under test (see module docstring above).
+# ---------------------------------------------------------------------------
+_script_dir = Path(__file__).resolve().parent.parent
+if str(_script_dir) not in sys.path:
+    sys.path.insert(0, str(_script_dir))
+
+import pr_report  # noqa: E402
+
+
+def test_parse_name_status_simple():
+    """
+    ``parse_name_status_line`` should split Modified and Deleted lines.
+
+    Tab-separated fields match what Git prints; the third tuple element is
+    ``None`` when there is only one path.
+    """
+    assert pr_report.parse_name_status_line("M\tsupport/models/articles/a.mdx") == (
+        "M",
+        "support/models/articles/a.mdx",
+        None,
+    )
+    assert pr_report.parse_name_status_line("D\tsupport/models/tags/old.mdx") == (
+        "D",
+        "support/models/tags/old.mdx",
+        None,
+    )
+
+
+def test_parse_rename():
+    """
+    Rename lines include **two** paths; status may include a similarity score.
+
+    Example prefix ``R095`` means roughly 95 percent similar; we only need the
+    leading ``R`` elsewhere in the code.
+    """
+    line = "R095\tsupport/models/tags/a.mdx\tsupport/models/tags/b.mdx"
+    assert pr_report.parse_name_status_line(line) == (
+        "R095",
+        "support/models/tags/a.mdx",
+        "support/models/tags/b.mdx",
+    )
+
+
+def test_categorize_article_modified():
+    """
+    A modified article under ``support/.../articles/`` counts toward badge sync.
+
+    Only the ``articles_badges_updated`` bucket should increment for this line.
+    """
+    lines = ["M\tsupport/models/articles/foo.mdx"]
+    b = pr_report.categorize_name_status_lines(lines)
+    assert b["articles_badges_updated"] == 1
+    assert b["tag_pages_modified"] == 0
+
+
+def test_categorize_tag_added_deleted_modified():
+    """
+    Added tag pages, deleted tag pages, and modified tag pages use different buckets.
+
+    - **A** on a tag file counts as a **new** keyword (new tag page).
+    - **D** counts as a keyword **no longer in use**.
+    - **M** counts as **tag pages modified** (content change, not add or remove).
+    """
+    b = pr_report.categorize_name_status_lines(
+        [
+            "A\tsupport/models/tags/new-tag.mdx",
+            "D\tsupport/models/tags/gone.mdx",
+            "M\tsupport/models/tags/existing.mdx",
+        ]
+    )
+    assert b["new_keywords_tag_pages"] == 1
+    assert b["keywords_no_longer_in_use"] == 1
+    assert b["tag_pages_modified"] == 1
+
+
+def test_categorize_product_index_and_support_root():
+    """
+    Product indexes, root ``support.mdx``, and ``docs.json`` each have their own flags.
+
+    ``support/models.mdx`` is two path segments; the root ``support.mdx`` is a
+    single file at the repository root, not inside ``support/``.
+    """
+    b = pr_report.categorize_name_status_lines(
+        [
+            "M\tsupport/models.mdx",
+            "M\tsupport.mdx",
+            "M\tdocs.json",
+        ]
+    )
+    assert b["product_index_pages"] == 1
+    assert b["support_mdx_root"] == 1
+    assert b["docs_json"] == 1
+
+
+def test_categorize_deleted_pages():
+    """A deleted article increments the general **deleted_pages** counter."""
+    b = pr_report.categorize_name_status_lines(
+        ["D\tsupport/models/articles/deleted.mdx"]
+    )
+    assert b["deleted_pages"] == 1
+
+
+def test_rename_tag_does_not_increment_tag_modified():
+    """
+    Renaming a tag file is **not** the same as modifying it in place.
+
+    We expect one "new keyword" (new path) and one "no longer in use" (old
+    path), but **zero** for ``tag_pages_modified`` (that bucket is for **M**
+    only on tag files).
+    """
+    lines = [
+        "R100\tsupport/models/tags/a.mdx\tsupport/models/tags/b.mdx",
+    ]
+    b = pr_report.categorize_name_status_lines(lines)
+    assert b["tag_pages_modified"] == 0
+    assert b["new_keywords_tag_pages"] == 1
+    assert b["keywords_no_longer_in_use"] == 1
+
+
+def test_unknown_keyword_distinct():
+    """
+    The same unknown keyword repeated across lines should dedupe to one entry.
+
+    ``distinct_unknown_keywords_from_warnings`` returns a **set**, which is an
+    unordered collection of unique items.
+    """
+    text = """
+    /path/gen.py:1: UserWarning: Unknown keyword `Foo` used in `support/x/a.mdx`.
+    /path/gen.py:2: UserWarning: Unknown keyword `Foo` used in `support/x/b.mdx`.
+    /path/gen.py:3: UserWarning: Unknown keyword `Bar` used in `support/x/c.mdx`.
+    """
+    s = pr_report.distinct_unknown_keywords_from_warnings(text)
+    assert s == {"Foo", "Bar"}
+
+
+def test_build_report_fallback():
+    """
+    With empty buckets, no unknown keywords, and no warnings text, output is the fallback constant.
+
+    We build an all-zero bucket dict by running ``categorize_name_status_lines``
+    on an empty list so keys always match production.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    out = pr_report.build_report_markdown(empty, set(), "")
+    assert out == pr_report.REPORT_FALLBACK_BODY
+
+
+def test_build_report_footer_includes_run_id():
+    """
+    The footer should embed ``GITHUB_RUN_ID`` in the Markdown link label.
+
+    The URL still points at the run; the id matches the ``/actions/runs/<id>`` segment.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    empty["docs_json"] = 1
+    out = pr_report.build_report_markdown(
+        empty,
+        set(),
+        "",
+        run_url="https://github.com/org/repo/actions/runs/12345",
+        run_id="12345",
+    )
+    assert "*From [workflow run 12345](https://github.com/org/repo/actions/runs/12345)*" in out
+
+
+def test_build_report_with_counts():
+    """
+    Non-zero buckets should appear as bullet lines under ``REPORT_TITLE``.
+
+    We mutate a fresh zero dict rather than hard-coding every key so new
+    bucket keys in production are picked up automatically.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    empty["articles_badges_updated"] = 2
+    empty["docs_json"] = 1
+    out = pr_report.build_report_markdown(empty, set(), "")
+    assert pr_report.REPORT_TITLE in out
+    assert "Articles with Badges updated: 2 articles" in out
+    assert "docs.json updated" in out
+
+
+def test_format_warnings_for_display_strips_path_and_scaffolding():
+    """
+    CI stderr includes a long path and a second ``warnings.warn(`` line.
+
+    Output should be a single Markdown bullet with only the UserWarning message.
+    """
+    raw = (
+        "/home/runner/work/docs/docs/scripts/knowledgebase-nav/generate_tags.py:"
+        "969: UserWarning: Unknown keyword `foobar` used in "
+        "`support/models/articles/adding-multiple-authors-to-a-report.mdx`. "
+        "Add it to `scripts/knowledgebase-nav/config.yaml` to suppress this warning.\n"
+        "  warnings.warn(\n"
+    )
+    out = pr_report.format_warnings_for_display(raw)
+    assert "home/runner" not in out
+    assert "warnings.warn" not in out
+    assert "Unknown keyword `foobar`" in out
+    assert out.startswith("- ")
+
+
+def test_format_pr_body_includes_marker():
+    """
+    PR comments need the HTML marker so the workflow can find and update them.
+
+    ``include_marker=True`` prepends ``REPORT_MARKER`` followed by a blank line.
+    The inner body includes ``REPORT_TITLE`` and the fallback paragraph.
+    """
+    inner = pr_report.REPORT_FALLBACK_BODY
+    body = pr_report.format_pr_body(inner, include_marker=True)
+    assert pr_report.REPORT_MARKER in body
+    assert pr_report.REPORT_FALLBACK_BODY in body
+    assert pr_report.REPORT_TITLE in body

--- a/support/inference.mdx
+++ b/support/inference.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Support: W&B Inference"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
 ---
 
 ## Browse by category

--- a/support/inference.mdx
+++ b/support/inference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Support: W&B Inference"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 ## Browse by category

--- a/support/inference/tags/administrator.mdx
+++ b/support/inference/tags/administrator.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Administrator"
 tag: "1"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="API error code 403 - The inference gateway is not enabled for your organization" href="/support/inference/articles/api-error-code-403-the-inference-gateway" arrow="true" horizontal>

--- a/support/inference/tags/administrator.mdx
+++ b/support/inference/tags/administrator.mdx
@@ -2,6 +2,7 @@
 title: "Administrator"
 tag: "1"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="API error code 403 - The inference gateway is not enabled for your organization" href="/support/inference/articles/api-error-code-403-the-inference-gateway" arrow="true" horizontal>

--- a/support/inference/tags/authentication-access.mdx
+++ b/support/inference/tags/authentication-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Authentication & Access"
 tag: "3"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="API error code 401 - Authentication failed" href="/support/inference/articles/api-error-code-401-authentication-failed" arrow="true" horizontal>

--- a/support/inference/tags/authentication-access.mdx
+++ b/support/inference/tags/authentication-access.mdx
@@ -2,6 +2,7 @@
 title: "Authentication & Access"
 tag: "3"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="API error code 401 - Authentication failed" href="/support/inference/articles/api-error-code-401-authentication-failed" arrow="true" horizontal>

--- a/support/inference/tags/billing.mdx
+++ b/support/inference/tags/billing.mdx
@@ -2,6 +2,7 @@
 title: "Billing"
 tag: "1"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>

--- a/support/inference/tags/billing.mdx
+++ b/support/inference/tags/billing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Billing"
 tag: "1"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>

--- a/support/inference/tags/quotas-rate-limits.mdx
+++ b/support/inference/tags/quotas-rate-limits.mdx
@@ -2,6 +2,7 @@
 title: "Quotas & Rate Limits"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>

--- a/support/inference/tags/quotas-rate-limits.mdx
+++ b/support/inference/tags/quotas-rate-limits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Quotas & Rate Limits"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="API error code 402 - You exceeded your current quota" href="/support/inference/articles/api-error-code-402-you-exceeded-your-cur" arrow="true" horizontal>

--- a/support/inference/tags/server-errors.mdx
+++ b/support/inference/tags/server-errors.mdx
@@ -2,6 +2,7 @@
 title: "Server Errors"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="API error code 500 - The server had an error while processing your request" href="/support/inference/articles/api-error-code-500-the-server-had-an-err" arrow="true" horizontal>

--- a/support/inference/tags/server-errors.mdx
+++ b/support/inference/tags/server-errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Server Errors"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="API error code 500 - The server had an error while processing your request" href="/support/inference/articles/api-error-code-500-the-server-had-an-err" arrow="true" horizontal>

--- a/support/models.mdx
+++ b/support/models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Support: W&B Models"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 ## Featured articles

--- a/support/models.mdx
+++ b/support/models.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Support: W&B Models"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
 ---
 
 ## Featured articles

--- a/support/models/tags/academic.mdx
+++ b/support/models/tags/academic.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Academic"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/academic.mdx
+++ b/support/models/tags/academic.mdx
@@ -2,6 +2,7 @@
 title: "Academic"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/administrator.mdx
+++ b/support/models/tags/administrator.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Administrator"
 tag: "23"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/administrator.mdx
+++ b/support/models/tags/administrator.mdx
@@ -2,6 +2,7 @@
 title: "Administrator"
 tag: "23"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/alerts.mdx
+++ b/support/models/tags/alerts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Alerts"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>

--- a/support/models/tags/alerts.mdx
+++ b/support/models/tags/alerts.mdx
@@ -2,6 +2,7 @@
 title: "Alerts"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>

--- a/support/models/tags/anonymous.mdx
+++ b/support/models/tags/anonymous.mdx
@@ -2,6 +2,7 @@
 title: "Anonymous"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How does someone without an account see run results?" href="/support/models/articles/how-does-someone-without-an-account-see-" arrow="true" horizontal>

--- a/support/models/tags/anonymous.mdx
+++ b/support/models/tags/anonymous.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Anonymous"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How does someone without an account see run results?" href="/support/models/articles/how-does-someone-without-an-account-see-" arrow="true" horizontal>

--- a/support/models/tags/artifacts.mdx
+++ b/support/models/tags/artifacts.mdx
@@ -2,6 +2,7 @@
 title: "Artifacts"
 tag: "13"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I turn off wandb when testing my code?" href="/support/models/articles/can-i-turn-off-wandb-when-testing-my-cod" arrow="true" horizontal>

--- a/support/models/tags/artifacts.mdx
+++ b/support/models/tags/artifacts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Artifacts"
 tag: "13"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I turn off wandb when testing my code?" href="/support/models/articles/can-i-turn-off-wandb-when-testing-my-cod" arrow="true" horizontal>

--- a/support/models/tags/aws.mdx
+++ b/support/models/tags/aws.mdx
@@ -2,6 +2,7 @@
 title: "AWS"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I use Sweeps and SageMaker?" href="/support/models/articles/can-i-use-sweeps-and-sagemaker" arrow="true" horizontal>

--- a/support/models/tags/aws.mdx
+++ b/support/models/tags/aws.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AWS"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I use Sweeps and SageMaker?" href="/support/models/articles/can-i-use-sweeps-and-sagemaker" arrow="true" horizontal>

--- a/support/models/tags/billing.mdx
+++ b/support/models/tags/billing.mdx
@@ -2,6 +2,7 @@
 title: "Billing"
 tag: "4"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I change my billing address?" href="/support/models/articles/how-do-i-change-my-billing-address" arrow="true" horizontal>

--- a/support/models/tags/billing.mdx
+++ b/support/models/tags/billing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Billing"
 tag: "4"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I change my billing address?" href="/support/models/articles/how-do-i-change-my-billing-address" arrow="true" horizontal>

--- a/support/models/tags/charts.mdx
+++ b/support/models/tags/charts.mdx
@@ -2,6 +2,7 @@
 title: "Charts"
 tag: "4"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>

--- a/support/models/tags/charts.mdx
+++ b/support/models/tags/charts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Charts"
 tag: "4"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>

--- a/support/models/tags/connectivity.mdx
+++ b/support/models/tags/connectivity.mdx
@@ -2,6 +2,7 @@
 title: "Connectivity"
 tag: "4"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>

--- a/support/models/tags/connectivity.mdx
+++ b/support/models/tags/connectivity.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Connectivity"
 tag: "4"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>

--- a/support/models/tags/environment-variables.mdx
+++ b/support/models/tags/environment-variables.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Environment Variables"
 tag: "12"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I run wandb offline?" href="/support/models/articles/can-i-run-wandb-offline" arrow="true" horizontal>

--- a/support/models/tags/environment-variables.mdx
+++ b/support/models/tags/environment-variables.mdx
@@ -2,6 +2,7 @@
 title: "Environment Variables"
 tag: "12"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I run wandb offline?" href="/support/models/articles/can-i-run-wandb-offline" arrow="true" horizontal>

--- a/support/models/tags/experiments.mdx
+++ b/support/models/tags/experiments.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Experiments"
 tag: "36"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I just set the run name to the run ID?" href="/support/models/articles/can-i-just-set-the-run-name-to-the-run-i" arrow="true" horizontal>

--- a/support/models/tags/experiments.mdx
+++ b/support/models/tags/experiments.mdx
@@ -2,6 +2,7 @@
 title: "Experiments"
 tag: "36"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I just set the run name to the run ID?" href="/support/models/articles/can-i-just-set-the-run-name-to-the-run-i" arrow="true" horizontal>

--- a/support/models/tags/hyperparameter.mdx
+++ b/support/models/tags/hyperparameter.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hyperparameter"
 tag: "3"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/hyperparameter.mdx
+++ b/support/models/tags/hyperparameter.mdx
@@ -2,6 +2,7 @@
 title: "Hyperparameter"
 tag: "3"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/inference.mdx
+++ b/support/models/tags/inference.mdx
@@ -2,6 +2,7 @@
 title: "Inference"
 tag: "5"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I fix Invalid Authentication (401) errors with W&B Inference?" href="/support/models/articles/how-do-i-fix-invalid-authentication-401-" arrow="true" horizontal>

--- a/support/models/tags/inference.mdx
+++ b/support/models/tags/inference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inference"
 tag: "5"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I fix Invalid Authentication (401) errors with W&B Inference?" href="/support/models/articles/how-do-i-fix-invalid-authentication-401-" arrow="true" horizontal>

--- a/support/models/tags/logs.mdx
+++ b/support/models/tags/logs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Logs"
 tag: "7"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Does logging block my training?" href="/support/models/articles/does-logging-block-my-training" arrow="true" horizontal>

--- a/support/models/tags/logs.mdx
+++ b/support/models/tags/logs.mdx
@@ -2,6 +2,7 @@
 title: "Logs"
 tag: "7"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Does logging block my training?" href="/support/models/articles/does-logging-block-my-training" arrow="true" horizontal>

--- a/support/models/tags/metrics.mdx
+++ b/support/models/tags/metrics.mdx
@@ -2,6 +2,7 @@
 title: "Metrics"
 tag: "16"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>

--- a/support/models/tags/metrics.mdx
+++ b/support/models/tags/metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metrics"
 tag: "16"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>

--- a/support/models/tags/notebooks.mdx
+++ b/support/models/tags/notebooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Notebooks"
 tag: "3"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>

--- a/support/models/tags/notebooks.mdx
+++ b/support/models/tags/notebooks.mdx
@@ -2,6 +2,7 @@
 title: "Notebooks"
 tag: "3"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Do 'Run Finished' alerts work in notebooks?" href="/support/models/articles/do-run-finished-alerts-work-in-notebooks" arrow="true" horizontal>

--- a/support/models/tags/outage.mdx
+++ b/support/models/tags/outage.mdx
@@ -2,6 +2,7 @@
 title: "Outage"
 tag: "3"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>

--- a/support/models/tags/outage.mdx
+++ b/support/models/tags/outage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Outage"
 tag: "3"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I resolve the Filestream rate limit exceeded error?" href="/support/models/articles/how-can-i-resolve-the-filestream-rate-li" arrow="true" horizontal>

--- a/support/models/tags/privacy.mdx
+++ b/support/models/tags/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Privacy"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>

--- a/support/models/tags/privacy.mdx
+++ b/support/models/tags/privacy.mdx
@@ -2,6 +2,7 @@
 title: "Privacy"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>

--- a/support/models/tags/projects.mdx
+++ b/support/models/tags/projects.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Projects"
 tag: "4"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I change the privacy of my project?" href="/support/models/articles/how-can-i-change-the-privacy-of-my-proje" arrow="true" horizontal>

--- a/support/models/tags/projects.mdx
+++ b/support/models/tags/projects.mdx
@@ -2,6 +2,7 @@
 title: "Projects"
 tag: "4"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I change the privacy of my project?" href="/support/models/articles/how-can-i-change-the-privacy-of-my-proje" arrow="true" horizontal>

--- a/support/models/tags/python.mdx
+++ b/support/models/tags/python.mdx
@@ -2,6 +2,7 @@
 title: "Python"
 tag: "6"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Does the W&B client support Python 2?" href="/support/models/articles/does-the-wb-client-support-python-2" arrow="true" horizontal>

--- a/support/models/tags/python.mdx
+++ b/support/models/tags/python.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Python"
 tag: "6"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Does the W&B client support Python 2?" href="/support/models/articles/does-the-wb-client-support-python-2" arrow="true" horizontal>

--- a/support/models/tags/reports.mdx
+++ b/support/models/tags/reports.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reports"
 tag: "15"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Adding multiple authors to a report" href="/support/models/articles/adding-multiple-authors-to-a-report" arrow="true" horizontal>

--- a/support/models/tags/reports.mdx
+++ b/support/models/tags/reports.mdx
@@ -2,6 +2,7 @@
 title: "Reports"
 tag: "15"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Adding multiple authors to a report" href="/support/models/articles/adding-multiple-authors-to-a-report" arrow="true" horizontal>

--- a/support/models/tags/resuming.mdx
+++ b/support/models/tags/resuming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Resuming"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I fix the error `resume='must' but run (<run_id>) doesn't exist`?" href="/support/models/articles/how-do-i-fix-the-error-resumemust-but-ru" arrow="true" horizontal>

--- a/support/models/tags/resuming.mdx
+++ b/support/models/tags/resuming.mdx
@@ -2,6 +2,7 @@
 title: "Resuming"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I fix the error `resume='must' but run (<run_id>) doesn't exist`?" href="/support/models/articles/how-do-i-fix-the-error-resumemust-but-ru" arrow="true" horizontal>

--- a/support/models/tags/run-crashes.mdx
+++ b/support/models/tags/run-crashes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Run Crashes"
 tag: "7"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I fix an error like `AttributeError: module 'wandb' has no attribute ...`?" href="/support/models/articles/how-can-i-fix-an-error-like-attributeerr" arrow="true" horizontal>

--- a/support/models/tags/run-crashes.mdx
+++ b/support/models/tags/run-crashes.mdx
@@ -2,6 +2,7 @@
 title: "Run Crashes"
 tag: "7"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I fix an error like `AttributeError: module 'wandb' has no attribute ...`?" href="/support/models/articles/how-can-i-fix-an-error-like-attributeerr" arrow="true" horizontal>

--- a/support/models/tags/runs.mdx
+++ b/support/models/tags/runs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Runs"
 tag: "18"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/runs.mdx
+++ b/support/models/tags/runs.mdx
@@ -2,6 +2,7 @@
 title: "Runs"
 tag: "18"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/security.mdx
+++ b/support/models/tags/security.mdx
@@ -2,6 +2,7 @@
 title: "Security"
 tag: "6"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>

--- a/support/models/tags/security.mdx
+++ b/support/models/tags/security.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Security"
 tag: "6"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can W&B team members see my data?" href="/support/models/articles/can-wb-team-members-see-my-data" arrow="true" horizontal>

--- a/support/models/tags/storage.mdx
+++ b/support/models/tags/storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Storage"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How much storage does each artifact version use?" href="/support/models/articles/how-much-storage-does-each-artifact-vers" arrow="true" horizontal>

--- a/support/models/tags/storage.mdx
+++ b/support/models/tags/storage.mdx
@@ -2,6 +2,7 @@
 title: "Storage"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How much storage does each artifact version use?" href="/support/models/articles/how-much-storage-does-each-artifact-vers" arrow="true" horizontal>

--- a/support/models/tags/sweeps.mdx
+++ b/support/models/tags/sweeps.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sweeps"
 tag: "16"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/sweeps.mdx
+++ b/support/models/tags/sweeps.mdx
@@ -2,6 +2,7 @@
 title: "Sweeps"
 tag: "16"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Best practices to organize hyperparameter searches" href="/support/models/articles/best-practices-to-organize-hyperparamete" arrow="true" horizontal>

--- a/support/models/tags/tables.mdx
+++ b/support/models/tags/tables.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tables"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>

--- a/support/models/tags/tables.mdx
+++ b/support/models/tags/tables.mdx
@@ -2,6 +2,7 @@
 title: "Tables"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I add Plotly or Bokeh Charts into Tables?" href="/support/models/articles/how-do-i-add-plotly-or-bokeh-charts-into" arrow="true" horizontal>

--- a/support/models/tags/team-management.mdx
+++ b/support/models/tags/team-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Team Management"
 tag: "12"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>

--- a/support/models/tags/team-management.mdx
+++ b/support/models/tags/team-management.mdx
@@ -2,6 +2,7 @@
 title: "Team Management"
 tag: "12"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I just log metrics, no code or dataset examples?" href="/support/models/articles/can-i-just-log-metrics-no-code-or-datase" arrow="true" horizontal>

--- a/support/models/tags/tensorboard.mdx
+++ b/support/models/tags/tensorboard.mdx
@@ -2,6 +2,7 @@
 title: "Tensorboard"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How is W&B different from TensorBoard?" href="/support/models/articles/how-is-wb-different-from-tensorboard" arrow="true" horizontal>

--- a/support/models/tags/tensorboard.mdx
+++ b/support/models/tags/tensorboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tensorboard"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How is W&B different from TensorBoard?" href="/support/models/articles/how-is-wb-different-from-tensorboard" arrow="true" horizontal>

--- a/support/models/tags/user-management.mdx
+++ b/support/models/tags/user-management.mdx
@@ -2,6 +2,7 @@
 title: "User Management"
 tag: "13"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/user-management.mdx
+++ b/support/models/tags/user-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: "User Management"
 tag: "13"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I get an academic plan as a student?" href="/support/models/articles/can-i-get-an-academic-plan-as-a-student" arrow="true" horizontal>

--- a/support/models/tags/workspaces.mdx
+++ b/support/models/tags/workspaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Workspaces"
 tag: "6"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Can I group runs without using the 'Group' feature?" href="/support/models/articles/can-i-group-runs-without-using-the-group" arrow="true" horizontal>

--- a/support/models/tags/workspaces.mdx
+++ b/support/models/tags/workspaces.mdx
@@ -2,6 +2,7 @@
 title: "Workspaces"
 tag: "6"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Can I group runs without using the 'Group' feature?" href="/support/models/articles/can-i-group-runs-without-using-the-group" arrow="true" horizontal>

--- a/support/models/tags/wysiwyg.mdx
+++ b/support/models/tags/wysiwyg.mdx
@@ -2,6 +2,7 @@
 title: "Wysiwyg"
 tag: "5"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I delete a panel grid?" href="/support/models/articles/how-do-i-delete-a-panel-grid" arrow="true" horizontal>

--- a/support/models/tags/wysiwyg.mdx
+++ b/support/models/tags/wysiwyg.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Wysiwyg"
 tag: "5"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I delete a panel grid?" href="/support/models/articles/how-do-i-delete-a-panel-grid" arrow="true" horizontal>

--- a/support/weave.mdx
+++ b/support/weave.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Support: W&B Weave"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 ## Browse by category

--- a/support/weave.mdx
+++ b/support/weave.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Support: W&B Weave"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
 ---
 
 ## Browse by category

--- a/support/weave/tags/client-info.mdx
+++ b/support/weave/tags/client-info.mdx
@@ -2,6 +2,7 @@
 title: "Client Info"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I disable client information capture?" href="/support/weave/articles/how-can-i-disable-client-information-cap" arrow="true" horizontal>

--- a/support/weave/tags/client-info.mdx
+++ b/support/weave/tags/client-info.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Client Info"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I disable client information capture?" href="/support/weave/articles/how-can-i-disable-client-information-cap" arrow="true" horizontal>

--- a/support/weave/tags/code-capture.mdx
+++ b/support/weave/tags/code-capture.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Code Capture"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I disable code capture?" href="/support/weave/articles/how-can-i-disable-code-capture" arrow="true" horizontal>

--- a/support/weave/tags/code-capture.mdx
+++ b/support/weave/tags/code-capture.mdx
@@ -2,6 +2,7 @@
 title: "Code Capture"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I disable code capture?" href="/support/weave/articles/how-can-i-disable-code-capture" arrow="true" horizontal>

--- a/support/weave/tags/data-capture.mdx
+++ b/support/weave/tags/data-capture.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Data Capture"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How is Weave data ingestion calculated?" href="/support/weave/articles/how-is-weave-data-ingestion-calculated" arrow="true" horizontal>

--- a/support/weave/tags/data-capture.mdx
+++ b/support/weave/tags/data-capture.mdx
@@ -2,6 +2,7 @@
 title: "Data Capture"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How is Weave data ingestion calculated?" href="/support/weave/articles/how-is-weave-data-ingestion-calculated" arrow="true" horizontal>

--- a/support/weave/tags/evaluation.mdx
+++ b/support/weave/tags/evaluation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Evaluation"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>

--- a/support/weave/tags/evaluation.mdx
+++ b/support/weave/tags/evaluation.mdx
@@ -2,6 +2,7 @@
 title: "Evaluation"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>

--- a/support/weave/tags/performance.mdx
+++ b/support/weave/tags/performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance"
 tag: "5"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>

--- a/support/weave/tags/performance.mdx
+++ b/support/weave/tags/performance.mdx
@@ -2,6 +2,7 @@
 title: "Performance"
 tag: "5"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Long eval clean up times" href="/support/weave/articles/long-eval-clean-up-times" arrow="true" horizontal>

--- a/support/weave/tags/system-info.mdx
+++ b/support/weave/tags/system-info.mdx
@@ -2,6 +2,7 @@
 title: "System Info"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How can I disable system information capture?" href="/support/weave/articles/how-can-i-disable-system-information-cap" arrow="true" horizontal>

--- a/support/weave/tags/system-info.mdx
+++ b/support/weave/tags/system-info.mdx
@@ -1,7 +1,7 @@
 ---
 title: "System Info"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How can I disable system information capture?" href="/support/weave/articles/how-can-i-disable-system-information-cap" arrow="true" horizontal>

--- a/support/weave/tags/trace-data.mdx
+++ b/support/weave/tags/trace-data.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Trace Data"
 tag: "3"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="Trace data is truncated" href="/support/weave/articles/trace-data-is-truncated" arrow="true" horizontal>

--- a/support/weave/tags/trace-data.mdx
+++ b/support/weave/tags/trace-data.mdx
@@ -2,6 +2,7 @@
 title: "Trace Data"
 tag: "3"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="Trace data is truncated" href="/support/weave/articles/trace-data-is-truncated" arrow="true" horizontal>

--- a/support/weave/tags/ui-rendering.mdx
+++ b/support/weave/tags/ui-rendering.mdx
@@ -1,7 +1,7 @@
 ---
 title: "UI Rendering"
 tag: "2"
-generator: knowledgebase-nav
+generator: "knowledgebase-nav"
 ---
 
 <Card title="How do I render Markdown in the UI?" href="/support/weave/articles/how-do-i-render-markdown-in-the-ui" arrow="true" horizontal>

--- a/support/weave/tags/ui-rendering.mdx
+++ b/support/weave/tags/ui-rendering.mdx
@@ -2,6 +2,7 @@
 title: "UI Rendering"
 tag: "2"
 generator: "knowledgebase-nav"
+template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
 ---
 
 <Card title="How do I render Markdown in the UI?" href="/support/weave/articles/how-do-i-render-markdown-in-the-ui" arrow="true" horizontal>


### PR DESCRIPTION
## Summary

This change replaces the knowledgebase-nav workflow’s **warnings-only** pull request comment with a **structured navigation report** that summarizes what the generator changed (using `git diff` after `generate_tags.py` runs), and surfaces the same report in the **Actions job summary** for manual `workflow_dispatch` runs. Fork pull requests still do not receive an automated comment (unchanged).

[WBDOCS-1997](https://wandb.atlassian.net/browse/WBDOCS-1997)

## Motivation

Reviewers and tech writers need a quick, repeatable summary of support navigation impact (articles, tag pages, product indexes, `docs.json`, root `support.mdx`, deletions, keyword-related counts, and unknown keywords) without reading full CI logs.

## Changes

### Workflow (`.github/workflows/knowledgebase-nav.yml`)

- **Pull requests (same-repo only):** After the generator runs, the workflow runs `scripts/knowledgebase-nav/pr_report.py`, writes the Markdown to `comment-body.md`, and **upserts** a single issue comment identified by `<!-- knowledgebase-nav-report -->` (create or PATCH; no longer deletes the comment when there are no warnings).
- **`workflow_dispatch`:** Appends the same Markdown (without the HTML marker) to `$GITHUB_STEP_SUMMARY` under a `## Knowledgebase navigation report` heading so manual runs still get feedback when there is no PR.
- Warning log step text updated to mention PR comment or job summary.

### New script (`scripts/knowledgebase-nav/pr_report.py`)

- Parses `git diff --name-status HEAD` and buckets paths into counts (badges/articles, modified tag pages, product indexes, root `support.mdx`, deletions, new tag pages, removed tag pages, `docs.json`).
- Parses `generator-warnings.log` for distinct **Unknown keyword** strings (aligned with `generate_tags.build_tag_index` warning text).
- Builds Markdown: category bullets (counts only), optional generator warnings fenced block, optional workflow run link via `--run-url`.
- Fallback message when there is no diff, no unknown keywords, and no warnings: the explicit sentence about no updates to support articles, tag pages, product indexes, `docs.json`, or root `support.mdx`.
- Documented for maintainers (module and function docstrings, section headers).

### Tests (`scripts/knowledgebase-nav/tests/test_pr_report.py`)

- Unit tests for parsing, categorization (including rename behavior for tag pages), unknown-keyword deduplication, Markdown output, and PR marker wrapping.

## Risk / review focus

- **Comment marker change:** Old comments used `<!-- knowledgebase-nav-warnings -->`; new runs use `<!-- knowledgebase-nav-report -->`. Stale old comments may remain on historical PRs until manually removed (low impact).
- **Fork PRs:** Still no auto-comment; behavior unchanged by design.

## Test plan

- [x] Run `pytest scripts/knowledgebase-nav/tests/test_pr_report.py -v` locally (or full `scripts/knowledgebase-nav/tests/`).
- [x] Open a same-repo PR that touches `support/**` or `scripts/knowledgebase-nav/**` and confirm the workflow posts or updates the navigation report comment.
- [x] Run **Knowledgebase Nav** from the Actions tab (`workflow_dispatch`) and confirm the job summary includes the report (including the fallback line when the generator makes no net changes).
- [x] Confirm fork PRs still skip the comment step but run the generator.



[WBDOCS-1997]: https://wandb.atlassian.net/browse/WBDOCS-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ