### PR TITLE
Add Dependabot job to track .claude submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "dependencies"
       - "submodule"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "submodule"
+      - "dependencies"
+      - "auto-generated"
     commit-message:
       prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "submodule"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    commit-message:
+      prefix: "ci"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
       - "submodule"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds a `gitsubmodule` entry to `.github/dependabot.yml` so Dependabot opens PRs daily when `coreweave/docs-skills` (the `.claude` submodule) has new upstream commits.

## Test plan

- [ ] Verify Dependabot picks up the new config after merge (check the Dependabot insights tab).
- [ ] Confirm a submodule-bump PR is opened on the next daily run when upstream has changed.