### PR TITLE
Automations are no longer Enterprise-only

### DIFF
--- a/ja/models/automations.mdx
+++ b/ja/models/automations.mdx
@@ -2,11 +2,6 @@
 title: オートメーション の概要
 description: W&B 内のイベントに基づいて ワークフロー をトリガーするには、W&B オートメーション を使用します。
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 このページでは、W&B における オートメーション について説明します。 [オートメーションを作成](/models/automations/create-automations/) することで、W&B 内のイベントをトリガーとして、モデルの自動テストやデプロイメントなどのワークフローのステップを実行できます。
 

--- a/ja/models/automations/automation-events.mdx
+++ b/ja/models/automations/automation-events.mdx
@@ -1,12 +1,7 @@
 ---
 title: オートメーションのイベントとスコープ
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
 import MultiTenantCloudOnly from "/snippets/en/_includes/multi-tenant-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 オートメーションは、Project または Registry 内で特定のイベントが発生したときに開始できます。このページでは、各スコープ内でオートメーションのトリガーとなるイベントについて説明します。オートメーションの詳細については、[Automations overview](/models/automations/) または [Create an automation](/models/automations/create-automations/) をご覧ください。
 

--- a/ja/models/automations/create-automations.mdx
+++ b/ja/models/automations/create-automations.mdx
@@ -2,11 +2,6 @@
 title: 概要
 description: ML ワークフローを効率化するための W&B オートメーション の作成と管理
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 このページでは、 W&B [オートメーション](/models/automations/) の作成と管理の概要について説明します。詳細な手順については、 [Slack オートメーションの作成](/models/automations/create-automations/slack/) または [Webhook オートメーションの作成](/models/automations/create-automations/webhook/) を参照してください。
 

--- a/ja/models/automations/create-automations/slack.mdx
+++ b/ja/models/automations/create-automations/slack.mdx
@@ -1,11 +1,6 @@
 ---
 title: Slack 自動化を作成する
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 このページでは、Slack [オートメーション](/models/automations/) を作成する方法について説明します。Webhook オートメーションを作成する場合は、代わりに [Create a webhook automation](/models/automations/create-automations/webhook/) を参照してください。
 

--- a/ja/models/automations/create-automations/webhook.mdx
+++ b/ja/models/automations/create-automations/webhook.mdx
@@ -1,11 +1,6 @@
 ---
 title: Webhook オートメーションの作成
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 このページでは、webhook [automation](/models/automations/) の作成方法について説明します。Slack のオートメーションを作成する場合は、代わりに [Create a Slack automation](/models/automations/create-automations/slack/) を参照してください。
 

--- a/ja/models/automations/view-automation-history.mdx
+++ b/ja/models/automations/view-automation-history.mdx
@@ -3,10 +3,7 @@ title: オートメーションの履歴を表示する
 ---
 
 <Note>
-この機能には Enterprise ライセンスが必要です。以下の環境で利用可能です：
-- W&B Multi-tenant Cloud
-- W&B 専用クラウド
-- W&B Self-Managed v0.75.0 以降
+オートメーションの実行履歴は、W&B Multi-tenant Cloud、W&B Dedicated Cloud、および W&B Self-Managed v0.75.0 以降で利用できます。
 </Note>
 
 このページでは、W&B [Automations](/models/automations) の実行履歴を表示し、内容を理解する方法について説明します。これには、何がオートメーションをトリガーしたか、どのようなアクションが実行されたか、そしてそれらが成功したか失敗したかが含まれます。

--- a/ja/models/core/automations.mdx
+++ b/ja/models/core/automations.mdx
@@ -2,12 +2,6 @@
 title: オートメーション
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 このページでは、W&B の _オートメーション_ について説明します。ワークフローステップをトリガーする [オートメーションの作成](/ja/models/core/automations/create-automations/) は、W&B 内のイベント（例えば、アーティファクトバージョンが作成されたとき）に基づいて、自動モデルテストやデプロイメントなどを行います。
 
 例えば、新しいバージョンが作成されたときに Slack のチャンネルに投稿したり、アーティファクトに `production` エイリアスが追加されたときに自動テストをトリガーするためにウェブフックを実行することができます。

--- a/ja/models/core/automations/automation-events.mdx
+++ b/ja/models/core/automations/automation-events.mdx
@@ -2,12 +2,6 @@
 title: 自動化イベントと範囲
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 あるオートメーションは、プロジェクトやレジストリのスコープ内で特定のイベントが発生したときに開始されます。プロジェクトの*スコープ*は[スコープの技術的定義を挿入]を参照してください。このページでは、それぞれのスコープ内でオートメーションをトリガーするイベントについて説明します。
 
 オートメーションの詳細は、[オートメーション概要](/ja/models/core/automations/)または[オートメーションの作成](/ja/models/core/automations/create-automations/)を参照してください。

--- a/ja/models/core/automations/create-automations.mdx
+++ b/ja/models/core/automations/create-automations.mdx
@@ -2,12 +2,6 @@
 title: 自動化の作成
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 このページでは、W&B の [オートメーション](/ja/models/core/automations/) を作成および管理する概要を示します。詳細な手順については [Slack オートメーションを作成する](/ja/models/core/automations/create-automations/slack) または [Webhook オートメーションを作成する](/ja/models/core/automations/create-automations/webhook) を参照してください。
 
 <Note>

--- a/ja/models/core/automations/create-automations/slack.mdx
+++ b/ja/models/core/automations/create-automations/slack.mdx
@@ -2,12 +2,6 @@
 title: Slack 自動化の作成
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 このページでは、Slack [オートメーション](/ja/models/core/automations/)を作成する方法を示します。ウェブフックオートメーションを作成するには、[ウェブフックオートメーションの作成](/ja/models/core/automations/create-automations/webhook)を参照してください。
 
 高レベルでは、Slackオートメーションを作成するには、以下の手順を行います:

--- a/ja/models/core/automations/create-automations/webhook.mdx
+++ b/ja/models/core/automations/create-automations/webhook.mdx
@@ -2,12 +2,6 @@
 title: Webhook オートメーションを作成する
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 このページでは、webhook のオートメーションを作成する方法を示します。Slack オートメーションを作成するには、代わりに [Slack オートメーションの作成](/ja/models/core/automations/create-automations/slack)を参照してください。
 
 webhook オートメーションを作成するための大まかな手順は以下の通りです。

--- a/ko/models/automations.mdx
+++ b/ko/models/automations.mdx
@@ -2,11 +2,6 @@
 title: Automations 개요
 description: thoughtful_thought W&B 내의 이벤트를 기반으로 워크플로우를 트리거하려면 W&B Automations를 사용하세요.
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 이 페이지는 W&B의 _automations_ (자동화)에 대해 설명합니다. W&B에서 발생한 이벤트를 기반으로 자동화된 모델 테스트 및 배포와 같은 워크플로우 단계를 트리거하려면 [automation 생성하기](/models/automations/create-automations/)를 참조하세요.
 

--- a/ko/models/automations/automation-events.mdx
+++ b/ko/models/automations/automation-events.mdx
@@ -1,12 +1,7 @@
 ---
 title: 자동화 이벤트 및 스코프
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
 import MultiTenantCloudOnly from "/snippets/en/_includes/multi-tenant-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 특정 이벤트가 Projects 또는 registry 내에서 발생할 때 자동화를 시작할 수 있습니다. 이 페이지에서는 각 범위 내에서 자동화를 트리거할 수 있는 이벤트에 대해 설명합니다. 자동화에 대한 자세한 내용은 [Automations 개요](/models/automations/) 또는 [자동화 만들기](/models/automations/create-automations/)에서 확인할 수 있습니다.
 

--- a/ko/models/automations/create-automations.mdx
+++ b/ko/models/automations/create-automations.mdx
@@ -2,11 +2,6 @@
 title: 개요
 description: ML 워크플로우 를 간소화하기 위한 W&B 자동화 기능을 생성하고 관리하세요
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 이 페이지는 W&B [automations](/models/automations/)를 생성하고 관리하는 방법에 대한 개요를 제공합니다. 더 자세한 지침은 [Slack automation 생성하기](/models/automations/create-automations/slack/) 또는 [Webhook automation 생성하기](/models/automations/create-automations/webhook/)를 참조하세요.
 

--- a/ko/models/automations/create-automations/slack.mdx
+++ b/ko/models/automations/create-automations/slack.mdx
@@ -1,11 +1,6 @@
 ---
 title: Slack 자동화 만들기
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 이 페이지는 Slack [automation](/models/automations/)을 생성하는 방법을 설명합니다. Webhook automation을 생성하려면 대신 [Create a webhook automation](/models/automations/create-automations/webhook/)을 참조하세요.
 

--- a/ko/models/automations/create-automations/webhook.mdx
+++ b/ko/models/automations/create-automations/webhook.mdx
@@ -1,11 +1,6 @@
 ---
 title: Webhook 자동화 생성하기
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 이 페이지는 webhook [automation](/models/automations/)을 생성하는 방법을 보여줍니다. Slack 자동화를 생성하려면 [Create a Slack automation](/models/automations/create-automations/slack/)을 대신 참조하세요.
 

--- a/ko/models/automations/view-automation-history.mdx
+++ b/ko/models/automations/view-automation-history.mdx
@@ -3,10 +3,7 @@ title: 자동화 히스토리 보기
 ---
 
 <Note>
-이 기능은 Enterprise 라이선스가 필요합니다. 다음 환경에서만 사용할 수 있습니다:
-- W&B Multi-tenant Cloud
-- W&B 전용 클라우드
-- W&B Self-Managed v0.75.0 이상
+자동화 실행 기록은 W&B Multi-tenant Cloud, W&B Dedicated Cloud, W&B Self-Managed v0.75.0 이상에서 사용할 수 있습니다.
 </Note>
 
 이 페이지에서는 W&B [automations](/models/automations)의 실행 기록을 확인하고 이해하는 방법을 설명합니다. 여기에는 무엇이 자동화를 트리거했는지, 어떤 액션이 취해졌는지, 그리고 실행의 성공 또는 실패 여부가 포함됩니다.

--- a/ko/models/core/automations.mdx
+++ b/ko/models/core/automations.mdx
@@ -2,12 +2,6 @@
 title: Automations
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 이 페이지는 W&B의 _자동화_ 에 대해 설명합니다. [자동화 생성](/ko/models/core/automations/create-automations/)을 통해, [artifact](/ko/models/artifacts/) 아티팩트 버전이 생성될 때와 같이 W&B의 이벤트에 따라 자동 모델 테스트 및 배포와 같은 워크플로우 단계를 트리거할 수 있습니다.
 
 예를 들어, 새로운 버전이 생성될 때 Slack 채널에 게시하거나, `production` 에일리어스가 아티팩트에 추가될 때 자동 테스트를 트리거하는 훅을 실행하는 자동화를 설정할 수 있습니다.

--- a/ko/models/core/automations/automation-events.mdx
+++ b/ko/models/core/automations/automation-events.mdx
@@ -2,12 +2,6 @@
 title: Automation events and scopes
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 자동화는 특정 이벤트가 프로젝트 또는 레지스트리의 범위 내에서 발생할 때 시작될 수 있습니다. 프로젝트의 *범위*는 [범위에 대한 기술적 정의 삽입]을 의미합니다. 이 페이지에서는 각 범위 내에서 자동화를 트리거할 수 있는 이벤트에 대해 설명합니다.
 
 자동화에 대해 자세히 알아보려면 [자동화 개요](/ko/models/core/automations/) 또는 [자동화 생성](/ko/models/core/automations/create-automations/)을 참조하세요.

--- a/ko/models/core/automations/create-automations.mdx
+++ b/ko/models/core/automations/create-automations.mdx
@@ -2,12 +2,6 @@
 title: Create an automation
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 이 페이지에서는 W&B [자동화](/ko/models/core/automations/) 생성 및 관리에 대한 개요를 제공합니다. 자세한 내용은 [Slack 자동화 생성](/ko/models/core/automations/create-automations/slack) 또는 [Webhook 자동화 생성](/ko/models/core/automations/create-automations/webhook)을 참조하세요.
 
 <Note>

--- a/ko/models/core/automations/create-automations/slack.mdx
+++ b/ko/models/core/automations/create-automations/slack.mdx
@@ -2,12 +2,6 @@
 title: Create a Slack automation
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 이 페이지에서는 Slack [자동화](/ko/models/core/automations/)를 만드는 방법을 보여줍니다. 웹훅 자동화를 만들려면 [웹훅 자동화 생성](/ko/models/core/automations/create-automations/webhook)를 대신 참조하세요.
 
 Slack 자동화를 생성하려면 다음과 같은 단계를 수행합니다.

--- a/ko/models/core/automations/create-automations/webhook.mdx
+++ b/ko/models/core/automations/create-automations/webhook.mdx
@@ -2,12 +2,6 @@
 title: Create a webhook automation
 ---
 
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
-
 이 페이지에서는 webhook [자동화](/ko/models/core/automations/)를 만드는 방법을 보여줍니다. Slack 자동화를 만들려면 [Slack 자동화 만들기](/ko/models/core/automations/create-automations/slack)를 참조하세요.
 
 개략적으로 webhook 자동화를 만들려면 다음 단계를 수행합니다.

--- a/models/automations.mdx
+++ b/models/automations.mdx
@@ -2,11 +2,6 @@
 title: Automations overview
 description: Use W&B Automations for triggering workflows based on events in W&B
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 This page describes _automations_ in W&B. [Create an automation](/models/automations/create-automations/) to trigger workflow steps, such as automated model testing and deployment, based on an event in W&B.
 

--- a/models/automations/automation-events.mdx
+++ b/models/automations/automation-events.mdx
@@ -2,12 +2,7 @@
 title: Automation events and scopes
 description: "Learn about events and scopes that trigger W&B Automations, including artifact changes, run status, and metric conditions."
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
 import MultiTenantCloudOnly from "/snippets/en/_includes/multi-tenant-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 An automation can start when a specific event occurs within a project or registry. This page describes the events that can trigger an automation within each scope. Learn more about automations in the [Automations overview](/models/automations) or [Create an automation](/models/automations/create-automations).
 

--- a/models/automations/create-automations.mdx
+++ b/models/automations/create-automations.mdx
@@ -2,11 +2,6 @@
 title: Overview
 description: Create and manage W&B automations to streamline your ML workflows
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 This page gives an overview of creating and managing W&B [automations](/models/automations/). For more detailed instructions, refer to [Create a Slack automation](/models/automations/create-automations/slack/) or [Create a webhook automation](/models/automations/create-automations/webhook/).
 

--- a/models/automations/create-automations/slack.mdx
+++ b/models/automations/create-automations/slack.mdx
@@ -2,11 +2,6 @@
 title: Create a Slack automation
 description: "Set up a Slack integration and create a W&B Automation that sends notifications to a Slack channel on specific events."
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 This page shows how to create a Slack [automation](/models/automations/). To create a webhook automation, refer to [Create a webhook automation](/models/automations/create-automations/webhook/) instead.
 

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -2,11 +2,6 @@
 title: Create a webhook automation
 description: "Create a webhook automation in W&B to send HTTP requests to external services when specific events occur."
 ---
-import EnterpriseCloudOnly from "/snippets/en/_includes/enterprise-cloud-only.mdx";
-
-<Info>
-<EnterpriseCloudOnly/>
-</Info>
 
 This page shows how to create a webhook [automation](/models/automations/). To create a Slack automation, refer to [Create a Slack automation](/models/automations/create-automations/slack/) instead.
 

--- a/models/automations/view-automation-history.mdx
+++ b/models/automations/view-automation-history.mdx
@@ -4,10 +4,7 @@ description: "View the execution history of your W&B Automations to check status
 ---
 
 <Note>
-This feature requires an Enterprise license. It is available only for:
-- W&B Multi-tenant Cloud
-- W&B Dedicated Cloud
-- W&B Self-Managed v0.75.0+
+Automation execution history is available on W&B Multi-tenant Cloud, W&B Dedicated Cloud, and W&B Self-Managed v0.75.0 and later.
 </Note>
 
 This page describes how to view and understand the execution history of your W&B [automations](/models/automations), including what triggered an automation, what actions were taken, and whether they succeeded or failed.


### PR DESCRIPTION
## Description
Automations are no longer Enterprise-only

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
