### PR TITLE
[WBDOCS-2003] Fix encoding in webhook examples

### DIFF
--- a/ja/models/automations/create-automations/webhook.mdx
+++ b/ja/models/automations/create-automations/webhook.mdx
@@ -311,8 +311,7 @@ PAYLOAD='{"key1": "value1", "key2": "value2"}'
 # セキュリティのため、Wandbはペイロードとwebhookに関連付けられた
 # 共有シークレットキーから、HMAC SHA-256アルゴリズムを使用して計算された
 # X-Wandb-Signatureをヘッダーに含めます。
-SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst \
--sha256 -hmac "$SECRET" -binary | base64)
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # cURLリクエストを実行
 curl -X POST \

--- a/ja/models/core/automations/create-automations/webhook.mdx
+++ b/ja/models/core/automations/create-automations/webhook.mdx
@@ -298,8 +298,7 @@ X-Wandb-Signature in the header computed
 # from the payload and the shared secret key 
 associated with the webhook
 # using the HMAC with SHA-256 algorithm.
-SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst 
--sha256 -hmac "$SECRET" -binary | base64)
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
 curl -X POST \

--- a/ko/models/automations/create-automations/webhook.mdx
+++ b/ko/models/automations/create-automations/webhook.mdx
@@ -311,8 +311,7 @@ PAYLOAD='{"key1": "value1", "key2": "value2"}'
 # 보안을 위해, Wandb는 페이로드와 webhook에 연결된 
 # 공유 비밀 키로부터 HMAC SHA-256 알고리즘을 사용하여 
 # 계산된 X-Wandb-Signature를 헤더에 포함합니다.
-SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst \
--sha256 -hmac "$SECRET" -binary | base64)
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # cURL 요청 실행
 curl -X POST \

--- a/ko/models/core/automations/create-automations/webhook.mdx
+++ b/ko/models/core/automations/create-automations/webhook.mdx
@@ -297,8 +297,7 @@ X-Wandb-Signature in the header computed
 # from the payload and the shared secret key 
 associated with the webhook
 # using the HMAC with SHA-256 algorithm.
-SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst 
--sha256 -hmac "$SECRET" -binary | base64)
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
 curl -X POST \

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -315,8 +315,7 @@ X-Wandb-Signature in the header computed
 # from the payload and the shared secret key 
 associated with the webhook
 # using the HMAC with SHA-256 algorithm.
-SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst 
--sha256 -hmac "$SECRET" -binary | base64)
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
 curl -X POST \


### PR DESCRIPTION
## Description
[WBDOCS-2003] Fix encoding in webhook examples

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed



[WBDOCS-2003]: https://wandb.atlassian.net/browse/WBDOCS-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ