### PR TITLE
[WBDOCS-1223] Document EvaluationLogger.log_example() convenience method

### DIFF
--- a/weave/guides/evaluation/evaluation_logger.mdx
+++ b/weave/guides/evaluation/evaluation_logger.mdx
@@ -196,13 +196,13 @@ await scoreLogger.finish();
 
 ## Simplified logging with `log_example()`
 
-Use `log_example()` to log inputs, an output, and scores in a single call. This Python convenience method combines `log_prediction()`, `log_score()`, and `finish()` into one step.
+Use `log_example()` to log inputs, an output, and scores in a single call. This convenience method combines `log_prediction()`, `log_score()`, and `finish()` into one step, and is useful when you already have the inputs, model outputs, and scores ready to log, such as during batch or offline evaluations.
 
 ```python lines
 import weave
 from weave import EvaluationLogger
 
-weave.init('your-team/your-project')
+weave.init('your-team-name/your-project-name')
 
 eval_logger = EvaluationLogger(
     model="my_model",
@@ -237,7 +237,7 @@ pred.finish()
 ```
 
 <Note>
-`log_example()` is available in the Python SDK only. TypeScript users should use the `logPrediction()` and `logScore()` pattern shown in the [basic example](#basic-example).
+`log_example()` is not available for the Weave TypeScript SDK. TypeScript users should use the `logPrediction()` and `logScore()` pattern shown in the [basic example](#basic-example).
 </Note>
 
 ## Advanced usage

--- a/weave/guides/evaluation/evaluation_logger.mdx
+++ b/weave/guides/evaluation/evaluation_logger.mdx
@@ -33,7 +33,7 @@ The `EvaluationLogger` offers flexibility while the standard framework offers st
 After calling `finish()` on a prediction, no more scores can be logged for it.
 </Warning>
 
-For a Python code demonstrating the described workflow, see the [Basic example](#basic-example).
+For a Python code demonstrating the described workflow, see the [Basic example](#basic-example). If the output and all scores are available at once, Python users can combine steps 2–4 into a single call using [`log_example()`](#simplified-logging-with-log_example).
 
 ## Basic example
 
@@ -193,6 +193,52 @@ await scoreLogger.finish();
 ```
 </Tab>
 </Tabs>
+
+## Simplified logging with `log_example()`
+
+Use `log_example()` to log inputs, an output, and scores in a single call. This Python convenience method combines `log_prediction()`, `log_score()`, and `finish()` into one step.
+
+```python lines
+import weave
+from weave import EvaluationLogger
+
+weave.init('your-team/your-project')
+
+eval_logger = EvaluationLogger(
+    model="my_model",
+    dataset="my_dataset"
+)
+
+eval_samples = [
+    {'inputs': {'a': 1, 'b': 2}, 'expected': 3},
+    {'inputs': {'a': 2, 'b': 3}, 'expected': 5},
+    {'inputs': {'a': 3, 'b': 4}, 'expected': 7},
+]
+
+for sample in eval_samples:
+    inputs = sample['inputs']
+    output = inputs['a'] + inputs['b']
+
+    eval_logger.log_example(
+        inputs=inputs,
+        output=output,
+        scores={"correctness": output == sample['expected']}
+    )
+
+eval_logger.log_summary({"avg_score": 1.0})
+```
+
+The `log_example()` call above is equivalent to:
+
+```python
+pred = eval_logger.log_prediction(inputs=inputs, output=output)
+pred.log_score(scorer="correctness", score=output == sample['expected'])
+pred.finish()
+```
+
+<Note>
+`log_example()` is available in the Python SDK only. TypeScript users should use the `logPrediction()` and `logScore()` pattern shown in the [basic example](#basic-example).
+</Note>
 
 ## Advanced usage
 


### PR DESCRIPTION
## Summary

- Adds a new **"Simplified logging with `log_example()`"** section to the EvaluationLogger page, between the existing Basic example and Advanced usage sections
- Adds a cross-reference to `log_example()` in the Basic workflow steps
- Python-only; no TypeScript equivalent exists (noted in a callout)

## What changed

`EvaluationLogger.log_example(inputs, output, scores)` is a convenience method that combines `log_prediction()`, `log_score()`, and `finish()` into one call. It was not previously documented anywhere in the Weave docs.

The new section shows:
1. A complete runnable Python example using `log_example()`
2. The equivalent multi-step pattern for comparison

## Test plan

- [ ] Review new section renders correctly on `evaluation_logger` page
- [ ] Verify anchor link `#simplified-logging-with-log_example` resolves correctly in Mintlify (heading contains backticks — confirm anchor generation)
- [ ] Confirm cross-reference in Basic workflow section links correctly

## Needs SME verification

> The following claims require technical validation from the SME reviewer (Andrew Truong).

### Technical accuracy
- [ ] `log_example()` signature is `log_example(inputs, output, scores)` where `scores` is a `dict[str, ScoreType]`
- [ ] `log_example()` calls `finish()` internally — no separate `finish()` call needed after `log_example()`
- [ ] There is no `logExample()` equivalent in the TypeScript SDK (confirmed by Andrew in Slack, but worth a final check in case it was added recently)

## Sources

- JIRA ticket: [WBDOCS-1223](https://coreweave.atlassian.net/browse/WBDOCS-1223)
- SME context: Slack conversation with Andrew Truong
- Method signature sourced from `weave/evaluation/eval_imperative.py` in `wandb/weave`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WBDOCS-1223]: https://wandb.atlassian.net/browse/WBDOCS-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ