### PR TITLE
feat: accessing /support opens the AI assistant, CSS "X" fix, and update skills submodule to latest sha

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".claude"]
 	path = .claude
-	url = git@github.com:coreweave/docs-skills.git
+	url = https://github.com/coreweave/docs-skills.git

--- a/docs.json
+++ b/docs.json
@@ -1151,7 +1151,9 @@
           {
             "tab": "Support",
             "icon": "/icons/cropped-reports.svg",
-            "href": "https://docs.wandb.ai/support?assistant"
+            "pages": [
+              "support"
+            ]
           },
           {
             "tab": "W&B Launch",

--- a/docs.json
+++ b/docs.json
@@ -1151,9 +1151,7 @@
           {
             "tab": "Support",
             "icon": "/icons/cropped-reports.svg",
-            "pages": [
-              "support"
-            ]
+            "href": "https://docs.wandb.ai/support?assistant"
           },
           {
             "tab": "W&B Launch",
@@ -3722,10 +3720,6 @@
     }
   },
   "redirects": [
-    {
-      "source": "/support",
-      "destination": "/support?assistant"
-    },
     {
       "source": "/_print/:slug*",
       "destination": "/:slug*"

--- a/docs.json
+++ b/docs.json
@@ -1151,9 +1151,7 @@
           {
             "tab": "Support",
             "icon": "/icons/cropped-reports.svg",
-            "pages": [
-              "support"
-            ]
+            "href": "https://docs.wandb.ai/support?assistant"
           },
           {
             "tab": "W&B Launch",
@@ -3722,6 +3720,10 @@
     }
   },
   "redirects": [
+    {
+      "source": "/support",
+      "destination": "/support?assistant"
+    },
     {
       "source": "/_print/:slug*",
       "destination": "/:slug*"

--- a/docs.json
+++ b/docs.json
@@ -1152,7 +1152,7 @@
             "tab": "Support",
             "icon": "/icons/cropped-reports.svg",
             "pages": [
-              "/support"
+              "support"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -1151,7 +1151,9 @@
           {
             "tab": "Support",
             "icon": "/icons/cropped-reports.svg",
-            "href": "https://docs.wandb.ai/support?assistant"
+            "pages": [
+              "/support"
+            ]
           },
           {
             "tab": "W&B Launch",

--- a/snippets/HelpQuestionForm.jsx
+++ b/snippets/HelpQuestionForm.jsx
@@ -3,6 +3,12 @@ export const HelpQuestionForm = () => {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
+    if (!params.has("assistant")) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("assistant", "");
+      window.location.href = url.toString();
+      return;
+    }
     setValue(params.get("assistant") || "");
   }, []);
 

--- a/table-styling.css
+++ b/table-styling.css
@@ -66,6 +66,6 @@ table tr:not(:last-child) td {
 .dark table tr:not(:last-child) td {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
-#banner > div > p, #banner > div > p > a, #banner > div, #banner > button > svg, .lucide-x {
+#banner > div > p, #banner > div > p > a, #banner > div, #banner > button > svg {
   color: black !important;
 }


### PR DESCRIPTION
What it says on the tin. The `?assistant` querystring forces the assistant window to be open.
Observe: https://docs.wandb.ai/support?assistant

Meanwhile the "X" button on the assistant window is being forced to be black in color and thus invisible in dark mode. 

Finally, let's update the git submodule for our skills to point to the latest commit