### PR TITLE
[Weave] Traces concept

### DIFF
--- a/weave/guides/tracking/tracing.mdx
+++ b/weave/guides/tracking/tracing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Understand Ops and Calls"
-description: "Learn how Ops and Calls create the foundation of W&B Weave's tracing system."
+title: "Understand Ops, Calls, and Traces"
+description: "Learn how Ops, Calls, and Traces create the foundation of W&B Weave's tracing system."
 ---
 
 
@@ -44,5 +44,6 @@ Calls are similar to spans in the [OpenTelemetry](https://opentelemetry.io) data
 - Belong to a Trace (a collection of calls in the same execution context)
 - Have parent and child Calls, forming a tree structure
 
+## Traces
 
-
+Traces are full trees of Calls that share the same execution context. Each Trace contains an ID (`trace_id`) you can use to retrieve the entire tree of Calls. Retrieving Call information using the Call's id only returns data about the specified Call and none of its child Calls.

--- a/weave/guides/tracking/tracing.mdx
+++ b/weave/guides/tracking/tracing.mdx
@@ -44,9 +44,7 @@ Traces are full trees of Calls that share the same execution context. Each Trace
 
 ## Threads
 
-Threads are collections of traces related to a single session or conversation with an agent, and they share he same `thread_id`. 
-
-In a conversation with an agent, each input and response produces a trace tree that is called a "turn". Weave collects all of a conversation's turns under a single thread ID.
+Threads are collections of traces related to a single session or conversation.  Threads can be used to do analysis or scoring on the [entire conversation] as a whole instead of individual Calls.
 
 The following diagram illustrates the relationships between threads, traces, and calls:
 

--- a/weave/guides/tracking/tracing.mdx
+++ b/weave/guides/tracking/tracing.mdx
@@ -3,8 +3,6 @@ title: "Understand Ops, Calls, and Traces"
 description: "Learn how Ops, Calls, and Traces create the foundation of W&B Weave's tracing system."
 ---
 
-
-
 ## Ops
 
 An **Op** is a versioned, tracked function. When you decorate a function with `@weave.op()` (Python) or wrap it with `weave.op()` (TypeScript), Weave automatically captures its code, inputs, outputs, and execution metadata. Ops are the building blocks of tracing, evaluation scorers, and any tracked computation.
@@ -24,9 +22,6 @@ const myFunctionOp = weave.op(myFunction)
 ```
 </CodeGroup>
 
-
-
-
 ## Calls
 
 A **Call** is a logged execution of an Op. Every time an Op runs, Weave creates a Call that captures:
@@ -39,7 +34,6 @@ A **Call** is a logged execution of an Op. Every time an Op runs, Weave creates 
 
 Calls show up as **Traces** in the Weave UI and provide the data for debugging, analysis, and evaluation. For the full Call object structure and properties, see the [Call schema reference](/weave/guides/tracking/call-schema-reference).
 
-
 Calls are similar to spans in the [OpenTelemetry](https://opentelemetry.io) data model. A Call can:
 - Belong to a Trace (a collection of calls in the same execution context)
 - Have parent and child Calls, forming a tree structure
@@ -47,3 +41,24 @@ Calls are similar to spans in the [OpenTelemetry](https://opentelemetry.io) data
 ## Traces
 
 Traces are full trees of Calls that share the same execution context. Each Trace contains an ID (`trace_id`) you can use to retrieve the entire tree of Calls. Retrieving Call information using the Call's id only returns data about the specified Call and none of its child Calls.
+
+## Threads
+
+Threads are collections of traces related to a single session or conversation with an agent, and they share he same `thread_id`. 
+
+In a conversation with an agent, each input and response produces a trace tree that is called a "turn". Weave collects all of a conversation's turns under a single thread ID.
+
+The following diagram illustrates the relationships between threads, traces, and calls:
+
+```
+Thread: "session-abc"
+  ├── Turn 1 (trace_id: aaa) → user says "Hi"
+  │     ├── LLM call
+  │     └── format response
+  ├── Turn 2 (trace_id: bbb) → user says "What is the capitol of Paris?"
+  │     ├── RAG retrieval
+  │     ├── LLM call
+  │     └── format response
+  └── Turn 3 (trace_id: ccc) → user says "Thanks"
+        └── LLM call
+```


### PR DESCRIPTION
## Description
Semi-addresses [WBDOCS-2000](https://coreweave.atlassian.net/browse/WBDOCS-2000). Adds a traces definition to the Ops and Calls page.

[WBDOCS-2000]: https://wandb.atlassian.net/browse/WBDOCS-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ