### PR TITLE
docs(mcp): rework MCP server page for users

### DIFF
--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -228,20 +228,22 @@ For detailed instructions on using these cloud-specific modules, see [Deploy wit
 
 ## Enable the MCP server
 
-The W&B [Model Context Protocol (MCP) server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server that is exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client (Cursor, VS Code, Claude Code, Gemini CLI, Claude Desktop, and others) can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, just pointed at your deployment's data.
+The W&B [Model Context Protocol (MCP) server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client (Cursor, VS Code, Claude Code, Gemini CLI, Claude Desktop, and others) can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, just pointed at your deployment's data.
 
 For end-user client configuration and the tool catalog, see [Use the W&B MCP server](/platform/mcp-server). This section only covers the operator-side enablement.
 
 ### Prerequisites
 
+Make sure your deployment meets the following requirements before you enable the MCP server:
+
 - **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`. The example below uses Datadog and privacy settings added after that initial release.
-- **Weave Traces enabled**: the MCP server calls Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces is not enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
-- **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from it and exposes itself at `<global.host>/mcp`.
-- **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has the headroom before enabling.
+- **Weave Traces enabled**: the MCP server depends on Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces isn't enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
+- **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from `global.host` and is available at `<global.host>/mcp`.
+- **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has enough headroom before you enable the subchart.
 
 ### Enable the subchart
 
-Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource, alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
+Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource (CR), alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
 
 ```yaml
 spec:
@@ -268,7 +270,7 @@ spec:
         logLevel: "standard"
 ```
 
-Keep `weave-trace.install: true` unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself. Use `datadog.mode: "agent"` for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod does not need a Datadog API key. Set `service`, `env`, `deploymentType`, `customer`, and `extraTags` to match your deployment's observability naming conventions. Set `customer` to an empty string if you do not want a customer tag.
+Keep `weave-trace.install: true` unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself. Use `datadog.mode: "agent"` for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod doesn't need a Datadog API key. Set `service`, `env`, `deploymentType`, `customer`, and `extraTags` to match your deployment's observability naming conventions. Set `customer` to an empty string if you don't want a customer tag.
 
 Use `privacy.logLevel: "standard"` for most self-managed Kubernetes installations. This redacts free-text parameter values in logs while preserving deployment identifiers that operators commonly use for debugging. Use `"strict"` when entity, project, run, or user identifiers should not remain in plaintext logs. Use `"off"` only when you explicitly want plaintext logging for those values.
 
@@ -292,11 +294,11 @@ curl -s http://localhost:8080/mcp/health
 curl -s "https://<HOST_URI>/mcp/health"
 ```
 
-Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy; the ingress check confirms routing. If you enabled Datadog, MCP server logs should also appear under the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
+Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy. The ingress check confirms routing. If you enabled Datadog, MCP server logs should also appear under the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
 
 ### Connect a client
 
-Point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations (Cursor, VS Code, Claude Code, and others), see [Use the W&B MCP server](/platform/mcp-server).
+After the MCP server is running and healthy, point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations (Cursor, VS Code, Claude Code, and others), see [Use the W&B MCP server](/platform/mcp-server).
 
 ### Troubleshooting
 
@@ -304,8 +306,8 @@ Point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bear
 |---------|----------------------|
 | `helm render` fails with `mcp-server requires weave-trace.install=true` | Add `weave-trace.install: true` to `spec.values`. The MCP server depends on Weave Traces for trace tools. |
 | `wandb-mcp-server` pod stuck in `Pending` with `Insufficient cpu` or `Insufficient memory` | Add node capacity, or lower `mcp-server.resources.requests` in your CR. Defaults are `500m` CPU and `1Gi` memory. |
-| `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Re-apply the CR and wait for the ingress controller to propagate the new path. |
-| MCP logs do not appear in Datadog | Confirm `mcp-server.datadog.enabled: true`, `mcp-server.datadog.mode: "agent"`, and that the Datadog Agent DaemonSet collects pod stdout. Search Datadog with the configured `service` and `env` values. |
+| `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Reapply the CR and wait for the ingress controller to propagate the new path. |
+| MCP logs don't appear in Datadog | Confirm `mcp-server.datadog.enabled: true`, `mcp-server.datadog.mode: "agent"`, and that the Datadog Agent DaemonSet collects pod stdout. Search Datadog with the configured `service` and `env` values. |
 | MCP logs include more user-supplied text than expected | Set `mcp-server.privacy.logLevel` to `"standard"` or `"strict"`. Use `"strict"` when identifiers such as entity, project, run, or user names should not remain in plaintext logs. |
 | `wandb-mcp-server` pod in `ImagePullBackOff` in an air-gapped or mirrored cluster | Mirror the image to your registry and override `mcp-server.image.repository` in your CR, the same pattern used for other W&B component images in air-gapped installs. See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/). |
 

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -226,6 +226,89 @@ For detailed instructions on using these cloud-specific modules, see [Deploy wit
 
 <SelfManagedVerifyInstallation/>
 
+## Enable the MCP server
+
+The W&B [Model Context Protocol (MCP) server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server that is exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client (Cursor, VS Code, Claude Code, Gemini CLI, Claude Desktop, and others) can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, just pointed at your deployment's data.
+
+For end-user client configuration and the tool catalog, see [Use the W&B MCP server](/platform/mcp-server). This section only covers the operator-side enablement.
+
+### Prerequisites
+
+- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`. The example below uses Datadog and privacy settings added after that initial release.
+- **Weave Traces enabled**: the MCP server calls Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces is not enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
+- **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from it and exposes itself at `<global.host>/mcp`.
+- **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has the headroom before enabling.
+
+### Enable the subchart
+
+Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource, alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
+
+```yaml
+spec:
+  values:
+    weave-trace:
+      install: true
+
+    mcp-server:
+      install: true
+      image:
+        repository: us-docker.pkg.dev/wandb-production/public/wandb/mcp-server
+        tag: "0.3.3"
+      datadog:
+        enabled: true
+        mode: "agent"
+        service: "wandb-mcp-server-<environment>"
+        env: "<environment>"
+        deploymentType: "self-managed"
+        customer: "<customer-name>"
+        extraTags:
+          - "region:<region>"
+          - "tier:<tier>"
+      privacy:
+        logLevel: "standard"
+```
+
+Keep `weave-trace.install: true` unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself. Use `datadog.mode: "agent"` for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod does not need a Datadog API key. Set `service`, `env`, `deploymentType`, `customer`, and `extraTags` to match your deployment's observability naming conventions. Set `customer` to an empty string if you do not want a customer tag.
+
+Use `privacy.logLevel: "standard"` for most self-managed Kubernetes installations. This redacts free-text parameter values in logs while preserving deployment identifiers that operators commonly use for debugging. Use `"strict"` when entity, project, run, or user identifiers should not remain in plaintext logs. Use `"off"` only when you explicitly want plaintext logging for those values.
+
+Apply the change to trigger a reconcile:
+
+```bash
+kubectl apply -f operator.yaml
+```
+
+The operator creates a `wandb-mcp-server` deployment and service in the release namespace, and extends the W&B ingress with a `/mcp` path.
+
+### Verify the MCP server
+
+Wait for the pod to become `Running`, then check the health endpoint in-cluster and through the ingress:
+
+```bash
+kubectl get pod -l app.kubernetes.io/component=mcp-server
+kubectl port-forward svc/wandb-mcp-server 8080:8080
+curl -s http://localhost:8080/mcp/health
+
+curl -s "https://<HOST_URI>/mcp/health"
+```
+
+Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy; the ingress check confirms routing. If you enabled Datadog, MCP server logs should also appear under the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
+
+### Connect a client
+
+Point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations (Cursor, VS Code, Claude Code, and others), see [Use the W&B MCP server](/platform/mcp-server).
+
+### Troubleshooting
+
+| Symptom | Likely cause and fix |
+|---------|----------------------|
+| `helm render` fails with `mcp-server requires weave-trace.install=true` | Add `weave-trace.install: true` to `spec.values`. The MCP server depends on Weave Traces for trace tools. |
+| `wandb-mcp-server` pod stuck in `Pending` with `Insufficient cpu` or `Insufficient memory` | Add node capacity, or lower `mcp-server.resources.requests` in your CR. Defaults are `500m` CPU and `1Gi` memory. |
+| `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Re-apply the CR and wait for the ingress controller to propagate the new path. |
+| MCP logs do not appear in Datadog | Confirm `mcp-server.datadog.enabled: true`, `mcp-server.datadog.mode: "agent"`, and that the Datadog Agent DaemonSet collects pod stdout. Search Datadog with the configured `service` and `env` values. |
+| MCP logs include more user-supplied text than expected | Set `mcp-server.privacy.logLevel` to `"standard"` or `"strict"`. Use `"strict"` when identifiers such as entity, project, run, or user names should not remain in plaintext logs. |
+| `wandb-mcp-server` pod in `ImagePullBackOff` in an air-gapped or mirrored cluster | Mirror the image to your registry and override `mcp-server.image.repository` in your CR, the same pattern used for other W&B component images in air-gapped installs. See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/). |
+
 ## Environment-specific considerations
 
 Kubernetes is the same whether it runs on-premises or in the cloud. The main differences are in naming and managed services (for example, MySQL vs RDS, or S3 vs on-premises object storage). This section covers considerations that vary by environment.

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -228,7 +228,7 @@ For detailed instructions on using these cloud-specific modules, see [Deploy wit
 
 ## Enable the MCP server
 
-The W&B [Model Context Protocol (MCP) server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client (Cursor, VS Code, Claude Code, Gemini CLI, Claude Desktop, and others) can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, just pointed at your deployment's data.
+The [W&B MCP Server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, but pointed at your deployment's data.
 
 For end-user client configuration and the tool catalog, see [Use the W&B MCP server](/platform/mcp-server). This section only covers the operator-side enablement.
 
@@ -236,7 +236,7 @@ For end-user client configuration and the tool catalog, see [Use the W&B MCP ser
 
 Make sure your deployment meets the following requirements before you enable the MCP server:
 
-- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`. The example below uses Datadog and privacy settings added after that initial release.
+- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`, but the Datadog and privacy fields used in the example below were added later.
 - **Weave Traces enabled**: the MCP server depends on Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces isn't enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
 - **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from `global.host` and is available at `<global.host>/mcp`.
 - **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has enough headroom before you enable the subchart.
@@ -270,11 +270,14 @@ spec:
         logLevel: "standard"
 ```
 
-Keep `weave-trace.install: true` unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself. Use `datadog.mode: "agent"` for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod doesn't need a Datadog API key. Set `service`, `env`, `deploymentType`, `customer`, and `extraTags` to match your deployment's observability naming conventions. Set `customer` to an empty string if you don't want a customer tag.
+Configure each block:
 
-Use `privacy.logLevel: "standard"` for most self-managed Kubernetes installations. This redacts free-text parameter values in logs while preserving deployment identifiers that operators commonly use for debugging. Use `"strict"` when entity, project, run, or user identifiers should not remain in plaintext logs. Use `"off"` only when you explicitly want plaintext logging for those values.
+- **`weave-trace.install: true`**: required unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself.
+- **`datadog.mode: "agent"`**: use for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod doesn't need a Datadog API key.
+- **`datadog.service`, `env`, `deploymentType`, `customer`, `extraTags`**: set these to match your deployment's observability naming conventions. Set `customer` to an empty string if you don't want a customer tag.
+- **`privacy.logLevel`**: use `"standard"` for most self-managed Kubernetes installations. This redacts free-text parameter values in logs while preserving deployment identifiers that operators commonly use for debugging. Use `"strict"` when entity, project, run, or user identifiers should not remain in plaintext logs. Use `"off"` only when you explicitly want plaintext logging for those values.
 
-Apply the change to trigger a reconcile:
+Apply the change to trigger reconciliation:
 
 ```bash
 kubectl apply -f operator.yaml
@@ -294,19 +297,19 @@ curl -s http://localhost:8080/mcp/health
 curl -s "https://<HOST_URI>/mcp/health"
 ```
 
-Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy. The ingress check confirms routing. If you enabled Datadog, MCP server logs should also appear under the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
+Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy. The ingress check confirms routing. If the in-cluster check returns `200 OK` but the ingress check returns `404 Not Found`, see [Troubleshooting](#troubleshooting). If you enabled Datadog, MCP server logs should also appear in Datadog with the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
 
 ### Connect a client
 
-After the MCP server is running and healthy, point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations (Cursor, VS Code, Claude Code, and others), see [Use the W&B MCP server](/platform/mcp-server).
+After the MCP server is healthy, configure your MCP client to use `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations, see [Use the W&B MCP server](/platform/mcp-server).
 
 ### Troubleshooting
 
-| Symptom | Likely cause and fix |
-|---------|----------------------|
+| Symptom | Cause and fix |
+|---------|---------------|
 | `helm render` fails with `mcp-server requires weave-trace.install=true` | Add `weave-trace.install: true` to `spec.values`. The MCP server depends on Weave Traces for trace tools. |
 | `wandb-mcp-server` pod stuck in `Pending` with `Insufficient cpu` or `Insufficient memory` | Add node capacity, or lower `mcp-server.resources.requests` in your CR. Defaults are `500m` CPU and `1Gi` memory. |
-| `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Reapply the CR and wait for the ingress controller to propagate the new path. |
+| `curl https://<HOST_URI>/mcp/health` returns 404 | The chart renders the `/mcp` ingress path only when `mcp-server.install: true`. Reapply the CR and wait for the ingress controller to propagate the new path. |
 | MCP logs don't appear in Datadog | Confirm `mcp-server.datadog.enabled: true`, `mcp-server.datadog.mode: "agent"`, and that the Datadog Agent DaemonSet collects pod stdout. Search Datadog with the configured `service` and `env` values. |
 | MCP logs include more user-supplied text than expected | Set `mcp-server.privacy.logLevel` to `"standard"` or `"strict"`. Use `"strict"` when identifiers such as entity, project, run, or user names should not remain in plaintext logs. |
 | `wandb-mcp-server` pod in `ImagePullBackOff` in an air-gapped or mirrored cluster | Mirror the image to your registry and override `mcp-server.image.repository` in your CR, the same pattern used for other W&B component images in air-gapped installs. See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/). |

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -1,123 +1,224 @@
 ---
-title: Use the W&B MCP Server
-description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to access your workspace data and documentation."
+title: Use the W&B MCP server
+description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-import McpConfig from '/snippets/_includes/mcp-config.mdx';
+The W&B Model Context Protocol (MCP) server exposes your W&B data as a set of tools that any [MCP](https://modelcontextprotocol.io) client can call. Connect your IDE or AI agent to the server and ask it to analyze experiments, debug Weave traces, generate reports, inspect artifacts and registry, and search W&B documentation, all without writing custom GraphQL or SDK code.
 
-Model Context Protocol (MCP) lets an LLM agent query and analyze data efficiently to minimize cost in tokens. This page shows how to use the W&B MCP server to query and analyze your W&B data from your IDE or MCP client and give your client programmatic access to W&B's documentation, so it can generate more accurate responses to W&B-related queries.
+Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex, Gemini CLI, Mistral LeChat, Claude Desktop, and the OpenAI Responses API.
 
-It integrates natively with most IDEs, coding clients, and chat agents, including:
-* Cursor
-* Visual Studio Code (VS Code)
-* Claude Code
-* Codex
-* Gemini CLI
-* Mistral LeChat
-* Claude Desktop
+## Which setup should I use?
 
-The W&B MCP server supports [hosted](#use-w&b’s-remote-mcp-server) and [local](#set-up-a-local-version-of-the-w&b-mcp-server) variants. The hosted version only supports [W&B Dedicated Cloud deployments](/platform/hosting/hosting-options/dedicated-cloud). The local version supports both Dedicated Cloud and [Self-Managed deployments](/platform/hosting/hosting-options/self-managed).
+W&B offers three ways to run the MCP server. Pick the one that matches your deployment:
 
-## W&B MCP Server capabilities
+<CardGroup cols={3}>
+  <Card title="Multi-tenant Cloud" icon="cloud">
+    Use the hosted server at `mcp.withwandb.com`. No installation required.
 
-You can use the MCP server to analyze experiments, debug traces, create reports, and get help with integrating your applications with W&B features.
+    [Use the hosted server](#use-the-hosted-server)
+  </Card>
+  <Card title="Dedicated Cloud or Self-Managed" icon="building">
+    Request enablement of the managed MCP server on your deployment. Your team connects to `https://<your-instance>/mcp` with an existing W&B API key.
 
-The following example prompts demonstrate some of the types of tasks your agent can do when connected to the MCP server:
+    [Use MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed)
+  </Card>
+  <Card title="Local install" icon="laptop-code">
+    Run the MCP server on your machine. Useful for air-gapped environments, development, and clients that require STDIO.
 
-* Show me the top 5 runs by eval/accuracy in your-team-name/your-project-name?
-* How did the latency of my hiring agent predict traces evolve over the last few months?
-* Generate a wandb report comparing the decisions made by the hiring agent last month.
-* How do I create a leaderboard in Weave - ask SupportBot?
+    [Run the MCP server locally](#run-the-mcp-server-locally)
+  </Card>
+</CardGroup>
+
+<Tip>
+To request the managed MCP server on a Dedicated Cloud or Self-Managed instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team.
+</Tip>
+
+## What you can do
+
+Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following are representative prompts:
+
+- "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`."
+- "How did the latency of my hiring agent's `predict` traces evolve over the last month?"
+- "Generate a W&B report comparing decisions made by the hiring agent last week."
+- "What versions of the `production-model` artifact exist, and what changed between `v2` and `v3`?"
+- "How do I create a leaderboard in Weave?"
 
 ### Available tools
 
-The W&B MCP server gives your agents access to the following tools:
+The server registers the following tools. The exact set depends on the server version and whether docs search is enabled.
 
-| Tool | Description | Example Query |
-|------|-------------|---------------|
-| **query_wandb_tool** | Query W&B runs, metrics, and experiments | *"Show me runs with loss < 0.1"* |
-| **query_weave_traces_tool** | Analyze LLM traces and evaluations | *"What's the average latency?"* |
-| **count_weave_traces_tool** | Count traces and get storage metrics | *"How many traces failed?"* |
-| **create_wandb_report_tool** | Create W&B reports programmatically | *"Create a performance report"* |
-| **query_wandb_entity_projects** | List projects for an entity | *"What projects exist?"* |
-| **query_wandb_support_bot** | Get help from W&B documentation | *"How do I use sweeps?"* |
+<Tabs>
+  <Tab title="Experiments and runs">
+    | Tool | Description |
+    |------|-------------|
+    | `query_wandb_tool` | Query W&B runs, metrics, configs, and summaries using GraphQL. |
+    | `get_run_history_tool` | Retrieve sampled time-series metric data for a run. |
+    | `query_wandb_entity_projects` | List projects visible to an entity. |
+  </Tab>
+  <Tab title="Weave traces">
+    | Tool | Description |
+    |------|-------------|
+    | `infer_trace_schema_tool` | Discover field names, types, and sample values before you query. |
+    | `query_weave_traces_tool` | Query Weave traces with a configurable `detail_level` and column projection. |
+    | `count_weave_traces_tool` | Count traces and retrieve storage metrics. |
+  </Tab>
+  <Tab title="Reports">
+    | Tool | Description |
+    |------|-------------|
+    | `create_wandb_report_tool` | Create W&B reports with Markdown, line plots, bar plots, and run comparisons. Accepts a `panels` parameter. |
+    | `log_analysis_to_wandb` | Log analysis results from the current MCP session to W&B as a run. |
+  </Tab>
+  <Tab title="Artifacts and registry">
+    | Tool | Description |
+    |------|-------------|
+    | `list_registries_tool` | List model registries in an organization. |
+    | `list_registry_collections_tool` | List collections within a registry. |
+    | `list_artifact_versions_tool` | List versions of an artifact collection. |
+    | `get_artifact_details_tool` | Get full details for an artifact version. |
+    | `compare_artifact_versions_tool` | Diff two artifact versions. |
+  </Tab>
+  <Tab title="Docs">
+    | Tool | Description |
+    |------|-------------|
+    | `search_wandb_docs_tool` | Search the official W&B documentation at [docs.wandb.ai](https://docs.wandb.ai). Controlled by `WANDB_MCP_PROXY_DOCS` (enabled by default). |
+  </Tab>
+</Tabs>
 
+### Schema-first trace queries
 
-## Use W&B's remote MCP server
+For Weave trace queries, call `infer_trace_schema_tool` first to discover available fields, then call `query_weave_traces_tool` with a precise column list and `detail_level`:
 
-W&B provides a hosted MCP server at `https://mcp.withwandb.com` that requires no installation. The following instructions show how to configure the hosted server with various AI assistants and IDEs.
+| `detail_level` | When to use |
+|----------------|-------------|
+| `schema` | Structural fields only. Fastest. Use for browsing and counting. |
+| `summary` | Truncated inputs and outputs. The default. |
+| `full` | Everything untruncated. Use to drill into a small number of specific traces. |
 
-### Prerequisites
+This pattern keeps token usage low for broad questions and lets the agent escalate to `full` only for the traces that matter.
 
-* A W&B Dedicated Cloud deployment.
-* A W&B API key. You can create a new one at [wandb.ai/authorize](https://wandb.ai/authorize).
-* Set your key as an environment variable named `WANDB_API_KEY`.
+## Prerequisites
 
-### Configure your MCP client
+Before you configure any client:
 
-Select the tab containing your MCP client's instructions:
+- A W&B API key. Create one at [wandb.ai/authorize](https://wandb.ai/authorize).
+- Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
+- For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
+
+## Use the hosted server
+
+W&B runs a hosted MCP server at `https://mcp.withwandb.com` for Multi-tenant Cloud users. There is nothing to install. Configure your client to connect to `https://mcp.withwandb.com/mcp` with a bearer token.
 
 <Tabs>
 <Tab title="Cursor">
 
-You can install the W&B server in Cursor automatically using a [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=) (requires adding `Bearer <your-wandb-api-key>` in the `Authorization` field), or manually using the following instructions:
+Install the server in Cursor automatically with the [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=), then replace `YOUR_WANDB_API_KEY` with your W&B API key in the `Authorization` field.
 
-1. On macOS, open the **Cursor** menu, select **Settings**, and then select **Cursor Settings**. On Windows or Linux, open the **Preferences** menu, select **Settings**, and then select **Cursor Settings**.
-2. From the Cursor Settings menu, select **Tools and MCP**. This opens the Tools menu. 
-3. In the Installed MCP Servers section, select **Add Custom MCP**. This opens the `mcp.json` configuration file.
-4. In the configuration file, in the `mcpServers` JSON object, add the following `wandb` object:
+To configure Cursor manually:
 
-  ```json
-  {
-    "mcpServers": {
-      "wandb": {
-        "transport": "http",
-        "url": "https://mcp.withwandb.com/mcp",
-        "headers": {
-          "Authorization": "Bearer <your-wandb-api-key>",
-          "Accept": "application/json, text/event-stream"
+1. On macOS, open **Cursor** > **Settings** > **Cursor Settings**. On Windows or Linux, open **Preferences** > **Settings** > **Cursor Settings**.
+2. Select **Tools and MCP**.
+3. In **Installed MCP Servers**, select **Add Custom MCP**. Cursor opens the `mcp.json` configuration file.
+4. Add the following to the `mcpServers` object:
+
+    ```json
+    {
+      "mcpServers": {
+        "wandb": {
+          "transport": "http",
+          "url": "https://mcp.withwandb.com/mcp",
+          "headers": {
+            "Authorization": "Bearer <your-wandb-api-key>",
+            "Accept": "application/json, text/event-stream"
+          }
         }
       }
     }
+    ```
+
+5. Restart Cursor.
+6. Verify the connection by asking the agent "List the projects in my W&B account."
+
+For more information, see [Cursor's MCP documentation](https://cursor.com/docs/context/mcp).
+</Tab>
+<Tab title="VS Code">
+
+Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `.vscode/mcp.json`) and add the following:
+
+```json
+{
+  "servers": {
+    "wandb": {
+      "type": "http",
+      "url": "https://mcp.withwandb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-wandb-api-key>"
+      }
+    }
   }
+}
 ```
 
-5. Restart Cursor to make the changes take effect.
-6. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
-
-For more detailed information, see [Cursor's documentation](https://cursor.com/docs/context/mcp).
-
+Restart VS Code and confirm the server appears in the MCP panel.
 </Tab>
 <Tab title="Claude Code">
 
-To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
+Run the following command in your terminal, replacing the bearer token with your W&B API key:
 
 ```bash
 claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
   --header "Authorization: Bearer <your-wandb-api-key>"
 ```
 
-Add `--scope user` for a global configuration, or omit it to configure for the current project only.
+Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
 
-For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
-
+For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
 </Tab>
 <Tab title="Codex">
 
-To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
+Export your W&B API key as an environment variable, then run:
 
 ```bash
 export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
+codex mcp add wandb \
+  --url https://mcp.withwandb.com/mcp \
+  --bearer-token-env-var WANDB_API_KEY
+```
+</Tab>
+<Tab title="Gemini CLI">
+
+Install the W&B MCP extension:
+
+```bash
+gemini extensions install https://github.com/wandb/wandb-mcp-server
 ```
 
+Restart Gemini CLI. Verify the connection by asking "List the projects in my W&B account."
+
+For more information, see [Gemini CLI's MCP documentation](https://geminicli.com/docs/tools/mcp-server/).
 </Tab>
-<Tab title="OpenAI">
-To add the W&B MCP server to your OpenAI calls, add the server's information to the `tools` field of your OpenAI responses configuration:
+<Tab title="Mistral LeChat">
+
+1. In LeChat, open the **Intelligence** menu and select **Add Connector**.
+2. Select **Custom MCP Connector**.
+3. Configure the following fields:
+    - **Connector Server**: `https://mcp.withwandb.com/mcp`
+    - **Description**: (Optional) A short description.
+    - **Authentication Method**: Select **API Token Authentication**.
+    - **Header name**: Leave as `Authorization`.
+    - **Header type**: Select **Bearer**.
+    - **Header value**: Your W&B API key.
+4. Select **Create**.
+5. Verify the connection by asking "List the projects in my W&B account."
+
+For more information, see [LeChat's MCP documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
+</Tab>
+<Tab title="OpenAI Responses API">
+
+Add the server to the `tools` field of your OpenAI Responses API call:
 
 ```python
-from openai import OpenAI
 import os
+from openai import OpenAI
 
 client = OpenAI()
 
@@ -128,7 +229,7 @@ resp = client.responses.create(
         "server_label": "wandb",
         "server_description": "Query W&B data",
         "server_url": "https://mcp.withwandb.com/mcp",
-        "authorization": os.getenv("<your-wandb-api-key>"),
+        "authorization": os.getenv("WANDB_API_KEY"),
         "require_approval": "never",
     }],
     input="List the projects in my W&B account.",
@@ -136,63 +237,52 @@ resp = client.responses.create(
 
 print(resp.output_text)
 ```
-</Tab>
-<Tab title="Gemini CLI">
-To add the W&B MCP server to Gemini CLI:
 
-1. Install the W&B MCP extension with a single command:
-
-    ```bash
-    # Install the extension
-    gemini extensions install https://github.com/wandb/wandb-mcp-server
-    ```
-2. Once installed, restart the Gemini CLI.
-3. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
-
-For more detailed information, see [Gemini's documentation](https://geminicli.com/docs/tools/mcp-server/).
-</Tab>
-<Tab title="Mistral LeChat">
-To add the W&B MCP server to Mistral LeChat: 
-
-1. From the **Intelligence** menu, select **Add Connector** to open the Connector window.
-2. Select the **Custom MCP Connector** tab.
-3. Configure the fields using the following values:
-
-    - **Connector Server**: `https://mcp.withwandb.com/mcp`
-    - **Description**: (Optional) A brief arbitrary description of the connection.
-    - **Authentication Method**: Select **API Token Authentication**. This opens additional fields.
-    - **Header name**: Leave the default value, **Authorization**.
-    - **Header type**: Select **Bearer**.
-    - **Header value**: Enter your W&B API token.
-
-3. Once you have configured all the fields, select **Create**. LeChat adds the MCP server to your configuration.
-4. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
-
-For more detailed information, see [LeChat's documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
+The OpenAI MCP integration runs server-side, so it cannot reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
 </Tab>
 </Tabs>
 
-## Set up a local version of the W&B MCP server
+## Use MCP on Dedicated Cloud or Self-Managed
 
-If you need to run the MCP server locally for W&B Self-Managed deployments, development, testing, or air-gapped environments, you can install and run it on your machine.
+The hosted server at `mcp.withwandb.com` targets Multi-tenant Cloud. [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) customers have two options.
 
-### Prerequisites
+### Request the managed MCP server on your deployment
 
-* A W&B API key. You can create a new one at [wandb.ai/authorize](https://wandb.ai/authorize).
-* Set your key as an environment variable named `WANDB_API_KEY`.
-* Set the `WANDB_BASE_URL` environment variable if you are using [W&B Self-Managed](/platform/hosting/hosting-options/self-managed).
-* Python 3.10 or higher
-* [uv](https://docs.astral.sh/uv/) (recommended) or pip
+W&B can enable a managed MCP server on your Dedicated Cloud or Self-Managed instance. Once enabled:
 
-See uv's docs for [installation instructions](https://docs.astral.sh/uv/getting-started/installation/).
+- The server is reachable at `https://<your-instance>/mcp`.
+- Your team authenticates with an existing W&B API key, the same way they authenticate to the W&B app.
+- The same tools described in [What you can do](#what-you-can-do) are available.
 
-### Install and configure the MCP server
+To request enablement, contact [W&B support](mailto:support@wandb.com) or your W&B account team. Once the server is available, configure your MCP client as shown in [Use the hosted server](#use-the-hosted-server), replacing the `https://mcp.withwandb.com/mcp` URL with `https://<your-instance>/mcp`.
 
-To install the MPC server locally:
+### Self-serve from the open-source repo
 
-To install the W&B MCP server on your local machine, use one of the following installation commands:
- 
+For air-gapped environments, development work, or instances where the managed MCP is not yet enabled, you can run the MCP server locally from the [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) open-source repository and point it at your instance.
+
+Install and configure the local server as described in [Run the MCP server locally](#run-the-mcp-server-locally), and set `WANDB_BASE_URL` to your instance URL.
+
+## Run the MCP server locally
+
+Run the MCP server on your own machine for air-gapped environments, development, testing, or clients that only support STDIO.
+
+### Local prerequisites
+
+- Python 3.11 or higher.
+- [`uv`](https://docs.astral.sh/uv/) is recommended. For installation instructions, see the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/). You can use `pip` instead.
+- A W&B API key, set as `WANDB_API_KEY`.
+- `WANDB_BASE_URL` set to your instance URL if you use Dedicated Cloud or Self-Managed.
+
+### Install the server
+
+Choose an install method:
+
 <Tabs>
+<Tab title="uvx (no install)">
+```bash
+uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
 <Tab title="uv">
 ```bash
 uv pip install wandb-mcp-server
@@ -203,14 +293,16 @@ uv pip install wandb-mcp-server
 pip install wandb-mcp-server
 ```
 </Tab>
-<Tab title="Install directly from GitHub">
+<Tab title="Install from GitHub">
 ```bash
 pip install git+https://github.com/wandb/wandb-mcp-server
 ```
 </Tab>
 </Tabs>
 
-Once you have installed the MCP server locally, configure your MCP client to use it. Select an MCP client to continue:
+### Configure your client
+
+Select your MCP client:
 
 <Tabs>
 <Tab title="Cursor">
@@ -236,6 +328,7 @@ Add the following to your `mcp.json` configuration:
 }
 ```
 
+Omit `WANDB_BASE_URL` to use the default W&B API endpoint.
 </Tab>
 <Tab title="VS Code">
 
@@ -262,35 +355,32 @@ Add the following to your `.vscode/mcp.json` or global MCP configuration:
 </Tab>
 <Tab title="Claude Code">
 
-Run the following command in your terminal. Add `--scope user` for a global configuration, or omit it to configure for the current project only.
+Run the following command. Add `--scope user` for a global configuration.
 
 ```bash
 claude mcp add wandb \
-  -e WANDB_API_KEY=your-api-key \
+  -e WANDB_API_KEY=<your-wandb-api-key> \
   -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
   -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
-
 </Tab>
 <Tab title="Codex">
 
-Run the following command in your terminal:
-
 ```bash
 codex mcp add wandb \
-  --env WANDB_API_KEY=your_api_key_here \
+  --env WANDB_API_KEY=<your-wandb-api-key> \
   --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
   -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
-
 </Tab>
 <Tab title="Claude Desktop">
-Open your Claude config file in a text editor. You can find the config file at the locations for your OS:
 
-* **macOS**: ~/Library/Application\ Support/Claude/claude_desktop_config.json
-* **Windows**: %APPDATA%\Claude\claude_desktop_config.json
+Open your Claude Desktop config file:
 
-Add the following to your JSON object to your Claude config file. Use the full path to `uvx` because Claude Desktop may not find your `uvx` installation otherwise.
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following JSON. Use the full path to `uvx` because Claude Desktop may not find it on your `PATH` otherwise.
 
 ```json
 {
@@ -311,31 +401,65 @@ Add the following to your JSON object to your Claude config file. Use the full p
 }
 ```
 
-Restart Claude Desktop to activate the new configuration.
-
+Restart Claude Desktop to apply the configuration.
 </Tab>
 </Tabs>
 
-For web-based clients or testing, run the server with HTTP transport:
+### Run the server with HTTP transport
+
+For web-based clients and for testing, run the server with HTTP transport:
 
 ```bash
 uvx wandb_mcp_server --transport http --host 0.0.0.0 --port 8080
 ```
 
-To expose the local server to external clients like OpenAI, use ngrok:
+To expose a local server to external clients, such as the OpenAI Responses API, use a tunnel:
 
 ```bash
 uvx wandb_mcp_server --transport http --port 8080
 
-# In another terminal, expose with ngrok
+# In another terminal
 ngrok http 8080
-    ```
+```
 
-If you expose the server using `ngrok`, update your MCP client configuration to use the `ngrok` URL.
+Update your MCP client configuration to use the tunnel URL.
 
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `WANDB_API_KEY` | W&B API key for authentication. Required. |
+| `WANDB_BASE_URL` | Custom W&B instance URL for Dedicated Cloud or Self-Managed. Defaults to `https://api.wandb.ai`. |
+| `WANDB_MCP_PROXY_DOCS` | Enable the `search_wandb_docs_tool` documentation search proxy. Default: `true`. |
+| `WANDBOT_BASE_URL` | Custom endpoint for the docs search proxy. |
+| `MAX_RESPONSE_TOKENS` | Token budget for tool-response truncation. Default: `30000`. |
+| `MCP_SERVER_LOG_LEVEL` | Logging verbosity. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+
+For the complete command-line reference and advanced options, see the [wandb-mcp-server README](https://github.com/wandb/wandb-mcp-server#readme).
 
 ## Usage tips
 
-- **Provide your W&B project and entity name**: Specify the W&B entity and project in your queries for accurate results.
-- **Avoid overly broad questions**: Instead of "what is my best evaluation?", ask "what eval had the highest f1 score?"
-- **Verify data retrieval**: When asking broad questions like "what are my best performing runs?", ask the assistant to confirm it retrieved all available runs.
+Follow these practices to get good results from the MCP server:
+
+- **Specify the entity and project.** MCP tools need an explicit entity and project name. Include both in every question, for example "in `your-team/your-project`".
+- **Ask focused questions.** Prefer "Which eval had the highest F1 score?" to "What is my best evaluation?". Specific metrics and time ranges produce better tool calls.
+- **Use the schema-first workflow for traces.** Have the agent call `infer_trace_schema_tool` before `query_weave_traces_tool`, and start with `detail_level: "summary"`. Escalate to `"full"` only when drilling into specific traces.
+- **Verify full retrieval.** For broad questions like "What are my best performing runs?", ask the agent to confirm that it retrieved all available runs rather than only the most recent ones.
+- **Combine with W&B Skills.** [W&B Skills](/platform/wb-skills) teach coding agents how to structure W&B workflows. Skills and MCP work well together, because Skills provide patterns and MCP provides data access.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---------|---------------|
+| `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
+| Empty results for queries you expect to succeed | The entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
+| Cannot reach `mcp.withwandb.com/mcp` from Dedicated Cloud or Self-Managed | The hosted server targets Multi-tenant Cloud only. Use [MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed) instead. |
+| `429 Too Many Requests` on Dedicated Cloud | You have hit your instance's rate limits. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for how to request higher limits. |
+| Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
+
+## Related
+
+- [Trace MCP clients and servers with Weave](/weave/guides/integrations/mcp) for end-to-end observability of MCP interactions.
+- [W&B Skills](/platform/wb-skills) for reusable agent instructions that pair with the MCP server.
+- [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) for the open-source server, command-line reference, and release notes.
+- [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) hosting options.

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -12,17 +12,17 @@ Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex,
 W&B offers three ways to run the MCP server. Pick the one that matches your deployment:
 
 <CardGroup cols={3}>
-  <Card title="Multi-tenant Cloud" icon="cloud">
+  <Card title="Multi-tenant Cloud">
     Use the hosted server at `mcp.withwandb.com`. No installation required.
 
     [Use the hosted server](#use-the-hosted-server)
   </Card>
-  <Card title="Dedicated Cloud or Self-Managed" icon="building">
+  <Card title="Dedicated Cloud or Self-Managed">
     Request enablement of the managed MCP server on your deployment. Your team connects to `https://<your-instance>/mcp` with an existing W&B API key.
 
     [Use MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed)
   </Card>
-  <Card title="Local install" icon="laptop-code">
+  <Card title="Local install">
     Run the MCP server on your machine. Useful for air-gapped environments, development, and clients that require STDIO.
 
     [Run the MCP server locally](#run-the-mcp-server-locally)
@@ -45,42 +45,64 @@ Use the MCP server to analyze experiments, debug traces, create reports, manage 
 
 ### Available tools
 
-The server registers the following tools. The exact set depends on the server version and whether docs search is enabled.
+The server registers a set of tools grouped by purpose. Each row lists the tool name, when the agent should pick it, and a concrete prompt a user can paste. Availability of `search_wandb_docs_tool` depends on `WANDB_MCP_PROXY_DOCS` (enabled by default).
 
 <Tabs>
+  <Tab title="Discovery">
+    Use these tools first when you do not know the exact entity, project, or schema to query.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `list_entities_tool` | You have not specified which entity to use, or need to see what teams and accounts the API key can reach. | "What W&B teams do I have access to?" |
+    | `query_wandb_entity_projects` | You know the entity but not the project name, or earlier queries failed with project not found. | "List all projects under `your-team`." |
+    | `probe_project_tool` | Starting work on an unfamiliar run-based project and you need to discover available metrics, config keys, and tags. | "Probe `your-team/your-project` and tell me what metrics are logged." |
+    | `infer_trace_schema_tool` | Starting work on an unfamiliar Weave traces project and you need field names, types, and sample values before querying. | "What fields are on the Weave traces in `your-team/your-project`?" |
+  </Tab>
   <Tab title="Experiments and runs">
-    | Tool | Description |
-    |------|-------------|
-    | `query_wandb_tool` | Query W&B runs, metrics, configs, and summaries using GraphQL. |
-    | `get_run_history_tool` | Retrieve sampled time-series metric data for a run. |
-    | `query_wandb_entity_projects` | List projects visible to an entity. |
+    Query, compare, and diagnose W&B Models runs.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `query_wandb_tool` | The question is about runs, sweeps, configs, summaries, or artifacts in W&B Models. Runs a GraphQL query. | "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`." |
+    | `get_run_history_tool` | The question is about training curves, metric trends over time, or any time-series logged to a run. | "Plot the loss curve for run `abc123` in `your-team/your-project`." |
+    | `compare_runs_tool` | The user asks what changed between two runs, or which of two runs is better. Returns config diff, metric delta, and optional aligned history. | "Compare runs `abc123` and `def456` in `your-team/your-project`." |
+    | `diagnose_run_tool` | The user asks if a run converged, is overfitting, or hit NaN values. Returns actionable recommendations. | "Is run `abc123` in `your-team/your-project` overfitting?" |
   </Tab>
   <Tab title="Weave traces">
-    | Tool | Description |
-    |------|-------------|
-    | `infer_trace_schema_tool` | Discover field names, types, and sample values before you query. |
-    | `query_weave_traces_tool` | Query Weave traces with a configurable `detail_level` and column projection. |
-    | `count_weave_traces_tool` | Count traces and retrieve storage metrics. |
+    Query and aggregate LLM traces and evaluations.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `query_weave_traces_tool` | You need trace data (LLM calls, evaluations, agent runs). Start with `detail_level="summary"` and escalate to `"full"` only for specific traces. | "Show me failed traces in `your-team/your-project` from the last 24 hours." |
+    | `count_weave_traces_tool` | The user asks how many traces or how many errors, and you do not need the trace data itself. | "How many traces failed in `your-team/your-project` this week?" |
+    | `resolve_trace_roots_tool` | After `query_weave_traces_tool` finds child traces and you need to map each back to its root session or workflow in one batched call. | "Find LLM calls that contain `rate limit` and tell me which sessions they belong to." |
+    | `summarize_evaluation_tool` | The user asks how an eval went, what the pass rate is, or which tasks fail most. Aggregates `Evaluation.evaluate` hierarchies. | "Summarize the most recent eval in `your-team/your-project`." |
   </Tab>
   <Tab title="Reports">
-    | Tool | Description |
-    |------|-------------|
-    | `create_wandb_report_tool` | Create W&B reports with Markdown, line plots, bar plots, and run comparisons. Accepts a `panels` parameter. |
-    | `log_analysis_to_wandb` | Log analysis results from the current MCP session to W&B as a run. |
+    Persist analysis back to W&B.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `create_wandb_report_tool` | The user explicitly asks to create a report or save findings. Accepts Markdown plus a `panels` array for line plots, bar plots, and run comparisons. | "Create a W&B report comparing runs `abc123` and `def456`." |
+    | `log_analysis_to_wandb` | You computed values in the MCP session (latency distributions, error breakdowns) that should be persisted as a run before being referenced in a report. | "Log these latency percentiles to W&B as an analysis run." |
   </Tab>
   <Tab title="Artifacts and registry">
-    | Tool | Description |
-    |------|-------------|
-    | `list_registries_tool` | List model registries in an organization. |
-    | `list_registry_collections_tool` | List collections within a registry. |
-    | `list_artifact_versions_tool` | List versions of an artifact collection. |
-    | `get_artifact_details_tool` | Get full details for an artifact version. |
-    | `compare_artifact_versions_tool` | Diff two artifact versions. |
+    Inspect and diff models, datasets, and other versioned artifacts.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `list_registries_tool` | The user asks about model registries, registered models, or registered datasets in an organization. | "What registries exist in `your-org`?" |
+    | `list_registry_collections_tool` | The user wants to see what models or datasets live inside a specific registry. | "What collections are in the `model` registry of `your-org`?" |
+    | `list_artifact_versions_tool` | The user wants to see available versions of a model, dataset, or other artifact collection. | "List versions of `production-model` in `your-team/your-project`." |
+    | `get_artifact_details_tool` | The user wants to inspect one specific artifact version, including lineage and files. | "What is in `production-model:v3`?" |
+    | `compare_artifact_versions_tool` | The user asks what changed between two artifact versions. | "Diff `production-model:v2` and `production-model:v3`." |
   </Tab>
   <Tab title="Docs">
-    | Tool | Description |
-    |------|-------------|
-    | `search_wandb_docs_tool` | Search the official W&B documentation at [docs.wandb.ai](https://docs.wandb.ai). Controlled by `WANDB_MCP_PROXY_DOCS` (enabled by default). |
+    Answer product questions from the official W&B documentation.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `search_wandb_docs_tool` | The user asks how to use a W&B or Weave feature or API. Proxies [docs.wandb.ai](https://docs.wandb.ai). | "How do I create a leaderboard in Weave?" |
   </Tab>
 </Tabs>
 
@@ -95,6 +117,46 @@ For Weave trace queries, call `infer_trace_schema_tool` first to discover availa
 | `full` | Everything untruncated. Use to drill into a small number of specific traces. |
 
 This pattern keeps token usage low for broad questions and lets the agent escalate to `full` only for the traces that matter.
+
+### Recommended workflows
+
+Most real questions need more than one tool. Ask your agent to follow one of these chains.
+
+#### Explore an unfamiliar project
+
+Use when you land on a new entity or project and do not know what is logged.
+
+1. `list_entities_tool` to find the entity.
+2. `query_wandb_entity_projects` to find the project.
+3. `probe_project_tool` for run-based projects, or `infer_trace_schema_tool` for Weave trace projects.
+4. A targeted `query_wandb_tool` or `query_weave_traces_tool` call using the discovered keys.
+
+#### Triage failing LLM calls
+
+Use when the agent needs to find bad traces and understand the sessions that produced them.
+
+1. `query_weave_traces_tool` with a filter on error or exception fields, and `detail_level="summary"`.
+2. `resolve_trace_roots_tool` on the resulting `trace_id` list to map each failure to its root session.
+3. `query_weave_traces_tool` with `detail_level="full"` on a small number of specific roots to drill in.
+4. `create_wandb_report_tool` to document the findings.
+
+#### Diagnose a bad training run
+
+Use when a run looks wrong and the user wants a health check.
+
+1. `get_run_history_tool` to pull the loss and validation curves.
+2. `diagnose_run_tool` for automated convergence, overfitting, and NaN checks.
+3. `compare_runs_tool` against a known-good baseline run.
+4. `create_wandb_report_tool` with line-plot panels to share the diagnosis.
+
+#### Summarize evals and compare model versions
+
+Use when the user asks which model version performed best on an evaluation.
+
+1. `summarize_evaluation_tool` for per-scorer pass rates and error counts.
+2. `list_artifact_versions_tool` on the relevant model collection.
+3. `compare_artifact_versions_tool` between the candidate and current production version.
+4. `log_analysis_to_wandb` and `create_wandb_report_tool` to publish the comparison.
 
 ## Prerequisites
 
@@ -111,7 +173,7 @@ W&B runs a hosted MCP server at `https://mcp.withwandb.com` for Multi-tenant Clo
 <Tabs>
 <Tab title="Cursor">
 
-Install the server in Cursor automatically with the [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=), then replace `YOUR_WANDB_API_KEY` with your W&B API key in the `Authorization` field.
+Install the server in Cursor automatically with the [one-click installation link](https://cursor.com/en/install-mcp?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIge3tXQU5EQl9BUElfS0VZfX0iLCJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2V2ZW50LXN0cmVhbSJ9fQ%3D%3D), then replace the placeholder with your W&B API key in the `Authorization` field.
 
 To configure Cursor manually:
 
@@ -136,9 +198,9 @@ To configure Cursor manually:
     ```
 
 5. Restart Cursor.
-6. Verify the connection by asking the agent "List the projects in my W&B account."
+6. Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
 
-For more information, see [Cursor's MCP documentation](https://cursor.com/docs/context/mcp).
+If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Cursor's MCP documentation](https://cursor.com/docs/context/mcp).
 </Tab>
 <Tab title="VS Code">
 
@@ -158,7 +220,9 @@ Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `
 }
 ```
 
-Restart VS Code and confirm the server appears in the MCP panel.
+Restart VS Code, confirm the server appears in the MCP panel, and verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
+
+If the connection fails, see [Troubleshooting](#troubleshooting).
 </Tab>
 <Tab title="Claude Code">
 
@@ -171,7 +235,7 @@ claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
 
 Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
 
-For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
 </Tab>
 <Tab title="Codex">
 
@@ -183,6 +247,8 @@ codex mcp add wandb \
   --url https://mcp.withwandb.com/mcp \
   --bearer-token-env-var WANDB_API_KEY
 ```
+
+Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting).
 </Tab>
 <Tab title="Gemini CLI">
 
@@ -192,9 +258,9 @@ Install the W&B MCP extension:
 gemini extensions install https://github.com/wandb/wandb-mcp-server
 ```
 
-Restart Gemini CLI. Verify the connection by asking "List the projects in my W&B account."
+Restart Gemini CLI. Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
 
-For more information, see [Gemini CLI's MCP documentation](https://geminicli.com/docs/tools/mcp-server/).
+If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Gemini CLI's MCP documentation](https://geminicli.com/docs/tools/mcp-server/).
 </Tab>
 <Tab title="Mistral LeChat">
 
@@ -208,9 +274,9 @@ For more information, see [Gemini CLI's MCP documentation](https://geminicli.com
     - **Header type**: Select **Bearer**.
     - **Header value**: Your W&B API key.
 4. Select **Create**.
-5. Verify the connection by asking "List the projects in my W&B account."
+5. Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
 
-For more information, see [LeChat's MCP documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
+If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [LeChat's MCP documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
 </Tab>
 <Tab title="OpenAI Responses API">
 
@@ -232,13 +298,13 @@ resp = client.responses.create(
         "authorization": os.getenv("WANDB_API_KEY"),
         "require_approval": "never",
     }],
-    input="List the projects in my W&B account.",
+    input="List my W&B entities.",
 )
 
 print(resp.output_text)
 ```
 
-The OpenAI MCP integration runs server-side, so it cannot reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
+Pass the raw W&B API key as the `authorization` value. OpenAI prepends `Bearer ` when it calls the server, so do not include it yourself. The OpenAI MCP integration runs server-side, so it cannot reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
 </Tab>
 </Tabs>
 
@@ -439,13 +505,40 @@ For the complete command-line reference and advanced options, see the [wandb-mcp
 
 ## Usage tips
 
-Follow these practices to get good results from the MCP server:
+The following practices apply to everyone. Read the subsection that matches your workload for more specific advice.
+
+### For everyone
 
 - **Specify the entity and project.** MCP tools need an explicit entity and project name. Include both in every question, for example "in `your-team/your-project`".
 - **Ask focused questions.** Prefer "Which eval had the highest F1 score?" to "What is my best evaluation?". Specific metrics and time ranges produce better tool calls.
-- **Use the schema-first workflow for traces.** Have the agent call `infer_trace_schema_tool` before `query_weave_traces_tool`, and start with `detail_level: "summary"`. Escalate to `"full"` only when drilling into specific traces.
-- **Verify full retrieval.** For broad questions like "What are my best performing runs?", ask the agent to confirm that it retrieved all available runs rather than only the most recent ones.
-- **Combine with W&B Skills.** [W&B Skills](/platform/wb-skills) teach coding agents how to structure W&B workflows. Skills and MCP work well together, because Skills provide patterns and MCP provides data access.
+- **Verify full retrieval.** For broad questions such as "What are my best performing runs?", ask the agent to confirm it retrieved all available runs rather than only the most recent ones.
+- **Combine with W&B Skills.** [W&B Skills](/platform/wb-skills) teach coding agents how to structure W&B workflows. Skills provide patterns and MCP provides data access, and the two work well together.
+
+### For trace-heavy workflows
+
+- **Start with the schema.** Call `infer_trace_schema_tool` before `query_weave_traces_tool` so the agent knows which fields and filter values are valid.
+- **Pick the right `detail_level`.** Use `schema` to browse, `summary` (the default) for analysis, and `full` only when drilling into a small number of specific traces.
+- **Chain `resolve_trace_roots_tool`.** After a child-trace query, pass the resulting `trace_id` list to `resolve_trace_roots_tool` to map each trace to its root session in one batched call.
+- **Prefer `summarize_evaluation_tool` for evals.** It aggregates the `Evaluation.evaluate` and `predict_and_score` hierarchy automatically. Only fall back to `query_weave_traces_tool` for raw trace data.
+
+### For run-heavy workflows
+
+- **Probe before you query.** Call `probe_project_tool` on an unfamiliar run-based project to discover metric keys, config keys, and tags before constructing GraphQL.
+- **Use `get_run_history_tool` for time series.** GraphQL does not sample, so for loss curves and other time-series data `get_run_history_tool` is both faster and cheaper.
+- **Let `compare_runs_tool` do the diff.** It returns config and metric deltas with aligned history in a single call, avoiding manual comparison.
+- **Run a health check first.** When a training run looks wrong, call `diagnose_run_tool` before digging into history manually.
+
+### For Dedicated Cloud and Self-Managed
+
+- Always set `WANDB_BASE_URL` (on the server, or in your client env block) to your instance URL. Without it, the server targets `api.wandb.ai` and no data will be found.
+- The managed MCP server exposes the same tools as the hosted Multi-tenant server.
+- Rate limits on Dedicated Cloud are separate from Multi-tenant. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for defaults and how to request changes.
+
+### For local installs
+
+- Prefer STDIO transport for desktop clients (Cursor, VS Code, Claude Code, Claude Desktop). Only switch to HTTP transport when a client explicitly requires it (for example, the OpenAI Responses API).
+- When tool calls fail silently, set `MCP_SERVER_LOG_LEVEL=DEBUG` in the client's `env` block and re-check the client's MCP logs.
+- If you install from GitHub (`uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server`), `uvx` pins to the default branch. Pin an explicit tag by appending `@v0.3.2` to the Git URL when you need a stable version.
 
 ## Troubleshooting
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -7,9 +7,9 @@ The W&B Model Context Protocol (MCP) server exposes your W&B data as a set of to
 
 Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex, Gemini CLI, Mistral LeChat, Claude Desktop, and the OpenAI Responses API.
 
-## Which setup should I use?
+## Choose a setup
 
-The hosted MCP server is the default for every deployment. The only thing that differs between deployment types is the URL your client connects to. Running the server locally is an escape hatch when you need more flexibility than the hosted server offers.
+The hosted MCP server is the default for every deployment. The only thing that differs between deployment types is the URL your client connects to. A local install is an escape hatch when you need more flexibility than the hosted server offers.
 
 <CardGroup cols={2}>
   <Card title="Hosted server (recommended)">
@@ -28,7 +28,7 @@ The hosted MCP server is the default for every deployment. The only thing that d
 </CardGroup>
 
 <Tip>
-If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server is not yet enabled on your instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it.
+If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server isn't yet enabled on your instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it.
 </Tip>
 
 ## What you can do
@@ -47,7 +47,7 @@ The server registers a set of tools grouped by purpose. Each row lists the tool 
 
 <Tabs>
   <Tab title="Discovery">
-    Use these tools first when you do not know the exact entity, project, or schema to query.
+    Use these tools first when you don't know the exact entity, project, or schema to query.
 
     | Tool | Use when | Example prompt |
     |------|----------|----------------|
@@ -122,7 +122,7 @@ Most real questions need more than one tool. Ask your agent to follow one of the
 
 #### Explore an unfamiliar project
 
-Use when you land on a new entity or project and do not know what is logged.
+Use when you land on a new entity or project and don't know what is logged.
 
 1. `list_entities_tool` to find the entity.
 2. `query_wandb_entity_projects` to find the project.
@@ -166,7 +166,7 @@ Before you configure any client:
 
 ## Use the hosted server
 
-W&B runs a managed MCP server for every deployment type. There is nothing to install. Configure your client to connect over HTTP with a W&B API key in the `Authorization` header.
+W&B runs a managed MCP server for every deployment type. You don't need to install anything. Configure your client to connect over HTTP with a W&B API key in the `Authorization` header.
 
 ### Connection URL
 
@@ -316,25 +316,27 @@ resp = client.responses.create(
 print(resp.output_text)
 ```
 
-Pass the raw W&B API key as the `authorization` value. OpenAI prepends `Bearer ` when it calls the server, so do not include it yourself. The OpenAI MCP integration runs server-side, so it cannot reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
+Pass the raw W&B API key as the `authorization` value. OpenAI prepends `Bearer ` when it calls the server, so don't include it yourself. The OpenAI MCP integration runs server-side, so it can't reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
 </Tab>
 </Tabs>
 
 ## Run the MCP server locally
 
-Running the MCP server locally is an escape hatch, not the default path for any particular deployment. Use it when the hosted server does not fit your setup.
+A local MCP server is an escape hatch, not the default path for any particular deployment. Use it when the hosted server doesn't fit your setup.
 
 Common reasons to run locally:
 
-- **Air-gapped or offline environments** where your client cannot reach a hosted W&B endpoint.
+- **Air-gapped or offline environments** where your client can't reach a hosted W&B endpoint.
 - **Pinned version**. The hosted server follows the main branch. A local install can pin to a specific release tag.
 - **Custom server behavior** such as changing tool descriptions, adding tools, or setting a non-default response token budget.
 - **Active development** on the server itself.
 - **STDIO-only clients** or clients that require a local process.
 
-For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only fall back to a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server is not yet enabled on your instance or one of the reasons above applies. Set `WANDB_BASE_URL` to your instance URL.
+For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only fall back to a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server isn't yet enabled on your instance or one of the reasons above applies. Set `WANDB_BASE_URL` to your instance URL.
 
 ### Local prerequisites
+
+To run the server locally, make sure you have the following:
 
 - Python 3.11 or higher.
 - [`uv`](https://docs.astral.sh/uv/) is recommended. For installation instructions, see the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/). You can use `pip` instead.
@@ -494,6 +496,8 @@ Update your MCP client configuration to use the tunnel URL.
 
 ### Environment variables
 
+The following environment variables control authentication, instance routing, and server behavior for local installs. Set them in your client's `env` block or export them in your shell.
+
 | Variable | Description |
 |----------|-------------|
 | `WANDB_API_KEY` | W&B API key for authentication. Required. |
@@ -507,9 +511,11 @@ For the complete command-line reference and advanced options, see the [wandb-mcp
 
 ## Usage tips
 
-The following practices apply to everyone. Read the subsection that matches your workload for more specific advice.
+The following practices help you get better results from the MCP server. Start with the general tips, then read the subsection that matches your workload for more specific advice.
 
 ### For everyone
+
+Follow these practices regardless of your workload:
 
 - **Specify the entity and project.** MCP tools need an explicit entity and project name. Include both in every question, for example "in `your-team/your-project`".
 - **Ask focused questions.** Prefer "Which eval had the highest F1 score?" to "What is my best evaluation?". Specific metrics and time ranges produce better tool calls.
@@ -518,6 +524,8 @@ The following practices apply to everyone. Read the subsection that matches your
 
 ### For trace-heavy workflows
 
+Follow these practices when working with Weave traces:
+
 - **Start with the schema.** Call `infer_trace_schema_tool` before `query_weave_traces_tool` so the agent knows which fields and filter values are valid.
 - **Pick the right `detail_level`.** Use `schema` to browse, `summary` (the default) for analysis, and `full` only when drilling into a small number of specific traces.
 - **Chain `resolve_trace_roots_tool`.** After a child-trace query, pass the resulting `trace_id` list to `resolve_trace_roots_tool` to map each trace to its root session in one batched call.
@@ -525,21 +533,27 @@ The following practices apply to everyone. Read the subsection that matches your
 
 ### For run-heavy workflows
 
+Follow these practices when working with W&B Models runs:
+
 - **Probe before you query.** Call `probe_project_tool` on an unfamiliar run-based project to discover metric keys, config keys, and tags before constructing GraphQL.
-- **Use `get_run_history_tool` for time series.** GraphQL does not sample, so for loss curves and other time-series data `get_run_history_tool` is both faster and cheaper.
+- **Use `get_run_history_tool` for time series.** GraphQL doesn't sample, so for loss curves and other time-series data `get_run_history_tool` is both faster and cheaper.
 - **Let `compare_runs_tool` do the diff.** It returns config and metric deltas with aligned history in a single call, avoiding manual comparison.
 - **Run a health check first.** When a training run looks wrong, call `diagnose_run_tool` before digging into history manually.
 
 ### For Dedicated Cloud and Self-Managed
 
-- Prefer the hosted server on your instance at `https://<your-instance>/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server is not yet enabled.
-- When you do run locally against your instance, set `WANDB_BASE_URL` to your instance URL in the client's `env` block. Without it, the server targets `api.wandb.ai` and no data will be found.
+Keep these considerations in mind for non-multi-tenant deployments:
+
+- Prefer the hosted server on your instance at `https://<your-instance>/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server isn't yet enabled.
+- When you do run locally against your instance, set `WANDB_BASE_URL` to your instance URL in the client's `env` block. Without it, the server targets `api.wandb.ai` and the server returns no data.
 - Rate limits on Dedicated Cloud are separate from Multi-tenant. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for defaults and how to request changes.
 
 ### For local installs
 
+Keep these considerations in mind when running the server on your own machine:
+
 - Prefer STDIO transport for desktop clients (Cursor, VS Code, Claude Code, Claude Desktop). Only switch to HTTP transport when a client explicitly requires it (for example, the OpenAI Responses API).
-- When tool calls fail silently, set `MCP_SERVER_LOG_LEVEL=DEBUG` in the client's `env` block and re-check the client's MCP logs.
+- When tool calls fail silently, set `MCP_SERVER_LOG_LEVEL=DEBUG` in the client's `env` block and recheck the client's MCP logs.
 - If you install from GitHub (`uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server`), `uvx` pins to the default branch. Pin an explicit tag by appending `@v0.3.2` to the Git URL when you need a stable version.
 
 ## Troubleshooting
@@ -553,6 +567,8 @@ The following practices apply to everyone. Read the subsection that matches your
 | Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
 
 ## Related
+
+Explore these resources for observability, reusable agent patterns, and advanced server configuration:
 
 - [Trace MCP clients and servers with Weave](/weave/guides/integrations/mcp) for end-to-end observability of MCP interactions.
 - [W&B Skills](/platform/wb-skills) for reusable agent instructions that pair with the MCP server.

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -9,28 +9,26 @@ Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex,
 
 ## Which setup should I use?
 
-W&B offers three ways to run the MCP server. Pick the one that matches your deployment:
+The hosted MCP server is the default for every deployment. The only thing that differs between deployment types is the URL your client connects to. Running the server locally is an escape hatch when you need more flexibility than the hosted server offers.
 
-<CardGroup cols={3}>
-  <Card title="Multi-tenant Cloud">
-    Use the hosted server at `mcp.withwandb.com`. No installation required.
+<CardGroup cols={2}>
+  <Card title="Hosted server (recommended)">
+    A W&B-managed MCP server that your client connects to over HTTP with your W&B API key. No installation, no local process to maintain.
+
+    - Multi-tenant Cloud: `https://mcp.withwandb.com/mcp`.
+    - Dedicated Cloud or Self-Managed: `https://<your-instance>/mcp`, once W&B enables it on your deployment.
 
     [Use the hosted server](#use-the-hosted-server)
   </Card>
-  <Card title="Dedicated Cloud or Self-Managed">
-    Request enablement of the managed MCP server on your deployment. Your team connects to `https://<your-instance>/mcp` with an existing W&B API key.
-
-    [Use MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed)
-  </Card>
-  <Card title="Local install">
-    Run the MCP server on your machine. Useful for air-gapped environments, development, and clients that require STDIO.
+  <Card title="Local install (escape hatch)">
+    Run the MCP server on your own machine over STDIO or HTTP. Use when you need air-gapped operation, pinning to a specific release, custom server behavior, active server development, or support for a client that only speaks STDIO.
 
     [Run the MCP server locally](#run-the-mcp-server-locally)
   </Card>
 </CardGroup>
 
 <Tip>
-To request the managed MCP server on a Dedicated Cloud or Self-Managed instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team.
+If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server is not yet enabled on your instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it.
 </Tip>
 
 ## What you can do
@@ -168,7 +166,21 @@ Before you configure any client:
 
 ## Use the hosted server
 
-W&B runs a hosted MCP server at `https://mcp.withwandb.com` for Multi-tenant Cloud users. There is nothing to install. Configure your client to connect to `https://mcp.withwandb.com/mcp` with a bearer token.
+W&B runs a managed MCP server for every deployment type. There is nothing to install. Configure your client to connect over HTTP with a W&B API key in the `Authorization` header.
+
+### Connection URL
+
+The URL depends on where your W&B deployment lives.
+
+| Deployment | Server URL |
+|------------|------------|
+| Multi-tenant Cloud | `https://mcp.withwandb.com/mcp` |
+| Dedicated Cloud | `https://<your-instance>/mcp` |
+| Self-Managed | `https://<your-instance>/mcp` |
+
+For Dedicated Cloud and Self-Managed, the MCP server must first be enabled on your instance. Contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it. Once enabled, your team authenticates with an existing W&B API key, exactly as they do against the W&B app.
+
+The client configurations below use the Multi-tenant URL. For Dedicated Cloud or Self-Managed, replace `https://mcp.withwandb.com/mcp` with `https://<your-instance>/mcp` and keep everything else the same.
 
 <Tabs>
 <Tab title="Cursor">
@@ -308,29 +320,19 @@ Pass the raw W&B API key as the `authorization` value. OpenAI prepends `Bearer `
 </Tab>
 </Tabs>
 
-## Use MCP on Dedicated Cloud or Self-Managed
-
-The hosted server at `mcp.withwandb.com` targets Multi-tenant Cloud. [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) customers have two options.
-
-### Request the managed MCP server on your deployment
-
-W&B can enable a managed MCP server on your Dedicated Cloud or Self-Managed instance. Once enabled:
-
-- The server is reachable at `https://<your-instance>/mcp`.
-- Your team authenticates with an existing W&B API key, the same way they authenticate to the W&B app.
-- The same tools described in [What you can do](#what-you-can-do) are available.
-
-To request enablement, contact [W&B support](mailto:support@wandb.com) or your W&B account team. Once the server is available, configure your MCP client as shown in [Use the hosted server](#use-the-hosted-server), replacing the `https://mcp.withwandb.com/mcp` URL with `https://<your-instance>/mcp`.
-
-### Self-serve from the open-source repo
-
-For air-gapped environments, development work, or instances where the managed MCP is not yet enabled, you can run the MCP server locally from the [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) open-source repository and point it at your instance.
-
-Install and configure the local server as described in [Run the MCP server locally](#run-the-mcp-server-locally), and set `WANDB_BASE_URL` to your instance URL.
-
 ## Run the MCP server locally
 
-Run the MCP server on your own machine for air-gapped environments, development, testing, or clients that only support STDIO.
+Running the MCP server locally is an escape hatch, not the default path for any particular deployment. Use it when the hosted server does not fit your setup.
+
+Common reasons to run locally:
+
+- **Air-gapped or offline environments** where your client cannot reach a hosted W&B endpoint.
+- **Pinned version**. The hosted server follows the main branch. A local install can pin to a specific release tag.
+- **Custom server behavior** such as changing tool descriptions, adding tools, or setting a non-default response token budget.
+- **Active development** on the server itself.
+- **STDIO-only clients** or clients that require a local process.
+
+For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only fall back to a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server is not yet enabled on your instance or one of the reasons above applies. Set `WANDB_BASE_URL` to your instance URL.
 
 ### Local prerequisites
 
@@ -530,8 +532,8 @@ The following practices apply to everyone. Read the subsection that matches your
 
 ### For Dedicated Cloud and Self-Managed
 
-- Always set `WANDB_BASE_URL` (on the server, or in your client env block) to your instance URL. Without it, the server targets `api.wandb.ai` and no data will be found.
-- The managed MCP server exposes the same tools as the hosted Multi-tenant server.
+- Prefer the hosted server on your instance at `https://<your-instance>/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server is not yet enabled.
+- When you do run locally against your instance, set `WANDB_BASE_URL` to your instance URL in the client's `env` block. Without it, the server targets `api.wandb.ai` and no data will be found.
 - Rate limits on Dedicated Cloud are separate from Multi-tenant. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for defaults and how to request changes.
 
 ### For local installs
@@ -546,7 +548,7 @@ The following practices apply to everyone. Read the subsection that matches your
 |---------|---------------|
 | `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
 | Empty results for queries you expect to succeed | The entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
-| Cannot reach `mcp.withwandb.com/mcp` from Dedicated Cloud or Self-Managed | The hosted server targets Multi-tenant Cloud only. Use [MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed) instead. |
+| `404 Not Found` or `connection refused` on `https://<your-instance>/mcp` | The hosted MCP server is not yet enabled on your Dedicated Cloud or Self-Managed instance, or the client is pointed at the wrong URL. Contact [W&B support](mailto:support@wandb.com) to request enablement, then confirm the URL in [Connection URL](#connection-url). |
 | `429 Too Many Requests` on Dedicated Cloud | You have hit your instance's rate limits. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for how to request higher limits. |
 | Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -247,20 +247,20 @@ Common reasons to run locally:
 - **Active development** on the server itself.
 - **STDIO-only clients** or clients that require a local process.
 
-For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only fall back to a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server isn't yet enabled on your instance or one of the reasons above applies. Set `WANDB_BASE_URL` to your instance URL.
+For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only use a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server isn't yet enabled on your instance or one of the reasons above applies. Set a `WANDB_BASE_URL` environment variable to your instance URL.
 
 ### Local prerequisites
 
 To run the server locally, make sure you have the following:
 
 - Python 3.11 or higher.
-- [`uv`](https://docs.astral.sh/uv/) is recommended. For installation instructions, see the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/). You can use `pip` instead.
+- [`uv`](https://docs.astral.sh/uv/) or `pip`.
 - A W&B API key, set as `WANDB_API_KEY`.
 - `WANDB_BASE_URL` set to your instance URL if you use Dedicated Cloud or Self-Managed.
 
 ### Install the server
 
-Choose an install method:
+Choose an install method and run the following command to install the MCP server:
 
 <Tabs>
 <Tab title="uvx (no permanent install)">
@@ -287,7 +287,7 @@ pip install git+https://github.com/wandb/wandb-mcp-server
 
 ### Configure your client
 
-Select your MCP client:
+Select your MCP client and then run the following configuration, replacing `<your-wandb-api-key>` with your W&B API key as necessary:
 
 <Tabs>
 <Tab title="Claude Code">

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -1,9 +1,9 @@
 ---
-title: Use the W&B MCP server
+title: Use the W&B MCP Server
 description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste.
+Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste.
 
 It integrates natively with most IDEs, coding clients, and chat agents, including:
 
@@ -511,7 +511,7 @@ This pattern keeps token usage low for broad questions and lets the agent escala
 
 ## Usage tips
 
-The following practices and workflows help you get better results from the W&B MCP server. Start with the general practices, then read the subsection that matches your workload for more specific advice and multi-step tool chains.
+The following practices and workflows help you get better results from the W&B MCP Server. Start with the general practices, then read the subsection that matches your workload for more specific advice and multi-step tool chains.
 
 ### General best practices
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -3,24 +3,29 @@ title: Use the W&B MCP server
 description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-The W&B Model Context Protocol (MCP) server exposes your W&B data as a set of tools that any [MCP](https://modelcontextprotocol.io) client can call. Connect your IDE or AI agent to the server and ask it to analyze experiments, debug Weave traces, generate reports, inspect artifacts and registry, and search W&B documentation, all without writing custom GraphQL or SDK code.
+Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste.
 
-Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex, Gemini CLI, Mistral LeChat, Claude Desktop, and the OpenAI Responses API.
+It integrates natively with most IDEs, coding clients, and chat agents, including:
 
-## Choose a setup
+- Cursor
+- Visual Studio Code (VS Code)
+- Claude Code
+- Codex
+- Gemini CLI
+- Mistral LeChat
+- Claude Desktop
 
-The hosted MCP server is the default for every deployment. The only thing that differs between deployment types is the URL your client connects to. A local install is an escape hatch when you need more flexibility than the hosted server offers.
+## Deployment types
+
+You can use either the hosted MCP server or set up a local version if you need more isolation and flexibility. Using the local version requires your client to use a different URL to access the server.
 
 <CardGroup cols={2}>
   <Card title="Hosted server (recommended)">
     A W&B-managed MCP server that your client connects to over HTTP with your W&B API key. No installation, no local process to maintain.
 
-    - Multi-tenant Cloud: `https://mcp.withwandb.com/mcp`.
-    - Dedicated Cloud or Self-Managed: `https://<your-instance>/mcp`, once W&B enables it on your deployment.
-
     [Use the hosted server](#use-the-hosted-server)
   </Card>
-  <Card title="Local install (escape hatch)">
+  <Card title="Local install">
     Run the MCP server on your own machine over STDIO or HTTP. Use when you need air-gapped operation, pinning to a specific release, custom server behavior, active server development, or support for a client that only speaks STDIO.
 
     [Run the MCP server locally](#run-the-mcp-server-locally)
@@ -31,136 +36,11 @@ The hosted MCP server is the default for every deployment. The only thing that d
 If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server isn't yet enabled on your instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it.
 </Tip>
 
-## What you can do
-
-Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following are representative prompts:
-
-- "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`."
-- "How did the latency of my hiring agent's `predict` traces evolve over the last month?"
-- "Generate a W&B report comparing decisions made by the hiring agent last week."
-- "What versions of the `production-model` artifact exist, and what changed between `v2` and `v3`?"
-- "How do I create a leaderboard in Weave?"
-
-### Available tools
-
-The server registers a set of tools grouped by purpose. Each row lists the tool name, when the agent should pick it, and a concrete prompt a user can paste. Availability of `search_wandb_docs_tool` depends on `WANDB_MCP_PROXY_DOCS` (enabled by default).
-
-<Tabs>
-  <Tab title="Discovery">
-    Use these tools first when you don't know the exact entity, project, or schema to query.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `list_entities_tool` | You have not specified which entity to use, or need to see what teams and accounts the API key can reach. | "What W&B teams do I have access to?" |
-    | `query_wandb_entity_projects` | You know the entity but not the project name, or earlier queries failed with project not found. | "List all projects under `your-team`." |
-    | `probe_project_tool` | Starting work on an unfamiliar run-based project and you need to discover available metrics, config keys, and tags. | "Probe `your-team/your-project` and tell me what metrics are logged." |
-    | `infer_trace_schema_tool` | Starting work on an unfamiliar Weave traces project and you need field names, types, and sample values before querying. | "What fields are on the Weave traces in `your-team/your-project`?" |
-  </Tab>
-  <Tab title="Experiments and runs">
-    Query, compare, and diagnose W&B Models runs.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `query_wandb_tool` | The question is about runs, sweeps, configs, summaries, or artifacts in W&B Models. Runs a GraphQL query. | "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`." |
-    | `get_run_history_tool` | The question is about training curves, metric trends over time, or any time-series logged to a run. | "Plot the loss curve for run `abc123` in `your-team/your-project`." |
-    | `compare_runs_tool` | The user asks what changed between two runs, or which of two runs is better. Returns config diff, metric delta, and optional aligned history. | "Compare runs `abc123` and `def456` in `your-team/your-project`." |
-    | `diagnose_run_tool` | The user asks if a run converged, is overfitting, or hit NaN values. Returns actionable recommendations. | "Is run `abc123` in `your-team/your-project` overfitting?" |
-  </Tab>
-  <Tab title="Weave traces">
-    Query and aggregate LLM traces and evaluations.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `query_weave_traces_tool` | You need trace data (LLM calls, evaluations, agent runs). Start with `detail_level="summary"` and escalate to `"full"` only for specific traces. | "Show me failed traces in `your-team/your-project` from the last 24 hours." |
-    | `count_weave_traces_tool` | The user asks how many traces or how many errors, and you do not need the trace data itself. | "How many traces failed in `your-team/your-project` this week?" |
-    | `resolve_trace_roots_tool` | After `query_weave_traces_tool` finds child traces and you need to map each back to its root session or workflow in one batched call. | "Find LLM calls that contain `rate limit` and tell me which sessions they belong to." |
-    | `summarize_evaluation_tool` | The user asks how an eval went, what the pass rate is, or which tasks fail most. Aggregates `Evaluation.evaluate` hierarchies. | "Summarize the most recent eval in `your-team/your-project`." |
-  </Tab>
-  <Tab title="Reports">
-    Persist analysis back to W&B.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `create_wandb_report_tool` | The user explicitly asks to create a report or save findings. Accepts Markdown plus a `panels` array for line plots, bar plots, and run comparisons. | "Create a W&B report comparing runs `abc123` and `def456`." |
-    | `log_analysis_to_wandb` | You computed values in the MCP session (latency distributions, error breakdowns) that should be persisted as a run before being referenced in a report. | "Log these latency percentiles to W&B as an analysis run." |
-  </Tab>
-  <Tab title="Artifacts and registry">
-    Inspect and diff models, datasets, and other versioned artifacts.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `list_registries_tool` | The user asks about model registries, registered models, or registered datasets in an organization. | "What registries exist in `your-org`?" |
-    | `list_registry_collections_tool` | The user wants to see what models or datasets live inside a specific registry. | "What collections are in the `model` registry of `your-org`?" |
-    | `list_artifact_versions_tool` | The user wants to see available versions of a model, dataset, or other artifact collection. | "List versions of `production-model` in `your-team/your-project`." |
-    | `get_artifact_details_tool` | The user wants to inspect one specific artifact version, including lineage and files. | "What is in `production-model:v3`?" |
-    | `compare_artifact_versions_tool` | The user asks what changed between two artifact versions. | "Diff `production-model:v2` and `production-model:v3`." |
-  </Tab>
-  <Tab title="Docs">
-    Answer product questions from the official W&B documentation.
-
-    | Tool | Use when | Example prompt |
-    |------|----------|----------------|
-    | `search_wandb_docs_tool` | The user asks how to use a W&B or Weave feature or API. Proxies [docs.wandb.ai](https://docs.wandb.ai). | "How do I create a leaderboard in Weave?" |
-  </Tab>
-</Tabs>
-
-### Schema-first trace queries
-
-For Weave trace queries, call `infer_trace_schema_tool` first to discover available fields, then call `query_weave_traces_tool` with a precise column list and `detail_level`:
-
-| `detail_level` | When to use |
-|----------------|-------------|
-| `schema` | Structural fields only. Fastest. Use for browsing and counting. |
-| `summary` | Truncated inputs and outputs. The default. |
-| `full` | Everything untruncated. Use to drill into a small number of specific traces. |
-
-This pattern keeps token usage low for broad questions and lets the agent escalate to `full` only for the traces that matter.
-
-### Recommended workflows
-
-Most real questions need more than one tool. Ask your agent to follow one of these chains.
-
-#### Explore an unfamiliar project
-
-Use when you land on a new entity or project and don't know what is logged.
-
-1. `list_entities_tool` to find the entity.
-2. `query_wandb_entity_projects` to find the project.
-3. `probe_project_tool` for run-based projects, or `infer_trace_schema_tool` for Weave trace projects.
-4. A targeted `query_wandb_tool` or `query_weave_traces_tool` call using the discovered keys.
-
-#### Triage failing LLM calls
-
-Use when the agent needs to find bad traces and understand the sessions that produced them.
-
-1. `query_weave_traces_tool` with a filter on error or exception fields, and `detail_level="summary"`.
-2. `resolve_trace_roots_tool` on the resulting `trace_id` list to map each failure to its root session.
-3. `query_weave_traces_tool` with `detail_level="full"` on a small number of specific roots to drill in.
-4. `create_wandb_report_tool` to document the findings.
-
-#### Diagnose a bad training run
-
-Use when a run looks wrong and the user wants a health check.
-
-1. `get_run_history_tool` to pull the loss and validation curves.
-2. `diagnose_run_tool` for automated convergence, overfitting, and NaN checks.
-3. `compare_runs_tool` against a known-good baseline run.
-4. `create_wandb_report_tool` with line-plot panels to share the diagnosis.
-
-#### Summarize evals and compare model versions
-
-Use when the user asks which model version performed best on an evaluation.
-
-1. `summarize_evaluation_tool` for per-scorer pass rates and error counts.
-2. `list_artifact_versions_tool` on the relevant model collection.
-3. `compare_artifact_versions_tool` between the candidate and current production version.
-4. `log_analysis_to_wandb` and `create_wandb_report_tool` to publish the comparison.
-
 ## Prerequisites
 
 Before you configure any client:
 
-- A W&B API key. Create one at [wandb.ai/authorize](https://wandb.ai/authorize).
+- Create a W&B API key at [wandb.ai/authorize](https://wandb.ai/authorize).
 - Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
 - For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
 
@@ -170,7 +50,7 @@ W&B runs a managed MCP server for every deployment type. You don't need to insta
 
 ### Connection URL
 
-The URL depends on where your W&B deployment lives.
+The URL depends on your type of W&B deployment:
 
 | Deployment | Server URL |
 |------------|------------|
@@ -178,11 +58,72 @@ The URL depends on where your W&B deployment lives.
 | Dedicated Cloud | `https://<your-instance>/mcp` |
 | Self-Managed | `https://<your-instance>/mcp` |
 
-For Dedicated Cloud and Self-Managed, the MCP server must first be enabled on your instance. Contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it. Once enabled, your team authenticates with an existing W&B API key, exactly as they do against the W&B app.
-
-The client configurations below use the Multi-tenant URL. For Dedicated Cloud or Self-Managed, replace `https://mcp.withwandb.com/mcp` with `https://<your-instance>/mcp` and keep everything else the same.
+For Dedicated Cloud or Self-Managed, replace `https://mcp.withwandb.com/mcp` with `https://<your-instance>/mcp` and keep everything else the same. The client configurations below use the Multi-tenant URL.
 
 <Tabs>
+<Tab title="Claude Code">
+
+Run the following command in your terminal, replacing the bearer token with your W&B API key:
+
+```bash
+claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
+  --header "Authorization: Bearer <your-wandb-api-key>"
+```
+
+Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
+
+Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+</Tab>
+<Tab title="Claude Desktop">
+
+Claude Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your bearer token.
+
+You need [Node.js](https://nodejs.org/) installed on your system.
+
+Open your Claude Desktop config file in a text editor. You can find the config file at the following location for your OS:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following to the JSON object in your config file, replacing `<your-wandb-api-key>` with your W&B API key:
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.withwandb.com/mcp",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer <your-wandb-api-key>"
+      }
+    }
+  }
+}
+```
+
+The full header value is set through the `env` field rather than directly in `args` to work around a space-escaping issue in some Claude Desktop versions.
+
+Restart Claude Desktop to activate the new configuration. Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting).
+</Tab>
+<Tab title="Codex">
+
+Export your W&B API key as an environment variable, then run:
+
+```bash
+export WANDB_API_KEY=<your-wandb-api-key>
+codex mcp add wandb \
+  --url https://mcp.withwandb.com/mcp \
+  --bearer-token-env-var WANDB_API_KEY
+```
+
+Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting).
+</Tab>
 <Tab title="Cursor">
 
 Install the server in Cursor automatically with the [one-click installation link](https://cursor.com/en/install-mcp?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIge3tXQU5EQl9BUElfS0VZfX0iLCJBY2NlcHQiOiJhcHBsaWNhdGlvbi9qc29uLCB0ZXh0L2V2ZW50LXN0cmVhbSJ9fQ%3D%3D), then replace the placeholder with your W&B API key in the `Authorization` field.
@@ -213,54 +154,6 @@ To configure Cursor manually:
 6. Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
 
 If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Cursor's MCP documentation](https://cursor.com/docs/context/mcp).
-</Tab>
-<Tab title="VS Code">
-
-Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `.vscode/mcp.json`) and add the following:
-
-```json
-{
-  "servers": {
-    "wandb": {
-      "type": "http",
-      "url": "https://mcp.withwandb.com/mcp",
-      "headers": {
-        "Authorization": "Bearer <your-wandb-api-key>"
-      }
-    }
-  }
-}
-```
-
-Restart VS Code, confirm the server appears in the MCP panel, and verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
-
-If the connection fails, see [Troubleshooting](#troubleshooting).
-</Tab>
-<Tab title="Claude Code">
-
-Run the following command in your terminal, replacing the bearer token with your W&B API key:
-
-```bash
-claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
-  --header "Authorization: Bearer <your-wandb-api-key>"
-```
-
-Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
-
-Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting). For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
-</Tab>
-<Tab title="Codex">
-
-Export your W&B API key as an environment variable, then run:
-
-```bash
-export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb \
-  --url https://mcp.withwandb.com/mcp \
-  --bearer-token-env-var WANDB_API_KEY
-```
-
-Verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams. If the connection fails, see [Troubleshooting](#troubleshooting).
 </Tab>
 <Tab title="Gemini CLI">
 
@@ -318,11 +211,33 @@ print(resp.output_text)
 
 Pass the raw W&B API key as the `authorization` value. OpenAI prepends `Bearer ` when it calls the server, so don't include it yourself. The OpenAI MCP integration runs server-side, so it can't reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
 </Tab>
+<Tab title="VS Code">
+
+Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `.vscode/mcp.json`) and add the following:
+
+```json
+{
+  "servers": {
+    "wandb": {
+      "type": "http",
+      "url": "https://mcp.withwandb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-wandb-api-key>"
+      }
+    }
+  }
+}
+```
+
+Restart VS Code, confirm the server appears in the MCP panel, and verify the connection by asking `List my W&B entities.` The agent should call `list_entities_tool` and return your username and any teams.
+
+If the connection fails, see [Troubleshooting](#troubleshooting).
+</Tab>
 </Tabs>
 
 ## Run the MCP server locally
 
-A local MCP server is an escape hatch, not the default path for any particular deployment. Use it when the hosted server doesn't fit your setup.
+A local install is an alternative to the hosted server, not the default for any deployment type. Use it when the hosted server doesn't fit your setup.
 
 Common reasons to run locally:
 
@@ -348,7 +263,7 @@ To run the server locally, make sure you have the following:
 Choose an install method:
 
 <Tabs>
-<Tab title="uvx (no install)">
+<Tab title="uvx (no permanent install)">
 ```bash
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
@@ -375,6 +290,56 @@ pip install git+https://github.com/wandb/wandb-mcp-server
 Select your MCP client:
 
 <Tabs>
+<Tab title="Claude Code">
+
+Run the following command. Add `--scope user` for a global configuration.
+
+```bash
+claude mcp add wandb \
+  -e WANDB_API_KEY=<your-wandb-api-key> \
+  -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
+<Tab title="Claude Desktop">
+
+Open your Claude Desktop config file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following JSON. Use the full path to `uvx` because Claude Desktop may not find it on your `PATH` otherwise.
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "command": "/full/path/to/uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/wandb/wandb-mcp-server",
+        "wandb_mcp_server"
+      ],
+      "env": {
+        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop to apply the configuration.
+</Tab>
+<Tab title="Codex">
+
+```bash
+codex mcp add wandb \
+  --env WANDB_API_KEY=<your-wandb-api-key> \
+  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
 <Tab title="Cursor">
 
 Add the following to your `mcp.json` configuration:
@@ -423,56 +388,6 @@ Add the following to your `.vscode/mcp.json` or global MCP configuration:
 }
 ```
 </Tab>
-<Tab title="Claude Code">
-
-Run the following command. Add `--scope user` for a global configuration.
-
-```bash
-claude mcp add wandb \
-  -e WANDB_API_KEY=<your-wandb-api-key> \
-  -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
-```
-</Tab>
-<Tab title="Codex">
-
-```bash
-codex mcp add wandb \
-  --env WANDB_API_KEY=<your-wandb-api-key> \
-  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
-```
-</Tab>
-<Tab title="Claude Desktop">
-
-Open your Claude Desktop config file:
-
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the following JSON. Use the full path to `uvx` because Claude Desktop may not find it on your `PATH` otherwise.
-
-```json
-{
-  "mcpServers": {
-    "wandb": {
-      "command": "/full/path/to/uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/wandb/wandb-mcp-server",
-        "wandb_mcp_server"
-      ],
-      "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
-        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Desktop to apply the configuration.
-</Tab>
 </Tabs>
 
 ### Run the server with HTTP transport
@@ -509,15 +424,100 @@ The following environment variables control authentication, instance routing, an
 
 For the complete command-line reference and advanced options, see the [wandb-mcp-server README](https://github.com/wandb/wandb-mcp-server#readme).
 
+## W&B MCP Server capabilities
+
+Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following example prompts demonstrate some of the tasks you can ask your agent to perform when it is connected to the W&B MCP Server:
+
+- "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`."
+- "How did the latency of my hiring agent's predict traces evolve over the last month?"
+- "Generate a W&B report comparing decisions made by the hiring agent last week."
+- "What versions of the `production-model` artifact exist, and what changed between `v2` and `v3`?"
+- "How do I create a leaderboard in Weave?"
+
+### Available tools
+
+The server offers several tools for various purposes. The following table lists each tool's name, when the agent should use it, and a concrete prompt you can use to invoke that tool.
+
+<Tabs>
+  <Tab title="Discovery">
+    Tools that help you discover project and entity names, and inspect schemas.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `list_entities_tool` | No entity is specified, or to enumerate the teams and accounts the API key can reach. | "What W&B teams do I have access to?" |
+    | `query_wandb_entity_projects` | The entity is known but the project name is not, or an earlier query failed with "project not found". | "List all projects under `your-team`." |
+    | `probe_project_tool` | To discover available metrics, config keys, and tags in an unfamiliar run-based project. | "Probe `your-team/your-project` and tell me what metrics are logged." |
+    | `infer_trace_schema_tool` | To discover field names, types, and sample values in an unfamiliar Weave traces project before querying. | "What fields are on the Weave traces in `your-team/your-project`?" |
+  </Tab>
+  <Tab title="Experiments and runs">
+    Tools that query, compare, and diagnose W&B Models runs.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `query_wandb_tool` | The question is about runs, sweeps, configs, summaries, or artifacts in W&B Models. Runs a GraphQL query. | "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`." |
+    | `get_run_history_tool` | The question is about training curves, metric trends over time, or any time-series logged to a run. | "Plot the loss curve for run `abc123` in `your-team/your-project`." |
+    | `compare_runs_tool` | The question is what changed between two runs, or which of two runs is better. Returns config diff, metric delta, and optional aligned history. | "Compare runs `abc123` and `def456` in `your-team/your-project`." |
+    | `diagnose_run_tool` | The question is whether a run converged, is overfitting, or hit NaN values. Returns actionable recommendations. | "Is run `abc123` in `your-team/your-project` overfitting?" |
+  </Tab>
+  <Tab title="Weave traces">
+    Tools that query and aggregate LLM traces and evaluations.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `query_weave_traces_tool` | Trace data is required (LLM calls, evaluations, agent runs). Start with `detail_level="summary"` and escalate to `"full"` only for specific traces. | "Show me failed traces in `your-team/your-project` from the last 24 hours." |
+    | `count_weave_traces_tool` | The question is how many traces or how many errors, and the trace data itself is not needed. | "How many traces failed in `your-team/your-project` this week?" |
+    | `resolve_trace_roots_tool` | After `query_weave_traces_tool` finds child traces, to map each back to its root session or workflow in one batched call. | "Find LLM calls that contain `rate limit` and tell me which sessions they belong to." |
+    | `summarize_evaluation_tool` | The question is how an eval went, what the pass rate is, or which tasks fail most. Aggregates `Evaluation.evaluate` hierarchies. | "Summarize the most recent eval in `your-team/your-project`." |
+  </Tab>
+  <Tab title="Reports">
+    Tools that persist analysis back to W&B.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `create_wandb_report_tool` | An explicit request to create a report or save findings. Accepts Markdown plus a `panels` array for line plots, bar plots, and run comparisons. | "Create a W&B report comparing runs `abc123` and `def456`." |
+    | `log_analysis_to_wandb` | Values computed in the MCP session (latency distributions, error breakdowns) need to be persisted as a run before being referenced in a report. | "Log these latency percentiles to W&B as an analysis run." |
+  </Tab>
+  <Tab title="Artifacts and registry">
+    Tools that enable you to inspect and diff models, datasets, and other versioned artifacts.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `list_registries_tool` | The question is about model registries, registered models, or registered datasets in an organization. | "What registries exist in `your-org`?" |
+    | `list_registry_collections_tool` | To see what models or datasets live inside a specific registry. | "What collections are in the `model` registry of `your-org`?" |
+    | `list_artifact_versions_tool` | To list available versions of a model, dataset, or other artifact collection. | "List versions of `production-model` in `your-team/your-project`." |
+    | `get_artifact_details_tool` | To inspect one specific artifact version, including lineage and files. | "What is in `production-model:v3`?" |
+    | `compare_artifact_versions_tool` | The question is what changed between two artifact versions. | "Diff `production-model:v2` and `production-model:v3`." |
+  </Tab>
+  <Tab title="Docs">
+    Tools that answer product questions from the official W&B documentation.
+
+    | Tool | Use when | Example prompt |
+    |------|----------|----------------|
+    | `search_wandb_docs_tool` | The question is how to use a W&B or Weave feature or API. Proxies [docs.wandb.ai](https://docs.wandb.ai). | "How do I create a leaderboard in Weave?" |
+  </Tab>
+</Tabs>
+
+### Schema-first trace queries
+
+For Weave trace queries, call `infer_trace_schema_tool` first to discover available fields, then call `query_weave_traces_tool` with a precise column list and `detail_level`:
+
+| `detail_level` | Returns | Use when |
+|----------------|---------|----------|
+| `schema` | Structural fields only. Fastest. | Browsing or counting. |
+| `summary` | Truncated inputs and outputs. The default. | Most analysis tasks. |
+| `full` | Everything untruncated. | Drilling into a small number of specific traces. |
+
+This pattern keeps token usage low for broad questions and lets the agent escalate to `full` only for the traces that matter.
+
 ## Usage tips
 
-The following practices help you get better results from the MCP server. Start with the general tips, then read the subsection that matches your workload for more specific advice.
+The following practices and workflows help you get better results from the W&B MCP server. Start with the general practices, then read the subsection that matches your workload for more specific advice and multi-step tool chains.
 
-### For everyone
+### General best practices
 
-Follow these practices regardless of your workload:
+Follow these practices regardless of your use case:
 
-- **Specify the entity and project.** MCP tools need an explicit entity and project name. Include both in every question, for example "in `your-team/your-project`".
+- **Specify the entity and project.** MCP tools need an explicit entity (your team or personal account) and project name. Include both in every question, for example "in `your-team/your-project`".
 - **Ask focused questions.** Prefer "Which eval had the highest F1 score?" to "What is my best evaluation?". Specific metrics and time ranges produce better tool calls.
 - **Verify full retrieval.** For broad questions such as "What are my best performing runs?", ask the agent to confirm it retrieved all available runs rather than only the most recent ones.
 - **Combine with W&B Skills.** [W&B Skills](/platform/wb-skills) teach coding agents how to structure W&B workflows. Skills provide patterns and MCP provides data access, and the two work well together.
@@ -531,6 +531,8 @@ Follow these practices when working with Weave traces:
 - **Chain `resolve_trace_roots_tool`.** After a child-trace query, pass the resulting `trace_id` list to `resolve_trace_roots_tool` to map each trace to its root session in one batched call.
 - **Prefer `summarize_evaluation_tool` for evals.** It aggregates the `Evaluation.evaluate` and `predict_and_score` hierarchy automatically. Only fall back to `query_weave_traces_tool` for raw trace data.
 
+For an end-to-end workflow, see [Triage failing LLM calls](#triage-failing-llm-calls).
+
 ### For run-heavy workflows
 
 Follow these practices when working with W&B Models runs:
@@ -540,9 +542,11 @@ Follow these practices when working with W&B Models runs:
 - **Let `compare_runs_tool` do the diff.** It returns config and metric deltas with aligned history in a single call, avoiding manual comparison.
 - **Run a health check first.** When a training run looks wrong, call `diagnose_run_tool` before digging into history manually.
 
+For end-to-end workflows, see [Diagnose a bad training run](#diagnose-a-bad-training-run) and [Summarize evals and compare model versions](#summarize-evals-and-compare-model-versions).
+
 ### For Dedicated Cloud and Self-Managed
 
-Keep these considerations in mind for non-multi-tenant deployments:
+Follow these practices for non-multi-tenant deployments:
 
 - Prefer the hosted server on your instance at `https://<your-instance>/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server isn't yet enabled.
 - When you do run locally against your instance, set `WANDB_BASE_URL` to your instance URL in the client's `env` block. Without it, the server targets `api.wandb.ai` and the server returns no data.
@@ -550,27 +554,60 @@ Keep these considerations in mind for non-multi-tenant deployments:
 
 ### For local installs
 
-Keep these considerations in mind when running the server on your own machine:
+Follow these practices when running the server on your own machine:
 
 - Prefer STDIO transport for desktop clients (Cursor, VS Code, Claude Code, Claude Desktop). Only switch to HTTP transport when a client explicitly requires it (for example, the OpenAI Responses API).
 - When tool calls fail silently, set `MCP_SERVER_LOG_LEVEL=DEBUG` in the client's `env` block and recheck the client's MCP logs.
 - If you install from GitHub (`uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server`), `uvx` pins to the default branch. Pin an explicit tag by appending `@v0.3.2` to the Git URL when you need a stable version.
 
+## Recommended workflows
+
+Most real questions need more than one tool. Ask your agent to follow one of these chains.
+
+### Explore an unfamiliar project
+
+To explore what has been logged to a project, chain these tools:
+
+1. `list_entities_tool` to find an entity or team.
+2. `query_wandb_entity_projects` to find the project.
+3. `probe_project_tool` for run-based projects, or `infer_trace_schema_tool` for Weave trace projects.
+4. A targeted `query_wandb_tool` or `query_weave_traces_tool` call using the discovered keys.
+
+### Triage failing LLM calls
+
+To find bad traces and the sessions that produced them, chain these tools:
+
+1. `query_weave_traces_tool` with a filter on error or exception fields, and `detail_level="summary"`.
+2. `resolve_trace_roots_tool` on the resulting `trace_id` list to map each failure to its root session.
+3. `query_weave_traces_tool` with `detail_level="full"` on a small number of specific roots to drill in.
+4. `create_wandb_report_tool` to document the findings.
+
+### Diagnose a bad training run
+
+To run a health check on a suspicious training run, chain these tools:
+
+1. `get_run_history_tool` to pull the loss and validation curves.
+2. `diagnose_run_tool` for automated convergence, overfitting, and NaN checks.
+3. `compare_runs_tool` against a known-good baseline run.
+4. `create_wandb_report_tool` with line-plot panels to share the diagnosis.
+
+### Summarize evals and compare model versions
+
+To find which model version performed best on an evaluation, chain these tools:
+
+1. `summarize_evaluation_tool` for per-scorer pass rates and error counts.
+2. `list_artifact_versions_tool` on the relevant model collection.
+3. `compare_artifact_versions_tool` between the candidate and current production version.
+4. `log_analysis_to_wandb` and `create_wandb_report_tool` to publish the comparison.
+
 ## Troubleshooting
+
+Use the following table to help you diagnose and resolve issues using the W&B MCP Server:
 
 | Symptom | Cause and fix |
 |---------|---------------|
-| `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
-| Empty results for queries you expect to succeed | The entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
+| `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity or team. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
+| Empty results for queries you expect to succeed | The team/entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
 | `404 Not Found` or `connection refused` on `https://<your-instance>/mcp` | The hosted MCP server is not yet enabled on your Dedicated Cloud or Self-Managed instance, or the client is pointed at the wrong URL. Contact [W&B support](mailto:support@wandb.com) to request enablement, then confirm the URL in [Connection URL](#connection-url). |
 | `429 Too Many Requests` on Dedicated Cloud | You have hit your instance's rate limits. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for how to request higher limits. |
 | Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
-
-## Related
-
-Explore these resources for observability, reusable agent patterns, and advanced server configuration:
-
-- [Trace MCP clients and servers with Weave](/weave/guides/integrations/mcp) for end-to-end observability of MCP interactions.
-- [W&B Skills](/platform/wb-skills) for reusable agent instructions that pair with the MCP server.
-- [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) for the open-source server, command-line reference, and release notes.
-- [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) hosting options.

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -1,193 +1,224 @@
 ---
-title: Use the W&B MCP Server
-description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to access your workspace data and documentation."
+title: Use the W&B MCP server
+description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-import McpConfig from '/snippets/_includes/mcp-config.mdx';
+The W&B Model Context Protocol (MCP) server exposes your W&B data as a set of tools that any [MCP](https://modelcontextprotocol.io) client can call. Connect your IDE or AI agent to the server and ask it to analyze experiments, debug Weave traces, generate reports, inspect artifacts and registry, and search W&B documentation, all without writing custom GraphQL or SDK code.
 
-Model Context Protocol (MCP) lets an LLM agent query and analyze data efficiently to minimize cost in tokens. This page shows how to use the W&B MCP server to query and analyze your W&B data from your IDE or MCP client and give your client programmatic access to W&B's documentation, so it can generate more accurate responses to W&B-related queries.
+Supported clients include Cursor, Visual Studio Code, Claude Code, OpenAI Codex, Gemini CLI, Mistral LeChat, Claude Desktop, and the OpenAI Responses API.
 
-It integrates natively with most IDEs, coding clients, and chat agents, including:
-* Claude Code
-* Claude Code Desktop
-* Codex
-* Cursor
-* Gemini CLI
-* Mistral LeChat
-* Visual Studio Code (VS Code)
+## Which setup should I use?
 
-The W&B MCP server supports [hosted](#use-w&b’s-remote-mcp-server) and [local](#set-up-a-local-version-of-the-w&b-mcp-server) variants. The hosted version only supports [W&B Dedicated Cloud deployments](/platform/hosting/hosting-options/dedicated-cloud). The local version supports both Dedicated Cloud and [Self-Managed deployments](/platform/hosting/hosting-options/self-managed).
+W&B offers three ways to run the MCP server. Pick the one that matches your deployment:
 
-## W&B MCP Server capabilities
+<CardGroup cols={3}>
+  <Card title="Multi-tenant Cloud" icon="cloud">
+    Use the hosted server at `mcp.withwandb.com`. No installation required.
 
-You can use the MCP server to analyze experiments, debug traces, create reports, and get help with integrating your applications with W&B features.
+    [Use the hosted server](#use-the-hosted-server)
+  </Card>
+  <Card title="Dedicated Cloud or Self-Managed" icon="building">
+    Request enablement of the managed MCP server on your deployment. Your team connects to `https://<your-instance>/mcp` with an existing W&B API key.
 
-The following example prompts demonstrate some of the types of tasks your agent can do when connected to the MCP server:
+    [Use MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed)
+  </Card>
+  <Card title="Local install" icon="laptop-code">
+    Run the MCP server on your machine. Useful for air-gapped environments, development, and clients that require STDIO.
 
-* Show me the top 5 runs by eval/accuracy in your-team-name/your-project-name?
-* How did the latency of my hiring agent predict traces evolve over the last few months?
-* Generate a wandb report comparing the decisions made by the hiring agent last month.
-* How do I create a leaderboard in Weave - ask SupportBot?
+    [Run the MCP server locally](#run-the-mcp-server-locally)
+  </Card>
+</CardGroup>
+
+<Tip>
+To request the managed MCP server on a Dedicated Cloud or Self-Managed instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team.
+</Tip>
+
+## What you can do
+
+Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following are representative prompts:
+
+- "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`."
+- "How did the latency of my hiring agent's `predict` traces evolve over the last month?"
+- "Generate a W&B report comparing decisions made by the hiring agent last week."
+- "What versions of the `production-model` artifact exist, and what changed between `v2` and `v3`?"
+- "How do I create a leaderboard in Weave?"
 
 ### Available tools
 
-The W&B MCP server gives your agents access to the following tools:
-
-| Tool | Description | Example Query |
-|------|-------------|---------------|
-| **query_wandb_tool** | Query W&B runs, metrics, and experiments | *"Show me runs with loss < 0.1"* |
-| **query_weave_traces_tool** | Analyze LLM traces and evaluations | *"What's the average latency?"* |
-| **count_weave_traces_tool** | Count traces and get storage metrics | *"How many traces failed?"* |
-| **create_wandb_report_tool** | Create W&B reports programmatically | *"Create a performance report"* |
-| **query_wandb_entity_projects** | List projects for an entity | *"What projects exist?"* |
-| **query_wandb_support_bot** | Get help from W&B documentation | *"How do I use sweeps?"* |
-
-
-## Use W&B's remote MCP server
-
-W&B provides a hosted MCP server at `https://mcp.withwandb.com` that requires no installation. The following instructions show how to configure the hosted server with various AI assistants and IDEs.
-
-### Prerequisites
-
-* A W&B Dedicated Cloud deployment.
-* A W&B API key. You can create a new one at [wandb.ai/authorize](https://wandb.ai/authorize).
-* Set your key as an environment variable named `WANDB_API_KEY`.
-
-### Configure your MCP client
-
-Select the tab containing your MCP client's instructions:
+The server registers the following tools. The exact set depends on the server version and whether docs search is enabled.
 
 <Tabs>
-<Tab title="Claude Code">
+  <Tab title="Experiments and runs">
+    | Tool | Description |
+    |------|-------------|
+    | `query_wandb_tool` | Query W&B runs, metrics, configs, and summaries using GraphQL. |
+    | `get_run_history_tool` | Retrieve sampled time-series metric data for a run. |
+    | `query_wandb_entity_projects` | List projects visible to an entity. |
+  </Tab>
+  <Tab title="Weave traces">
+    | Tool | Description |
+    |------|-------------|
+    | `infer_trace_schema_tool` | Discover field names, types, and sample values before you query. |
+    | `query_weave_traces_tool` | Query Weave traces with a configurable `detail_level` and column projection. |
+    | `count_weave_traces_tool` | Count traces and retrieve storage metrics. |
+  </Tab>
+  <Tab title="Reports">
+    | Tool | Description |
+    |------|-------------|
+    | `create_wandb_report_tool` | Create W&B reports with Markdown, line plots, bar plots, and run comparisons. Accepts a `panels` parameter. |
+    | `log_analysis_to_wandb` | Log analysis results from the current MCP session to W&B as a run. |
+  </Tab>
+  <Tab title="Artifacts and registry">
+    | Tool | Description |
+    |------|-------------|
+    | `list_registries_tool` | List model registries in an organization. |
+    | `list_registry_collections_tool` | List collections within a registry. |
+    | `list_artifact_versions_tool` | List versions of an artifact collection. |
+    | `get_artifact_details_tool` | Get full details for an artifact version. |
+    | `compare_artifact_versions_tool` | Diff two artifact versions. |
+  </Tab>
+  <Tab title="Docs">
+    | Tool | Description |
+    |------|-------------|
+    | `search_wandb_docs_tool` | Search the official W&B documentation at [docs.wandb.ai](https://docs.wandb.ai). Controlled by `WANDB_MCP_PROXY_DOCS` (enabled by default). |
+  </Tab>
+</Tabs>
 
-To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
+### Schema-first trace queries
 
-```bash
-claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
-  --header "Authorization: Bearer <your-wandb-api-key>"
-```
+For Weave trace queries, call `infer_trace_schema_tool` first to discover available fields, then call `query_weave_traces_tool` with a precise column list and `detail_level`:
 
-Add `--scope user` for a global configuration, or omit it to configure for the current project only.
+| `detail_level` | When to use |
+|----------------|-------------|
+| `schema` | Structural fields only. Fastest. Use for browsing and counting. |
+| `summary` | Truncated inputs and outputs. The default. |
+| `full` | Everything untruncated. Use to drill into a small number of specific traces. |
 
-For more detailed information, see [Claude's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+This pattern keeps token usage low for broad questions and lets the agent escalate to `full` only for the traces that matter.
 
+## Prerequisites
+
+Before you configure any client:
+
+- A W&B API key. Create one at [wandb.ai/authorize](https://wandb.ai/authorize).
+- Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
+- For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
+
+## Use the hosted server
+
+W&B runs a hosted MCP server at `https://mcp.withwandb.com` for Multi-tenant Cloud users. There is nothing to install. Configure your client to connect to `https://mcp.withwandb.com/mcp` with a bearer token.
+
+<Tabs>
+<Tab title="Cursor">
+
+Install the server in Cursor automatically with the [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=), then replace `YOUR_WANDB_API_KEY` with your W&B API key in the `Authorization` field.
+
+To configure Cursor manually:
+
+1. On macOS, open **Cursor** > **Settings** > **Cursor Settings**. On Windows or Linux, open **Preferences** > **Settings** > **Cursor Settings**.
+2. Select **Tools and MCP**.
+3. In **Installed MCP Servers**, select **Add Custom MCP**. Cursor opens the `mcp.json` configuration file.
+4. Add the following to the `mcpServers` object:
+
+    ```json
+    {
+      "mcpServers": {
+        "wandb": {
+          "transport": "http",
+          "url": "https://mcp.withwandb.com/mcp",
+          "headers": {
+            "Authorization": "Bearer <your-wandb-api-key>",
+            "Accept": "application/json, text/event-stream"
+          }
+        }
+      }
+    }
+    ```
+
+5. Restart Cursor.
+6. Verify the connection by asking the agent "List the projects in my W&B account."
+
+For more information, see [Cursor's MCP documentation](https://cursor.com/docs/context/mcp).
 </Tab>
-<Tab title="Claude Code Desktop">
+<Tab title="VS Code">
 
-Claude Code Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Code Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your Bearer token.
-
-You need [Node.js](https://nodejs.org/) installed on your system.
-
-Open your Claude Code Desktop config file in a text editor. You can find the config file at the following location for your OS:
-
-* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the following to the JSON object in your config file, replacing `<your-wandb-api-key>` with your W&B API key:
+Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `.vscode/mcp.json`) and add the following:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "wandb": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.withwandb.com/mcp",
-        "--header",
-        "Authorization:${AUTH_HEADER}"
-      ],
-      "env": {
-        "AUTH_HEADER": "Bearer <your-wandb-api-key>"
+      "type": "http",
+      "url": "https://mcp.withwandb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-wandb-api-key>"
       }
     }
   }
 }
 ```
 
-The full header value is set through the `env` field rather than directly in `args` to work around a space-escaping issue in some Claude Desktop versions.
+Restart VS Code and confirm the server appears in the MCP panel.
+</Tab>
+<Tab title="Claude Code">
 
-Restart Claude Code Desktop to activate the new configuration. Verify the connection by entering the prompt "List the projects in my W&B account."
+Run the following command in your terminal, replacing the bearer token with your W&B API key:
+
+```bash
+claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
+  --header "Authorization: Bearer <your-wandb-api-key>"
+```
+
+Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
+
+For more information, see [Claude Code's MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
 </Tab>
 <Tab title="Codex">
 
-To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
+Export your W&B API key as an environment variable, then run:
 
 ```bash
 export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
+codex mcp add wandb \
+  --url https://mcp.withwandb.com/mcp \
+  --bearer-token-env-var WANDB_API_KEY
 ```
-
-</Tab>
-<Tab title="Cursor">
-
-You can install the W&B server in Cursor automatically using a [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=) (requires adding `Bearer <your-wandb-api-key>` in the `Authorization` field), or manually using the following instructions:
-
-1. On macOS, open the **Cursor** menu, select **Settings**, and then select **Cursor Settings**. On Windows or Linux, open the **Preferences** menu, select **Settings**, and then select **Cursor Settings**.
-2. From the Cursor Settings menu, select **Tools and MCP**. This opens the Tools menu. 
-3. In the Installed MCP Servers section, select **Add Custom MCP**. This opens the `mcp.json` configuration file.
-4. In the configuration file, in the `mcpServers` JSON object, add the following `wandb` object:
-
-  ```json
-  {
-    "mcpServers": {
-      "wandb": {
-        "transport": "http",
-        "url": "https://mcp.withwandb.com/mcp",
-        "headers": {
-          "Authorization": "Bearer <your-wandb-api-key>",
-          "Accept": "application/json, text/event-stream"
-        }
-      }
-    }
-  }
-```
-
-5. Restart Cursor to make the changes take effect.
-6. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
-
-For more detailed information, see [Cursor's documentation](https://cursor.com/docs/context/mcp).
-
 </Tab>
 <Tab title="Gemini CLI">
-To add the W&B MCP server to Gemini CLI:
 
-1. Install the W&B MCP extension with a single command:
+Install the W&B MCP extension:
 
-    ```bash
-    # Install the extension
-    gemini extensions install https://github.com/wandb/wandb-mcp-server
-    ```
-2. Once installed, restart the Gemini CLI.
-3. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
+```bash
+gemini extensions install https://github.com/wandb/wandb-mcp-server
+```
 
-For more detailed information, see [Gemini's documentation](https://geminicli.com/docs/tools/mcp-server/).
+Restart Gemini CLI. Verify the connection by asking "List the projects in my W&B account."
+
+For more information, see [Gemini CLI's MCP documentation](https://geminicli.com/docs/tools/mcp-server/).
 </Tab>
 <Tab title="Mistral LeChat">
-To add the W&B MCP server to Mistral LeChat: 
 
-1. From the **Intelligence** menu, select **Add Connector** to open the Connector window.
-2. Select the **Custom MCP Connector** tab.
-3. Configure the fields using the following values:
-
+1. In LeChat, open the **Intelligence** menu and select **Add Connector**.
+2. Select **Custom MCP Connector**.
+3. Configure the following fields:
     - **Connector Server**: `https://mcp.withwandb.com/mcp`
-    - **Description**: (Optional) A brief arbitrary description of the connection.
-    - **Authentication Method**: Select **API Token Authentication**. This opens additional fields.
-    - **Header name**: Leave the default value, **Authorization**.
+    - **Description**: (Optional) A short description.
+    - **Authentication Method**: Select **API Token Authentication**.
+    - **Header name**: Leave as `Authorization`.
     - **Header type**: Select **Bearer**.
-    - **Header value**: Enter your W&B API token.
+    - **Header value**: Your W&B API key.
+4. Select **Create**.
+5. Verify the connection by asking "List the projects in my W&B account."
 
-3. Once you have configured all the fields, select **Create**. LeChat adds the MCP server to your configuration.
-4. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
-
-For more detailed information, see [LeChat's documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
+For more information, see [LeChat's MCP documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
 </Tab>
-<Tab title="OpenAI">
-To add the W&B MCP server to your OpenAI calls, add the server's information to the `tools` field of your OpenAI responses configuration:
+<Tab title="OpenAI Responses API">
+
+Add the server to the `tools` field of your OpenAI Responses API call:
 
 ```python
-from openai import OpenAI
 import os
+from openai import OpenAI
 
 client = OpenAI()
 
@@ -198,7 +229,7 @@ resp = client.responses.create(
         "server_label": "wandb",
         "server_description": "Query W&B data",
         "server_url": "https://mcp.withwandb.com/mcp",
-        "authorization": os.getenv("<your-wandb-api-key>"),
+        "authorization": os.getenv("WANDB_API_KEY"),
         "require_approval": "never",
     }],
     input="List the projects in my W&B account.",
@@ -206,30 +237,52 @@ resp = client.responses.create(
 
 print(resp.output_text)
 ```
+
+The OpenAI MCP integration runs server-side, so it cannot reach a local MCP server. For local development, see [Run the MCP server locally](#run-the-mcp-server-locally).
 </Tab>
 </Tabs>
 
-## Set up a local version of the W&B MCP server
+## Use MCP on Dedicated Cloud or Self-Managed
 
-If you need to run the MCP server locally for W&B Self-Managed deployments, development, testing, or air-gapped environments, you can install and run it on your machine.
+The hosted server at `mcp.withwandb.com` targets Multi-tenant Cloud. [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) customers have two options.
 
-### Prerequisites
+### Request the managed MCP server on your deployment
 
-* A W&B API key. You can create a new one at [wandb.ai/authorize](https://wandb.ai/authorize).
-* Set your key as an environment variable named `WANDB_API_KEY`.
-* Set the `WANDB_BASE_URL` environment variable if you are using [W&B Self-Managed](/platform/hosting/hosting-options/self-managed).
-* Python 3.10 or higher
-* [uv](https://docs.astral.sh/uv/) (recommended) or pip
+W&B can enable a managed MCP server on your Dedicated Cloud or Self-Managed instance. Once enabled:
 
-See uv's docs for [installation instructions](https://docs.astral.sh/uv/getting-started/installation/).
+- The server is reachable at `https://<your-instance>/mcp`.
+- Your team authenticates with an existing W&B API key, the same way they authenticate to the W&B app.
+- The same tools described in [What you can do](#what-you-can-do) are available.
 
-### Install and configure the MCP server
+To request enablement, contact [W&B support](mailto:support@wandb.com) or your W&B account team. Once the server is available, configure your MCP client as shown in [Use the hosted server](#use-the-hosted-server), replacing the `https://mcp.withwandb.com/mcp` URL with `https://<your-instance>/mcp`.
 
-To install the MPC server locally:
+### Self-serve from the open-source repo
 
-To install the W&B MCP server on your local machine, use one of the following installation commands:
- 
+For air-gapped environments, development work, or instances where the managed MCP is not yet enabled, you can run the MCP server locally from the [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) open-source repository and point it at your instance.
+
+Install and configure the local server as described in [Run the MCP server locally](#run-the-mcp-server-locally), and set `WANDB_BASE_URL` to your instance URL.
+
+## Run the MCP server locally
+
+Run the MCP server on your own machine for air-gapped environments, development, testing, or clients that only support STDIO.
+
+### Local prerequisites
+
+- Python 3.11 or higher.
+- [`uv`](https://docs.astral.sh/uv/) is recommended. For installation instructions, see the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/). You can use `pip` instead.
+- A W&B API key, set as `WANDB_API_KEY`.
+- `WANDB_BASE_URL` set to your instance URL if you use Dedicated Cloud or Self-Managed.
+
+### Install the server
+
+Choose an install method:
+
 <Tabs>
+<Tab title="uvx (no install)">
+```bash
+uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
 <Tab title="uv">
 ```bash
 uv pip install wandb-mcp-server
@@ -240,70 +293,18 @@ uv pip install wandb-mcp-server
 pip install wandb-mcp-server
 ```
 </Tab>
-<Tab title="Install directly from GitHub">
+<Tab title="Install from GitHub">
 ```bash
 pip install git+https://github.com/wandb/wandb-mcp-server
 ```
 </Tab>
 </Tabs>
 
-Once you have installed the MCP server locally, configure your MCP client to use it. Select an MCP client to continue:
+### Configure your client
+
+Select your MCP client:
 
 <Tabs>
-<Tab title="Claude Code CLI">
-
-Run the following command in your terminal. Add `--scope user` for a global configuration, or omit it to configure for the current project only.
-
-```bash
-claude mcp add wandb \
-  -e WANDB_API_KEY=your-api-key \
-  -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
-```
-
-</Tab>
-<Tab title="Claude Code Desktop">
-Open your Claude Code Desktop config file in a text editor. You can find the config file at the locations for your OS:
-
-* **macOS**: ~/Library/Application\ Support/Claude/claude_desktop_config.json
-* **Windows**: %APPDATA%\Claude\claude_desktop_config.json
-
-Add the following to your JSON object to your Claude Code Desktop config file. Use the full path to `uvx` because Claude Code Desktop may not find your `uvx` installation otherwise.
-
-```json
-{
-  "mcpServers": {
-    "wandb": {
-      "command": "/full/path/to/uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/wandb/wandb-mcp-server",
-        "wandb_mcp_server"
-      ],
-      "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
-        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Desktop to activate the new configuration.
-
-</Tab>
-<Tab title="Codex">
-
-Run the following command in your terminal:
-
-```bash
-codex mcp add wandb \
-  --env WANDB_API_KEY=your_api_key_here \
-  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
-```
-
-</Tab>
 <Tab title="Cursor">
 
 Add the following to your `mcp.json` configuration:
@@ -327,6 +328,7 @@ Add the following to your `mcp.json` configuration:
 }
 ```
 
+Omit `WANDB_BASE_URL` to use the default W&B API endpoint.
 </Tab>
 <Tab title="VS Code">
 
@@ -351,28 +353,113 @@ Add the following to your `.vscode/mcp.json` or global MCP configuration:
 }
 ```
 </Tab>
+<Tab title="Claude Code">
+
+Run the following command. Add `--scope user` for a global configuration.
+
+```bash
+claude mcp add wandb \
+  -e WANDB_API_KEY=<your-wandb-api-key> \
+  -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
+<Tab title="Codex">
+
+```bash
+codex mcp add wandb \
+  --env WANDB_API_KEY=<your-wandb-api-key> \
+  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+</Tab>
+<Tab title="Claude Desktop">
+
+Open your Claude Desktop config file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following JSON. Use the full path to `uvx` because Claude Desktop may not find it on your `PATH` otherwise.
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "command": "/full/path/to/uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/wandb/wandb-mcp-server",
+        "wandb_mcp_server"
+      ],
+      "env": {
+        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop to apply the configuration.
+</Tab>
 </Tabs>
 
-For web-based clients or testing, run the server with HTTP transport:
+### Run the server with HTTP transport
+
+For web-based clients and for testing, run the server with HTTP transport:
 
 ```bash
 uvx wandb_mcp_server --transport http --host 0.0.0.0 --port 8080
 ```
 
-To expose the local server to external clients like OpenAI, use ngrok:
+To expose a local server to external clients, such as the OpenAI Responses API, use a tunnel:
 
 ```bash
 uvx wandb_mcp_server --transport http --port 8080
 
-# In another terminal, expose with ngrok
+# In another terminal
 ngrok http 8080
-    ```
+```
 
-If you expose the server using `ngrok`, update your MCP client configuration to use the `ngrok` URL.
+Update your MCP client configuration to use the tunnel URL.
 
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `WANDB_API_KEY` | W&B API key for authentication. Required. |
+| `WANDB_BASE_URL` | Custom W&B instance URL for Dedicated Cloud or Self-Managed. Defaults to `https://api.wandb.ai`. |
+| `WANDB_MCP_PROXY_DOCS` | Enable the `search_wandb_docs_tool` documentation search proxy. Default: `true`. |
+| `WANDBOT_BASE_URL` | Custom endpoint for the docs search proxy. |
+| `MAX_RESPONSE_TOKENS` | Token budget for tool-response truncation. Default: `30000`. |
+| `MCP_SERVER_LOG_LEVEL` | Logging verbosity. One of `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+
+For the complete command-line reference and advanced options, see the [wandb-mcp-server README](https://github.com/wandb/wandb-mcp-server#readme).
 
 ## Usage tips
 
-- **Provide your W&B project and entity name**: Specify the W&B entity and project in your queries for accurate results.
-- **Avoid overly broad questions**: Instead of "what is my best evaluation?", ask "what eval had the highest f1 score?"
-- **Verify data retrieval**: When asking broad questions like "what are my best performing runs?", ask the assistant to confirm it retrieved all available runs.
+Follow these practices to get good results from the MCP server:
+
+- **Specify the entity and project.** MCP tools need an explicit entity and project name. Include both in every question, for example "in `your-team/your-project`".
+- **Ask focused questions.** Prefer "Which eval had the highest F1 score?" to "What is my best evaluation?". Specific metrics and time ranges produce better tool calls.
+- **Use the schema-first workflow for traces.** Have the agent call `infer_trace_schema_tool` before `query_weave_traces_tool`, and start with `detail_level: "summary"`. Escalate to `"full"` only when drilling into specific traces.
+- **Verify full retrieval.** For broad questions like "What are my best performing runs?", ask the agent to confirm that it retrieved all available runs rather than only the most recent ones.
+- **Combine with W&B Skills.** [W&B Skills](/platform/wb-skills) teach coding agents how to structure W&B workflows. Skills and MCP work well together, because Skills provide patterns and MCP provides data access.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---------|---------------|
+| `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
+| Empty results for queries you expect to succeed | The entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
+| Cannot reach `mcp.withwandb.com/mcp` from Dedicated Cloud or Self-Managed | The hosted server targets Multi-tenant Cloud only. Use [MCP on your deployment](#use-mcp-on-dedicated-cloud-or-self-managed) instead. |
+| `429 Too Many Requests` on Dedicated Cloud | You have hit your instance's rate limits. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for how to request higher limits. |
+| Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
+
+## Related
+
+- [Trace MCP clients and servers with Weave](/weave/guides/integrations/mcp) for end-to-end observability of MCP interactions.
+- [W&B Skills](/platform/wb-skills) for reusable agent instructions that pair with the MCP server.
+- [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) for the open-source server, command-line reference, and release notes.
+- [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed) hosting options.

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -3,7 +3,7 @@ title: Use the W&B MCP Server
 description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste.
+Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste. For a full list of what you can do with the server, see the [W&B MCP Server capabilities](#w&b-mcp-server-capabilities) section.
 
 It integrates natively with most IDEs, coding clients, and chat agents, including:
 


### PR DESCRIPTION
## Summary

Full rewrite of [`platform/mcp-server.mdx`](platform/mcp-server.mdx) to bring the page up to the bar of `platform/hosting.mdx` / `platform/wb-skills.mdx` and to align with the shipped behavior in [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) (v0.3.2). Drafted using the docs-team `author-docs` and `style-guide` skill conventions from `.claude/skills/`.

Key improvements:

- **Decision-first IA.** New `<CardGroup>` at the top lets readers pick Multi-tenant Cloud / Dedicated or Self-Managed / Local install before drowning in client configs.
- **Dedicated Cloud and Self-Managed are now first-class.** New section leads with "request enablement from W&B support or your account team" (no Helm, no operator internals, no image tags, matching the house style in `platform/hosting/hosting-options/*.mdx`). Self-serve from the open-source repo is documented as a fallback for air-gapped / dev use.
- **Tool catalog updated 6 -> 14 tools**, grouped by use case. Adds the schema-first trace workflow and the `detail_level` reference (`schema` / `summary` / `full`) that the server actually exposes.
- **Local install now mirrors the repo.** Adds VS Code and Mistral LeChat tabs, `uvx` quickstart, HTTP transport + tunnel guidance, and a complete env-var table (`WANDB_MCP_PROXY_DOCS`, `WANDBOT_BASE_URL`, `MAX_RESPONSE_TOKENS`, `MCP_SERVER_LOG_LEVEL`). Cross-links to the repo README for the CLI reference instead of duplicating it.
- **Expanded usage tips** (entity/project, schema-first, `detail_level` escalation, retrieval verification, W&B Skills pairing) and a new troubleshooting table (401, empty results, hosted-vs-dedicated confusion, 429, Claude Desktop `uvx` path).
- **Fixes broken anchors.** The previous `#use-w&b's-remote-mcp-server` style anchors contain literal ampersands that break Mintlify fragment links; new slugs are plain.
- **Cross-links** to `/weave/guides/integrations/mcp`, `/platform/wb-skills`, `https://github.com/wandb/wandb-mcp-server`, and the hosting option pages.

## Out of scope (intentional)

- No Helm values, operator chart versions, subchart names, or cluster-admin instructions in user-facing docs. W&B manages that side of the Dedicated / Self-Managed experience.
- Localized `ja/`, `ko/`, `fr/` copies and localized snippets are untouched. Translation pipeline will re-sync them once this English source merges.
- No changes to `weave/guides/integrations/mcp.mdx` (Weave client/server tracing, a different feature) beyond a cross-link.
- No changes in the `wandb/wandb-mcp-server` repo itself. The repo README remains the canonical developer reference.

## Sources and decision log

- Tool list and descriptions: [`src/wandb_mcp_server/server.py`](https://github.com/wandb/wandb-mcp-server/blob/main/src/wandb_mcp_server/server.py) `register_tools()` (14 tools) and each tool module in [`src/wandb_mcp_server/mcp_tools/`](https://github.com/wandb/wandb-mcp-server/tree/main/src/wandb_mcp_server/mcp_tools). Confirms that `query_wandb_support_bot` has been removed and superseded by `search_wandb_docs_tool`.
- Environment variables: [`env.example`](https://github.com/wandb/wandb-mcp-server/blob/main/env.example) and [`README.md`](https://github.com/wandb/wandb-mcp-server/blob/main/README.md#environment-variables).
- Dedicated/Self-Managed managed offering: repo README ("Contact your W&B account team to enable MCP on your dedicated deployment"). Framed in docs as "contact W&B support or your account team" to match the pattern used in [`platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx`](platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx).
- Page IA modeled on [`platform/hosting.mdx`](platform/hosting.mdx) (`<CardGroup>` decision matrix) and [`platform/wb-skills.mdx`](platform/wb-skills.mdx) (prompt examples, usage tips table).
- Style conventions from [`AGENTS.md`](AGENTS.md) and `.claude/skills/author-docs/SKILL.md` / `.claude/skills/style-guide/SKILL.md`. Applied manually: sentence-case headings, no emojis, no Latin abbreviations, straight quotes, no em/en dashes, code fences with language tags, active voice, second person imperative.

## Needs SME verification

The rewrite preserves existing technical content that is accurate against the repo README. The following items would benefit from SME confirmation before merge:

- [ ] **Managed MCP availability framing.** Is the managed MCP server on Dedicated Cloud / Self-Managed generally available, early access, or still "contact-us"? Current wording is "W&B can enable a managed MCP server on your Dedicated Cloud or Self-Managed instance" + "contact W&B support or your W&B account team." Update if we can call it GA.
- [ ] **Minimum server version for the managed offering.** The repo README references image `wandb/mcp-server:0.3.0` or later; this docs page intentionally does not surface image versions. Confirm there is no customer-facing pre-req we need to call out (for example, a minimum operator chart version communicated on the docs side).
- [ ] **Python version floor.** `pyproject.toml` requires `>=3.11`; the previous page said `3.10+`. Rewrite says 3.11. Confirm.
- [ ] **Docs proxy default.** The env table says `WANDB_MCP_PROXY_DOCS` defaults to `true`. Confirm this is still the ship default in 0.3.2.
- [ ] **Troubleshooting entries.** Are there common issues seen in the field that should be added (OAuth for ChatGPT, multi-tenant auth flow, specific client regressions)?

## Test plan

- [ ] `mint dev` renders the page without warnings.
- [ ] `mint broken-links` passes for all in-page anchors (`#use-the-hosted-server`, `#use-mcp-on-dedicated-cloud-or-self-managed`, `#run-the-mcp-server-locally`, `#what-you-can-do`).
- [ ] All tab panels render with copy-pasteable JSON / bash.
- [ ] Cross-links to `/platform/hosting/hosting-options/dedicated-cloud`, `/platform/hosting/hosting-options/self-managed`, `/platform/hosting/hosting-options/dedicated-cloud/rate-limits`, `/weave/guides/integrations/mcp`, and `/platform/wb-skills` resolve.
- [ ] One-click Cursor install link still resolves to the same base64-encoded config.

## Resume prompt

> Pick up the W&B MCP docs rework in `wandb/docs#<PR>` (branch `anish/docs-mcp-server-rework`). English source of `platform/mcp-server.mdx` is fully rewritten; localized `ja/ko/fr` copies are pending the translation pipeline. Open items are in the "Needs SME verification" checklist in the PR description: confirm managed-MCP GA framing, minimum server versions, Python floor, docs-proxy default, and additional troubleshooting entries. After SME sign-off, merge and let the translation pipeline re-sync localized pages.


Made with [Cursor](https://cursor.com)