### PR TITLE
Inference - show model-specific max LoRA rank

### DIFF
--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -85,7 +85,6 @@ You can add LoRAs to your W&B account and start using them with two methods:
 
     * The LoRA must have been trained using one of the models listed in the [Supported Base Models section](#supported-base-models).
     * A LoRA saved in PEFT format as a `lora` type artifact in your W&B account.
-    * The maximum supported rank is 16.
     * The LoRA must be stored in the `storage_region="coreweave-us"` for low latency.
     * When uploading, include the name of the base model you trained it on (for example, `meta-llama/Llama-3.1-8B-Instruct`). This ensures W&B can load it with the correct model.
   </Tab>
@@ -109,11 +108,14 @@ model_name = f"wandb-artifact:///{WB_TEAM}/{WB_PROJECT}/your_trained_lora:latest
 
 Inference currently supports the following LLMs (use the exact strings in `wandb.base_model`). More models coming soon:
 
-{/* takeru lora-base-models - This list is automatically generated, do not edit manually. */}
-- `meta-llama/Llama-3.1-70B-Instruct`
-- `meta-llama/Llama-3.1-8B-Instruct`
-- `OpenPipe/Qwen3-14B-Instruct`
-- `Qwen/Qwen3-30B-A3B-Instruct-2507`
+{/* takeru lora-base-models - This table is automatically generated, do not edit manually. */}
+| Model ID (for API usage)            | Maximum LoRA Rank |
+| ----------------------------------- | ----------------- |
+| `meta-llama/Llama-3.1-70B-Instruct` | 16                |
+| `meta-llama/Llama-3.1-8B-Instruct`  | 16                |
+| `openai/gpt-oss-120b`               | 64                |
+| `OpenPipe/Qwen3-14B-Instruct`       | 16                |
+| `Qwen/Qwen3-30B-A3B-Instruct-2507`  | 16                |
 
 ## Pricing
 


### PR DESCRIPTION
## Description

Previously the maximum LoRA rank for all models that had that feature was 16. We have just added LoRA support to `openai/gpt-oss-120b` with max rank 64.

Updated the LoRA page to include this model and show a table with per-model rank values instead of just a bulleted list of model IDs. This table will be kept in sync with the ground truth catalog data via the takeru script as before.

Before:
<img width="363" height="146" alt="Screenshot 2026-03-25 at 11 01 19 PM" src="https://github.com/user-attachments/assets/a4080351-e1f6-4be6-9d34-ae1b0de7dc5f" />

After:
<img width="755" height="260" alt="Screenshot 2026-03-25 at 11 01 05 PM" src="https://github.com/user-attachments/assets/02ba9273-f933-4ddb-8795-0e61f5fdbea8" />


## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed