### PR TITLE
docs(mcp): enable the MCP subchart on self-managed

### DIFF
--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -226,6 +226,67 @@ For detailed instructions on using these cloud-specific modules, see [Deploy wit
 
 <SelfManagedVerifyInstallation/>
 
+## Enable the MCP server
+
+The W&B [Model Context Protocol (MCP) server](/platform/mcp-server) ships as an optional subchart in `operator-wandb`. When enabled, the operator deploys an in-cluster MCP server that is exposed through your existing ingress at `<global.host>/mcp`, so any MCP-compatible client (Cursor, VS Code, Claude Code, Gemini CLI, Claude Desktop, and others) can connect using a W&B API key. This is the same server W&B runs as the hosted offering at `https://mcp.withwandb.com/mcp`, just pointed at your deployment's data.
+
+For end-user client configuration and the tool catalog, see [Use the W&B MCP server](/platform/mcp-server). This section only covers the operator-side enablement.
+
+### Prerequisites
+
+- **Chart version**: `operator-wandb` `0.42.1` or later. The `mcp-server` subchart was introduced in `0.42.1`.
+- **Weave Traces enabled**: the MCP server calls Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces is not enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
+- **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from it and exposes itself at `<global.host>/mcp`.
+- **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has the headroom before enabling.
+
+### Enable the subchart
+
+Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource, alongside your existing `global`, `ingress`, and other overrides:
+
+```yaml
+spec:
+  values:
+    weave-trace:
+      install: true
+    mcp-server:
+      install: true
+```
+
+Apply the change to trigger a reconcile:
+
+```shell
+kubectl apply -f operator.yaml
+```
+
+The operator creates a `wandb-mcp-server` deployment and service in the release namespace, and extends the W&B ingress with a `/mcp` path.
+
+### Verify the MCP server
+
+Wait for the pod to become `Running`, then check the health endpoint in-cluster and through the ingress:
+
+```shell
+kubectl get pod -l app.kubernetes.io/component=mcp-server
+kubectl port-forward svc/wandb-mcp-server 8080:8080
+curl -s http://localhost:8080/mcp/health
+
+curl -s "https://<HOST_URI>/mcp/health"
+```
+
+Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy; the ingress check confirms routing.
+
+### Connect a client
+
+Point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bearer token. For IDE and agent configurations (Cursor, VS Code, Claude Code, and others), see [Use the W&B MCP server](/platform/mcp-server).
+
+### Troubleshooting
+
+| Symptom | Likely cause and fix |
+|---------|----------------------|
+| `helm render` fails with `mcp-server requires weave-trace.install=true` | Add `weave-trace.install: true` to `spec.values`. The MCP server depends on Weave Traces for trace tools. |
+| `wandb-mcp-server` pod stuck in `Pending` with `Insufficient cpu` or `Insufficient memory` | Add node capacity, or lower `mcp-server.resources.requests` in your CR. Defaults are `500m` CPU and `1Gi` memory. |
+| `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Re-apply the CR and wait for the ingress controller to propagate the new path. |
+| `wandb-mcp-server` pod in `ImagePullBackOff` in an air-gapped or mirrored cluster | Mirror the image to your registry and override `mcp-server.image.repository` in your CR, the same pattern used for other W&B component images in air-gapped installs. See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/). |
+
 ## Environment-specific considerations
 
 Kubernetes is the same whether it runs on-premises or in the cloud. The main differences are in naming and managed services (for example, MySQL vs RDS, or S3 vs on-premises object storage). This section covers considerations that vary by environment.

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -234,27 +234,47 @@ For end-user client configuration and the tool catalog, see [Use the W&B MCP ser
 
 ### Prerequisites
 
-- **Chart version**: `operator-wandb` `0.42.1` or later. The `mcp-server` subchart was introduced in `0.42.1`.
+- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`. The example below uses Datadog and privacy settings added after that initial release.
 - **Weave Traces enabled**: the MCP server calls Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces is not enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
 - **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from it and exposes itself at `<global.host>/mcp`.
 - **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has the headroom before enabling.
 
 ### Enable the subchart
 
-Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource, alongside your existing `global`, `ingress`, and other overrides:
+Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource, alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
 
 ```yaml
 spec:
   values:
     weave-trace:
       install: true
+
     mcp-server:
       install: true
+      image:
+        repository: us-docker.pkg.dev/wandb-production/public/wandb/mcp-server
+        tag: "0.3.3"
+      datadog:
+        enabled: true
+        mode: "agent"
+        service: "wandb-mcp-server-<environment>"
+        env: "<environment>"
+        deploymentType: "self-managed"
+        customer: "<customer-name>"
+        extraTags:
+          - "region:<region>"
+          - "tier:<tier>"
+      privacy:
+        logLevel: "standard"
 ```
+
+Keep `weave-trace.install: true` unless you set `mcp-server.env.WF_TRACE_SERVER_URL` yourself. Use `datadog.mode: "agent"` for Kubernetes deployments where the Datadog Agent DaemonSet owns log and trace collection. In agent mode, the MCP pod does not need a Datadog API key. Set `service`, `env`, `deploymentType`, `customer`, and `extraTags` to match your deployment's observability naming conventions. Set `customer` to an empty string if you do not want a customer tag.
+
+Use `privacy.logLevel: "standard"` for most self-managed Kubernetes installations. This redacts free-text parameter values in logs while preserving deployment identifiers that operators commonly use for debugging. Use `"strict"` when entity, project, run, or user identifiers should not remain in plaintext logs. Use `"off"` only when you explicitly want plaintext logging for those values.
 
 Apply the change to trigger a reconcile:
 
-```shell
+```bash
 kubectl apply -f operator.yaml
 ```
 
@@ -264,7 +284,7 @@ The operator creates a `wandb-mcp-server` deployment and service in the release 
 
 Wait for the pod to become `Running`, then check the health endpoint in-cluster and through the ingress:
 
-```shell
+```bash
 kubectl get pod -l app.kubernetes.io/component=mcp-server
 kubectl port-forward svc/wandb-mcp-server 8080:8080
 curl -s http://localhost:8080/mcp/health
@@ -272,7 +292,7 @@ curl -s http://localhost:8080/mcp/health
 curl -s "https://<HOST_URI>/mcp/health"
 ```
 
-Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy; the ingress check confirms routing.
+Both requests should return `200 OK`. The in-cluster check confirms the pod is healthy; the ingress check confirms routing. If you enabled Datadog, MCP server logs should also appear under the configured `mcp-server.datadog.service` and `mcp-server.datadog.env` values.
 
 ### Connect a client
 
@@ -285,6 +305,8 @@ Point your MCP client at `https://<HOST_URI>/mcp` with a W&B API key as the bear
 | `helm render` fails with `mcp-server requires weave-trace.install=true` | Add `weave-trace.install: true` to `spec.values`. The MCP server depends on Weave Traces for trace tools. |
 | `wandb-mcp-server` pod stuck in `Pending` with `Insufficient cpu` or `Insufficient memory` | Add node capacity, or lower `mcp-server.resources.requests` in your CR. Defaults are `500m` CPU and `1Gi` memory. |
 | `curl https://<HOST_URI>/mcp/health` returns 404 | The `/mcp` ingress path is only rendered when `mcp-server.install: true`. Re-apply the CR and wait for the ingress controller to propagate the new path. |
+| MCP logs do not appear in Datadog | Confirm `mcp-server.datadog.enabled: true`, `mcp-server.datadog.mode: "agent"`, and that the Datadog Agent DaemonSet collects pod stdout. Search Datadog with the configured `service` and `env` values. |
+| MCP logs include more user-supplied text than expected | Set `mcp-server.privacy.logLevel` to `"standard"` or `"strict"`. Use `"strict"` when identifiers such as entity, project, run, or user names should not remain in plaintext logs. |
 | `wandb-mcp-server` pod in `ImagePullBackOff` in an air-gapped or mirrored cluster | Mirror the image to your registry and override `mcp-server.image.repository` in your CR, the same pattern used for other W&B component images in air-gapped installs. See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/). |
 
 ## Environment-specific considerations


### PR DESCRIPTION
## Summary

Stacked on top of #2531 (`anish/docs-mcp-server-rework`). Adds one new `## Enable the MCP server` section to [`platform/hosting/self-managed/operator.mdx`](platform/hosting/self-managed/operator.mdx) so self-managed operators can turn on the `mcp-server` subchart shipped in `operator-wandb` `0.42.1`.

The parent PR rewrites the end-user MCP page (`platform/mcp-server.mdx`) and explicitly keeps \"Helm values, operator chart versions, subchart names, or cluster-admin instructions\" out of scope. This PR fills that gap on the operator side only.

## What this adds

A single section between `### Verify the installation` and `## Environment-specific considerations`, with:

- **Overview**: what the subchart is, what `<global.host>/mcp` exposes, and a pointer to `/platform/mcp-server` for client setup.
- **Prerequisites**: chart `0.42.1+`, `weave-trace.install: true` (hard fail-guard in the chart), ingress reachable at `global.host`, node headroom for default resource requests (`500m` CPU / `1Gi` memory).
- **Enable**: minimal YAML patch for the existing `WeightsAndBiases` CR.
- **Verify**: in-cluster port-forward check against `/mcp/health` plus the same check through the ingress.
- **Connect a client**: one-line hand-off to `/platform/mcp-server`.
- **Troubleshooting**: 4-row table covering the weave-trace fail-guard, pod `Pending` due to resource requests, ingress 404 on `/mcp`, and image pull failures in air-gapped / mirrored clusters.

## What this deliberately omits

- No Datadog / OpenTelemetry setup docs (the hosting section doesn't document Datadog anywhere today; adding it here would be inconsistent).
- No image registry details, GKE HTTP LB addon / NEG troubleshooting, or Workload Identity recipes. Operators use the default image or mirror via the one-line override noted in the troubleshooting table.
- No changes to `platform/mcp-server.mdx` (handled by #2531), localized `fr/ja/ko` copies (translation pipeline re-syncs from English), or `docs.json` nav (no new page).

## Source references

- `mcp-server` subchart defaults: [`charts/operator-wandb/values.yaml`](https://github.com/wandb/helm-charts/blob/main/charts/operator-wandb/values.yaml) lines 2845-2894.
- Fail-guard requiring `weave-trace.install`: [`charts/operator-wandb/templates/_mcp.tpl`](https://github.com/wandb/helm-charts/blob/main/charts/operator-wandb/templates/_mcp.tpl) lines 7-11.
- Chart version floor `0.42.1`: wandb/helm-charts#571 (introduces the subchart) and wandb/helm-charts#590 (scope fix in `wandb.mcpEnvs`).

## Test plan

- [ ] `mint dev` renders `platform/hosting/self-managed/operator.mdx` without warnings.
- [ ] The new `Enable the MCP server` section appears in the right-rail TOC, between \"Verify the installation\" and \"Environment-specific considerations\".
- [ ] Cross-links to `/platform/mcp-server` and `/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped` resolve.
- [ ] Anchor `#enable-the-mcp-server` is linkable from the parent PR's Dedicated/Self-Managed card once both merge.

Made with [Cursor](https://cursor.com)