### PR TITLE
Inference - fixes for reasoning model instructions

### DIFF
--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -5,9 +5,9 @@ description: How to return and view reasoning in your W&B Inference responses
 
 Reasoning models, like [OpenAI's GPT OSS 20B](https://huggingface.co/openai/gpt-oss-20b), include information about their reasoning steps as part of the output returned in addition to the final answer. This is automatic and no additional input parameters are needed.
 
-You can determine whether a model supports reasoning or not by checking the Supported Features sections of its catalog page in the UI.
+You can determine whether a model supports reasoning or not by checking the Supported Features section of its catalog page in the UI.
 
-You can find reasoning information in the `reasoning_content` field of responses. This field is not present in the outputs of other models.
+You can find reasoning information in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
 <Tabs>
   <Tab title="Python">
@@ -26,7 +26,7 @@ You can find reasoning information in the `reasoning_content` field of responses
         ],
     )
 
-    print(response.choices[0].message.reasoning_content)
+    print(response.choices[0].message.reasoning)
     print("--------------------------------")
     print(response.choices[0].message.content)
     ```
@@ -40,7 +40,7 @@ You can find reasoning information in the `reasoning_content` field of responses
         "model": "openai/gpt-oss-20b",
         "messages": [
           { "role": "user", "content": "3.11 and 3.8, which is greater?" }
-        ],
+        ]
       }'
     ```
   </Tab>


### PR DESCRIPTION
## Description

Fixes for Inference's docs on reasoning models.
1. `reasoning_content` name was deprecated and is no longer available, `reasoning` is current. [Ref]( https://github.com/vllm-project/vllm/pull/33402)
2. Correction that field is present but null-valued for non-reasoning models.
3. Trailing comma in curl example made that JSON invalid
4. There's only one Supported Features section on the page so make that singular.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
