### PR TITLE
docs(weave): add cross-service tracing how-to guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -780,6 +780,7 @@
                           "weave/guides/tracking/trace-generator-func",
                           "weave/tutorial-tracing_2",
                           "weave/guides/tracking/threads",
+                          "weave/guides/tracking/cross-service-tracing",
                           "weave/guides/tracking/ops",
                           "weave/guides/tools/attributes",
                           "weave/guides/core-types/media",

--- a/weave/guides/tracking/cross-service-tracing.mdx
+++ b/weave/guides/tracking/cross-service-tracing.mdx
@@ -54,7 +54,7 @@ def top_level_op(value: int) -> int:
 
 `get_current_call()` returns `None` if called outside a `@weave.op` function. Always call it from within an op.
 
-After this step, you have the two values — `trace_id` and `call.id` — that the downstream service needs to attach its calls to the correct location in the trace tree.
+After this step, you have the two values — `call.trace_id` and `call.id` — that the downstream service needs to attach its calls to the correct location in the trace tree.
 
 ## Pass the context to the downstream service
 
@@ -121,6 +121,10 @@ After this step, the downstream service is configured to emit calls that appear 
 ## Complete example
 
 The following example simulates three services using Python's `multiprocessing` module so that each service has an independent Weave context. In a real deployment, replace the pipe-based communication with your actual inter-service transport (HTTP, gRPC, message queue, and so on).
+
+<Note>
+Each subprocess must exit its event loop cleanly — not be forcefully terminated — so that Weave can flush its pending traces to the server before the process shuts down. The example below signals a graceful shutdown using a `None` sentinel value sent through the pipe.
+</Note>
 
 ```python
 from contextlib import contextmanager
@@ -191,14 +195,15 @@ def middle_service(
         return from_bottom.recv().value * 2
 
     while True:
-        try:
-            payload: Payload = from_top.recv()
-            # Set the upstream call as the parent before executing ops
-            with parent_call(payload.trace_id, payload.parent_call_id):
-                result = middle_op(payload.value)
-            to_top.send(Payload(result, payload.trace_id, payload.parent_call_id))
-        except EOFError:
+        payload = from_top.recv()
+        if payload is None:
             break
+        with parent_call(payload.trace_id, payload.parent_call_id):
+            result = middle_op(payload.value)
+        to_top.send(Payload(result, payload.trace_id, payload.parent_call_id))
+
+    # Signal the bottom service to shut down
+    to_bottom.send(None)
 
 
 def bottom_service(from_middle: Connection, to_middle: Connection) -> None:
@@ -209,13 +214,12 @@ def bottom_service(from_middle: Connection, to_middle: Connection) -> None:
         return value + 1
 
     while True:
-        try:
-            payload: Payload = from_middle.recv()
-            with parent_call(payload.trace_id, payload.parent_call_id):
-                result = bottom_op(payload.value)
-            to_middle.send(Payload(result, payload.trace_id, payload.parent_call_id))
-        except EOFError:
+        payload = from_middle.recv()
+        if payload is None:
             break
+        with parent_call(payload.trace_id, payload.parent_call_id):
+            result = bottom_op(payload.value)
+        to_middle.send(Payload(result, payload.trace_id, payload.parent_call_id))
 
 
 # --- Entrypoint -------------------------------------------------------------
@@ -240,14 +244,22 @@ if __name__ == "__main__":
 
     top_level_service(main_to_mid, main_from_mid)
 
-    main_to_mid.close()
-    p_mid.terminate()
-    p_bot.terminate()
+    # Send a stop signal so subprocesses exit their loops cleanly,
+    # allowing Weave to flush pending traces before shutdown.
+    main_to_mid.send(None)
     p_mid.join()
     p_bot.join()
 ```
 
-After running this example, open the Weave UI and navigate to your project's **Traces** page. You see a single trace containing all calls from the three services, nested under `top_op`.
+After running this example, open the Weave UI and navigate to your project's **Traces** page. You see a single trace with all calls from the three services nested under `top_op`:
+
+```
+top_op
+  └── middle_op
+  │     └── bottom_op
+  └── middle_op
+        └── bottom_op
+```
 
 ## Limitations
 
@@ -255,5 +267,6 @@ Be aware of the following constraints before using this approach in production.
 
 - This workaround uses internal Weave APIs (`set_call_stack` from `weave.trace.context.call_context`) that may change without notice.
 - A `Call` object constructed as a placeholder does not correspond to a real logged call. The placeholder is only used to establish call context and does not appear in the trace tree itself.
+- Downstream services must exit their event loops cleanly for Weave to flush pending traces. Forceful process termination (for example, `SIGKILL`) will drop any traces that have not yet been sent to the server.
 - Passing call context between services is the responsibility of your implementation. Weave does not automatically propagate context across process or network boundaries.
 - This approach is Python-only. Cross-service tracing is not currently supported in the TypeScript SDK.

--- a/weave/guides/tracking/cross-service-tracing.mdx
+++ b/weave/guides/tracking/cross-service-tracing.mdx
@@ -1,0 +1,240 @@
+---
+title: "Trace calls across services"
+description: "Link traces across multiple independent services or processes into a single trace tree in W&B Weave."
+---
+
+By default, each service or process that calls `weave.init()` maintains an independent call context. Calls made in one service appear as separate, unrelated root traces in the Weave UI, even when those services are coordinating to fulfill a single request. This guide shows you how to connect traces across services so they appear as a single unified trace tree. It is intended for Python developers building multi-service systems who want end-to-end visibility into a single request across process or network boundaries.
+
+<Warning>
+This guide describes a workaround that relies on internal Weave APIs that are not part of the stable public interface and may change in future releases. A native, first-class API for cross-service tracing is planned. Use this approach with the understanding that it may require updates when you upgrade the Weave SDK.
+</Warning>
+
+## How it works
+
+Weave uses a call context—a trace ID and a call ID—to determine which calls belong to the same trace and how they nest under one another. When you want a call in a downstream service to appear as a child of a call in an upstream service, you must:
+
+1. Extract the trace ID and call ID from the active call in the upstream service.
+2. Transmit those two values to the downstream service alongside your request payload (for example, in HTTP headers, gRPC metadata, or a message queue field).
+3. In the downstream service, set the call context to a placeholder parent before executing any ops.
+
+The result is that calls from all participating services appear under the same trace in the Weave UI, with the correct parent-child relationships.
+
+## Prerequisites
+
+Before you begin, make sure the following conditions are met.
+
+- All services must have the W&B Weave Python SDK installed (`pip install weave`).
+- Each service must call `weave.init()` independently.
+- All services must log to the same W&B project.
+
+## Extract the call context in the upstream service
+
+Inside any `@weave.op`-decorated function, call `weave.get_current_call()` to get the active call object. Extract its `trace_id` and `id` (the call ID) before making the downstream call.
+
+```python
+import weave
+
+weave.init("your-entity/your-project")
+
+@weave.op
+def top_level_op(value: int) -> int:
+    # Get the current call context
+    current_call = weave.get_current_call()
+    trace_id = current_call.trace_id
+    call_id = current_call.id
+
+    # Pass trace_id and call_id to your downstream service.
+    # The transport mechanism is up to you: HTTP headers,
+    # gRPC metadata, a message queue field, and so on.
+    result = call_downstream_service(
+        value,
+        trace_id=trace_id,
+        parent_id=call_id,
+    )
+    return result
+```
+
+`weave.get_current_call()` returns `None` if called outside a `@weave.op` function. Always call it from within an op.
+
+After this step, you have the two values — `trace_id` and `call_id` — that the downstream service needs to attach its calls to the correct location in the trace tree.
+
+## Pass the context to the downstream service
+
+How you transmit `trace_id` and `parent_id` depends on your communication protocol. Some common patterns:
+
+- **HTTP**: Add them as custom request headers, for example `X-Weave-Trace-Id` and `X-Weave-Parent-Id`.
+- **gRPC**: Include them in the request metadata.
+- **Message queues**: Add them as fields in the message envelope.
+
+The downstream service receives these values and uses them to set the call context before executing any ops, as described in the next section.
+
+After this step, the downstream service has the `trace_id` and `parent_id` values it needs to reconstruct the call context.
+
+## Set the parent call context in the downstream service
+
+In the downstream service, use the following `with_parent_call` context manager before calling any ops. This sets a placeholder parent call in the Weave call stack so that subsequent op calls in this context appear as children of the upstream call.
+
+```python
+from contextlib import contextmanager
+
+import weave
+from weave.trace.weave_client import Call
+from weave.trace.context import call_context
+
+weave.init("your-entity/your-project")
+
+@contextmanager
+def with_parent_call(trace_id: str, parent_id: str):
+    """Set a placeholder parent call so downstream ops appear
+    nested under the upstream call in the Weave trace tree.
+
+    Note: This context manager uses internal Weave APIs
+    (call_context.set_call_stack) that are not part of the
+    stable public interface.
+    """
+    parent = Call(
+        op_name="__parent__",
+        trace_id=trace_id,
+        parent_id=None,
+        id=parent_id,
+        inputs={},
+    )
+    token = call_context.set_call_stack([parent])
+    try:
+        yield
+    finally:
+        call_context.reset_call_stack(token)
+
+
+@weave.op
+def downstream_op(value: int) -> int:
+    return value * 2
+
+
+def handle_request(value: int, trace_id: str, parent_id: str) -> int:
+    with with_parent_call(trace_id=trace_id, parent_id=parent_id):
+        return downstream_op(value)
+```
+
+When the downstream service handles a request, it calls `handle_request` with the `trace_id` and `parent_id` received from the upstream service. Any ops called within the `with_parent_call` block become children of the upstream call.
+
+After this step, the downstream service is configured to emit calls that appear nested under the correct upstream call in the Weave UI.
+
+## Complete example
+
+The following example simulates three services communicating through in-process function calls. In a real deployment, replace the direct function calls with your actual inter-service communication (HTTP, gRPC, message queue, and so on).
+
+```python
+from contextlib import contextmanager
+import multiprocessing as mp
+from multiprocessing.connection import Connection
+import weave
+from weave.trace.weave_client import Call
+from weave.trace.context import call_context
+
+
+# --- Shared helper ----------------------------------------------------------
+
+@contextmanager
+def with_parent_call(trace_id: str, parent_id: str):
+    """Set a placeholder parent call in the Weave call stack.
+
+    Note: This uses internal Weave APIs not part of the stable
+    public interface.
+    """
+    parent = Call(
+        op_name="__parent__",
+        trace_id=trace_id,
+        parent_id=None,
+        id=parent_id,
+        inputs={},
+    )
+    token = call_context.set_call_stack([parent])
+    try:
+        yield
+    finally:
+        call_context.reset_call_stack(token)
+
+
+# --- Bottom-level service ---------------------------------------------------
+
+def run_bottom_service(conn: Connection) -> None:
+    weave.init("your-entity/your-project")
+
+    @weave.op
+    def bottom_op(value: int) -> int:
+        return value + 1
+
+    for trace_id, parent_id, value in iter(conn.recv, None):
+        with with_parent_call(trace_id=trace_id, parent_id=parent_id):
+            result = bottom_op(value)
+        conn.send(result)
+
+
+# --- Middle-level service ---------------------------------------------------
+
+def run_middle_service(conn: Connection, bottom_conn: Connection) -> None:
+    weave.init("your-entity/your-project")
+
+    @weave.op
+    def middle_op(value: int) -> int:
+        current_call = weave.get_current_call()
+        bottom_conn.send((current_call.trace_id, current_call.id, value))
+        return bottom_conn.recv() * 2
+
+    for trace_id, parent_id, value in iter(conn.recv, None):
+        with with_parent_call(trace_id=trace_id, parent_id=parent_id):
+            result = middle_op(value)
+        conn.send(result)
+
+
+# --- Top-level service (entry point) ----------------------------------------
+
+def run_top_service() -> None:
+    weave.init("your-entity/your-project")
+
+    # Start sub-processes to simulate independent services
+    bottom_parent, bottom_child = mp.Pipe()
+    middle_parent, middle_child = mp.Pipe()
+
+    bottom_proc = mp.Process(target=run_bottom_service, args=(bottom_child,))
+    middle_proc = mp.Process(
+        target=run_middle_service, args=(middle_child, bottom_parent)
+    )
+    bottom_proc.start()
+    middle_proc.start()
+
+    @weave.op
+    def top_op(value: int) -> int:
+        current_call = weave.get_current_call()
+        # Send call context to the middle service along with the request
+        middle_parent.send((current_call.trace_id, current_call.id, value))
+        result_a = middle_parent.recv()
+        middle_parent.send((current_call.trace_id, current_call.id, value + 1))
+        result_b = middle_parent.recv()
+        return result_a + result_b
+
+    result = top_op(42)
+    print(f"Result: {result}")
+
+    # Shut down sub-processes
+    middle_parent.send(None)
+    bottom_parent.send(None)
+    middle_proc.join()
+    bottom_proc.join()
+
+
+if __name__ == "__main__":
+    run_top_service()
+```
+
+After running this example, open the Weave UI and navigate to your project's **Traces** page. You see a single trace containing all calls from the three services, nested under `top_op`.
+
+## Limitations
+
+Be aware of the following constraints before using this approach in production.
+
+- This workaround uses internal Weave APIs (`call_context.set_call_stack`, `call_context.reset_call_stack`) that may change without notice.
+- A `Call` object constructed as a placeholder does not correspond to a real logged call. The placeholder is only used to establish call context and does not appear in the trace tree itself.
+- Passing call context between services is the responsibility of your implementation. Weave does not automatically propagate context across process or network boundaries.
+- This approach is Python-only. Cross-service tracing is not currently supported in the TypeScript SDK.

--- a/weave/guides/tracking/cross-service-tracing.mdx
+++ b/weave/guides/tracking/cross-service-tracing.mdx
@@ -11,7 +11,7 @@ This guide describes a workaround that relies on internal Weave APIs that are no
 
 ## How it works
 
-Weave uses a call context—a trace ID and a call ID—to determine which calls belong to the same trace and how they nest under one another. When you want a call in a downstream service to appear as a child of a call in an upstream service, you must:
+Weave uses a call context — a trace ID and a call ID — to determine which calls belong to the same trace and how they nest under one another. When you want a call in a downstream service to appear as a child of a call in an upstream service, you must:
 
 1. Extract the trace ID and call ID from the active call in the upstream service.
 2. Transmit those two values to the downstream service alongside your request payload (for example, in HTTP headers, gRPC metadata, or a message queue field).
@@ -29,81 +29,79 @@ Before you begin, make sure the following conditions are met.
 
 ## Extract the call context in the upstream service
 
-Inside any `@weave.op`-decorated function, call `weave.get_current_call()` to get the active call object. Extract its `trace_id` and `id` (the call ID) before making the downstream call.
+Inside any `@weave.op`-decorated function, call `get_current_call()` to get the active call object. Extract its `trace_id` and `id` (the call ID) before making the downstream call.
 
 ```python
 import weave
+from weave.trace.context.call_context import get_current_call
 
 weave.init("your-entity/your-project")
 
 @weave.op
 def top_level_op(value: int) -> int:
-    # Get the current call context
-    current_call = weave.get_current_call()
-    trace_id = current_call.trace_id
-    call_id = current_call.id
+    call = get_current_call()
 
-    # Pass trace_id and call_id to your downstream service.
+    # Pass trace_id and call.id to your downstream service.
     # The transport mechanism is up to you: HTTP headers,
     # gRPC metadata, a message queue field, and so on.
     result = call_downstream_service(
         value,
-        trace_id=trace_id,
-        parent_id=call_id,
+        trace_id=call.trace_id,
+        parent_call_id=call.id,
     )
     return result
 ```
 
-`weave.get_current_call()` returns `None` if called outside a `@weave.op` function. Always call it from within an op.
+`get_current_call()` returns `None` if called outside a `@weave.op` function. Always call it from within an op.
 
-After this step, you have the two values — `trace_id` and `call_id` — that the downstream service needs to attach its calls to the correct location in the trace tree.
+After this step, you have the two values — `trace_id` and `call.id` — that the downstream service needs to attach its calls to the correct location in the trace tree.
 
 ## Pass the context to the downstream service
 
-How you transmit `trace_id` and `parent_id` depends on your communication protocol. Some common patterns:
+How you transmit `trace_id` and `parent_call_id` depends on your communication protocol. Some common patterns:
 
 - **HTTP**: Add them as custom request headers, for example `X-Weave-Trace-Id` and `X-Weave-Parent-Id`.
 - **gRPC**: Include them in the request metadata.
 - **Message queues**: Add them as fields in the message envelope.
 
-The downstream service receives these values and uses them to set the call context before executing any ops, as described in the next section.
+A `dataclass` is a clean way to bundle the call context alongside the request data so both travel together across the service boundary:
 
-After this step, the downstream service has the `trace_id` and `parent_id` values it needs to reconstruct the call context.
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Payload:
+    value: int
+    trace_id: str
+    parent_call_id: str
+```
+
+The downstream service receives these values and uses them to set the call context before executing any ops, as described in the next section.
 
 ## Set the parent call context in the downstream service
 
-In the downstream service, use the following `with_parent_call` context manager before calling any ops. This sets a placeholder parent call in the Weave call stack so that subsequent op calls in this context appear as children of the upstream call.
+In the downstream service, use the `parent_call` context manager below before calling any ops. It creates a placeholder parent in the Weave call stack so that subsequent op calls in that block appear as children of the upstream call.
 
 ```python
 from contextlib import contextmanager
 
 import weave
 from weave.trace.weave_client import Call
-from weave.trace.context import call_context
+from weave.trace.context.call_context import set_call_stack
 
 weave.init("your-entity/your-project")
 
 @contextmanager
-def with_parent_call(trace_id: str, parent_id: str):
-    """Set a placeholder parent call so downstream ops appear
-    nested under the upstream call in the Weave trace tree.
-
-    Note: This context manager uses internal Weave APIs
-    (call_context.set_call_stack) that are not part of the
-    stable public interface.
-    """
-    parent = Call(
-        op_name="__parent__",
+def parent_call(trace_id: str, parent_call_id: str):
+    with set_call_stack([Call(
         trace_id=trace_id,
+        id=parent_call_id,
+        _op_name="",    # required field, value is ignored
+        project_id="",  # required field, value is ignored
         parent_id=None,
-        id=parent_id,
         inputs={},
-    )
-    token = call_context.set_call_stack([parent])
-    try:
+    )]):
         yield
-    finally:
-        call_context.reset_call_stack(token)
 
 
 @weave.op
@@ -111,121 +109,142 @@ def downstream_op(value: int) -> int:
     return value * 2
 
 
-def handle_request(value: int, trace_id: str, parent_id: str) -> int:
-    with with_parent_call(trace_id=trace_id, parent_id=parent_id):
+def handle_request(value: int, trace_id: str, parent_call_id: str) -> int:
+    with parent_call(trace_id=trace_id, parent_call_id=parent_call_id):
         return downstream_op(value)
 ```
 
-When the downstream service handles a request, it calls `handle_request` with the `trace_id` and `parent_id` received from the upstream service. Any ops called within the `with_parent_call` block become children of the upstream call.
+Any ops called within the `parent_call` block become children of the upstream call in the Weave trace tree.
 
 After this step, the downstream service is configured to emit calls that appear nested under the correct upstream call in the Weave UI.
 
 ## Complete example
 
-The following example simulates three services communicating through in-process function calls. In a real deployment, replace the direct function calls with your actual inter-service communication (HTTP, gRPC, message queue, and so on).
+The following example simulates three services using Python's `multiprocessing` module so that each service has an independent Weave context. In a real deployment, replace the pipe-based communication with your actual inter-service transport (HTTP, gRPC, message queue, and so on).
 
 ```python
 from contextlib import contextmanager
 import multiprocessing as mp
 from multiprocessing.connection import Connection
+from dataclasses import dataclass
+
 import weave
 from weave.trace.weave_client import Call
-from weave.trace.context import call_context
+from weave.trace.context.call_context import get_current_call, set_call_stack
 
 
-# --- Shared helper ----------------------------------------------------------
+# --- parent_call: copy this helper into each downstream service -------------
 
 @contextmanager
-def with_parent_call(trace_id: str, parent_id: str):
-    """Set a placeholder parent call in the Weave call stack.
-
-    Note: This uses internal Weave APIs not part of the stable
-    public interface.
-    """
-    parent = Call(
-        op_name="__parent__",
+def parent_call(trace_id: str, parent_call_id: str):
+    with set_call_stack([Call(
         trace_id=trace_id,
+        id=parent_call_id,
+        _op_name="",    # required field, value is ignored
+        project_id="",  # required field, value is ignored
         parent_id=None,
-        id=parent_id,
         inputs={},
-    )
-    token = call_context.set_call_stack([parent])
-    try:
+    )]):
         yield
-    finally:
-        call_context.reset_call_stack(token)
 
 
-# --- Bottom-level service ---------------------------------------------------
+# --- Payload: bundles request data with call context -----------------------
 
-def run_bottom_service(conn: Connection) -> None:
+@dataclass
+class Payload:
+    value: int
+    trace_id: str
+    parent_call_id: str
+
+
+# --- Services ---------------------------------------------------------------
+
+def top_level_service(to_middle: Connection, from_middle: Connection) -> None:
+    weave.init("your-entity/your-project")
+
+    @weave.op
+    def top_op(value: int) -> int:
+        call = get_current_call()
+        # Send each downstream request with the current trace_id and call id
+        to_middle.send(Payload(value, call.trace_id, call.id))
+        result_a = from_middle.recv().value
+        to_middle.send(Payload(value + 1, call.trace_id, call.id))
+        result_b = from_middle.recv().value
+        return result_a + result_b
+
+    print(top_op(42))
+
+
+def middle_service(
+    from_top: Connection,
+    to_top: Connection,
+    to_bottom: Connection,
+    from_bottom: Connection,
+) -> None:
+    weave.init("your-entity/your-project")
+
+    @weave.op
+    def middle_op(value: int) -> int:
+        call = get_current_call()
+        # Pass call context down to the next service
+        to_bottom.send(Payload(value, call.trace_id, call.id))
+        return from_bottom.recv().value * 2
+
+    while True:
+        try:
+            payload: Payload = from_top.recv()
+            # Set the upstream call as the parent before executing ops
+            with parent_call(payload.trace_id, payload.parent_call_id):
+                result = middle_op(payload.value)
+            to_top.send(Payload(result, payload.trace_id, payload.parent_call_id))
+        except EOFError:
+            break
+
+
+def bottom_service(from_middle: Connection, to_middle: Connection) -> None:
     weave.init("your-entity/your-project")
 
     @weave.op
     def bottom_op(value: int) -> int:
         return value + 1
 
-    for trace_id, parent_id, value in iter(conn.recv, None):
-        with with_parent_call(trace_id=trace_id, parent_id=parent_id):
-            result = bottom_op(value)
-        conn.send(result)
+    while True:
+        try:
+            payload: Payload = from_middle.recv()
+            with parent_call(payload.trace_id, payload.parent_call_id):
+                result = bottom_op(payload.value)
+            to_middle.send(Payload(result, payload.trace_id, payload.parent_call_id))
+        except EOFError:
+            break
 
 
-# --- Middle-level service ---------------------------------------------------
-
-def run_middle_service(conn: Connection, bottom_conn: Connection) -> None:
-    weave.init("your-entity/your-project")
-
-    @weave.op
-    def middle_op(value: int) -> int:
-        current_call = weave.get_current_call()
-        bottom_conn.send((current_call.trace_id, current_call.id, value))
-        return bottom_conn.recv() * 2
-
-    for trace_id, parent_id, value in iter(conn.recv, None):
-        with with_parent_call(trace_id=trace_id, parent_id=parent_id):
-            result = middle_op(value)
-        conn.send(result)
-
-
-# --- Top-level service (entry point) ----------------------------------------
-
-def run_top_service() -> None:
-    weave.init("your-entity/your-project")
-
-    # Start sub-processes to simulate independent services
-    bottom_parent, bottom_child = mp.Pipe()
-    middle_parent, middle_child = mp.Pipe()
-
-    bottom_proc = mp.Process(target=run_bottom_service, args=(bottom_child,))
-    middle_proc = mp.Process(
-        target=run_middle_service, args=(middle_child, bottom_parent)
-    )
-    bottom_proc.start()
-    middle_proc.start()
-
-    @weave.op
-    def top_op(value: int) -> int:
-        current_call = weave.get_current_call()
-        # Send call context to the middle service along with the request
-        middle_parent.send((current_call.trace_id, current_call.id, value))
-        result_a = middle_parent.recv()
-        middle_parent.send((current_call.trace_id, current_call.id, value + 1))
-        result_b = middle_parent.recv()
-        return result_a + result_b
-
-    result = top_op(42)
-    print(f"Result: {result}")
-
-    # Shut down sub-processes
-    middle_parent.send(None)
-    bottom_parent.send(None)
-    middle_proc.join()
-    bottom_proc.join()
-
+# --- Entrypoint -------------------------------------------------------------
 
 if __name__ == "__main__":
-    run_top_service()
+    main_to_mid, mid_from_main = mp.Pipe()
+    mid_to_main, main_from_mid = mp.Pipe()
+    mid_to_bot, bot_from_mid = mp.Pipe()
+    bot_to_mid, mid_from_bot = mp.Pipe()
+
+    p_mid = mp.Process(
+        target=middle_service,
+        args=(mid_from_main, mid_to_main, mid_to_bot, mid_from_bot),
+    )
+    p_bot = mp.Process(
+        target=bottom_service,
+        args=(bot_from_mid, bot_to_mid),
+    )
+
+    p_mid.start()
+    p_bot.start()
+
+    top_level_service(main_to_mid, main_from_mid)
+
+    main_to_mid.close()
+    p_mid.terminate()
+    p_bot.terminate()
+    p_mid.join()
+    p_bot.join()
 ```
 
 After running this example, open the Weave UI and navigate to your project's **Traces** page. You see a single trace containing all calls from the three services, nested under `top_op`.
@@ -234,7 +253,7 @@ After running this example, open the Weave UI and navigate to your project's **T
 
 Be aware of the following constraints before using this approach in production.
 
-- This workaround uses internal Weave APIs (`call_context.set_call_stack`, `call_context.reset_call_stack`) that may change without notice.
+- This workaround uses internal Weave APIs (`set_call_stack` from `weave.trace.context.call_context`) that may change without notice.
 - A `Call` object constructed as a placeholder does not correspond to a real logged call. The placeholder is only used to establish call context and does not appear in the trace tree itself.
 - Passing call context between services is the responsibility of your implementation. Weave does not automatically propagate context across process or network boundaries.
 - This approach is Python-only. Cross-service tracing is not currently supported in the TypeScript SDK.


### PR DESCRIPTION
## Summary

- Adds `weave/guides/tracking/cross-service-tracing.mdx`: a how-to guide for linking traces across independent services/processes into a single Weave trace tree
- Adds the page to `docs.json` navigation under **Trace your application > Advanced Ops**, after the Threads page
- Resolves WBDOCS-1249

## What this covers

The guide documents the current workaround for cross-service tracing using `weave.get_current_call()` (public API) combined with a `with_parent_call` context manager that uses internal Weave APIs. It includes:

- A conceptual overview of how call context propagation works
- Step-by-step instructions for extracting, transmitting, and reconstructing call context
- A complete three-service multiprocessing example
- A prominent `<Warning>` block noting that this uses internal APIs pending a native built-in

## Sources and decision log

| Claim | Source |
|---|---|
| This workaround is the current best approach | Tim Sweeney, #weave-internal (2026-04-02): "yes — but in fairness, we should make `parent_call` a builtin" |
| `weave.get_current_call()` is a public API | `weave/reference/python-sdk.mdx` — documented at `weave.trace.context.call_context#get_current_call` |
| The mechanism uses `set_call_stack` with a sentinel `Call` | Tim Sweeney Loom transcript (2024-11-15), shared internally by Tim and referenced in WBDOCS-1249 |
| A native built-in is planned | Tim Sweeney, #weave-internal: "we should make `parent_call` a builtin method" |
| Request originated from Chris Van Pelt and Nicolas Remerscheid | #weave-internal thread, 2024-11-15 |

**Navigation placement:** After `weave/guides/tracking/threads` in Advanced Ops — the threads guide also covers Weave's context propagation across async boundaries, making this a natural neighbor.

**Tone decision:** The Warning block uses "may require updates" rather than "will break" to accurately reflect that internal APIs *could* change, not that they change on every release.

## Needs SME verification

The following items require technical review before merging. The `with_parent_call` implementation was derived from Tim Sweeney's Loom transcript description and could not be verified against the current SDK source.

### Technical accuracy
- [ ] Confirm `from weave.trace.context import call_context` is the correct import path in the current SDK
- [ ] Confirm `call_context.set_call_stack([parent])` and `call_context.reset_call_stack(token)` are the correct method names and signatures
- [ ] Confirm the `Call` constructor arguments used (`op_name`, `trace_id`, `parent_id`, `id`, `inputs`) match the current `weave.trace.weave_client.Call` dataclass
- [ ] Confirm `weave.get_current_call()` returns an object with `.trace_id` and `.id` attributes (not `.call_id` or similar)
- [ ] Verify the complete example runs end-to-end against the current SDK version

### Missing content
- [ ] Consider adding a link to `weave.get_current_call()` in the API reference from the prose
- [ ] Consider adding a link to `@weave.op` docs on first use in the guide
- [ ] "A native, first-class API for cross-service tracing is planned" — if there's a public tracking issue or roadmap entry, link it here

## Resume prompt

To continue this session in a new Claude Code window:
> PR wandb/docs#[this PR number] covers WBDOCS-1249 (cross-service tracing how-to). The doc is at `weave/guides/tracking/cross-service-tracing.mdx` on branch `weave/cross-agent-tracing`. The main open question is whether the internal API calls in `with_parent_call` are correct — specifically the import path `weave.trace.context.call_context` and the method names `set_call_stack` / `reset_call_stack`. Tim Sweeney is the SME. Checkpoint 2 style passes (language, terminology, formatting, polish) have not been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)