### PR TITLE
Update cheat sheet script and action to fix a git clone error

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,7 @@ Automatically syncs ground truth code examples from the [docs-code-eval](https:/
 
 If changes are detected:
 - Creates a draft PR named: `🔄 Sync code examples from docs-code-eval`
+- **Base branch**: the repository default branch (for example `main`), even if you ran the workflow from another branch
 - Branch name: `sync-code-examples-{run_number}`
 - Status: Draft (must be marked ready for review)
 - Labels: `documentation`, `automated`, `code-examples`
@@ -67,7 +68,17 @@ When the draft PR is created:
 The workflow uses:
 - **Python**: 3.11
 - **Permissions**: `contents: write`, `pull-requests: write`
-- **Action**: `peter-evans/create-pull-request@v6`
+- **Action**: `peter-evans/create-pull-request@v8`
+
+**Authentication and `docs-code-eval`**
+
+The automatic `GITHUB_TOKEN` is scoped to this repository (`wandb/docs`) only. It does not grant read access to other private repositories in the org, so it cannot replace a PAT for cloning `wandb/docs-code-eval` when that repo is private.
+
+To sync from a **private** `docs-code-eval`, add a repository secret named `DOCS_CODE_EVAL_READ_PAT`: a fine-grained personal access token (or classic PAT) with **Contents** read access to `wandb/docs-code-eval`. The sync script uses it only for `git clone`. If the secret is not set and `docs-code-eval` is public, the workflow clones without a token.
+
+**Clone fails with `could not read Username for 'https://github.com'`**
+
+That usually means Git tried to prompt for credentials (no TTY in Actions) or a credential helper failed. The sync script clears `credential.helper` for the clone and uses HTTPS with `x-access-token` when `DOCS_CODE_EVAL_READ_PAT` is set. If the log shows **anonymous** clone but the repo is private, the secret is missing, misnamed, or not available to this workflow (for example some fork contexts). Re-check the secret name `DOCS_CODE_EVAL_READ_PAT` and that the job log line above the clone says **PAT over HTTPS**.
 
 ### Troubleshooting
 

--- a/.github/workflows/sync-code-examples.yml
+++ b/.github/workflows/sync-code-examples.yml
@@ -14,14 +14,26 @@ jobs:
       - name: Checkout docs repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+          # Do not persist GITHUB_TOKEN as http.https://github.com/.extraheader:
+          # a later `git clone` of docs-code-eval would reuse it and often exit 128.
+          persist-credentials: false
+
+      # Do not use actions/checkout for wandb/docs-code-eval. GITHUB_TOKEN is scoped
+      # to this repository only, so the REST get-repository call for another repo returns
+      # Not Found for a private docs-code-eval. Clone in the script instead.
+      #
+      # For a private docs-code-eval, add repository secret DOCS_CODE_EVAL_READ_PAT
+      # (PAT with contents:read on wandb/docs-code-eval). Optional if the eval repo is public.
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
       - name: Run sync script
+        env:
+          DOCS_CODE_EVAL_READ_TOKEN: ${{ secrets.DOCS_CODE_EVAL_READ_PAT }}
+          GIT_TERMINAL_PROMPT: "0"
         run: |
           chmod +x scripts/sync_code_examples.sh
           ./scripts/sync_code_examples.sh
@@ -60,6 +72,9 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # workflow_dispatch checks out the branch you pick; without this, the PR base
+          # would be that branch instead of the repo default (for example main).
+          base: ${{ github.event.repository.default_branch }}
           commit-message: |
             Sync code examples from docs-code-eval
             

--- a/scripts/generate_code_snippet_component.py
+++ b/scripts/generate_code_snippet_component.py
@@ -37,8 +37,6 @@ def generate_component(py_files):
  * AUTO-GENERATED: Do not edit manually. Run sync_code_examples.sh to regenerate.
  */
 
-import React from 'react';
-
 // Import all MDX-wrapped code examples
 {imports_str}
 

--- a/scripts/sync_code_examples.sh
+++ b/scripts/sync_code_examples.sh
@@ -8,19 +8,41 @@ set -e  # Exit on error
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DOCS_ROOT="$(dirname "$SCRIPT_DIR")"
 SUBMODULE_PATH="$DOCS_ROOT/.temp_code_eval"
-EVAL_REPO_URL="https://github.com/wandb/docs-code-eval.git"
 
 echo "🔄 Syncing code examples from docs-code-eval..."
 
-# Clean up any existing temp submodule
-if [ -d "$SUBMODULE_PATH" ]; then
-    echo "   Removing existing temporary directory..."
-    rm -rf "$SUBMODULE_PATH"
+# Optional: fine-grained or classic PAT with contents:read on wandb/docs-code-eval.
+# Set by CI via secrets (see sync-code-examples workflow). Unset = anonymous clone (public repo only).
+if [ -n "${DOCS_CODE_EVAL_READ_TOKEN:-}" ]; then
+    EVAL_CLONE_URL="https://x-access-token:${DOCS_CODE_EVAL_READ_TOKEN}@github.com/wandb/docs-code-eval.git"
+else
+    EVAL_CLONE_URL="https://github.com/wandb/docs-code-eval.git"
 fi
 
-# Clone the repo (not as submodule, just a temp clone)
-echo "   Cloning docs-code-eval repository..."
-git clone --depth 1 "$EVAL_REPO_URL" "$SUBMODULE_PATH" --quiet
+# Prefer an existing .temp_code_eval (e.g. local prep). In CI we clone after docs
+# checkout with persist-credentials false; see sync-code-examples workflow comments.
+if [ -d "$SUBMODULE_PATH/ground_truth" ] && compgen -G "$SUBMODULE_PATH/ground_truth/"*.py > /dev/null; then
+    echo "   Using existing docs-code-eval checkout at $SUBMODULE_PATH"
+else
+    if [ -d "$SUBMODULE_PATH" ]; then
+        echo "   Removing existing temporary directory..."
+        rm -rf "$SUBMODULE_PATH"
+    fi
+    echo "   Cloning docs-code-eval repository..."
+    if [ -n "${DOCS_CODE_EVAL_READ_TOKEN:-}" ]; then
+        echo "   (HTTPS with PAT from DOCS_CODE_EVAL_READ_PAT)"
+    else
+        echo "   (anonymous HTTPS; set secret DOCS_CODE_EVAL_READ_PAT if the eval repo is private)"
+    fi
+    # - Clear extraheader so a stale Actions token does not override URL credentials.
+    # - credential.helper= stops the runner's helper from prompting (CI has no TTY; you
+    #   may otherwise see "could not read Username" / "No such device or address").
+    export GIT_TERMINAL_PROMPT=0
+    git \
+        -c http.https://github.com/.extraheader= \
+        -c credential.helper= \
+        clone --depth 1 "$EVAL_CLONE_URL" "$SUBMODULE_PATH" --quiet
+fi
 
 # Copy Python files and create MDX wrappers
 echo "   Copying Python code examples and creating MDX wrappers..."


### PR DESCRIPTION
## Description
Update cheat sheet script and action to fix a git clone error

Ref: https://github.com/wandb/docs/actions/runs/23814259775/job/69409384077

Fixes WBDOCS-2008

## Testing
- [x] Run script locally and verify it correctly regenerates the. cheat sheet
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
- [x] Run action from this PR branch and verify it correctly cuts a [draft PR](https://github.com/wandb/docs/pull/2404)
