### PR TITLE
Remove sidebarTitle from Weave SDK release notes

### DIFF
--- a/release-notes/weave-sdk-releases.mdx
+++ b/release-notes/weave-sdk-releases.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Weave SDK releases"
 description: "View release notes for the Weave Python SDK (`weave` package), including new features, bug fixes, and performance improvements by version."
-sidebarTitle: "Weave SDK"
 rss: true
 ---
 


### PR DESCRIPTION
## Description
Remove sidebarTitle from Weave SDK release notes

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
