### PR TITLE
[WBDOCS-1370] Add more ways to use secrets

### DIFF
--- a/models/automations/automation-events.mdx
+++ b/models/automations/automation-events.mdx
@@ -17,6 +17,8 @@ A Registry automation can watch for these events:
 - **A new version is linked to a collection**: Test and validate new models or datasets when they are added to a registry.
 - **An artifact alias is added**: Trigger a specific step of your workflow when a new artifact version has a specific alias applied. For example, deploy a model when it has the `production` alias applied.
 
+When the automation calls a webhook, it can access the same team-level webhook configurations and [team secrets](/platform/secrets) as project-scoped automations.
+
 ## Project
 This section describes the scopes and events for an automation in a [project](/models/track/project-page).
 

--- a/models/registry/aliases.mdx
+++ b/models/registry/aliases.mdx
@@ -15,7 +15,7 @@ Use an alias to reference a specific artifact version. Each alias within a colle
 Use tags to organize and group artifact versions or collections based on a common theme. Multiple artifact versions and collections can share the same tag.
 </Note>
 
-When you add an alias to an artifact version, you can optionally start a [Registry automation](/models/automations/automation-events/#registry) to notify a Slack channel or trigger a webhook.
+When you add an alias to an artifact version, you can optionally start a [Registry automation](/models/automations/automation-events/#registry) to notify a Slack channel or trigger a webhook. If the automation calls a webhook that needs an access token or other sensitive value in the request, store those strings as [team secrets](/platform/secrets) and select them when you configure the webhook for the automation.
 
 ## Default aliases
 

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -23,7 +23,7 @@ Team secrets can be used in W&B in multiple contexts. After you [add a secret](#
 
 - **Webhook automations**: When an automation sends an HTTP request to a [webhook](/models/automations/create-automations/webhook/), you can attach team secrets for authentication headers and for values referenced in the payload. Automations can be scoped to a [project](/models/automations/automation-events/#project) or a [Registry](/models/automations/automation-events/#registry). Registry-scoped automations that call a webhook use the same team webhooks and team secrets as project-scoped webhook automations.
 - **Weave Playground**: Provider credentials are supplied as named team secrets. See [Add provider credentials and information](/weave/guides/tools/playground#add-provider-credentials-and-information).
-- **Sandboxes**: Runs can receive team secrets as environment variables. See [Secrets in sandboxes](/sandboxes/secrets).
+- **Sandboxes**: Securely provide team secrets to your sandboxes to make them available as environment variables. See [Secrets in sandboxes](/sandboxes/secrets).
 - **LLM evaluation jobs:** Some benchmarks need API keys or tokens stored as team secrets. See the [Evaluation benchmark catalog](/models/launch/evaluations).
 
 ## Add a secret

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -3,7 +3,7 @@ description: Overview of W&B secrets, how they work, and how to get started usin
 title: Manage secrets
 ---
 
-W&B Secret Manager allows you to securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. W&B Secret Manager removes the need to add sensitive strings directly to your code or when configuring a webhook's header or [payload](/models/automations/).
+W&B Secret Manager allows you to securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. Configure and manage team secrets in [team settings](/platform/app/settings-page/teams). W&B features can read team secret values, removing the need to paste them or store them in code, training scripts, or plain-text automation configuration.
 
 Secrets are stored and managed in each team's Secret Manager, in the **Team secrets** section of the [team settings](/platform/app/settings-page/teams/).
 
@@ -17,17 +17,26 @@ Secrets are stored and managed in each team's Secret Manager, in the **Team secr
   - W&B recommends against using a Kubernetes cluster as the backend of your secrets store unless you are unable to use a W&B instance of a cloud secrets manager (AWS, Google Cloud, or Azure), and you understand how to prevent security vulnerabilities that can occur if you use a cluster.
 </Note>
 
+## Where team secrets are used
+
+Team secrets can be used in W&B in multiple contexts. After you [add a secret](#add-a-secret), a feature like W&B Automations can access the secret by name.
+
+- **Webhook automations**: When an automation sends an HTTP request to a [webhook](/models/automations/create-automations/webhook/), you can attach team secrets for authentication headers and for values referenced in the payload. Automations can be scoped to a [project](/models/automations/automation-events/#project) or a [Registry](/models/automations/automation-events/#registry). Registry-scoped automations that call a webhook use the same team webhooks and team secrets as project-scoped webhook automations.
+- **Weave Playground**: Provider credentials are supplied as named team secrets. See [Add provider credentials and information](/weave/guides/tools/playground#add-provider-credentials-and-information).
+- **Sandboxes**: Runs can receive team secrets as environment variables. See [Secrets in sandboxes](/sandboxes/secrets).
+- **LLM evaluation jobs:** Some benchmarks need API keys or tokens stored as team secrets. See the [Evaluation benchmark catalog](/models/launch/evaluations).
+
 ## Add a secret
 To add a secret:
 
-1. If the receiving service requires it to authenticate incoming webhooks, generate the required token or API key. If necessary, save the sensitive string securely, such as in a password manager.
+1. If an external service gives you a token or API key, obtain that value through that service's normal flow. If necessary, save the sensitive string securely, such as in a password manager, before you paste it into W&B Secret Manager.
 1. Log in to W&B and go to the team's **Settings** page.
 1. In the **Team Secrets** section, click **New secret**.
 1. Using letters, numbers, and underscores (`_`), provide a name for the secret.
 1. Paste the sensitive string into the **Secret** field.
 1. Click **Add secret**.
 
-Specify the secrets you want to use for your webhook automation when you configure the webhook. See the [Configure a webhook](#configure-a-webhook) section for more information. 
+When you configure a webhook for an automation, select which team secrets the webhook may use. For field names, access tokens, and payload variables, see [Create a webhook automation](/models/automations/create-automations/webhook).
 
 <Note>
 Once you create a secret, you can access that secret in a [webhook automation's payload](/models/automations/create-automations/webhook/) using the format `${SECRET_NAME}`.
@@ -43,10 +52,14 @@ To rotate a secret and update its value:
 After a secret is created or updated, you can no longer reveal its current value. Instead, rotate the secret to a new value.
 </Note>
 
+Rotating or replacing a secret can affect every feature that still expects the old value. Update [webhook automations](/models/automations/create-automations/webhook), [sandboxes](/sandboxes/secrets) that inject the secret, [evaluation jobs](/models/launch/evaluations), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), or other consumers before you rely on the new value everywhere.
+
 ## Delete a secret
 To delete a secret:
 1. Click the trash icon in the secret's row.
 1. Read the confirmation dialog, then click **Delete**. The secret is deleted immediately and permanently.
 
 ## Manage access to secrets
-A team's automations can use the team's secrets. Before you remove a secret, update or remove automations that use it so they don't stop working.
+A team's secrets can be referenced by name in [webhook automations](/models/automations/create-automations/webhook), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), [sandboxes](/sandboxes/secrets), [LLM evaluation jobs](/models/launch/evaluations), and other team-scoped features that select secrets by name.
+
+Before you remove a secret, update or remove every automation, job, sandbox configuration, or Playground flow that uses it so they do not stop working.


### PR DESCRIPTION
## Description
[WBDOCS-1370] Add more ways to use secrets

- Update the Secrets landing page
    - Mention using secrets in Weave playground, LLM Evaluation Jobs, Weave playground,
      and Sandboxes
    - Add links
- Update Registry Aliases page with a bit more detail
- Update Automation Events page with a bit more detail


## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed


[WBDOCS-1370]: https://coreweave.atlassian.net/browse/WBDOCS-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ