### PR TITLE
Fix typo and link in registry.mdx

### DIFF
--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -6,7 +6,7 @@ import { ColabLink } from '/snippets/en/_includes/colab-link.mdx';
 
 <ColabLink url="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/wandb_registry/zoo_wandb.ipynb" />
 
-W&B Registry is a curated central repository of [W&B Artifact versions](/models/artifacts/create-a-new-artifact-version) within your organization. Users who [have permission](/models/registry/configure_registry/) within your organization can [download and use artifacts](/models/registry/download_use_artifact/), share, and collaboratively manage the lifecycle of all artifacts, regardless of the team that user belongs to.
+W&B Registry is a curated central repository of [W&B Artifact versions](/models/artifacts/create-a-new-artifact-version) within your organization. Users who [have permission](/models/registry/configure_registry/) within your organization can [download and use artifacts](/models/registry/download_use_artifact/), share, and collaboratively manage the lifecycle of all artifacts, regardless of the team that the user belongs to.
 
 Use the Registry to track artifact versions, audit the history of an artifact's usage and changes, ensure governance and compliance of your artifacts, and [automate downstream processes such as model CI/CD](/models/automations/).
 
@@ -85,7 +85,7 @@ W&B automatically creates a collection for you if the collection you specify in 
 
 Continuing from the previous example, after you run the script, navigate to W&B Registry to view artifact versions that you and other members of your organization publish. Select **Registry** in the project sidebar below **Applications**. Select the `"Model"` registry. Within the registry, you should see the `"first-collection"` collection with your linked artifact version.
 
-Once you link an artifact version to a collection within a registry, members of your organization can [view](/models/registry/lineage), [download](/models/registry/search_registry), [organize](/models/registry/organize-with-tags), and manage your artifact versions, create downstream automations, and more if they have the proper permissions.
+Once you link an artifact version to a collection within a registry, members of your organization can [view](/models/registry/lineage), [download](/models/registry/download_use_artifact), [organize](/models/registry/organize-with-tags), and manage your artifact versions, create downstream automations, and more if they have the proper permissions.
 
 <Note>
 If an artifact version logs metrics (such as by using `wandb.Run.log_artifact()`), you can view metrics for that version from its details page, and you can compare metrics across artifact versions from the collection's page. Refer to [View linked artifacts in a registry](/models/registry/link_version/#view-linked-artifacts-in-a-registry).


### PR DESCRIPTION
Add a missing article, correct a link so that it points to the download_use_artifact page.

## Description

- Added a missing article: "the team that user belongs to" → "the team that _the_ user belongs to"
- Corrected a cross-link: The "download" link pointed to `search_registry` but should likely point to `download_use_artifact`
- The GitHub web editor added a trailing newline