### PR TITLE
Inference - Finer grained reasoning information

### DIFF
--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -3,16 +3,15 @@ title: "View reasoning information"
 description: How to return and view reasoning in your W&B Inference responses
 ---
 
-Reasoning models, like [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), include information about their reasoning steps as part of the output returned in addition to the final answer.
+Reasoning models, such as [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), return information about their reasoning steps alongside the final answer. This page explains how to identify reasoning-capable models on W&B Inference, where to find reasoning output in a response, and how to turn reasoning on or off for models that support toggling it.
 
-You can determine whether a model supports reasoning or not by checking the [Supported Models](#supported-models) table below or the Supported Features section of its catalog page in the UI.
+To determine whether a model supports reasoning, check the following [Supported models](#supported-models) table or the Supported Features section of its catalog page in the UI.
 
-You can find reasoning information in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
+Reasoning information appears in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
+## Supported models
 
-## Supported Models
-
-Models that support reasoning might default to not reasoning, default to reasoning enabled, or always include reasoning. The per-model behavior is documented in the following table:
+The following table lists the models on W&B Inference that return reasoning output. Each supported model might disable reasoning by default, enable reasoning by default, or always include reasoning:
 
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)                       | Support            |
@@ -28,9 +27,9 @@ Models that support reasoning might default to not reasoning, default to reasoni
 | `zai-org/GLM-5.1`                              | Enabled by default |
 | `zai-org/GLM-5-FP8`                            | Enabled by default |
 
-## Disabling reasoning
+## Disable reasoning
 
-If a model is listed as "Enabled by default" in the [table above](#supported-models), you have the option of disabling reasoning:
+If a model is listed as "Enabled by default" in the preceding [Supported models](#supported-models) table, you can disable reasoning to reduce token usage or simplify the response. Use the `enable_thinking` flag in `chat_template_kwargs` to opt out of reasoning for a request:
 
 <Tabs>
   <Tab title="Python">
@@ -39,7 +38,7 @@ If a model is listed as "Enabled by default" in the [table above](#supported-mod
 
     client = openai.OpenAI(
         base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+        api_key="[YOUR-API-KEY]",  # Create an API key at https://wandb.ai/settings
     )
 
     response = client.chat.completions.create(
@@ -59,7 +58,7 @@ If a model is listed as "Enabled by default" in the [table above](#supported-mod
     ```bash highlight={9}
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
+      -H "Authorization: Bearer [YOUR-API-KEY]" \
       -d '{
         "model": "google/gemma-4-31B-it",
         "messages": [
@@ -71,6 +70,7 @@ If a model is listed as "Enabled by default" in the [table above](#supported-mod
   </Tab>
 </Tabs>
 
-## Enabling reasoning
+## Enable reasoning
 
-To enable reasoning for a model that is "Disabled by default" in the [table above](#supported-models), set the `enable_thinking` flag as in the code snippet above but with the value `True` (Python) or `true` (curl).
+To enable reasoning for a model listed as "Disabled by default" in the preceding [Supported models](#supported-models) table, set the `enable_thinking` flag as in the preceding code snippet but with the value `True` (Python) or `true` (Bash).
+

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -3,15 +3,17 @@ title: "View reasoning information"
 description: How to return and view reasoning in your W&B Inference responses
 ---
 
-Reasoning models, like [OpenAI's GPT OSS 20B](https://huggingface.co/openai/gpt-oss-20b), include information about their reasoning steps as part of the output returned in addition to the final answer. This is automatic and no additional input parameters are needed.
+Reasoning models, like [OpenAI's GPT OSS 20B](https://huggingface.co/openai/gpt-oss-20b), include information about their reasoning steps as part of the output returned in addition to the final answer.
 
-You can determine whether a model supports reasoning or not by checking the Supported Features section of its catalog page in the UI.
+You can determine whether a model supports reasoning or not by checking the [Supported Models](#supported-models) table below or the Supported Features section of its catalog page in the UI.
 
 You can find reasoning information in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
+Models that support reasoning might default to not reasoning, default to reasoning enabled, or always reason. The per-model behavior is  [documented below](#supported-models). When calling the model, we recommend setting the `enable_thinking` boolean flag, as shown below, to clearly indicate the intended behavior.
+
 <Tabs>
   <Tab title="Python">
-    ```python
+    ```python highlight={13-17}
     import openai
 
     client = openai.OpenAI(
@@ -24,6 +26,11 @@ You can find reasoning information in the `reasoning` field of responses. The va
         messages=[
             {"role": "user", "content": "3.11 and 3.8, which is greater?"}
         ],
+        extra_body={
+            "chat_template_kwargs": {
+                "enable_thinking": True
+            }
+        },
     )
 
     print(response.choices[0].message.reasoning)
@@ -32,7 +39,7 @@ You can find reasoning information in the `reasoning` field of responses. The va
     ```
   </Tab>
   <Tab title="Bash">
-    ```bash
+    ```bash highlight={9}
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer <your-api-key>" \
@@ -40,8 +47,27 @@ You can find reasoning information in the `reasoning` field of responses. The va
         "model": "openai/gpt-oss-20b",
         "messages": [
           { "role": "user", "content": "3.11 and 3.8, which is greater?" }
-        ]
+        ],
+        "chat_template_kwargs": {"enable_thinking": true}
       }'
     ```
   </Tab>
 </Tabs>
+
+## Supported Models
+
+The following models support reasoning mode:
+
+{/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
+| Model ID (for API usage)                       | Support            |
+| ---------------------------------------------- | ------------------ |
+| `google/gemma-4-31B-it`                        | Enabled by default |
+| `MiniMaxAI/MiniMax-M2.5`                       | Always on          |
+| `moonshotai/Kimi-K2.5`                         | Always on          |
+| `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8` | Enabled by default |
+| `openai/gpt-oss-120b`                          | Always on          |
+| `openai/gpt-oss-20b`                           | Always on          |
+| `Qwen/Qwen3.5-35B-A3B`                         | Enabled by default |
+| `Qwen/Qwen3-235B-A22B-Thinking-2507`           | Always on          |
+| `zai-org/GLM-5.1`                              | Enabled by default |
+| `zai-org/GLM-5-FP8`                            | Enabled by default |

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -3,60 +3,16 @@ title: "View reasoning information"
 description: How to return and view reasoning in your W&B Inference responses
 ---
 
-Reasoning models, like [OpenAI's GPT OSS 20B](https://huggingface.co/openai/gpt-oss-20b), include information about their reasoning steps as part of the output returned in addition to the final answer.
+Reasoning models, like [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), include information about their reasoning steps as part of the output returned in addition to the final answer.
 
 You can determine whether a model supports reasoning or not by checking the [Supported Models](#supported-models) table below or the Supported Features section of its catalog page in the UI.
 
 You can find reasoning information in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
-Models that support reasoning might default to not reasoning, default to reasoning enabled, or always reason. The per-model behavior is  [documented below](#supported-models). When calling the model, we recommend setting the `enable_thinking` boolean flag, as shown below, to clearly indicate the intended behavior.
-
-<Tabs>
-  <Tab title="Python">
-    ```python highlight={13-17}
-    import openai
-
-    client = openai.OpenAI(
-        base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
-    )
-
-    response = client.chat.completions.create(
-        model="openai/gpt-oss-20b",
-        messages=[
-            {"role": "user", "content": "3.11 and 3.8, which is greater?"}
-        ],
-        extra_body={
-            "chat_template_kwargs": {
-                "enable_thinking": True
-            }
-        },
-    )
-
-    print(response.choices[0].message.reasoning)
-    print("--------------------------------")
-    print(response.choices[0].message.content)
-    ```
-  </Tab>
-  <Tab title="Bash">
-    ```bash highlight={9}
-    curl https://api.inference.wandb.ai/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
-      -d '{
-        "model": "openai/gpt-oss-20b",
-        "messages": [
-          { "role": "user", "content": "3.11 and 3.8, which is greater?" }
-        ],
-        "chat_template_kwargs": {"enable_thinking": true}
-      }'
-    ```
-  </Tab>
-</Tabs>
 
 ## Supported Models
 
-The following models support reasoning mode:
+Models that support reasoning might default to not reasoning, default to reasoning enabled, or always include reasoning. The per-model behavior is documented in the following table:
 
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)                       | Support            |
@@ -71,3 +27,50 @@ The following models support reasoning mode:
 | `Qwen/Qwen3-235B-A22B-Thinking-2507`           | Always on          |
 | `zai-org/GLM-5.1`                              | Enabled by default |
 | `zai-org/GLM-5-FP8`                            | Enabled by default |
+
+## Disabling reasoning
+
+If a model is listed as "Enabled by default" in the [table above](#supported-models), you have the option of disabling reasoning:
+
+<Tabs>
+  <Tab title="Python">
+    ```python highlight={13-17}
+    import openai
+
+    client = openai.OpenAI(
+        base_url='https://api.inference.wandb.ai/v1',
+        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+    )
+
+    response = client.chat.completions.create(
+        model="google/gemma-4-31B-it",
+        messages=[
+            {"role": "user", "content": "3.11 and 3.8, which is greater?"}
+        ],
+        extra_body={
+            "chat_template_kwargs": {
+                "enable_thinking": False
+            }
+        },
+    )
+    ```
+  </Tab>
+  <Tab title="Bash">
+    ```bash highlight={9}
+    curl https://api.inference.wandb.ai/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer <your-api-key>" \
+      -d '{
+        "model": "google/gemma-4-31B-it",
+        "messages": [
+          { "role": "user", "content": "3.11 and 3.8, which is greater?" }
+        ],
+        "chat_template_kwargs": {"enable_thinking": false}
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+## Enabling reasoning
+
+To enable reasoning for a model that is "Disabled by default" in the [table above](#supported-models), set the `enable_thinking` flag as in the code snippet above but with the value `True` (Python) or `true` (curl).

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -5,13 +5,13 @@ description: How to return and view reasoning in your W&B Inference responses
 
 Reasoning models, such as [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), return information about their reasoning steps alongside the final answer. This page explains how to identify reasoning-capable models on W&B Inference, where to find reasoning output in a response, and how to turn reasoning on or off for models that support toggling it.
 
-To determine whether a model supports reasoning, check the following [Supported models](#supported-models) table or the Supported Features section of its catalog page in the UI.
+To determine whether a model supports reasoning, check the following Supported models table or the Supported Features section of its catalog page in the UI.
 
 Reasoning information appears in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
-## Supported models
+## Supported models with reasoning
 
-The following table lists the models on W&B Inference that return reasoning output. Each supported model might disable reasoning by default, enable reasoning by default, or always include reasoning:
+The following table lists the models on W&B Inference that return reasoning output. Each supported model might always include reasoning, or might disable or enable reasoning by default:
 
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)                       | Support            |
@@ -27,13 +27,17 @@ The following table lists the models on W&B Inference that return reasoning outp
 | `zai-org/GLM-5.1`                              | Enabled by default |
 | `zai-org/GLM-5-FP8`                            | Enabled by default |
 
-## Disable reasoning
+### Models with `Always on` reasoning
 
-If a model is listed as "Enabled by default" in the preceding [Supported models](#supported-models) table, you can disable reasoning to reduce token usage or simplify the response. Use the `enable_thinking` flag in `chat_template_kwargs` to opt out of reasoning for a request:
+If a model is listed as `Always on` in the preceding [Supported models](#supported-models) table, it always includes reasoning and this cannot be disabled.
+
+### Disable reasoning
+
+If a model is listed as `Enabled by default` in the preceding [Supported models](#supported-models) table, you can disable reasoning to reduce token usage or simplify the response. To opt out of reasoning for a request, in `chat_template_kwargs`, set the `enable_thinking` flag to the value `False` (Python) or `false` (Bash):
 
 <Tabs>
   <Tab title="Python">
-    ```python highlight={13-17}
+    ```python lines highlight={13-17}
     import openai
 
     client = openai.OpenAI(
@@ -55,7 +59,7 @@ If a model is listed as "Enabled by default" in the preceding [Supported models]
     ```
   </Tab>
   <Tab title="Bash">
-    ```bash highlight={9}
+    ```bash lines highlight={9}
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer [YOUR-API-KEY]" \
@@ -70,7 +74,7 @@ If a model is listed as "Enabled by default" in the preceding [Supported models]
   </Tab>
 </Tabs>
 
-## Enable reasoning
+### Enable reasoning
 
-To enable reasoning for a model listed as "Disabled by default" in the preceding [Supported models](#supported-models) table, set the `enable_thinking` flag as in the preceding code snippet but with the value `True` (Python) or `true` (Bash).
+If a model is listed as `Disabled by default` in the preceding [Supported models](#supported-models) table, you can enable reasoning by setting the `enable_thinking` flag to the value `True` (Python) or `true` (Bash) in the preceding code snippet.
 

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -14,7 +14,7 @@ Reasoning information appears in the `reasoning` field of responses. The value o
 The following table lists the models on W&B Inference that return reasoning output. Each supported model might always include reasoning, or might disable or enable reasoning by default:
 
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
-| Model ID (for API usage)                       | Support            |
+| Model ID (for API usage)                       | Reasoning support  |
 | ---------------------------------------------- | ------------------ |
 | `google/gemma-4-31B-it`                        | Enabled by default |
 | `MiniMaxAI/MiniMax-M2.5`                       | Always on          |


### PR DESCRIPTION
## Description

Update Inference's reasoning page to provide more information about how to enable/disable it. (To date, we've forced it on for all models that support it, but we expect to change that soon.) Add a dynamically generated table of models that support reasoning along with a column about configurability.

Changed the example model to Gemma 4 so users would only have to change one thing in the code example if they want to try out reasoning vs. not.

<img width="3416" height="4735" alt="image" src="https://github.com/user-attachments/assets/f0984a2e-b1e2-41ea-80e0-a8eb1c378eab" />

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
