### PR TITLE
chore: share Cursor MCP plugin settings repo-wide

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,16 @@
+{
+  "plugins": {
+    "atlassian": {
+      "enabled": true
+    },
+    "slack": {
+      "enabled": true
+    },
+    "notion-workspace": {
+      "enabled": true
+    },
+    "glean": {
+      "enabled": true
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@
 go.mod
 go.sum
 
-# Cursor editor local state (per-developer), but share repo-wide settings
-.cursor/*
-!.cursor/settings.json
 
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,9 @@
 go.mod
 go.sum
 
-# Misc
-# Cursor editor local rules and config (per-developer)
-.cursor
+# Cursor editor local state (per-developer), but share repo-wide settings
+.cursor/*
+!.cursor/settings.json
 
 .DS_Store
 .env.local


### PR DESCRIPTION
## Summary
Track `.cursor/settings.json` so contributors using Cursor get the same set of enabled MCP plugins by default, without each person having to enable them individually. Per-developer Cursor state under `.cursor/` stays ignored.

## Changes
- **.gitignore**: Replace blanket `.cursor` rule with `.cursor/*` plus `!.cursor/settings.json` so only the shared settings file is tracked.
- **.cursor/settings.json** (new): Enables the Atlassian, Slack, Notion-workspace, and Glean MCP plugins. These are the plugins the docs team uses day-to-day for ticket lookup, cross-team context, doc research, and internal search.

## Verification
- `git check-ignore -v .cursor/settings.json` resolves to the `!.cursor/settings.json` negation (tracked).
- `git check-ignore -v .cursor/_testfile.tmp` resolves to `.cursor/*` (ignored), confirming other per-developer state still does not land in the repo.

## Notes
- Cursor reads `.cursor/settings.json` as the repo-level plugin config; users can still override or add personal plugins in their user settings.
- No content or docs changes.