### PR TITLE
Remove incorrect links from CLI ref landing page

### DIFF
--- a/models/ref/cli.mdx
+++ b/models/ref/cli.mdx
@@ -45,13 +45,9 @@ wandb [OPTIONS] COMMAND [ARGS]...
 | [launch](/models/ref/cli/wandb-launch) | Launch or queue a W&B Job. |
 | [launch-agent](/models/ref/cli/wandb-launch-agent) | Run a W&B launch agent. |
 | [launch-sweep](/models/ref/cli/wandb-launch-sweep) | Run a W&B launch sweep (Experimental). |
-| [local](/models/ref/cli/wandb-local) | Start a local W&B container (deprecated, see wandb server --help) |
 | [login](/models/ref/cli/wandb-login) | Authenticate your machine with W&B. |
-| [off](/models/ref/cli/wandb-off) | No description available |
 | [offline](/models/ref/cli/wandb-offline) | Save data logged to W&B locally without uploading it to the cloud. |
-| [on](/models/ref/cli/wandb-on) | No description available |
 | [online](/models/ref/cli/wandb-online) | Re-enable cloud syncing for W&B runs. |
-| [projects](/models/ref/cli/wandb-projects) | List projects for the current entity. |
 | [pull](/models/ref/cli/wandb-pull) | Download files from a W&B run. |
 | [purge-cache](/models/ref/cli/wandb-purge-cache) | Purges cached logs, run history, and artifacts from the local W&B cache. |
 | [restore](/models/ref/cli/wandb-restore) | Restore the code, config, or Docker environement from a previous W&B run. |


### PR DESCRIPTION
## Description
Remove incorrect links from CLI ref landing page

Previous tooling was incorrectly creating pages for these commands. The recent rollout of the new tooling removed the pages but not these links, resulting in some 404s.

Fixes WBDOCS-2031

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
