### PR TITLE
[WBDOCS-1996] Fix word wrapping issues in webhook script

### DIFF
--- a/ja/models/automations/create-automations/webhook.mdx
+++ b/ja/models/automations/create-automations/webhook.mdx
@@ -304,6 +304,9 @@ W&B が `POST` リクエストに使用する形式の詳細については、**
 ACCESS_TOKEN="your_api_key"
 SECRET="your_api_secret"
 
+# webhook エンドポイントの URL
+API_ENDPOINT="https://your.webhook.endpoint/path"
+
 # 送信したいデータ（例：JSON形式）
 PAYLOAD='{"key1": "value1", "key2": "value2"}'
 
@@ -318,7 +321,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "X-Wandb-Signature: $SIGNATURE" \
-  -d "$PAYLOAD" API_ENDPOINT
+  -d "$PAYLOAD" "$API_ENDPOINT"
 ```
 </Tab>
 </Tabs>

--- a/ja/models/core/automations/create-automations/webhook.mdx
+++ b/ja/models/core/automations/create-automations/webhook.mdx
@@ -288,16 +288,15 @@ W&B アプリ UI または Bash スクリプトを使用して、インタラク
 ACCESS_TOKEN="your_api_key"
 SECRET="your_api_secret"
 
-# The data you want to send (for example, in JSON 
-format)
+# URL of your webhook endpoint
+API_ENDPOINT="https://your.webhook.endpoint/path"
+
+# The data you want to send (for example, in JSON format)
 PAYLOAD='{"key1": "value1", "key2": "value2"}'
 
-# Generate the HMAC signature
-# For security, Wandb includes the 
-X-Wandb-Signature in the header computed
-# from the payload and the shared secret key 
-associated with the webhook
-# using the HMAC with SHA-256 algorithm.
+# Generate the HMAC signature. For security, W&B includes the
+# X-Wandb-Signature header computed from the payload and the shared secret
+# associated with the webhook using HMAC with SHA-256.
 SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
@@ -305,7 +304,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "X-Wandb-Signature: $SIGNATURE" \
-  -d "$PAYLOAD" API_ENDPOINT
+  -d "$PAYLOAD" "$API_ENDPOINT"
 ```
 </Tab>
 </Tabs>

--- a/ko/models/automations/create-automations/webhook.mdx
+++ b/ko/models/automations/create-automations/webhook.mdx
@@ -304,6 +304,9 @@ webhook 문제를 해결하려면 아래 코드를 쉘 스크립트에 복사하
 ACCESS_TOKEN="your_api_key"
 SECRET="your_api_secret"
 
+# webhook 엔드포인트 URL
+API_ENDPOINT="https://your.webhook.endpoint/path"
+
 # 전송하려는 데이터 (예: JSON 형식)
 PAYLOAD='{"key1": "value1", "key2": "value2"}'
 
@@ -318,7 +321,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "X-Wandb-Signature: $SIGNATURE" \
-  -d "$PAYLOAD" API_ENDPOINT
+  -d "$PAYLOAD" "$API_ENDPOINT"
 ```
 </Tab>
 </Tabs>

--- a/ko/models/core/automations/create-automations/webhook.mdx
+++ b/ko/models/core/automations/create-automations/webhook.mdx
@@ -287,16 +287,15 @@ W&B App UI를 사용하여 대화식으로 또는 Bash 스크립트를 사용하
 ACCESS_TOKEN="your_api_key"
 SECRET="your_api_secret"
 
-# The data you want to send (for example, in JSON 
-format)
+# URL of your webhook endpoint
+API_ENDPOINT="https://your.webhook.endpoint/path"
+
+# The data you want to send (for example, in JSON format)
 PAYLOAD='{"key1": "value1", "key2": "value2"}'
 
-# Generate the HMAC signature
-# For security, Wandb includes the 
-X-Wandb-Signature in the header computed
-# from the payload and the shared secret key 
-associated with the webhook
-# using the HMAC with SHA-256 algorithm.
+# Generate the HMAC signature. For security, W&B includes the
+# X-Wandb-Signature header computed from the payload and the shared secret
+# associated with the webhook using HMAC with SHA-256.
 SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
@@ -304,7 +303,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "X-Wandb-Signature: $SIGNATURE" \
-  -d "$PAYLOAD" API_ENDPOINT
+  -d "$PAYLOAD" "$API_ENDPOINT"
 ```
 </Tab>
 </Tabs>

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -305,16 +305,15 @@ Copy and paste the code below into a shell script to troubleshoot your webhook. 
 ACCESS_TOKEN="your_api_key"
 SECRET="your_api_secret"
 
-# The data you want to send (for example, in JSON 
-format)
+# URL of your webhook endpoint
+API_ENDPOINT="https://your.webhook.endpoint/path"
+
+# The data you want to send (for example, in JSON format)
 PAYLOAD='{"key1": "value1", "key2": "value2"}'
 
-# Generate the HMAC signature
-# For security, Wandb includes the 
-X-Wandb-Signature in the header computed
-# from the payload and the shared secret key 
-associated with the webhook
-# using the HMAC with SHA-256 algorithm.
+# Generate the HMAC signature. For security, W&B includes the
+# X-Wandb-Signature header computed from the payload and the shared secret
+# associated with the webhook using HMAC with SHA-256.
 SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
 
 # Make the cURL request
@@ -322,7 +321,7 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "X-Wandb-Signature: $SIGNATURE" \
-  -d "$PAYLOAD" API_ENDPOINT
+  -d "$PAYLOAD" "$API_ENDPOINT"
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Description
[WBDOCS-1996] Fix word wrapping issues in webhook script

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed



[WBDOCS-1996]: https://wandb.atlassian.net/browse/WBDOCS-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ