### PR TITLE
docs(weave): format trace data for Chat view (DOCS-2518)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -781,6 +781,7 @@
                           "weave/guides/tracking/tracing",
                           "weave/guides/tracking/create-call",
                           "weave/guides/tracking/trace-tree",
+                          "weave/guides/tracking/trace-chat-view",
                           "weave/guides/tools/comparison",
                           "weave/guides/tracking/querying-calls"
                         ]

--- a/weave/cookbooks/weave_via_service_api.mdx
+++ b/weave/cookbooks/weave_via_service_api.mdx
@@ -17,6 +17,8 @@ In the following guide, you will learn how to use the Weave Service API to log t
 2. [Create a mock of a more complex LLM call and response, and log it to Weave.](#complex-trace)
 3. [Run a sample lookup query on the logged traces.](#run-a-lookup-query)
 
+For a concise explanation of which request and response fields enable the Chat view in the Trace UI, see [Format trace data for the Chat view](/weave/guides/tracking/trace-chat-view).
+
 > **View logged traces**
 >
 > You can view all of the Weave traces created when you run the code in this guide by going to the **Traces** tab in your Weave project (specified by `team_id\project_id`), and selecting the name of the trace.

--- a/weave/guides/tracking/trace-chat-view.mdx
+++ b/weave/guides/tracking/trace-chat-view.mdx
@@ -1,0 +1,62 @@
+---
+title: "Format trace data for the Chat view"
+description: "Structure call inputs and outputs so Weave shows the conversational Chat view when you inspect a trace."
+---
+
+With W&B Weave, the Trace view **Call** panel can render inputs and outputs as a **Chat** view (message bubbles) when the logged data matches a chat-completion style shape. Integrations that patch OpenAI or Anthropic clients usually produce this shape automatically. If you log calls yourself, for example through the [Weave Service API](/weave/cookbooks/weave_via_service_api), you need to format request and response payloads so Weave can recognize them.
+
+## When the Chat view appears
+
+Weave looks for patterns similar to common LLM chat APIs:
+
+- **Inputs** include a `messages` array. Each item should include `role` (for example `user`, `assistant`, or `system`) and `content`. Including a `model` field alongside `messages` matches what many providers log for a single completion call.
+- **Outputs** include a `choices` array. Each item should include a `message` object with a `content` field for the assistant reply.
+
+If the data does not match this shape, the Call panel still shows **Input** and **Output**, but not the Chat layout.
+
+## Shape inputs and outputs
+
+The following example shows the minimal structure for one user turn and one assistant reply. Values are illustrative.
+
+```json
+{
+  "inputs": {
+    "model": "gpt-4o",
+    "messages": [
+      { "role": "user", "content": "Why is the sky blue?" }
+    ]
+  },
+  "output": {
+    "choices": [
+      {
+        "message": {
+          "content": "It is largely due to Rayleigh scattering of sunlight in the atmosphere."
+        }
+      }
+    ]
+  }
+}
+```
+
+For multi-turn conversations, add more objects to `messages` with the appropriate `role` and `content` values.
+
+## Log calls with the Service API
+
+To start and end calls over HTTP, send payloads that put the fields above on the call record:
+
+- On **call start**, set `inputs` to include `messages` (and typically `model`).
+- On **call end**, set `output` to include `choices` with `message.content` for the completion text.
+
+A full walkthrough with working Python examples is in [Use the Service API to trace](/weave/cookbooks/weave_via_service_api). See the [simple trace](/weave/cookbooks/weave_via_service_api#simple-trace) section for a minimal end-to-end sample.
+
+## Log calls with the SDK or integrations
+
+When you use W&B Weave integrations with provider SDKs, traced calls often inherit the correct structure without manual formatting. For background on how chat-style data appears in thread views, see [Chat view behavior](/weave/guides/tracking/threads#chat-view-behavior) in the Threads documentation.
+
+## Customize or override display
+
+If you need different rendering than the default Chat view, you can still control how data appears using `weave.Markdown` and postprocessors. See [View and customize trace display](/weave/guides/tracking/view-call).
+
+## OpenTelemetry traces
+
+Traces ingested as OpenTelemetry may not show tool calls in the Chat view the same way as native Weave calls. For details, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).

--- a/weave/guides/tracking/trace-tree.mdx
+++ b/weave/guides/tracking/trace-tree.mdx
@@ -87,7 +87,7 @@ The graph view shows hierarchical relationships between ops. This is useful for 
 
 After you have selected an op in the trace tree, details for that op display in the next panel. These details are grouped into the following tabs:
 
-- **Call**: The input and output to the op execution.
+- **Call**: The input and output to the op execution. When the data matches a chat-completion style shape, Weave can show a **Chat** view in this panel. For how to format inputs and outputs for that view, see [Format trace data for the Chat view](/weave/guides/tracking/trace-chat-view).
 - **Code**: The code that was used when the call was made.
 - **Feedback**: Any available [feedback](/weave/guides/tracking/feedback) for the op. You can provide feedback directly within Weave or through the API.
 - **Scores**: Any available [scores](/weave/guides/evaluation/scorers) for the op. Calls are scored by running Evaluations.


### PR DESCRIPTION
## Summary

Adds a focused how-to for DOCS-2518: which call input and output shapes trigger the **Chat** view in Trace details when logging manually (including via the Service API).

## Changes

- New page: `weave/guides/tracking/trace-chat-view.mdx` — OpenAI-style `messages` + `choices` shape, links to Service API cookbook, Threads Chat behavior, OTel note, and trace display customization.
- Navigation: entry under **Tracing basics** in `docs.json` (after **Navigate the Weave Trace view**).
- Cross-links: **Navigate the Weave Trace view** (Call tab bullet) and **Use the Service API to trace** cookbook intro.

## Sources

- Existing Service API cookbook (`weave_via_service_api.mdx`) — canonical payload examples for `messages` / `choices`.
- `threads.mdx` — Chat view behavior for threads (linked for SDK integration context).
- `otel.mdx` — OTel Chat view limitations (linked).

## Needs SME verification

- [ ] Confirm whether additional provider-specific shapes are officially supported beyond the OpenAI-style `messages` / `choices` pattern documented here (internal discussion referenced Zachary Birenbaum for a full list; this PR documents the pattern already shown in the public cookbook).

DOCS-2518

---

**Resume prompt for follow-up:** PR: (fill after push). Ticket DOCS-2518. SME: verify completeness of recognized chat formats beyond OpenAI-style JSON.

```json
{
  "skill": "author-docs",
  "version": "1.0.0",
  "depends_on": {"style-guide": "1.0.0"},
  "model": "unknown"
}
```

Made with [Cursor](https://cursor.com)