### PR TITLE
Exclude koog.ai URLs from Lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -57,6 +57,7 @@ exclude = [
   # Match full URLs to image directories on any domain (including preview sites)
   '(http|https)://[^/]+/images/',
   '(http|https)://kubeflow\.mysite\.com',
+  '(http|https)://.*\.?koog\.ai',
   '(http|https)://my-fake-url\.com',
   '(http|https)://my\.domain\.net',
   'https://wiki.python.org/moin/UsingPickle',


### PR DESCRIPTION
## Description
Exclude koog.ai URLs from Lychee

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
