### PR TITLE
Scrub for W&B branding consistency

### DIFF
--- a/models/integrations/tensorboard.mdx
+++ b/models/integrations/tensorboard.mdx
@@ -7,7 +7,7 @@ import { ColabLink } from '/snippets/_includes/colab-link.mdx';
 <ColabLink url="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/tensorboard/TensorBoard_and_Weights_and_Biases.ipynb" />
 
 <Note>
-W&B support embedded TensorBoard for W&B Multi-tenant SaaS.
+W&B supports embedded TensorBoard for W&B Multi-tenant Cloud.
 </Note>
 
 Upload your TensorBoard logs to the cloud, quickly share your results among colleagues and classmates and keep your analysis in one centralized location.

--- a/models/track/limits.mdx
+++ b/models/track/limits.mdx
@@ -102,7 +102,7 @@ throughput = logged points × log frequency
 ```
 
 <Warning>
-The following sections apply to W&B SaaS Cloud. If you use a different W&B deployment type, check with your administrator for deployment-specific guidance or limits.
+The following sections apply to W&B Multi-tenant Cloud. If you use a different W&B deployment type, check with your administrator for deployment-specific guidance or limits.
 </Warning>
 
 ## Recommendations at scale
@@ -345,7 +345,7 @@ W&B does not enforce hard product limits for these recommendations beyond API ra
 
 ## Rate limits
 
-W&B SaaS Cloud APIs use rate limits to maintain service reliability and availability.
+W&B Multi-tenant Cloud APIs use rate limits to maintain service reliability and availability.
 
 <Note>
 Rate limits are subject to change.
@@ -395,7 +395,7 @@ For manual syncing, use `wandb sync <run-file-path>`. See [`wandb sync`](/models
 
 The W&B app and the [public API](/models/ref/python/public-api/api) use GraphQL requests to query and modify data.
 
-For SaaS Cloud:
+For Multi-tenant Cloud:
 
 * unauthorized requests are rate-limited per IP address
 * authorized requests are rate-limited per user

--- a/platform/hosting.mdx
+++ b/platform/hosting.mdx
@@ -20,7 +20,7 @@ Some features and functionality require an [Enterprise](https://wandb.ai/site/pr
   </Card>
   
   <a id="wb-dedicated-cloud" aria-label="W&B Dedicated Cloud"></a><Card title="W&B Dedicated Cloud">
-    A single-tenant, fully managed service deployed in W&B's cloud infrastructure. It is the best place to onboard W&B if your organization requires conformance to strict governance controls including data residency, have need of advanced security capabilities, and are looking to optimize their AI operating costs by not having to build & manage the required infrastructure with security, scale & performance characteristics.
+    A fully managed service with dedicated, isolated infrastructure in W&B's cloud. It is the best place to onboard W&B if your organization requires conformance to strict governance controls including data residency, have need of advanced security capabilities, and are looking to optimize their AI operating costs by not having to build & manage the required infrastructure with security, scale & performance characteristics.
     
     See **[W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud)** for more information.
   </Card>

--- a/platform/hosting/enterprise-licenses.mdx
+++ b/platform/hosting/enterprise-licenses.mdx
@@ -14,7 +14,7 @@ This page provides a comprehensive overview of Enterprise licenses, including wh
 ## Deployment options
 Enterprise licenses are available for W&B Dedicated Cloud and Self-Managed deployments.
 
-- [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) provides single-tenant infrastructure managed by W&B, deployed in Google Cloud. Dedicated Cloud deployments automatically include an Enterprise license. No additional configuration is required, and all Enterprise features are available immediately upon provisioning.
+- [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) provides dedicated, isolated infrastructure managed by W&B, deployed in Google Cloud. Dedicated Cloud deployments automatically include an Enterprise license. No additional configuration is required, and all Enterprise features are available immediately upon provisioning.
 - [W&B Self-Managed](/platform/hosting/hosting-options/self-managed) is deployed on your own infrastructure, providing full control over your deployment and data. Air-gapped deployments are supported. Without an Enterprise license, [Enterprise features](#enterprise-features) are unavailable.
 
 ## Obtain an Enterprise license

--- a/platform/hosting/hosting-options.mdx
+++ b/platform/hosting/hosting-options.mdx
@@ -10,7 +10,7 @@ This section describes the different ways can you can deploy W&B.
 See [W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) or [get started for free](https://app.wandb.ai/login?signup=true).
 
 ## W&B Dedicated Cloud
-[W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) is a single-tenant, fully managed platform designed with enterprise organizations in mind. W&B Dedicated Cloud is deployed in W&B's AWS, Google Cloud or Azure account. Dedicated Cloud provides more flexibility than Multi-tenant Cloud, but less complexity than W&B Self-Managed. Upgrades, maintenance, platform security, and capacity planning are managed by W&B. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances.
+[W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) is a fully managed platform with dedicated, isolated infrastructure, designed with enterprise organizations in mind. W&B Dedicated Cloud is deployed in W&B's AWS, Google Cloud or Azure account. Dedicated Cloud provides more flexibility than Multi-tenant Cloud, but less complexity than W&B Self-Managed. Upgrades, maintenance, platform security, and capacity planning are managed by W&B. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances.
 
 Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 

--- a/platform/hosting/hosting-options/dedicated-cloud.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud.mdx
@@ -3,7 +3,7 @@ description: "Learn about W&B Dedicated Cloud deployment features including comp
 title: Dedicated Cloud
 ---
 
-W&B Dedicated Cloud is a single-tenant, fully managed platform deployed in W&B's AWS, Google Cloud, or Azure cloud accounts. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances. Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services.
+W&B Dedicated Cloud is a fully managed platform with dedicated, isolated infrastructure, deployed in W&B's AWS, Google Cloud, or Azure cloud accounts. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances. Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services.
 
 W&B Dedicated Cloud is available in [multiple global regions for each cloud provider](./dedicated-cloud/regions)
 

--- a/platform/hosting/iam/access-management/restricted-projects.mdx
+++ b/platform/hosting/iam/access-management/restricted-projects.mdx
@@ -41,7 +41,7 @@ Set a project's visibility scope when you create a project or when editing it la
 
 #### Set visibility scope when you create a new project
 
-1. Navigate to your W&B organization on SaaS Cloud, Dedicated Cloud, or Self-Managed instance.
+1. Navigate to your W&B organization on a W&B Multi-tenant Cloud, Dedicated Cloud, or Self-Managed instance.
 2. Click the **Create a new project** button in the left hand sidebar's **My projects** section. Alternatively, navigate to the **Projects** tab of your team and click the **Create new project** button in the upper right hand corner.
 3. After selecting the parent team and entering the name of the project, select the desired scope from the **Project Visibility** dropdown.
    <Frame>
@@ -91,7 +91,7 @@ Set a project's visibility scope when you create a project or when editing it la
 For the _Team_ or _Restricted_ scoped projects in your team, you can assign a specific role to a user, which could be different from that user's team level role. For example, if a user has _Member_ role at the team level, you can assign the _View-Only_, or _Admin_, or any available custom role to that user within a _Team_ or _Restricted_ scope project in that team.
 
 <Note>
-Project level roles are in preview on SaaS Cloud, Dedicated Cloud, and Self-Managed instances.
+Project level roles are in preview on W&B Multi-tenant Cloud, Dedicated Cloud, and Self-Managed instances.
 </Note>
 
 ### Assign project level role to a user

--- a/platform/hosting/iam/scim.mdx
+++ b/platform/hosting/iam/scim.mdx
@@ -22,7 +22,7 @@ For practical Python examples demonstrating how to interact with the SCIM API, v
 - **Service Account Authentication**: Organization service accounts can access the API
 
 <Note>
-If you are an admin of multiple Enterprise [Multi-tenant SaaS](/platform/hosting/hosting-options/multi_tenant_cloud) organizations, you must configure the organization where SCIM API requests are sent to ensure SCIM API requests sent using your API Key affect the correct organization. Click your profile image, then click **User Settings**, then check the setting **Default API organization**.
+If you are an admin of multiple Enterprise [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) organizations, you must configure the organization where SCIM API requests are sent to ensure SCIM API requests sent using your API Key affect the correct organization. Click your profile image, then click **User Settings**, then check the setting **Default API organization**.
 
 The chosen hosting option determines the value for the `<host-url>` placeholder used in the examples in this page.
 
@@ -697,7 +697,7 @@ Reactivates a previously deactivated user in your organization.
 <Note>
 - User reactivation works for users only, not service accounts. Reactivation is not supported for service accounts. Manage service accounts in the settings for the W&B Team.
 
-- User reactivation is not supported in [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud). To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account is not managed by the organization. An attempt to reactivate a user results in a HTTP `400` error:
+- User reactivation is not supported in [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud). To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account is not managed by the organization. An attempt to reactivate a user results in a HTTP `400` error. The `detail` field in the response body is returned verbatim from the API and may still use legacy product wording:
     ```json
     {
         "schemas": [
@@ -2298,7 +2298,7 @@ W&B maintains two separate SCIM API implementations, and the features differ bet
 ## Limitations
 
 - **Maximum results**: 9999 items per request.
-- **Single-tenant environments**: Only support one email per user.
+- **Dedicated Cloud and Self-Managed**: Only support one email per user.
 - **Team deletion**: Not supported via SCIM (use the W&B web interface).
 - **User reactivation**: Not supported in Multi-tenant Cloud environments.
 - **Seat limits**: Operations may fail if organization seat limits are reached.

--- a/platform/hosting/iam/sso.mdx
+++ b/platform/hosting/iam/sso.mdx
@@ -19,7 +19,7 @@ In the context of W&B, access tokens authorize requests to APIs on behalf of the
 
 You can use environment variables to [configure IAM options](/platform/hosting/iam/advanced_env_vars) for your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instance.
 
-To assist with configuring Identity Providers for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) W&B installations, follow these guidelines to follow for various IdPs. If you’re using the SaaS version of W&B, reach out to [support@wandb.com](mailto:support@wandb.com) for assistance in configuring an Auth0 tenant for your organization.
+To assist with configuring Identity Providers for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) deployments, follow these guidelines. If you’re using W&B Multi-tenant Cloud, reach out to [support@wandb.com](mailto:support@wandb.com) for assistance.
 
 ## Configure your IdP
 This section shows how to configure your identity provider (IdP) for OIDC. Select the tab for your IdP for details.

--- a/release-notes/server-releases-archived.mdx
+++ b/release-notes/server-releases-archived.mdx
@@ -407,7 +407,7 @@ Due to a release versioning issue, 0.56.0 is the next major release after 0.54.0
 <Update label="v0.44.1" description="October 12, 2023">
 
 ## Features
-**Add OpenAI proxy UI to SaaS and Server**
+**Add OpenAI proxy UI to W&B**
 
 <Frame>
 ![Image showing the new OpenAI proxy UI](https://github.com/wandb/server/assets/7208315/8bc78df9-e0e7-455e-8c74-975caa96eccf)

--- a/support/models/articles/workspace-loads-slowly-with-many-metric.mdx
+++ b/support/models/articles/workspace-loads-slowly-with-many-metric.mdx
@@ -28,7 +28,7 @@ Having hundreds of sections hurts performance. Consider using the workspace sett
 
 ### Too many runs
 
-Keep the total number of runs in a single project under 100,000 on SaaS Cloud, or 10,000 on Dedicated Cloud or Self-Managed. If your project exceeds these limits, consider [moving less frequently used runs](/models/runs/manage-runs/) to an archive project.
+Keep the total number of runs in a single project under 100,000 on W&B Multi-tenant Cloud, or 10,000 on Dedicated Cloud or Self-Managed. If your project exceeds these limits, consider [moving less frequently used runs](/models/runs/manage-runs/) to an archive project.
 
 For more information, see [Experiments limits and performance](/models/track/limits/).
 

--- a/weave/guides/platform.mdx
+++ b/weave/guides/platform.mdx
@@ -22,7 +22,7 @@ Use the identity and access management capabilities for secure authentication an
 
 ## Data security
 
-- **SaaS Cloud:** Data for all Weave users is stored in a shared Clickhouse Cloud cluster, encrypted using cloud-native encryption. Shared compute services process the data, ensuring isolation through a security context comprising your W&B organization, team, and project.
+- **Multi-tenant Cloud:** Data for all Weave users is stored in a shared Clickhouse Cloud cluster, encrypted using cloud-native encryption. Shared compute services process the data, ensuring isolation through a security context comprising your W&B organization, team, and project.
 
 - **Dedicated Cloud:** Data is stored in a unique Clickhouse Cloud cluster in the cloud and region of your choice. A unique compute environment processes the data, with the following additional protections:
   - **[IP allowlisting](/platform/hosting/data-security/ip-allowlisting):** Authorize access to your instance from specific IP addresses. This is an optional capability.
@@ -36,7 +36,7 @@ Use the identity and access management capabilities for secure authentication an
 
 ## Maintenance 
 
-If you're using Weave on SaaS Cloud or Dedicated Cloud, you avoid the overhead and costs of provisioning, operating, and maintaining the W&B platform, as it is fully managed for you.
+If you're using Weave on Multi-tenant Cloud or Dedicated Cloud, you avoid the overhead and costs of provisioning, operating, and maintaining the W&B platform, as it is fully managed for you.
 
 ## Compliance
 
@@ -44,4 +44,4 @@ If you're using Weave on SaaS Cloud or Dedicated Cloud, you avoid the overhead a
 To request SOC 2 reports and other security and compliance documents, refer to the [W&B Security Portal](https://security.wandb.ai/) or contact your W&B team for more information.
 </Tip>
 
-Security controls for both SaaS Cloud and Dedicated Cloud are periodically audited internally and externally. Both platforms are SOC 2 Type II compliant. Additionally, Dedicated Cloud is HIPAA-compliant for organizations managing PHI data while building Generative AI applications.
+Security controls for both Multi-tenant Cloud and Dedicated Cloud are periodically audited internally and externally. Both platforms are SOC 2 Type II compliant. Additionally, Dedicated Cloud is HIPAA-compliant for organizations managing PHI data while building Generative AI applications.


### PR DESCRIPTION
## Description
Scrub for W&B branding consistency

- Bias toward terminology in public pricing page and other authoritative pages, recent blog posts, FullyConnected, social posts
- Squash 'SaaS', 'single-tenant', and other conflations that tend to creep back in

Fixes WBDOCS-1919

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
