### PR TITLE
Add dismissible banner linking to docs feedback survey

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -25,6 +25,10 @@
     "href": "https://docs.wandb.ai/"
   },
   "favicon": "/favicon.png",
+  "banner": {
+    "content": "Help us improve these docs. [Take our quick survey.](https://forms.gle/a843ZFZu8oKqXYVDA)",
+    "dismissible": true
+  },
   "background": {
     "decoration": "gradient"
   },


### PR DESCRIPTION
## Summary

- Adds a site-wide Mintlify banner to `docs.json` that prompts readers to take the [W&B Docs Survey](https://forms.gle/a843ZFZu8oKqXYVDA).
- The banner is dismissible so it does not permanently block content. Once dismissed, it stays hidden until the banner content changes.

> Note: This PR is pitching both the survey itself and the experience people have seeing a prominent link to it. Feel free to comment on either.

## Test plan

- [ ] Run `mint dev` and confirm the banner appears at the top of every page.
- [ ] Confirm the survey link opens correctly.
- [ ] Confirm dismissing the banner hides it on subsequent page loads.

Made with [Cursor](https://cursor.com)