### PR TITLE
docs: refresh README for docs.wandb.ai and Mintlify conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Weights & Biases Docs ([https://docs.wandb.ai/](https://docs.wandb.ai/)) is 
 
 1. Edit the desired files.
 1. Create a pull request proposing your changes.
-1. Confirm changes don’t break the docs, which will be tested by CI.
+1. Confirm that all CI checks pass to ensure that your changes don’t break the docs.
 1. Respond to feedback from the W&B docs team and CI checks.
 
 After this, someone from the docs team will merge the PR and it will go live in a matter of minutes!

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 The Weights & Biases Docs ([https://docs.wandb.ai/](https://docs.wandb.ai/)) is built using Mintlify, a static website generator. The high level overview of the doc writing process is:
 
 1. Edit the desired files
-2. Create a pull request proposing your changes
-3. Confirm changes don’t break the docs, which will be tested by CI
-4. Respond to feedback from the W&B docs team and CI checks
+1. Create a pull request proposing your changes
+1. Confirm changes don’t break the docs, which will be tested by CI
+1. Respond to feedback from the W&B docs team and CI checks
 
 After this, someone from the docs team will merge the PR and it will go live in a matter of minutes!
 
@@ -15,7 +15,7 @@ This section shows how to edit a page or report a bug from within your browser w
 
 ### Edit a page
 
-1. To edit a page you're reading on docs.wandb.com, scroll to the bottom of the page and click **Edit page** to open the Markdown file in the GitHub editor.
+1. To edit a page you're reading on docs.wandb.ai, scroll to the bottom of the page and click **Edit page** to open the Markdown file in the GitHub editor.
 
    To edit a page from https://github.com/wandb/docs, browse to or search for the page, then click the pencil icon to open the Markdown file in the GitHub editor.
 1. Edit the page, then click **Commit changes**. In the dialog, choose to create a new branch, then specify:
@@ -30,11 +30,9 @@ This section shows how to edit a page or report a bug from within your browser w
 
 If you work for Weights & Biases, file a doc JIRA, using this template: https://wandb.atlassian.net/secure/CreateIssue!default.jspa?project=DOCS.
 
-{/*
-To report a bug on a page you're reading on docs.wandb.com:
+To report a bug on a page you're reading on docs.wandb.ai:
 1. Scroll to the bottom of the page and click **Report issue**.
 1. Provide a title and optionally edit the description, then click **Create**.
-*/}
 
 To report a bug from https://github.com/wandb/docs:
 1. Click the **Issues** tab.
@@ -45,41 +43,40 @@ To report a bug from https://github.com/wandb/docs:
 
 The `mint` CLI is required for local builds. See https://www.mintlify.com/docs/installation. Install it from `npx` or from Homebrew.
 
-
 ### macOS
 
 After cloning this repo:
 1. `cd` into the clone.
-2. Create a working branch:
+1. Create a working branch:
     ```shell
     git checkout -b my_working_branch origin/main
     ```
-3. Build and serve the docs locally:
+1. Build and serve the docs locally:
     ```shell
     mint dev
     ```
     By default, content is served from `https://localhost:3000/`.
-4. Check for broken links and images:
+1. Check for broken links and images:
   ```shell
   mint broken-links
   ```
-5. Push your branch to `origin`:
+1. Push your branch to `origin`:
     ```shell
     git push origin my_working_branch
     ```
-6. The first time you push a new branch, the terminal output includes a link to create a PR. Click the link and create a draft PR. CI tests will run.
-7. When you are satisfied with your PR and all tests pass, click **Ready for review** to convert the draft PR to a reviewable PR. A member of the W&B docs team will review your changes and give feedback.
-8. When all feedback is addressed and the PR is approved, the reviewer will merge the PR.
-
+1. The first time you push a new branch, the terminal output includes a link to create a PR. Click the link and create a draft PR. CI tests will run.
+1. When you are satisfied with your PR and all tests pass, click **Ready for review** to convert the draft PR to a reviewable PR. A member of the W&B docs team will review your changes and give feedback.
+1. When all feedback is addressed and the PR is approved, the reviewer will merge the PR.
 
 ## Exiting `mint dev`
 
 To interrupt the Mintlify server, type `CTRL+C` in the terminal where it is running.
 
 ## Mintlify compatibility
+
 Mintlify processes Markdown files in `.mdx` format, which has stricter requirements than `.md`. If a file contains incompatible Markdown, `mint dev` will fail and `mint broken-links` will show errors. For example, HTML comments (`<!-- like this -->`) are not supported. Instead, use this syntax for comments: `{/* like this */}`.
 
-For general guidelinest, refer to the **Create content** section of the [Mintlify documentation](https://www.mintlify.com/docs/). For example:
+For general guidelines, refer to the **Create content** section of the [Mintlify documentation](https://www.mintlify.com/docs/). For example:
 - [Format text](https://www.mintlify.com/docs/create/text)
 - [Lists and tables](https://www.mintlify.com/docs/create/list-table)
 - [Images and embeds](https://www.mintlify.com/docs/create/image-embeds)
@@ -90,42 +87,43 @@ This list of links is not exhaustive. Check the Mintlify documentation for full 
 
 ## How to edit the docs locally
 
-1. Navigate to your local clone this repo and pull the latest changes from main:
+1. Navigate to your local clone of this repo and pull the latest changes from main:
     ```bash
     git pull origin main
     ```
-2. Create a feature branch off of `main`.
+1. Create a feature branch off of `main`.
     ```bash
     git checkout -b <your-feature-branch>
     ```
-3. After installing the prerequsites documented above, start a local preview of the docs.
+1. After installing the prerequisites documented above, start a local preview of the docs.
     ```bash
     mint dev
     ```
     This will return the localhost URL and port number where you can preview your changes to the docs as you make them (e.g. `https://localhost:3000`).
-4. Make your changes on the new branch.
-5. Check your changes are rendered correctly. Any time you save a file, the preview automatically updates.
-7. Commit the changes to the branch.
+1. Make your changes on the new branch.
+1. Check your changes are rendered correctly. Any time you save a file, the preview automatically updates.
+1. Commit the changes to the branch.
     ```bash
     git add .
     git commit -m 'Useful commit message.'
     ```
-8. Push the branch to GitHub.
+1. Push the branch to GitHub.
     ```bash
     git push origin <your-feature-branch>
     ```
-9. Open a pull request from the new branch to the original repo.
+1. Open a pull request from the new branch to the original repo.
 
 ## What files do I edit?
+
 You can edit most `.mdx` files in the repo directly. Content in a few directories is generated from upstream code. Edit the code in the source repo, not in `wandb/docs`. After your upstream change is merged and released, when the relevant content is next generated, your change will be included.
 
-| Directory | Source repo |
-|-----------|-------------|
-| `/ref/python/`| [`wandb/wandb`](https://github.com/wandb/wandb) |
-| `/models/ref/cli/` | [`wandb/wandb`](https://github.com/wandb/wandb)|
+| Directory               | Source repo                                     |
+|-------------------------|-------------------------------------------------|
+| `/ref/python/`          | [`wandb/wandb`](https://github.com/wandb/wandb) |
+| `/models/ref/cli/`      | [`wandb/wandb`](https://github.com/wandb/wandb) |
 | `/weave/api-reference/` | [`wandb/weave`](https://github.com/wandb/weave) |
-| `/weave/cookbooks/` | [`wandb/weave`](https://github.com/wandb/weave) |
-| `/weave/reference/` | [`wandb/weave`](https://github.com/wandb/weave) |
+| `/weave/cookbooks/`     | [`wandb/weave`](https://github.com/wandb/weave) |
+| `/weave/reference/`     | [`wandb/weave`](https://github.com/wandb/weave) |
 
 ## AI resources
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 The Weights & Biases Docs ([https://docs.wandb.ai/](https://docs.wandb.ai/)) is built using Mintlify, a static website generator. The high level overview of the doc writing process is:
 
-1. Edit the desired files
-1. Create a pull request proposing your changes
-1. Confirm changes don’t break the docs, which will be tested by CI
-1. Respond to feedback from the W&B docs team and CI checks
+1. Edit the desired files.
+1. Create a pull request proposing your changes.
+1. Confirm changes don’t break the docs, which will be tested by CI.
+1. Respond to feedback from the W&B docs team and CI checks.
 
 After this, someone from the docs team will merge the PR and it will go live in a matter of minutes!
 
@@ -19,22 +19,26 @@ This section shows how to edit a page or report a bug from within your browser w
 
    To edit a page from https://github.com/wandb/docs, browse to or search for the page, then click the pencil icon to open the Markdown file in the GitHub editor.
 1. Edit the page, then click **Commit changes**. In the dialog, choose to create a new branch, then specify:
-  - A name for the branch
-  - A commit message that describes the change. By default, this becomes the pull request title.
-  - An optional extended description. By default, this becomes the pull request body.
+
+   - A name for the branch
+   - A commit message that describes the change. By default, this becomes the pull request title.
+   - An optional extended description. By default, this becomes the pull request body.
+
 1. Click **Propose change**. A new branch is created with the commit you just created. A new dialog opens where you can create a pull request.
 1. Optionally edit the pull request's title and description. Markdown is allowed. You can refer to a PR or issue by number or URL, and you can refer to a JIRA issue by its ID.
 1. Click **Create pull request**. A member of @docs-team reviews your changes, provides feedback, and works with you to merge the change.
 
 ### Report a bug
 
-If you work for Weights & Biases, file a doc JIRA, using this template: https://wandb.atlassian.net/secure/CreateIssue!default.jspa?project=DOCS.
+If you work for CoreWeave or Weights & Biases, file a doc JIRA, using the template at https://coreweave.atlassian.net/jira/core/projects/WBDOCS/form/2725.
 
 To report a bug on a page you're reading on docs.wandb.ai:
+
 1. Scroll to the bottom of the page and click **Report issue**.
 1. Provide a title and optionally edit the description, then click **Create**.
 
 To report a bug from https://github.com/wandb/docs:
+
 1. Click the **Issues** tab.
 1. Click **New issue**. Optionally select a template, then click **Create**.
 1. Provide a title and a description. If applicable, include the URL of the page with the bug. Click **Create**.
@@ -46,24 +50,33 @@ The `mint` CLI is required for local builds. See https://www.mintlify.com/docs/i
 ### macOS
 
 After cloning this repo:
+
 1. `cd` into the clone.
 1. Create a working branch:
+
     ```shell
     git checkout -b my_working_branch origin/main
     ```
+
 1. Build and serve the docs locally:
+
     ```shell
     mint dev
     ```
+
     By default, content is served from `https://localhost:3000/`.
 1. Check for broken links and images:
-  ```shell
-  mint broken-links
-  ```
+
+    ```shell
+    mint broken-links
+    ```
+
 1. Push your branch to `origin`:
+
     ```shell
     git push origin my_working_branch
     ```
+
 1. The first time you push a new branch, the terminal output includes a link to create a PR. Click the link and create a draft PR. CI tests will run.
 1. When you are satisfied with your PR and all tests pass, click **Ready for review** to convert the draft PR to a reviewable PR. A member of the W&B docs team will review your changes and give feedback.
 1. When all feedback is addressed and the PR is approved, the reviewer will merge the PR.
@@ -77,40 +90,52 @@ To interrupt the Mintlify server, type `CTRL+C` in the terminal where it is runn
 Mintlify processes Markdown files in `.mdx` format, which has stricter requirements than `.md`. If a file contains incompatible Markdown, `mint dev` will fail and `mint broken-links` will show errors. For example, HTML comments (`<!-- like this -->`) are not supported. Instead, use this syntax for comments: `{/* like this */}`.
 
 For general guidelines, refer to the **Create content** section of the [Mintlify documentation](https://www.mintlify.com/docs/). For example:
+
 - [Format text](https://www.mintlify.com/docs/create/text)
 - [Lists and tables](https://www.mintlify.com/docs/create/list-table)
 - [Images and embeds](https://www.mintlify.com/docs/create/image-embeds)
 - [Callouts](https://www.mintlify.com/docs/components/callouts)
 - [Cards](https://www.mintlify.com/docs/components/cards)
 - [Tabs](https://www.mintlify.com/docs/components/tabs)
+
 This list of links is not exhaustive. Check the Mintlify documentation for full details.
 
 ## How to edit the docs locally
 
 1. Navigate to your local clone of this repo and pull the latest changes from main:
+
     ```bash
     git pull origin main
     ```
+
 1. Create a feature branch off of `main`.
+
     ```bash
     git checkout -b <your-feature-branch>
     ```
+
 1. After installing the prerequisites documented above, start a local preview of the docs.
+
     ```bash
     mint dev
     ```
+
     This will return the localhost URL and port number where you can preview your changes to the docs as you make them (e.g. `https://localhost:3000`).
 1. Make your changes on the new branch.
 1. Check your changes are rendered correctly. Any time you save a file, the preview automatically updates.
 1. Commit the changes to the branch.
+
     ```bash
     git add .
     git commit -m 'Useful commit message.'
     ```
+
 1. Push the branch to GitHub.
+
     ```bash
     git push origin <your-feature-branch>
     ```
+
 1. Open a pull request from the new branch to the original repo.
 
 ## What files do I edit?


### PR DESCRIPTION
## Description

- Point contributor instructions at docs.wandb.ai
- Normalize ordered lists to repeated 1. entries for Mintlify
- Show the in-site bug-reporting steps by removing the MDX comment wrapper
- Fix copy (typos, wording, step numbering) and tidy the generated-content source table.

## Jira

https://coreweave.atlassian.net/browse/WBDOCS-2025
