### PR TITLE
Ignore .cursor/ in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ go.sum
 
 # Misc
 # Cursor editor local rules and config (per-developer)
-.cursor/
+.cursor
 
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ go.mod
 go.sum
 
 # Misc
+# Cursor editor local rules and config (per-developer)
+.cursor/
+
 .DS_Store
 .env.local
 .env.development.local


### PR DESCRIPTION
Adds `.cursor/` to `.gitignore` so local Cursor rules and editor config stay untracked and out of PR diffs.

Each developer can keep personal rules (for example Jira MCP routing) under `.cursor/rules` without committing them.

Made with [Cursor](https://cursor.com)