### PR TITLE
DOCS-2518: Document chat-style rendering in Weave Trace view

### DIFF
--- a/weave/guides/tracking/threads.mdx
+++ b/weave/guides/tracking/threads.mdx
@@ -87,7 +87,7 @@ In the Weave sidebar, select **Threads** to access the [Threads list view](#thre
 
 ### Chat view behavior
 
-The chat pane displays structured message data extracted from LLM Calls made during each turn. This view gives you a conversational-style rendering of the interaction.
+The chat pane displays structured message data extracted from LLM Calls made during each turn. This view gives you a conversational-style rendering of the interaction. For chat-style rendering on a **single** call in the Trace view (not the Threads pane), see [Chat-style rendering in the Trace view](/weave/guides/tracking/view-call#chat-style-rendering-in-the-trace-view).
 
 <Frame>
 ![Chat view](/weave/guides/tracking/imgs/threads-chat-view.png)

--- a/weave/guides/tracking/trace-tree.mdx
+++ b/weave/guides/tracking/trace-tree.mdx
@@ -87,7 +87,7 @@ The graph view shows hierarchical relationships between ops. This is useful for 
 
 After you have selected an op in the trace tree, details for that op display in the next panel. These details are grouped into the following tabs:
 
-- **Call**: The input and output to the op execution.
+- **Call**: The input and output to the op execution. For LLM calls whose inputs and outputs match common provider formats, Weave may render a chat-style layout in this tab. For details, see [Chat-style rendering in the Trace view](/weave/guides/tracking/view-call#chat-style-rendering-in-the-trace-view).
 - **Code**: The code that was used when the call was made.
 - **Feedback**: Any available [feedback](/weave/guides/tracking/feedback) for the op. You can provide feedback directly within Weave or through the API.
 - **Scores**: Any available [scores](/weave/guides/evaluation/scorers) for the op. Calls are scored by running Evaluations.

--- a/weave/guides/tracking/view-call.mdx
+++ b/weave/guides/tracking/view-call.mdx
@@ -61,6 +61,25 @@ curl -L 'https://trace.wandb.ai/call/read' \
 </Tab>
 </Tabs>
 
+## Chat-style rendering in the Trace view
+
+When you [open a trace](/weave/guides/tracking/trace-tree) and select a call in the trace tree, the **Call** tab shows inputs and outputs for that op. For many LLM calls, Weave recognizes common provider request and response shapes and renders them as a **chat-style layout** (conversation bubbles) instead of only raw JSON.
+
+This applies to a single call inside the Trace view. For multi-turn sessions and the Threads chat pane, see [Chat view behavior](/weave/guides/tracking/threads#chat-view-behavior).
+
+### When chat-style rendering appears
+
+Weave looks for structured message data in the logged inputs and outputs. Examples include:
+
+- **OpenAI Chat Completions-style requests**: A `messages` array whose elements include `role` and `content`, similar to the payload passed to `client.chat.completions.create(...)`. When you use [OpenAI tracing](/weave/guides/integrations/openai), those calls are logged in this shape automatically.
+- **Matching responses**: Response objects that carry assistant text in fields such as `choices` and nested `message` content, consistent with Chat Completions API responses.
+
+Other integrations that log compatible chat completion inputs and outputs (for example [Hugging Face Inference Client](/weave/guides/integrations/huggingface) `chat_completion` calls) can also render as chat in the UI.
+
+### When you see raw JSON instead
+
+If inputs and outputs do not match a recognized pattern, the Call tab shows structured JSON. To improve readability while keeping the underlying data, use [`weave.Markdown`](#customize-rendered-traces-with-weavemarkdown) with `postprocess_inputs` and `postprocess_output` on `@weave.op` functions, as described in the next section.
+
 ## Customize rendered traces with `weave.Markdown`
 
 Use `weave.Markdown` to customize how your trace information is displayed without losing the original data. This allows you to render your inputs and outputs as readable blocks of formatted content while preserving the underlying data structure.


### PR DESCRIPTION
## Summary

Adds a section to [View and customize trace display](/weave/guides/tracking/view-call) explaining when the Trace view **Call** tab shows chat-style (bubble) rendering versus raw JSON, with links from the Trace and Threads guides.

## Related

- [DOCS-2518](https://coreweave.atlassian.net/browse/DOCS-2518)

## Checklist

- [ ] SME accuracy review (Weave UI / provider formats)
- [ ] Editorial pass

Made with [Cursor](https://cursor.com)

[DOCS-2518]: https://coreweave.atlassian.net/browse/DOCS-2518