### PR TITLE
[WEAVE] Fix incomplete auth/routing snippet in OTeL docs (DOCS-2570)

### DIFF
--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -33,9 +33,11 @@ The following example shows how to configure authentication and project routing:
 <CodeGroup>
 ```python Python lines {7,8}
 import os
+from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
@@ -55,9 +57,12 @@ tracer_provider = trace_sdk.TracerProvider(resource=Resource({
     "wandb.entity": ENTITY,
     "wandb.project": PROJECT,
 }))
+tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(tracer_provider)
 ```
 ```typescript TypeScript lines
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { Resource } from "@opentelemetry/resources";
 
@@ -80,9 +85,16 @@ const provider = new NodeTracerProvider({
     "wandb.entity": ENTITY,
     "wandb.project": PROJECT,
   }),
+  spanProcessors: [new BatchSpanProcessor(exporter)],
 });
+
+provider.register();
 ```
 </CodeGroup>
+
+<Note>
+This snippet shows authentication and routing configuration only. For complete, runnable examples that include application code and instrumentation, see the [Examples](#examples) section below.
+</Note>
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- The Python and TypeScript snippets in the **Authentication and routing** section were missing span processor registration and provider setup calls — copy-pasting them produced silence (no traces sent)
- Added missing imports, `add_span_processor` + `trace.set_tracer_provider` (Python), `spanProcessors` constructor option + `provider.register()` (TypeScript)
- Added a `<Note>` callout making it explicit these snippets show configuration only and pointing to the full runnable Examples below

## Test plan

- [ ] Verify Python snippet now includes `from opentelemetry import trace`, `from opentelemetry.sdk.trace.export import BatchSpanProcessor`, `add_span_processor(BatchSpanProcessor(exporter))`, and `trace.set_tracer_provider(tracer_provider)`
- [ ] Verify TypeScript snippet now includes `BatchSpanProcessor` import, `spanProcessors` option in provider constructor, and `provider.register()`
- [ ] Verify `<Note>` callout appears after the CodeGroup and links to `#examples`
- [ ] Run the updated Python snippet end-to-end to confirm traces appear in Weave

## Related

- JIRA: [DOCS-2570](https://coreweave.atlassian.net/browse/DOCS-2570)
- Source: [Slack thread](https://coreweave.enterprise.slack.com/archives/C0880TX4U5V/p1776790260500349) (Griffin Tarpenning, 2026-04-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2570]: https://coreweave.atlassian.net/browse/DOCS-2570