### PR TITLE
Inference - add generated model price table

### DIFF
--- a/inference/usage-limits.mdx
+++ b/inference/usage-limits.mdx
@@ -9,7 +9,29 @@ Learn about pricing, limits, and other important usage information before using 
 
 ## Pricing
 
-For detailed model pricing information, visit [W&B Inference pricing](https://wandb.ai/site/pricing/inference).
+Model pricing is subject to change. Prices shown are per 1 million tokens.
+
+{/* takeru pricing - This table is automatically generated, do not edit manually. */}
+| Model ID                                       | Input Tokens | Cached Tokens | Output Tokens |
+| ---------------------------------------------- | ------------ | ------------- | ------------- |
+| `deepseek-ai/DeepSeek-V3.1`                    | $0.55        | $0.55         | $1.65         |
+| `meta-llama/Llama-4-Scout-17B-16E-Instruct`    | $0.17        | $0.17         | $0.66         |
+| `meta-llama/Llama-3.3-70B-Instruct`            | $0.71        | $0.71         | $0.71         |
+| `meta-llama/Llama-3.1-70B-Instruct`            | $0.80        | $0.80         | $0.80         |
+| `meta-llama/Llama-3.1-8B-Instruct`             | $0.22        | $0.22         | $0.22         |
+| `microsoft/Phi-4-mini-instruct`                | $0.08        | $0.08         | $0.35         |
+| `MiniMaxAI/MiniMax-M2.5`                       | $0.30        | $0.30         | $1.20         |
+| `moonshotai/Kimi-K2.5`                         | $0.60        | $0.10         | $3.00         |
+| `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8` | $0.20        | $0.20         | $0.80         |
+| `openai/gpt-oss-120b`                          | $0.15        | $0.15         | $0.60         |
+| `openai/gpt-oss-20b`                           | $0.05        | $0.05         | $0.20         |
+| `OpenPipe/Qwen3-14B-Instruct`                  | $0.05        | $0.05         | $0.22         |
+| `Qwen/Qwen3-235B-A22B-Instruct-2507`           | $0.10        | $0.10         | $0.10         |
+| `Qwen/Qwen3-235B-A22B-Thinking-2507`           | $0.10        | $0.10         | $0.10         |
+| `Qwen/Qwen3-30B-A3B-Instruct-2507`             | $0.10        | $0.10         | $0.30         |
+| `Qwen/Qwen3-Coder-480B-A35B-Instruct`          | $1.00        | $1.00         | $1.50         |
+| `Qwen/Qwen3.5-35B-A3B`                         | $0.25        | $0.25         | $1.25         |
+| `zai-org/GLM-5-FP8`                            | $1.00        | $1.00         | $3.20         |
 
 ## Purchase more credits
 
@@ -44,4 +66,4 @@ The Inference service is only available from supported geographic locations. For
 ## Next steps
 
 - Review the [prerequisites](/inference/prerequisites/) before getting started.
-- See [available models](/inference/models) and their specific pricing. 
+- See [available models](/inference/models) and their specific pricing.


### PR DESCRIPTION
## Description

Currently the product docs just defer to the marketing site for pricing information. This was originally done to reduce manual effort and the likelihood of unsynchronized information.

Now, with the `takeru` tooling, keeping information in the product docs synchronized with the model catalog is significantly simplified. It seems better to keep users in the docs then send them elsewhere.

Note that this change reflects an upcoming pricing adjustment for `moonshotai/Kimi-K2.5` and merging this PR should wait on synchronization with changes elsewhere.

Before:

<img width="3398" height="1744" alt="image" src="https://github.com/user-attachments/assets/3b35446e-ff7c-4b40-851a-63a61d5cca29" />

After:

<img width="3398" height="1744" alt="image" src="https://github.com/user-attachments/assets/0032d65e-911e-4b91-853a-14ff093d7906" />

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed

