### PR TITLE
Inference - GLM 5.1 GA / GLM 5 deprecate

### DIFF
--- a/inference/lifecycle.mdx
+++ b/inference/lifecycle.mdx
@@ -32,7 +32,9 @@ Models that are in the **deprecated** stage continue to serve requests.
 The following W&B Inference models are **deprecated**:
 
 {/* takeru lifecycle-deprecated - This table is automatically generated, do not edit manually. */}
-_None currently_
+| Deprecation date | Retirement date | Model ID            | Recommended replacement |
+| ---------------- | --------------- | ------------------- | ----------------------- |
+| 2026-04-24       | 2026-05-11      | `zai-org/GLM-5-FP8` | `zai-org/GLM-5.1`       |
 
 
 ## Retired models

--- a/inference/models.mdx
+++ b/inference/models.mdx
@@ -31,16 +31,14 @@ The following models are [generally available](/inference/lifecycle#model-lifecy
 | Qwen3 235B A22B-2507          | `Qwen/Qwen3-235B-A22B-Instruct-2507`           | Text         | 262k           | 22B-235B (Active-Total)   | Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning.                                             |
 | Qwen3 30B A3B                 | `Qwen/Qwen3-30B-A3B-Instruct-2507`             | Text         | 262k           | 3.3B-30.5B (Active-Total) | Qwen3-30B-A3B-Instruct-2507 is a 30.5B MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding.               |
 | Qwen3 Coder 480B A35B         | `Qwen/Qwen3-Coder-480B-A35B-Instruct`          | Text         | 262k           | 35B-480B (Active-Total)   | Mixture-of-Experts model optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning.                       |
-| Z.AI GLM 5                    | `zai-org/GLM-5-FP8`                            | Text         | 200k           | 40B-744B (Active-Total)   | Mixture-of-Experts model for long-horizon agentic tasks with strong performance on reasoning and coding.                                          |
+| Z.AI GLM 5.1                  | `zai-org/GLM-5.1`                              | Text         | 203k           | 40B-744B (Active-Total)   | Powerful MoE model for long-horizon agentic engineering and advanced reasoning.                                                                   |
 
 ## Experimental models
 
 The following models are [experimental](/inference/lifecycle#model-lifecycle-stages):
 
 {/* takeru inference-models-experimental - This table is automatically generated, do not edit manually. */}
-| Model        | Model ID (for API usage) | Type | Context Window | Parameters              | Description                                                                     |
-| ------------ | ------------------------ | ---- | -------------- | ----------------------- | ------------------------------------------------------------------------------- |
-| Z.AI GLM 5.1 | `zai-org/GLM-5.1`        | Text | 203k           | 40B-744B (Active-Total) | Powerful MoE model for long-horizon agentic engineering and advanced reasoning. |
+_None currently_
 
 
 ## Deprecated models
@@ -48,7 +46,9 @@ The following models are [experimental](/inference/lifecycle#model-lifecycle-sta
 The following models are [deprecated](/inference/lifecycle#model-lifecycle-stages):
 
 {/* takeru inference-models-deprecated - This table is automatically generated, do not edit manually. */}
-_None currently_
+| Model      | Model ID (for API usage) | Type | Context Window | Parameters              | Description                                                                                              |
+| ---------- | ------------------------ | ---- | -------------- | ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| Z.AI GLM 5 | `zai-org/GLM-5-FP8`      | Text | 200k           | 40B-744B (Active-Total) | Mixture-of-Experts model for long-horizon agentic tasks with strong performance on reasoning and coding. |
 
 
 ## Using model IDs

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -25,7 +25,6 @@ The following table lists the models on W&B Inference that return reasoning outp
 | `Qwen/Qwen3.5-35B-A3B`                         | Enabled by default |
 | `Qwen/Qwen3-235B-A22B-Thinking-2507`           | Always on          |
 | `zai-org/GLM-5.1`                              | Enabled by default |
-| `zai-org/GLM-5-FP8`                            | Enabled by default |
 
 ### Models with `Always on` reasoning
 


### PR DESCRIPTION
## Description

Automated takeru changes, reflecting GLM 5.1 promotion from experimental to GA and related deprecation of GLM 5.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
