### PR TITLE
Add W&B Sandboxes to Platform nav and docs home page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -113,7 +113,8 @@
                   "product-models",
                   "product-weave",
                   "product-inference",
-                  "product-training"
+                  "product-training",
+                  "product-sandboxes"
                 ]
               },
               {
@@ -1362,7 +1363,8 @@
                   "fr/product-models",
                   "fr/product-weave",
                   "fr/product-inference",
-                  "fr/product-training"
+                  "fr/product-training",
+                  "fr/product-sandboxes"
                 ]
               },
               {
@@ -2610,7 +2612,8 @@
                   "ja/product-models",
                   "ja/product-weave",
                   "ja/product-inference",
-                  "ja/product-training"
+                  "ja/product-training",
+                  "ja/product-sandboxes"
                 ]
               },
               {
@@ -3858,7 +3861,8 @@
                   "ko/product-models",
                   "ko/product-weave",
                   "ko/product-inference",
-                  "ko/product-training"
+                  "ko/product-training",
+                  "ko/product-sandboxes"
                 ]
               },
               {

--- a/fr/index.mdx
+++ b/fr/index.mdx
@@ -56,5 +56,16 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
       • <a href="/fr/training">Introduction</a><br />
       • <a href="/fr/training/prerequisites">Démarrage rapide</a><br />
     </ProductCard>
+
+    <ProductCard title="W&B Sandboxes" iconSrc="icons/cropped-launch.svg" href="/fr/sandboxes" subtitle="Exécutez du code dans des environnements isolés">
+      Désormais en aperçu privé, utilisez W&amp;B Sandboxes pour créer des environnements de calcul isolés à la demande depuis Python. Les fonctionnalités incluent un système de fichiers et un réseau par sandbox, l&#39;exécution de commandes, la lecture/écriture et le montage de fichiers, ainsi que la gestion de plusieurs sandboxes par session.
+
+      <br />
+
+      <br />
+
+      • <a href="/fr/sandboxes">Introduction</a><br />
+      • <a href="/fr/sandboxes/create-sandbox">Démarrage rapide</a><br />
+    </ProductCard>
   </div>
 </HomeWrapper>

--- a/fr/product-sandboxes.mdx
+++ b/fr/product-sandboxes.mdx
@@ -1,0 +1,4 @@
+---
+title: "W&B Sandboxes"
+url: "/sandboxes"
+---

--- a/index.mdx
+++ b/index.mdx
@@ -63,5 +63,18 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
         • <a href="/training">Introduction</a><br/>
         • <a href="/training/prerequisites">Quickstart</a><br/>
     </ProductCard>
+
+    <ProductCard
+        title="W&B Sandboxes"
+        iconSrc="icons/cropped-launch.svg"
+        href="/sandboxes"
+        subtitle="Run code in isolated environments"
+    >
+        Now in private preview, use W&B Sandboxes to create on-demand, isolated compute environments from Python. Features include per-sandbox filesystems and networks, command execution, file read/write and mounting, and session-based management of multiple sandboxes.
+        <br/>
+        <br/>
+        • <a href="/sandboxes">Introduction</a><br/>
+        • <a href="/sandboxes/create-sandbox">Quickstart</a><br/>
+    </ProductCard>
 </div>
 </HomeWrapper>

--- a/ja/index.mdx
+++ b/ja/index.mdx
@@ -56,5 +56,16 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
       • <a href="/ja/training">概要</a><br />
       • <a href="/ja/training/prerequisites">クイックスタート</a><br />
     </ProductCard>
+
+    <ProductCard title="W&B Sandboxes" iconSrc="icons/cropped-launch.svg" href="/ja/sandboxes" subtitle="分離された環境でコードを実行">
+      現在プライベートプレビュー中の W&amp;B Sandboxes を使用すると、Python からオンデマンドで分離された計算環境を作成できます。機能には、サンドボックスごとのファイルシステムとネットワーク、コマンドの実行、ファイルの読み書きとマウント、セッションによる複数サンドボックスの管理が含まれます。
+
+      <br />
+
+      <br />
+
+      • <a href="/ja/sandboxes">概要</a><br />
+      • <a href="/ja/sandboxes/create-sandbox">クイックスタート</a><br />
+    </ProductCard>
   </div>
 </HomeWrapper>

--- a/ja/product-sandboxes.mdx
+++ b/ja/product-sandboxes.mdx
@@ -1,0 +1,4 @@
+---
+title: "W&B Sandboxes"
+url: "/sandboxes"
+---

--- a/ko/index.mdx
+++ b/ko/index.mdx
@@ -56,5 +56,16 @@ import {ProductCard} from "/snippets/ProductCard.jsx";
       • <a href="/ko/training">소개</a><br />
       • <a href="/ko/training/prerequisites">퀵스타트</a><br />
     </ProductCard>
+
+    <ProductCard title="W&B Sandboxes" iconSrc="icons/cropped-launch.svg" href="/ko/sandboxes" subtitle="격리된 환경에서 코드 실행">
+      현재 비공개 프리뷰로 제공되는 W&amp;B Sandboxes를 사용해 Python에서 온디맨드로 격리된 컴퓨트 환경을 생성하세요. 샌드박스별 파일 시스템과 네트워크, 명령어 실행, 파일 읽기/쓰기 및 마운트, 세션 기반의 다중 샌드박스 관리 등의 기능을 제공합니다.
+
+      <br />
+
+      <br />
+
+      • <a href="/ko/sandboxes">소개</a><br />
+      • <a href="/ko/sandboxes/create-sandbox">퀵스타트</a><br />
+    </ProductCard>
   </div>
 </HomeWrapper>

--- a/ko/product-sandboxes.mdx
+++ b/ko/product-sandboxes.mdx
@@ -1,0 +1,4 @@
+---
+title: "W&B Sandboxes"
+url: "/sandboxes"
+---

--- a/product-sandboxes.mdx
+++ b/product-sandboxes.mdx
@@ -1,0 +1,4 @@
+---
+title: "W&B Sandboxes"
+url: "/sandboxes"
+---


### PR DESCRIPTION
## Description

W&B Sandboxes shipped recently but was missing from two entry points:

- The **Platform** tab's left-nav — Sandboxes was not listed in the "Products" group alongside Models, Weave, Inference, and Training.
- The **docs home page** (`index.mdx`) — no `ProductCard` for Sandboxes.

This PR adds both, across all four locales (en, fr, ja, ko):

- `docs.json` — adds `product-sandboxes` to each Products group.
- `product-sandboxes.mdx` redirect stubs in the root and each locale, matching the pattern used by the other products (e.g. `product-training.mdx`).
- `ProductCard` for W&B Sandboxes on each locale's home page, linking to the introduction and the create-a-sandbox quickstart.

### Known follow-up

There's no `cropped-sandboxes.svg` icon yet, so the card uses `cropped-launch.svg` as a thematic placeholder. A dedicated icon would be a nice follow-up.

## Testing

- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)