### PR TITLE
WEAVE: DeepSeek model slug correction

### DIFF
--- a/weave/quickstart-inference.mdx
+++ b/weave/quickstart-inference.mdx
@@ -268,7 +268,7 @@ class InferenceModel(weave.Model):
 
 # Create instances for different models
 llama_model = InferenceModel(model_name="meta-llama/Llama-3.1-8B-Instruct")
-deepseek_model = InferenceModel(model_name="deepseek-ai/DeepSeek-V3-0324")
+deepseek_model = InferenceModel(model_name="deepseek-ai/DeepSeek-V3.1")
 
 # Compare their responses
 test_question = "Explain quantum computing in one paragraph for a high school student."
@@ -308,7 +308,7 @@ function createModel(modelName: string) {
 
 // Create instances for different models
 const llamaModel = createModel('meta-llama/Llama-3.1-8B-Instruct');
-const deepseekModel = createModel('deepseek-ai/DeepSeek-V3-0324');
+const deepseekModel = createModel('deepseek-ai/DeepSeek-V3.1');
 
 // Compare their responses
 const testQuestion = 'Explain quantum computing in one paragraph for a high school student.';
@@ -493,7 +493,7 @@ async function evaluateModel(
 // Compare multiple models - a key feature of Weave's evaluation framework
 const modelsToCompare = [
   { model: llamaModel, name: 'meta-llama/Llama-3.1-8B-Instruct' },
-  { model: deepseekModel, name: 'deepseek-ai/DeepSeek-V3-0324' },
+  { model: deepseekModel, name: 'deepseek-ai/DeepSeek-V3.1' },
 ];
 
 for (const { model, name } of modelsToCompare) {


### PR DESCRIPTION
## Description
Resolves [WBDOCS-1980](https://coreweave.atlassian.net/browse/WBDOCS-1980). Correct the DeepSeek model slug used in the Weave Inference Quickstart doc.

[WBDOCS-1980]: https://wandb.atlassian.net/browse/WBDOCS-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ