### PR TITLE
WEAVE: Accumulator documentation

### DIFF
--- a/weave/guides/tracking/trace-generator-func.mdx
+++ b/weave/guides/tracking/trace-generator-func.mdx
@@ -72,7 +72,7 @@ Weave captures generator outputs only after you fully consume the generator. Con
 
 For more on decorating functions and methods with `@weave.op`, see [Create calls](/weave/guides/tracking/create-call).
 
-## Use the accumulator parameter
+## Accumulate yielded values into a single trace
 
 You can use the `weave.op`'s `accumulator` parameter to customize how yielded values are combined from generator functions, for example, to join streamed text tokens into a single string. The accumulator is a two-argument function that Weave calls once per yielded value, building up a result incrementally.
 

--- a/weave/guides/tracking/trace-generator-func.mdx
+++ b/weave/guides/tracking/trace-generator-func.mdx
@@ -71,3 +71,33 @@ The following screenshot shows the **Traces** page with a selected trace of the 
 Weave captures generator outputs only after you fully consume the generator. Consume the generator by iterating over it (for example, with `list()`, a `for` loop, or `next()` until exhaustion). The same applies to async generators when you use `async for` or equivalent consumption.
 
 For more on decorating functions and methods with `@weave.op`, see [Create calls](/weave/guides/tracking/create-call).
+
+## Use the accumulator parameter
+
+You can use the `weave.op`'s `accumulator` parameter to customize how yielded values are combined from generator functions, for example, to join streamed text tokens into a single string. The accumulator is a two-argument function that Weave calls once per yielded value, building up a result incrementally.
+
+The following example demonstrates a custom accumulator that appends each yielded value to a list, so Weave records that list as the call output after the generator is fully consumed.
+
+```python
+from typing import Generator
+import weave
+
+weave.init("your-team-name/your-project-name")
+
+# Weave calls this after each yield; acc is None on the first call.
+# The last value you return becomes the traced op output.
+def list_accumulator(acc, value):
+    if acc is None:
+        acc = []
+    acc.append(value)
+    return acc
+
+# Set the accumulator parameter
+@weave.op(accumulator=list_accumulator)
+def basic_gen_with_accumulator(x: int) -> Generator[int, None, None]:
+    yield from range(x)
+
+# Iterate to completion so every yield runs and the accumulator can produce the final traced output.
+result = list(basic_gen_with_accumulator(3))
+print(result)
+```

--- a/weave/guides/tracking/trace-generator-func.mdx
+++ b/weave/guides/tracking/trace-generator-func.mdx
@@ -20,7 +20,7 @@ To ensure Weave captures outputs in the trace, fully consume the generator (for 
     weave.init("my-project")
 
     # This function uses a simple sync generator.
-    # Weave will trace the call and its input (`x`),
+    # Weave will trace the Call and its input (`x`),
     # but output values are only captured once the generator is consumed (for example, with `list()`).
     @weave.op
     def basic_gen(x: int) -> Generator[int, None, None]:
@@ -33,14 +33,14 @@ To ensure Weave captures outputs in the trace, fully consume the generator (for 
         return x + 1
 
     # A sync generator that calls another traced function (`inner`).
-    # Each yielded value comes from a separate traced call to `inner`.
+    # Each yielded value comes from a separate traced Call to `inner`.
     @weave.op
     def nested_generator(x: int) -> Generator[int, None, None]:
         for i in range(x):
             yield inner(i)
 
     # A more complex generator that composes the above generator.
-    # Tracing here produces a hierarchical call tree:
+    # Tracing here produces a hierarchical Call tree:
     # - `deeply_nested_generator` (parent)
     #   - `nested_generator` (child)
     #     - `inner` (grandchild)
@@ -89,7 +89,7 @@ import weave
 weave.init("your-team-name/your-project-name")
 
 # Weave calls this after each yield; acc is None on the first call.
-# The last value you return becomes the traced op output.
+# The last value you return becomes the traced Op output.
 def list_accumulator(acc, value):
     if acc is None:
         acc = []

--- a/weave/guides/tracking/trace-generator-func.mdx
+++ b/weave/guides/tracking/trace-generator-func.mdx
@@ -76,6 +76,10 @@ For more on decorating functions and methods with `@weave.op`, see [Create calls
 
 You can use the `weave.op`'s `accumulator` parameter to customize how yielded values are combined from generator functions, for example, to join streamed text tokens into a single string. The accumulator is a two-argument function that Weave calls once per yielded value, building up a result incrementally.
 
+<Note>
+The `accumulator` parameter is not available for the TypeScript.
+</Note>
+
 The following example demonstrates a custom accumulator that appends each yielded value to a list, so Weave records that list as the call output after the generator is fully consumed.
 
 ```python


### PR DESCRIPTION
## Description
Resolves [WBDOCS-409](https://coreweave.atlassian.net/browse/WBDOCS-409). Adds a new section to the generator function docs that teaches users how to use the `accumulator` parameter with `weave.op()`.

[WBDOCS-409]: https://wandb.atlassian.net/browse/WBDOCS-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ