### PR TITLE
chore(weave_ts): mentions the minimum requirement of openai/agents dependency

### DIFF
--- a/weave/guides/integrations/openai_agents.mdx
+++ b/weave/guides/integrations/openai_agents.mdx
@@ -68,7 +68,7 @@ The [OpenAI Agents Node SDK](https://github.com/openai/openai-node) is a lightwe
 
 ## Installation
 
-Install the required dependencies using `npm`:
+Install the required dependencies using `npm`. Weave's TypeScript integration requires `@openai/agents` version `0.4.15` or later:
 
 ```bash
 npm install weave @openai/agents zod


### PR DESCRIPTION
## Description

TypeScript SDK requires a minimum version of openai/agents to activate.

As seen in:

https://github.com/wandb/weave/blob/8fd291f781fa3d5ecc0f5128fda0d2b35357a160/sdks/node/src/integrations/openai.agent.ts#L723


<!-- Uncomment and add a description of the change -->


<!-- Optionally, uncomment the heading and add details about how you tested the change and how reviewers should test it. For example:
## Testing
- [ ] Local build succeeds without errors (`mint dev`)
- [ ] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Replace the `[ ]` with `[x]` to check off the item instead of leaving it unchecked.

Otherwise, delete this entire section from opening to closing comment.
-->

<!-- Optionally, uncomment the heading and add one or more lines like these. Otherwise, delete this entire section from opening to closing comment.

## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->

Doc team members: I am not familiar with doc change procedures, so feel free to revise my change as you see fit. 