### PR TITLE
Allow Ellipsis in card previews

### DIFF
--- a/scripts/knowledgebase-nav/generate_tags.py
+++ b/scripts/knowledgebase-nav/generate_tags.py
@@ -443,7 +443,7 @@ def plain_text(body: str) -> str:
     text = text.translate(_PLAIN_TEXT_TYPOGRAPHIC_TO_ASCII)
 
     # Allowlist: drop anything that could still be markup or stray symbols.
-    text = re.sub(r"[^a-zA-Z0-9 .,:;!?&'\"()\-/_=@+]", " ", text)
+    text = re.sub(r"[^a-zA-Z0-9 .,:;!?&⋯'\"()\-/_=@+]", " ", text)
     return re.sub(r"\s+", " ", text).strip()
 
 


### PR DESCRIPTION
Allows the "⋯" character in Knowledgebase Card previews.