### PR TITLE
Remove docs.json update logic

### DIFF
--- a/.github/workflows/knowledgebase-nav.yml
+++ b/.github/workflows/knowledgebase-nav.yml
@@ -6,9 +6,13 @@
 # -----------------------
 # Runs the Python script scripts/knowledgebase-nav/generate_tags.py against
 # the repo root. That script syncs keyword footers on support articles,
-# rebuilds tag pages and product index MDX, and updates docs.json and the
-# root support.mdx counts. See scripts/knowledgebase-nav/README.md and
-# Architecture.md for the full pipeline.
+# rebuilds tag pages and product index MDX, and updates the root support.mdx
+# counts. The generator never edits docs.json. When the set of tag pages
+# changes, the PR comment posted by scripts/knowledgebase-nav/pr_report.py
+# lists the page ids a human must add to or remove from each
+# "Support: <display_name>" tab in docs.json by hand. See
+# scripts/knowledgebase-nav/README.md and Architecture.md for the full
+# pipeline.
 #
 # When it runs
 # ------------
@@ -101,7 +105,7 @@ jobs:
         id: nav_commit
         if: github.event_name == 'pull_request'
         run: |
-          CHORE_SUBJECT="chore: regenerate support tag pages and docs.json navigation"
+          CHORE_SUBJECT="chore: regenerate support tag pages"
           FIRST="$(git log -1 --pretty=%B | head -n1)"
           if [ "${FIRST}" = "${CHORE_SUBJECT}" ]; then
             echo "is_auto_nav_commit=true" >> "${GITHUB_OUTPUT}"
@@ -128,9 +132,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r scripts/knowledgebase-nav/requirements.txt
 
-      # Writes into the working tree (support/, docs.json, support.mdx, etc.).
-      # stderr (Python warnings) is captured for the PR comment steps below.
-      - name: Generate tag pages and update docs.json
+      # Writes into the working tree (support/, support.mdx, etc.). Never
+      # edits docs.json. stderr (Python warnings) is captured for the PR
+      # comment steps below.
+      - name: Generate tag pages and product index
         run: python scripts/knowledgebase-nav/generate_tags.py --repo-root . 2>generator-warnings.log
 
       - name: Show generator warnings in log
@@ -195,11 +200,12 @@ jobs:
           echo "::notice::Fork PR: auto-commit is skipped. Push regenerated files from scripts/knowledgebase-nav (see README) or a maintainer can run the generator after merge."
 
       # Commits only if the generator changed files; file_pattern limits
-      # which paths are staged. Skipped for fork PRs and unnecessary for
-      # pushes with no diff (action is a no-op).
+      # which paths are staged. docs.json is excluded so generator runs never
+      # mutate it. Skipped for fork PRs and unnecessary for pushes with no
+      # diff (action is a no-op).
       - name: Commit generated changes
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "chore: regenerate support tag pages and docs.json navigation"
-          file_pattern: "support.mdx support/*/articles/*.mdx support/*/tags/*.mdx support/*.mdx docs.json"
+          commit_message: "chore: regenerate support tag pages"
+          file_pattern: "support.mdx support/*/articles/*.mdx support/*/tags/*.mdx support/*.mdx"

--- a/scripts/knowledgebase-nav/Architecture.md
+++ b/scripts/knowledgebase-nav/Architecture.md
@@ -4,7 +4,7 @@ This document describes the **Knowledgebase Nav** system in the `wandb-docs` rep
 
 ## Purpose
 
-The generator keeps support (knowledgebase) navigation consistent with article content. It runs over configured products (for example models, weave, inference), reads MDX articles under `support/<product>/articles/`, and updates generated MDX pages, root `support.mdx` counts, and English support tabs in `docs.json`.
+The generator keeps support (knowledgebase) navigation consistent with article content. It runs over configured products (for example models, weave, inference), reads MDX articles under `support/<product>/articles/`, and updates generated MDX pages and root `support.mdx` counts. The generator never reads or writes `docs.json`; humans edit that file by hand based on the workflow's PR comment.
 
 ## High-level context
 
@@ -19,7 +19,6 @@ flowchart LR
     GEN["generate_tags.py"]
     OUT1["support/*/tags/*.mdx"]
     OUT2["support/<product>.mdx"]
-    DJ["docs.json"]
     SM["support.mdx"]
   end
   CFG --> GEN
@@ -27,32 +26,34 @@ flowchart LR
   ART --> GEN
   GEN --> OUT1
   GEN --> OUT2
-  GEN --> DJ
   GEN --> SM
   GEN --> ART
 ```
 
 The arrow back to **articles** means phase 4 updates only `<Badge>` links that point at tag pages under `/support/<product>/tags/`, wrapped in MDX comment markers. Other content (including `---`, other Badges, and text outside the markers) is not rewritten.
 
+`docs.json` is intentionally absent from this diagram. When tag pages are added or removed, the workflow's PR comment (built by `pr_report.py`) lists the page ids that a human must add to or remove from the matching `Support: <display_name>` tab in `docs.json` by hand.
+
 ## Automation workflow
 
-Pull requests trigger the **Knowledgebase Nav** workflow when files under `support/**` or `scripts/knowledgebase-nav/**` change (including new pushes to an open PR). It installs Python dependencies, runs the generator, and commits matching paths when there are diffs. Pull requests from **forks** check out the fork head commit and still run the generator, but the auto-commit step is skipped because the default token cannot push to forks.
+Pull requests trigger the **Knowledgebase Nav** workflow when files under `support/**` or `scripts/knowledgebase-nav/**` change (including new pushes to an open PR). It installs Python dependencies, runs the generator, posts a PR comment with any "docs.json update required" instructions, and commits matching paths when there are diffs. Pull requests from **forks** check out the fork head commit and still run the generator, but the auto-commit step is skipped because the default token cannot push to forks.
 
 ```mermaid
 flowchart TD
   A[PR or manual workflow_dispatch] --> B[Checkout ref]
   B --> C[Python 3.11 + pip install requirements.txt]
   C --> D["generate_tags.py --repo-root ."]
-  D --> E{Files changed?}
+  D --> R["pr_report.py (lists tag-page adds/removes)"]
+  R --> E{Files changed?}
   E -->|yes| F[git-auto-commit selected paths]
   E -->|no| G[No commit]
 ```
 
-Committed path patterns include `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, `support/*.mdx` (product indexes), and `docs.json`.
+Committed path patterns include `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, and `support/*.mdx` (product indexes). `docs.json` is intentionally excluded; humans update it manually.
 
 ## Pipeline orchestration
 
-`run_pipeline(repo_root, config_path)` is the single entry point used by the CLI and tests. It loads `config.yaml`, builds one Jinja2 environment for all products, then loops each product. After the loop it updates `docs.json` once and `support.mdx` once.
+`run_pipeline(repo_root, config_path)` is the single entry point used by the CLI and tests. It loads `config.yaml`, builds one Jinja2 environment for all products, then loops each product. After the loop it updates `support.mdx` once. It does not touch `docs.json`.
 
 ```mermaid
 flowchart TD
@@ -67,10 +68,9 @@ flowchart TD
   P4 --> P5[sync_all_support_article_footers]
   P5 --> P6[Record product_stats]
   P6 --> LOOP
-  LOOP -->|done| P7[update_docs_json]
-  P7 --> P8[update_support_index]
-  P8 --> P9[update_support_featured]
-  P9 --> DONE([Done])
+  LOOP -->|done| P7[update_support_index]
+  P7 --> P8[update_support_featured]
+  P8 --> DONE([Done])
 ```
 
 ## Per-product data flow
@@ -102,18 +102,19 @@ flowchart LR
   PATHS --> TAGS
 ```
 
-`render_tag_pages` returns sorted page id strings (for example `support/models/tags/security`) that `update_docs_json` merges into the English navigation tab for that product.
+`render_tag_pages` returns sorted page id strings (for example `support/models/tags/security`). `pr_report.py` consumes the same ids when it builds the "docs.json update required" section in the workflow's PR comment so a human can update the matching `Support: <display_name>` tab in `docs.json`.
 
 ## Components and files
 
 | Component | Path | Role |
 |-----------|------|------|
-| CLI and logic | `generate_tags.py` | All phases, parsing, slug rules, previews, JSON and MDX rewrites |
+| CLI and logic | `generate_tags.py` | All phases, parsing, slug rules, previews, MDX rewrites (does not touch `docs.json`) |
+| PR report | `pr_report.py` | Markdown report from `git diff`; lists added/removed tag pages so a human can update `docs.json` |
 | Product and tag registry | `config.yaml` | `slug`, `display_name`, `allowed_keywords` per product |
 | Tag listing template | `templates/support_tag.mdx.j2` | One Card per article on a tag page |
 | Product hub template | `templates/support_product_index.mdx.j2` | Featured section and browse-by-category Cards |
 | Dependencies | `requirements.txt` | PyYAML, Jinja2 |
-| Unit tests | `tests/test_generate_tags.py` | Mocked filesystem and `docs.json` |
+| Unit tests | `tests/test_generate_tags.py` | Mocked filesystem |
 | Integration tests | `tests/test_golden_output.py` | Full pipeline on a temp copy of the real repo |
 | Pytest markers | `tests/conftest.py` | Registers the `integration` marker for the golden suite |
 | CI | `.github/workflows/knowledgebase-nav.yml` | Triggers, run script, auto-commit |
@@ -158,14 +159,15 @@ Functions are grouped below the way they appear in the source file. Names refer 
 
 - **`tojson_unicode`**, **`create_template_env`** configure Jinja2 for MDX (templates use the `tojson_unicode` filter for YAML front matter values).
 - **`render_tag_pages`** writes `support/<product>/tags/<tag-slug>.mdx`.
-- **`cleanup_stale_tag_pages`** deletes `.mdx` files in the tags directory that were not just generated, keeping the directory and `docs.json` free of stale entries.
+- **`cleanup_stale_tag_pages`** deletes `.mdx` files in the tags directory that were not just generated, keeping the tags directory free of stale entries.
 - **`render_product_index`** writes `support/<product>.mdx`.
 
 ### Site-wide updates
 
-- **`update_docs_json`** updates or creates hidden `Support: <display_name>` tabs under `navigation.languages` where `language` is `en`, setting `pages` to the product index plus sorted tag paths.
 - **`update_support_index`** updates count lines on product Cards in root `support.mdx`. Locates markers via `_COUNTS_START_RE` / `_COUNTS_END_RE`; falls back to a bare count-line pattern for migration.
 - **`update_support_featured`** regenerates the featured-articles section in root `support.mdx`, locating the block via `_FEATURED_START_RE` / `_FEATURED_END_RE`.
+
+The pipeline does not edit `docs.json`. Tag-page additions and removals are surfaced to humans through `pr_report.py`, which lists the affected page ids in the workflow's PR comment.
 
 ### CLI
 
@@ -174,7 +176,6 @@ Functions are grouped below the way they appear in the source file. Names refer 
 ## Constants
 
 - **`BODY_PREVIEW_MAX_LENGTH`** and **`BODY_PREVIEW_SUFFIX`** control Card preview length and ellipsis.
-- **`DOCS_JSON_NAV_LANGUAGE`** is `"en"` and scopes navigation edits to the English tree only.
 - **`_make_markers(keyword)`** generates the four constants below for each managed section: canonical start/end strings for writing and compiled `re.Pattern` objects for reading.
 - **`_BADGE_START`** / **`_BADGE_END`** — canonical `{/* AUTO-GENERATED: tab badges */}` strings written to article files. **`_BADGE_START_RE`** / **`_BADGE_END_RE`** — patterns used to locate the block (case-insensitive, colon optional, keyword anywhere in the comment).
 - **`_COUNTS_START`** / **`_COUNTS_END`** — canonical `{/* AUTO-GENERATED: counts */}` strings written to `support.mdx`. **`_COUNTS_START_RE`** / **`_COUNTS_END_RE`** — patterns used inside the Card-anchored structural pattern that locates and replaces count lines.
@@ -185,9 +186,10 @@ Functions are grouped below the way they appear in the source file. Names refer 
 - **Monolithic script**: one file holds all logic so the workflow and contributors have a single place to read and change behavior.
 - **Allowed keywords**: `config.yaml` lists valid tags per product; unknown tags still generate pages but emit warnings so content is never dropped silently.
 - **Tab Badge ownership**: only `<Badge>` elements linking to `/support/<product>/tags/...` are derived from `keywords`. These are wrapped in marker comments located by `_BADGE_START_RE` / `_BADGE_END_RE`. The `---` line between body and badges is cosmetic; `_extract_body` uses `_BADGE_START_RE` as the boundary and trims a trailing `---` only as cleanup.
-- **Stale tag cleanup**: tag pages that no longer correspond to any article keyword are deleted after generation, before `docs.json` is updated. This keeps the tags directory and navigation free of orphaned entries.
+- **Stale tag cleanup**: tag pages that no longer correspond to any article keyword are deleted after generation. This keeps the tags directory free of orphaned entries; the workflow's PR comment then asks a human to remove the matching entries from `docs.json`.
 - **Marker-based editing**: all auto-generated sections (article tab Badges, `support.mdx` count lines, and featured articles) use MDX comment markers generated by `_make_markers`. Matching is case-insensitive with an optional colon, and the keyword can appear anywhere inside the comment, so authors can freely annotate markers without breaking the generator. Each marker pair has a migration path that wraps bare content on first run.
-- **Golden tests**: compare generated tag pages, product index pages, article files (including footer markers), support tabs in `docs.json`, and root `support.mdx` to the committed tree so output drift is visible as a unified diff.
+- **`docs.json` is human-edited**: the generator never reads or writes `docs.json`. Tag page additions and removals are surfaced through `pr_report.py`, which lists page ids grouped by `Support: <display_name>` so a human can update the matching tab by hand.
+- **Golden tests**: compare generated tag pages, product index pages, article files (including footer markers), and root `support.mdx` to the committed tree so output drift is visible as a unified diff. The golden suite also asserts that `docs.json` is never produced in the temp tree.
 
 ## Related reading
 

--- a/scripts/knowledgebase-nav/README.md
+++ b/scripts/knowledgebase-nav/README.md
@@ -1,14 +1,15 @@
 # Knowledgebase Nav Generator
 
-A standalone script that regenerates knowledgebase nav pages and updates the `docs.json` navigation for the W&B documentation repository.
+A standalone script that regenerates knowledgebase nav pages for the W&B documentation repository.
 
 The generator reads MDX article files from `support/<product>/articles/`, aggregates them by keyword tags, and:
 
 - **Updates tab-page Badges on articles.** Only `<Badge>` components whose link goes to `/support/<product>/tags/<tag-slug>` are rewritten from `keywords` (order preserved). Managed Badges are wrapped in MDX comment markers — any `{/* ... */}` comment that contains `AUTO-GENERATED: tab badges` anywhere inside it is the start marker; any comment that contains `END AUTO-GENERATED: tab badges` anywhere inside it is the end marker. You can add notes anywhere inside these comments without breaking the generator. Other Badges, prose, and anything outside the markers stay as you wrote them. If a new article has no tab Badges yet, the generator will insert them for you when `keywords` is non-empty.
 - **Produces tag pages** at `support/<product>/tags/<tag-slug>.mdx`. Each lists the articles tagged with that keyword as Mintlify Card components.
 - **Product index pages** at `support/<product>.mdx`. Each shows a "Featured articles" section (if any) and a "Browse by category" listing of all tags with article counts.
-- **Updated `docs.json` navigation.** Hidden support tabs are updated to reflect the current set of tag pages.
 - **Updated root `support.mdx`.** The generator replaces the article and tag count lines inside each product `<Card>` (matched by `href="/support/<slug>"`) so the landing page stays in sync with the crawl. Count lines are wrapped between `{/* AUTO-GENERATED: counts */}` and `{/* END AUTO-GENERATED: counts */}` markers. The featured-articles section is managed between `{/* AUTO-GENERATED: featured articles */}` and `{/* END AUTO-GENERATED: featured articles */}` markers. For all markers: matching is case-insensitive, the colon after "generated" is optional, and the keyword can appear anywhere inside the comment — so you can add notes without breaking the generator.
+
+The generator never reads, parses, or writes `docs.json`. When tag pages are added or removed, a human must update the matching `Support: <display_name>` tab under `navigation.languages[language="en"].tabs[]` by hand. The PR comment posted by `pr_report.py` lists the exact page ids to add or remove, grouped by product, so the edit can be made with copy and paste.
 
 The generator runs automatically through GitHub Actions (workflow file `.github/workflows/knowledgebase-nav.yml`) when a pull request is opened, updated with new commits, or reopened, and at least one changed file matches `support/**` or `scripts/knowledgebase-nav/**`. You can also run that workflow manually from the Actions tab for previews.
 
@@ -45,7 +46,7 @@ If you want to run the generator locally (for example to preview footers and tag
 
    The generator recognises any `{/* ... */}` comment that contains `AUTO-GENERATED: tab badges` anywhere inside it as the start marker, and any comment that contains `END AUTO-GENERATED: tab badges` anywhere inside it as the end marker. You can add notes anywhere inside these comments — before the keyword, after it, or both — without breaking the generator. The canonical marker text is always written on output regardless of what was in the original comment.
 
-4. Open a pull request. The workflow checks out your branch, runs the generator, and commits any updates to article footers, tag pages, product index pages, `docs.json`, and `support.mdx` when those files change. You do not need to edit generated files by hand. **Pull requests from forks** still run the generator (so logs show problems), but GitHub cannot push commits back to your fork. Run the generator locally and push the regenerated files, or ask a maintainer to regenerate after merge.
+4. Open a pull request. The workflow checks out your branch, runs the generator, and commits any updates to article footers, tag pages, product index pages, and `support.mdx` when those files change. The generator does not edit `docs.json`. If your change adds or removes any tag pages, the workflow's PR comment lists the exact page ids that need to be added to or removed from the matching `Support: <display_name>` tab in `docs.json`; a human (you or a reviewer) must make that edit by hand and push it on the PR branch. You do not need to edit any other generated files by hand. **Pull requests from forks** still run the generator (so logs show problems), but GitHub cannot push commits back to your fork. Run the generator locally and push the regenerated files, or ask a maintainer to regenerate after merge.
 
    If you remove every keyword from front matter (`keywords: []` or omit the field), the generator removes tab-page Badges only. Other Badges are unchanged.
 
@@ -78,7 +79,7 @@ If you want to use a keyword that is not yet recognized for a product, you need 
        - API Keys
    ```
 
-3. Use the keyword in your article's `keywords` front matter. On the next PR, the generator creates a new tag page at `support/<product>/tags/api-keys.mdx` and adds it to the `docs.json` navigation.
+3. Use the keyword in your article's `keywords` front matter. On the next PR, the generator creates a new tag page at `support/<product>/tags/api-keys.mdx`. The PR comment posted by the workflow lists the new page id (for example `support/<product>/tags/api-keys`) under "docs.json update required". Add that line to the matching `Support: <display_name>` tab's `pages` array in `docs.json` and push it on the PR branch — the generator will not do this for you.
 
 **What if I forget to update config.yaml?** The generator still creates the tag page, but prints a warning in the CI logs. This is intentional. We never silently drop content. Resolve the warning by adding the keyword to config.yaml.
 
@@ -157,7 +158,7 @@ These steps are written for **macOS**. They use a **virtual environment** so pac
 
 **Prerequisites:** [Python](https://www.python.org/downloads/) 3.11 or another current Python 3 release (3.11 is what CI uses).
 
-1. Open Terminal and go to the root of the `wandb-docs` clone (the directory that contains `docs.json` and `support/`).
+1. Open Terminal and go to the root of the `wandb-docs` clone (the directory that contains the `support/` folder).
 
 2. Create a virtual environment in a folder named `.venv` (you can pick another name, but keep that folder out of git commits), then activate it:
 
@@ -181,7 +182,7 @@ These steps are written for **macOS**. They use a **virtual environment** so pac
    python scripts/knowledgebase-nav/generate_tags.py --repo-root .
    ```
 
-   The command updates article footers, tag pages, product indexes, `docs.json`, and `support.mdx` in your working tree. Review the changes with `git diff` before you commit.
+   The command updates article footers, tag pages, product indexes, and `support.mdx` in your working tree. It does not modify `docs.json`. Review the changes with `git diff` before you commit.
 
 5. When you are done, leave the virtual environment:
 
@@ -210,7 +211,7 @@ scripts/knowledgebase-nav/
   tests/
     __init__.py             Package marker for tests
     conftest.py             Registers the `integration` pytest marker
-    test_generate_tags.py   Unit tests (pytest, mocked filesystem and docs.json)
+    test_generate_tags.py   Unit tests (pytest, mocked filesystem)
     test_golden_output.py   Golden-file integration tests (real repo layout)
 ```
 
@@ -220,15 +221,15 @@ The script runs one pipeline after loading `config.yaml` and Jinja2 templates. T
 
 1. **Crawl and parse** (`crawl_articles`, `parse_frontmatter`, `build_tag_index`, `get_featured_articles`): For each product, reads every `.mdx` file in `support/<product>/articles/`, parses YAML front matter (`title`, `keywords`, `featured`), and extracts the article body (everything before the first `_BADGE_START_RE` match). The `keywords` field is normalized with `_normalize_keywords` (YAML list of strings; a single string is coerced to a one-item list with a warning; other shapes warn and become an empty list). Body text is turned into a Card preview with `plain_text` and `extract_body_preview`. The `plain_text` step removes fenced code, horizontal rules, links and image syntax (keeping link labels), autolinks, bare `http(s)` URLs, HTML and MDX or JSX tags and simple `{...}` expressions, emphasis markers, common list or heading prefixes, decodes HTML entities, replaces non-breaking spaces (U+00A0) with a normal space, maps typographic quotes and apostrophes to ASCII, then applies an allowlist of safe characters (including `_` and `=` for identifiers) and collapses whitespace. `extract_body_preview` truncates to 120 characters and appends ` ...` when longer. Unknown `keywords` values warn once per keyword but still get tag pages.
 
-2. **Generate tag pages** (`render_tag_pages`, `cleanup_stale_tag_pages`): For each tag that appears in at least one article, renders `support/<product>/tags/<tag-slug>.mdx` from `support_tag.mdx.j2`. Tags present only in `config.yaml` and not used by any article do not get a file. After writing current pages, `cleanup_stale_tag_pages` deletes any `.mdx` files in the tags directory that no longer correspond to a keyword used by any article, keeping the tags directory and `docs.json` free of stale entries.
+2. **Generate tag pages** (`render_tag_pages`, `cleanup_stale_tag_pages`): For each tag that appears in at least one article, renders `support/<product>/tags/<tag-slug>.mdx` from `support_tag.mdx.j2`. Tags present only in `config.yaml` and not used by any article do not get a file. After writing current pages, `cleanup_stale_tag_pages` deletes any `.mdx` files in the tags directory that no longer correspond to a keyword used by any article, keeping the tags directory free of stale entries.
 
 3. **Generate product index pages** (`render_product_index`): Renders `support/<product>.mdx` with optional "Featured articles" and a "Browse by category" section from `support_product_index.mdx.j2`.
 
 4. **Sync tab Badges** (`sync_all_support_article_footers`, `sync_support_article_footer`, `build_tab_badges_mdx`, `build_keyword_footer_mdx`): For each `support/<product>/articles/*.mdx` file, replaces managed `<Badge>` links with one Badge per `keywords` entry (in list order). Managed Badges are located via `_BADGE_START_RE` and `_BADGE_END_RE`: any `{/* ... */}` comment containing `AUTO-GENERATED: tab badges` anywhere inside it is the start; any comment containing `END AUTO-GENERATED: tab badges` anywhere inside it is the end — authors can add notes anywhere in these comments without breaking the generator. The generator falls back to regex matching for articles that predate markers. Other Badges and the rest of the body are not edited. If there are no such Badges yet and `keywords` is non-empty, appends a blank line, canonical markers, and the tab Badges (no `---`). If `keywords` is empty, removes the marker block (or bare tab-page Badges). Runs after tag pages are generated so articles are not modified if earlier phases fail.
 
-5. **Update docs.json** (`update_docs_json`): Reads `docs.json`, finds the English entry (`navigation.languages[]` where `language == "en"`), then finds or creates hidden tabs named `Support: <display_name>`. Each tab's `pages` list is `support/<slug>` followed by sorted tag page paths. Other language entries and non-support tabs are left unchanged.
+5. **Update support landing page** (`update_support_index`, `update_support_featured`): Edits the repository root `support.mdx` in place. Count lines inside each product `<Card>` are located via `_COUNTS_START_RE` / `_COUNTS_END_RE` (any `{/* ... */}` comment containing `AUTO-GENERATED: counts` / `END AUTO-GENERATED: counts`, falling back to a bare count-line pattern for migration) and replaced with current article and tag counts (including singular or plural labels). The featured-articles section is regenerated between markers located via `_FEATURED_START_RE` / `_FEATURED_END_RE` (any comment containing `AUTO-GENERATED: featured articles` / `END AUTO-GENERATED: featured articles`). All marker matching is case-insensitive with an optional colon after "generated".
 
-6. **Update support landing page** (`update_support_index`, `update_support_featured`): Edits the repository root `support.mdx` in place. Count lines inside each product `<Card>` are located via `_COUNTS_START_RE` / `_COUNTS_END_RE` (any `{/* ... */}` comment containing `AUTO-GENERATED: counts` / `END AUTO-GENERATED: counts`, falling back to a bare count-line pattern for migration) and replaced with current article and tag counts (including singular or plural labels). The featured-articles section is regenerated between markers located via `_FEATURED_START_RE` / `_FEATURED_END_RE` (any comment containing `AUTO-GENERATED: featured articles` / `END AUTO-GENERATED: featured articles`). All marker matching is case-insensitive with an optional colon after "generated".
+`docs.json` is intentionally not on this list. The generator does not read or write that file. After the generator runs, the workflow's PR comment (built by `pr_report.py`) lists the page ids of any tag pages that were added or removed, grouped by `Support: <display_name>`, so a human can update the matching tab in `docs.json` by hand.
 
 ### Running locally
 
@@ -254,15 +255,15 @@ pytest scripts/knowledgebase-nav/tests/test_golden_output.py -v -m integration
 
 The unit tests use mocked file systems and run fast.
 
-The golden-file module (`test_golden_output.py`) is marked `@pytest.mark.integration`. The marker is registered in `tests/conftest.py` so pytest does not warn about an unknown mark. It copies `support/`, `docs.json`, and `support.mdx` from the real repo into a temporary directory, runs the full pipeline there, and asserts:
+The golden-file module (`test_golden_output.py`) is marked `@pytest.mark.integration`. The marker is registered in `tests/conftest.py` so pytest does not warn about an unknown mark. It copies `support/` and `support.mdx` from the real repo into a temporary directory, runs the full pipeline there, and asserts:
 
 - Every tag page under `support/<product>/tags/*.mdx` matches the real repo byte-for-byte (including that generated and existing tag file sets match).
 - Each product index `support/<product>.mdx` matches the real repo byte-for-byte.
 - Every article under `support/<product>/articles/*.mdx` matches the real repo byte-for-byte (catches regressions in footer sync and marker formatting).
-- Support tabs in `docs.json` (names, `pages` order, `hidden: true`) match the real file, and tabs that do not start with `Support:` are unchanged.
+- No `docs.json` file is created in the temp tree, so the pipeline never reads or writes it.
 - Root `support.mdx` matches the real file byte-for-byte.
 
-If `docs.json` is not found at the repository root the tests resolve to (the parent directory of `scripts/`, when this package lives at `scripts/knowledgebase-nav/`), the golden tests skip.
+If `support.mdx` is not found at the repository root the tests resolve to (the parent directory of `scripts/`, when this package lives at `scripts/knowledgebase-nav/`), the golden tests skip.
 
 ### Adding a new product
 
@@ -281,9 +282,21 @@ If `docs.json` is not found at the repository root the tests resolve to (the par
 
    Without the markers (or the bare count-line pattern for migration), the generator warns and leaves that card unchanged.
 
-5. Run the generator (or open a PR). It creates the `tags/` directory as needed, generates tag pages and the product index page, adds or updates the hidden support tab in `docs.json`, and refreshes counts on `support.mdx`.
+5. Run the generator (or open a PR). It creates the `tags/` directory as needed, generates tag pages and the product index page, and refreshes counts on `support.mdx`. The generator does not edit `docs.json`. Add a new hidden tab to `docs.json` by hand at the same time you add the product:
 
-### How docs.json merging works
+   ```json
+   {
+     "tab": "Support: W&B NewProduct",
+     "hidden": true,
+     "pages": [
+       "support/<slug>"
+     ]
+   }
+   ```
+
+   Append the tag page ids to `pages` as the workflow's PR comment lists them.
+
+### How docs.json edits are coordinated
 
 The W&B docs site uses a multi-language navigation structure:
 
@@ -298,19 +311,19 @@ The W&B docs site uses a multi-language navigation structure:
 }
 ```
 
-The generator only modifies the English (`"en"`) language entry. Within that entry, it finds or creates hidden tabs named `"Support: <display_name>"` (for example `"Support: W&B Models"`). Each tab's `pages` list is set to:
+Hidden tabs named `"Support: <display_name>"` (for example `"Support: W&B Models"`) live under the English (`"en"`) language entry. Each tab's `pages` list looks like:
 
 ```
 ["support/<slug>", "support/<slug>/tags/tag-a", "support/<slug>/tags/tag-b", ...]
 ```
 
-All other tabs, groups, and non-support navigation entries are preserved untouched.
+The generator never edits this file. When tag pages change, the workflow's PR comment (built by `pr_report.py`) shows a "docs.json update required" section grouped by `Support: <display_name>` listing the page ids to add or remove from each tab's `pages` array. A human (the PR author or a reviewer) makes those edits by hand and pushes them on the PR branch.
 
 ### How the CI workflow triggers
 
 Workflow name: **Knowledgebase Nav** (file `.github/workflows/knowledgebase-nav.yml`). The job does not run `pytest`; run tests locally as above.
 
-- **Pull requests**: Runs when a PR is opened, synchronized (new pushes to the branch), or reopened, and the path filter matches. Only runs that include changes under `support/**` or `scripts/knowledgebase-nav/**` trigger the workflow (see GitHub path filters for `pull_request`). After generation, `stefanzweifel/git-auto-commit-action` commits only if something changed, using `file_pattern`: `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, `support/*.mdx`, and `docs.json`.
+- **Pull requests**: Runs when a PR is opened, synchronized (new pushes to the branch), or reopened, and the path filter matches. Only runs that include changes under `support/**` or `scripts/knowledgebase-nav/**` trigger the workflow (see GitHub path filters for `pull_request`). After generation, `stefanzweifel/git-auto-commit-action` commits only if something changed, using `file_pattern`: `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, and `support/*.mdx`. `docs.json` is intentionally not in this list — it is edited by humans only.
 
 - **workflow_dispatch**: Run from the Actions tab. Optional input `branch`: when set, checkout uses that branch name. When empty, checkout uses `github.ref` (the branch selected in the "Use workflow from" dropdown). On `pull_request` events, checkout uses the PR head repository and head commit SHA (including forks); auto-commit runs only for same-repo PRs, not forks.
 
@@ -318,11 +331,11 @@ Workflow name: **Knowledgebase Nav** (file `.github/workflows/knowledgebase-nav.
 
 **"Unknown keyword" warnings in CI logs**: An article uses a keyword not listed in `config.yaml`. The tag page is still generated, but add the keyword to config.yaml to suppress the warning.
 
-**Allowed keyword in config but no tag page file**: A keyword is listed in `config.yaml` but no article lists it in `keywords`. The generator only writes tag pages for tags that appear on at least one article, so no file is created for unused keywords. If a tag page previously existed but all articles stopped using that keyword, the generator deletes the stale file and removes it from `docs.json`.
+**Allowed keyword in config but no tag page file**: A keyword is listed in `config.yaml` but no article lists it in `keywords`. The generator only writes tag pages for tags that appear on at least one article, so no file is created for unused keywords. If a tag page previously existed but all articles stopped using that keyword, the generator deletes the stale file. The PR comment will list the removed page id under "docs.json update required" so a human can also remove it from the matching `Support:` tab in `docs.json`.
 
-**Tag page not appearing in docs.json**: Verify the keyword is used in at least one article's `keywords` front matter and that the generator ran successfully.
+**Tag page not appearing in docs.json**: The generator does not edit `docs.json`. After a new tag page is created, copy the page id (for example `support/models/tags/api-keys`) from the workflow's "docs.json update required" PR comment into the matching `Support: <display_name>` tab's `pages` array in `docs.json`, then commit and push the edit.
 
-**Golden test failures after intentional changes**: If you intentionally changed templates, slug logic, body preview rules, keyword footer formatting (including marker comments), product index output, `docs.json` support tabs, or `support.mdx` count lines or featured-article markers, the golden test will fail. Run the generator from the repo root, commit the updated generated files, then re-run the golden tests.
+**Golden test failures after intentional changes**: If you intentionally changed templates, slug logic, body preview rules, keyword footer formatting (including marker comments), product index output, or `support.mdx` count lines or featured-article markers, the golden test will fail. Run the generator from the repo root, commit the updated generated files, then re-run the golden tests.
 
 **Warning about a missing product card in `support.mdx`**: A product in `config.yaml` has no matching `<Card href="/support/<slug>">` or the count line does not match the expected pattern. Add or fix the card so counts can update.
 

--- a/scripts/knowledgebase-nav/generate_tags.py
+++ b/scripts/knowledgebase-nav/generate_tags.py
@@ -3,14 +3,20 @@
 Knowledgebase Nav Generator
 =========================
 
-A standalone script that regenerates knowledgebase nav pages and updates the
-docs.json navigation for the Weights & Biases documentation repository.
+A standalone script that regenerates knowledgebase nav pages for the Weights
+& Biases documentation repository.
 
 This script is designed to run as part of a GitHub Actions workflow, but can
 also be run locally for testing and previewing changes.
 
-What it does (six phases)
--------------------------
+The generator never reads, parses, or writes ``docs.json``. When the set of
+tag pages changes, a human must manually edit the matching
+``Support: <display_name>`` tab in ``docs.json``. The PR report posted by
+``pr_report.py`` lists the exact page ids that were added or removed so the
+docs.json edit can be made by hand.
+
+What it does (five phases)
+--------------------------
 
 Phase 1. Crawl and parse:
     Walks each product's articles/ directory and parses YAML front matter and
@@ -42,12 +48,7 @@ Phase 4. Sync tab-page Badges:
     Runs after tag pages are generated so articles are not modified if
     earlier phases fail.
 
-Phase 5. Update docs.json navigation (meta-generator pattern):
-    Reads the existing docs.json, finds or creates hidden support tabs for
-    each product, updates the page lists to reflect current tags, and writes
-    the file back while preserving all unrelated navigation entries.
-
-Phase 6. Update support.mdx (meta-generator pattern):
+Phase 5. Update support.mdx (meta-generator pattern):
     Refreshes article and tag counts on the root support landing page.
     Count lines are wrapped in ``{/* AUTO-GENERATED: counts */}`` /
     ``{/* END AUTO-GENERATED: counts */}`` markers (located by
@@ -64,7 +65,6 @@ Inputs
 - Article MDX files under support/<product>/articles/*.mdx
 - Configuration file (config.yaml) listing products and allowed keywords
 - Jinja2 templates in the templates/ directory
-- The existing docs.json in the repo root
 
 Outputs
 -------
@@ -78,16 +78,19 @@ Outputs
   ``keywords`` is non-empty)
 - Tag page MDX files at support/<product>/tags/<tag-slug>.mdx
 - Product index MDX files at support/<product>.mdx
-- Updated docs.json with correct support navigation tabs
 - Updated support.mdx product card counts (inside marker comments)
   and featured-articles section (inside marker comments)
+
+The generator does not modify ``docs.json``. After the generator runs, a
+human must update the support navigation tabs in ``docs.json`` to reflect any
+tag pages that were added or removed.
 
 Usage
 -----
     python generate_tags.py --repo-root /path/to/wandb-docs
 
 The --repo-root argument should point to the root of the wandb-docs repo
-(the directory that contains docs.json and the support/ folder).
+(the directory that contains the support/ folder and support.mdx).
 """
 
 import argparse
@@ -131,11 +134,6 @@ _PLAIN_TEXT_TYPOGRAPHIC_TO_ASCII = str.maketrans(
         "\u2033": '"',
     }
 )
-
-# The language entry in docs.json that contains the English navigation.
-# The W&B docs site uses a multi-language navigation structure under
-# navigation.languages[]; we only modify the English ("en") entry.
-DOCS_JSON_NAV_LANGUAGE = "en"
 
 # ---------------------------------------------------------------------------
 # MDX auto-generated marker constants
@@ -182,9 +180,9 @@ def _make_markers(keyword: str):
 
 # Tab badges (Phase 4)
 _BADGE_START, _BADGE_END, _BADGE_START_RE, _BADGE_END_RE = _make_markers("tab badges")
-# Article/tag counts in support.mdx Cards (Phase 6)
+# Article/tag counts in support.mdx Cards (Phase 5)
 _COUNTS_START, _COUNTS_END, _COUNTS_START_RE, _COUNTS_END_RE = _make_markers("counts")
-# Featured articles block in support.mdx (Phase 6)
+# Featured articles block in support.mdx (Phase 5)
 _FEATURED_START, _FEATURED_END, _FEATURED_START_RE, _FEATURED_END_RE = _make_markers("featured articles")
 
 
@@ -1266,9 +1264,11 @@ def render_tag_pages(
     Returns
     -------
     list of str
-        The docs.json page paths for the generated tag pages
+        The page paths for the generated tag pages
         (for example ``["support/models/tags/experiments", ...]``), sorted
-        alphabetically.
+        alphabetically. Page paths use the docs.json page id form (no
+        ``.mdx`` suffix) so callers can list them in PR comments for the
+        human who edits ``docs.json``.
 
     Side effects
     ------------
@@ -1416,124 +1416,7 @@ def render_product_index(
 
 
 # ---------------------------------------------------------------------------
-# Phase 5: docs.json navigation update
-# ---------------------------------------------------------------------------
-
-def update_docs_json(
-    repo_root: Path,
-    products: List[Dict[str, Any]],
-    all_tag_page_paths: Dict[str, List[str]],
-) -> None:
-    """
-    Update the docs.json navigation with current support tag pages.
-
-    Reads the existing docs.json, finds the English ("en") language
-    navigation root, and for each product either updates the existing
-    hidden support tab or creates a new one.  Each tab's page list is
-    set to the product overview page followed by sorted tag page paths.
-
-    All non-support navigation entries are preserved untouched.
-
-    Parameters
-    ----------
-    repo_root : Path
-        Path to the root of the wandb-docs repository.
-    products : list of dict
-        Product definitions from config.yaml, each with ``slug`` and
-        ``display_name`` keys.
-    all_tag_page_paths : dict
-        Mapping of product slug to sorted list of tag page paths
-        (as returned by ``render_tag_pages``).
-
-    Side effects
-    ------------
-    Overwrites docs.json with updated navigation.
-
-    Raises
-    ------
-    FileNotFoundError
-        If docs.json does not exist at the repo root.
-    ValueError
-        If the English language navigation entry is not found.
-
-    Example
-    -------
-    The resulting tab structure for each product looks like::
-
-        {
-            "tab": "Support: W&B Models",
-            "hidden": true,
-            "pages": [
-                "support/models",
-                "support/models/tags/academic",
-                "support/models/tags/administrator",
-                ...
-            ]
-        }
-    """
-    docs_json_path = repo_root / "docs.json"
-    if not docs_json_path.exists():
-        raise FileNotFoundError(
-            f"docs.json not found at {docs_json_path}. "
-            "Ensure this script is run from the wandb-docs repo root."
-        )
-
-    with open(docs_json_path, "r", encoding="utf-8") as f:
-        config = json.load(f)
-
-    # Navigate to the English language navigation root.
-    # The W&B docs site uses navigation.languages[] for multi-language
-    # support; we only modify the English entry.
-    nav = config.get("navigation", {})
-    languages = nav.get("languages", [])
-    en_root = None
-    for lang_entry in languages:
-        if isinstance(lang_entry, dict) and lang_entry.get("language") == DOCS_JSON_NAV_LANGUAGE:
-            en_root = lang_entry
-            break
-
-    if en_root is None:
-        raise ValueError(
-            f"docs.json navigation.languages[] has no entry with "
-            f"language='{DOCS_JSON_NAV_LANGUAGE}'. Cannot update navigation."
-        )
-
-    tabs = en_root.setdefault("tabs", [])
-
-    for product in products:
-        slug = product["slug"]
-        display_name = product["display_name"]
-        tab_name = f"Support: {display_name}"
-
-        # The overview page is always first in the tab's page list
-        overview_page = f"support/{slug}"
-        tag_pages = all_tag_page_paths.get(slug, [])
-        new_pages = [overview_page] + tag_pages
-
-        # Find the existing tab or create a new one
-        target_tab = None
-        for tab in tabs:
-            if isinstance(tab, dict) and tab.get("tab") == tab_name:
-                target_tab = tab
-                break
-
-        if target_tab is None:
-            # Create a new hidden tab and append it
-            target_tab = {"tab": tab_name, "hidden": True, "pages": new_pages}
-            tabs.append(target_tab)
-        else:
-            # Update existing tab's pages; preserve hidden flag
-            target_tab["pages"] = new_pages
-
-    # Write the updated docs.json back.
-    # Use indent=2 and a trailing newline to match the existing format.
-    with open(docs_json_path, "w", encoding="utf-8") as f:
-        json.dump(config, f, indent=2)
-        f.write("\n")
-
-
-# ---------------------------------------------------------------------------
-# Phase 6: Update support.mdx (counts and featured articles)
+# Phase 5: Update support.mdx (counts and featured articles)
 # ---------------------------------------------------------------------------
 
 def _build_featured_section_mdx(
@@ -1749,9 +1632,13 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     Execute the full knowledgebase nav generation pipeline.
 
     Orchestrates all phases: crawl articles, generate tag pages, generate
-    product index pages, sync tab-page Badges on articles, update docs.json
-    navigation, and update support.mdx product card counts and featured
-    articles.
+    product index pages, sync tab-page Badges on articles, and update
+    support.mdx product card counts and featured articles.
+
+    The pipeline does not touch ``docs.json``. When tag pages are added or
+    removed, the surrounding workflow (see ``pr_report.py``) lists the
+    affected page ids in a PR comment so a human can update the
+    ``Support: <display_name>`` tabs in ``docs.json`` by hand.
 
     Parameters
     ----------
@@ -1767,7 +1654,6 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     - Writes tag page MDX files under support/<product>/tags/ and deletes
       stale ones that no longer correspond to any article keyword
     - Writes product index MDX files at support/<product>.mdx
-    - Overwrites docs.json with updated navigation
     - Updates support.mdx with current article/tag counts and featured articles
     - Prints summary information to stdout
     - Emits warnings for unknown keywords, invalid ``keywords`` types, skipped
@@ -1787,9 +1673,6 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     script_dir = Path(__file__).resolve().parent
     templates_dir = script_dir / "templates"
     template_env = create_template_env(templates_dir)
-
-    # Track tag page paths per product for the docs.json update step
-    all_tag_page_paths: Dict[str, List[str]] = {}
 
     # Track article and tag counts per product for the support.mdx update step
     product_stats: Dict[str, Dict[str, int]] = {}
@@ -1822,7 +1705,6 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
 
         # Phase 2: Generate tag pages and remove stale ones
         tag_page_paths = render_tag_pages(repo_root, slug, tag_index, template_env)
-        all_tag_page_paths[slug] = tag_page_paths
         print(f"  Generated {len(tag_page_paths)} tag pages")
 
         removed = cleanup_stale_tag_pages(repo_root, slug, tag_page_paths)
@@ -1846,18 +1728,13 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
         if footer_updates:
             print(f"  Updated tab Badges on {footer_updates} article(s)")
 
-        # Record stats for Phase 6
+        # Record stats for Phase 5
         product_stats[slug] = {
             "article_count": len(articles),
             "tag_count": len(tag_index),
         }
 
-    # Phase 5: Update docs.json navigation
-    update_docs_json(repo_root, products, all_tag_page_paths)
-    print(f"\n--- docs.json ---")
-    print(f"  Updated navigation for {len(products)} products")
-
-    # Phase 6: Update support.mdx product card counts and featured articles
+    # Phase 5: Update support.mdx product card counts and featured articles
     update_support_index(repo_root, product_stats)
     update_support_featured(repo_root, all_featured)
     print(f"\n--- support.mdx ---")
@@ -1884,7 +1761,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Sync support article keyword footers, regenerate tag and index pages, "
-            "and update docs.json and support.mdx."
+            "and update support.mdx."
         ),
         epilog="See README.md for detailed usage instructions.",
     )
@@ -1892,7 +1769,7 @@ def main() -> None:
         "--repo-root",
         type=Path,
         required=True,
-        help="Path to the root of the wandb-docs repository (contains docs.json).",
+        help="Path to the root of the wandb-docs repository (contains the support/ folder).",
     )
     parser.add_argument(
         "--config",

--- a/scripts/knowledgebase-nav/pr_report.py
+++ b/scripts/knowledgebase-nav/pr_report.py
@@ -30,15 +30,21 @@ What this script does (high level)
    like ``M\\tsupport/models/articles/foo.mdx`` where the first letter is the
    **change type** (Modified, Added, Deleted, Renamed, and so on).
 2. We **parse** those lines and **count** how many paths fall into each bucket
-   (articles, tag pages, ``docs.json``, and others).
-3. We read **stderr** that was saved to ``generator-warnings.log`` and count
+   (articles, tag pages, and others).
+3. We collect the page ids of any tag pages that were **added** or
+   **removed** so the report can ask a human to update the matching
+   ``Support: <display_name>`` tab in ``docs.json``. The generator never edits
+   ``docs.json`` itself.
+4. We read **stderr** that was saved to ``generator-warnings.log`` and count
    distinct **unknown keyword** warnings so tech writers see how many tags are
    not in ``config.yaml`` yet.
-4. We **build Markdown** (plain text with ``#`` headings and bullet lists) and
+5. We **build Markdown** (plain text with ``#`` headings and bullet lists) and
    print it to **stdout**. The workflow captures that output and posts it.
 
 This file is intentionally **standalone**: it does not import ``generate_tags.py``
-so you can test the reporting logic without running the full generator.
+so you can test the reporting logic without running the full generator. It
+does optionally read ``config.yaml`` to map product slugs to display names so
+the docs.json edit instructions can name the right ``Support:`` tab.
 
 See also
 --------
@@ -55,6 +61,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+import yaml
+
 # ---------------------------------------------------------------------------
 # Constants (shared with tests via REPORT_FALLBACK_BODY and REPORT_MARKER)
 # ---------------------------------------------------------------------------
@@ -70,7 +78,23 @@ REPORT_TITLE = "## Knowledgebase navigation update"
 # Paragraph when there is nothing to report: no file changes vs HEAD,
 # no unknown-keyword warnings parsed from the log, and an empty warnings file.
 REPORT_FALLBACK_PARAGRAPH = (
-    "No updates to support articles, tag pages, product indexes or docs.json from this run."
+    "No updates to support articles, tag pages, or product indexes from this run."
+)
+
+# Default location of the generator config (relative to repo root).  Used by
+# the docs.json edit section to look up the ``Support: <display_name>`` tab
+# for each product slug.  When the config cannot be read the section falls
+# back to ``Support: <slug>`` so the report still renders.
+DEFAULT_CONFIG_PATH = Path("scripts/knowledgebase-nav/config.yaml")
+
+# Heading and intro paragraph for the "docs.json update required" section.
+# The generator never modifies docs.json; humans must edit it after the
+# workflow posts this comment.
+DOCS_JSON_SECTION_HEADING = "### docs.json update required"
+DOCS_JSON_SECTION_INTRO = (
+    "A human must update `docs.json` because tag pages were added or removed. "
+    "Edit the matching `Support: <display_name>` tab under "
+    "`navigation.languages[language=\"en\"].tabs[]`."
 )
 
 # Full Markdown for the empty case: title plus fallback paragraph.
@@ -229,20 +253,34 @@ def _is_root_support_mdx(path: str) -> bool:
     return path == "support.mdx"
 
 
-def _is_docs_json(path: str) -> bool:
-    """True if ``path`` is the Mintlify navigation file at the repo root."""
-    return path == "docs.json"
-
-
 def _is_deleted_pages_scope(path: str) -> bool:
     """
     True if a **deleted** path should count toward the "pages deleted" bucket.
 
-    We include anything under ``support/`` plus ``docs.json``. We do not count
-    deletions only under ``scripts/knowledgebase-nav/`` in that bucket so the
-    report stays focused on reader-facing content.
+    We include anything under ``support/``. We do not count deletions only
+    under ``scripts/knowledgebase-nav/`` in that bucket so the report stays
+    focused on reader-facing content.
     """
-    return path == "docs.json" or path.startswith("support/")
+    return path.startswith("support/")
+
+
+def _tag_page_id_from_path(path: str) -> Optional[Tuple[str, str]]:
+    """
+    Convert a ``support/<product>/tags/<slug>.mdx`` path to a docs.json id.
+
+    Returns
+    -------
+    tuple of (product_slug, page_id) or None
+        ``page_id`` is the docs.json page id form (no ``.mdx`` suffix), for
+        example ``support/models/tags/experiments``.  Returns ``None`` if
+        ``path`` is not a tag-page filesystem path.
+    """
+    if not _is_tag_page_path(path):
+        return None
+    parts = path.split("/")
+    product_slug = parts[1]
+    file_stem = parts[3][: -len(".mdx")]
+    return product_slug, f"support/{product_slug}/tags/{file_stem}"
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +321,6 @@ def categorize_name_status_lines(lines: List[str]) -> Dict[str, int]:
         "deleted_pages": 0,
         "new_keywords_tag_pages": 0,
         "keywords_no_longer_in_use": 0,
-        "docs_json": 0,
     }
 
     for raw in lines:
@@ -310,8 +347,6 @@ def categorize_name_status_lines(lines: List[str]) -> Dict[str, int]:
             # Tag renames are counted as new + removed keywords, not as "modified".
             if _is_root_support_mdx(new_p):
                 buckets["support_mdx_root"] += 1
-            if _is_docs_json(new_p):
-                buckets["docs_json"] += 1
             continue
 
         path = first
@@ -329,8 +364,6 @@ def categorize_name_status_lines(lines: List[str]) -> Dict[str, int]:
                 buckets["product_index_pages"] += 1
             if _is_root_support_mdx(path):
                 buckets["support_mdx_root"] += 1
-            if _is_docs_json(path):
-                buckets["docs_json"] += 1
         elif st == "M":
             if _is_article_path(path):
                 buckets["articles_badges_updated"] += 1
@@ -340,10 +373,118 @@ def categorize_name_status_lines(lines: List[str]) -> Dict[str, int]:
                 buckets["product_index_pages"] += 1
             if _is_root_support_mdx(path):
                 buckets["support_mdx_root"] += 1
-            if _is_docs_json(path):
-                buckets["docs_json"] += 1
 
     return buckets
+
+
+def collect_tag_page_changes(
+    lines: List[str],
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+    """
+    Collect tag page additions and removals grouped by product slug.
+
+    Walks ``git diff --name-status HEAD`` lines and returns two dicts mapping
+    product slug to the docs.json **page ids** (no ``.mdx`` suffix) of the
+    affected tag pages.  Renames produce one entry in each dict (the new path
+    is added, the old path is removed).
+
+    Parameters
+    ----------
+    lines
+        Complete lines from ``git diff --name-status HEAD``.
+
+    Returns
+    -------
+    tuple of (added, removed)
+        ``added`` maps product slug to a sorted list of new tag page ids.
+        ``removed`` maps product slug to a sorted list of removed tag page
+        ids.  Each list is deduplicated and sorted alphabetically so the
+        output of the report is deterministic.
+    """
+    added: Dict[str, set] = {}
+    removed: Dict[str, set] = {}
+
+    def _add(bucket: Dict[str, set], product: str, page_id: str) -> None:
+        bucket.setdefault(product, set()).add(page_id)
+
+    for raw in lines:
+        parsed = parse_name_status_line(raw)
+        if parsed is None:
+            continue
+        status, first, second = parsed
+        st = status[0]
+
+        if st in ("R", "C"):
+            assert second is not None
+            old_info = _tag_page_id_from_path(first)
+            new_info = _tag_page_id_from_path(second)
+            if old_info is not None:
+                _add(removed, *old_info)
+            if new_info is not None:
+                _add(added, *new_info)
+            continue
+
+        if st == "A":
+            info = _tag_page_id_from_path(first)
+            if info is not None:
+                _add(added, *info)
+        elif st == "D":
+            info = _tag_page_id_from_path(first)
+            if info is not None:
+                _add(removed, *info)
+
+    return (
+        {slug: sorted(ids) for slug, ids in added.items()},
+        {slug: sorted(ids) for slug, ids in removed.items()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loading product display names from config.yaml
+# ---------------------------------------------------------------------------
+
+
+def load_product_display_names(config_path: Path) -> Dict[str, str]:
+    """
+    Read product slug -> display name mapping from ``config.yaml``.
+
+    The mapping is used to build the ``Support: <display_name>`` heading in
+    the docs.json edit section.  Returns an empty dict if the file is
+    missing, unreadable, or malformed; the caller falls back to the slug.
+
+    Parameters
+    ----------
+    config_path
+        Path to ``scripts/knowledgebase-nav/config.yaml`` (or any file with
+        the same shape).
+
+    Returns
+    -------
+    dict
+        Mapping of product slug to display name.  Products missing either
+        ``slug`` or ``display_name`` are skipped silently.
+    """
+    if not config_path.exists():
+        return {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+    products = config.get("products") if isinstance(config, dict) else None
+    if not isinstance(products, list):
+        return {}
+
+    mapping: Dict[str, str] = {}
+    for product in products:
+        if not isinstance(product, dict):
+            continue
+        slug = product.get("slug")
+        display_name = product.get("display_name")
+        if isinstance(slug, str) and isinstance(display_name, str):
+            mapping[slug] = display_name
+    return mapping
 
 
 def distinct_unknown_keywords_from_warnings(warnings_text: str) -> Set[str]:
@@ -375,23 +516,103 @@ def distinct_unknown_keywords_from_warnings(warnings_text: str) -> Set[str]:
 # ---------------------------------------------------------------------------
 
 
+def build_docs_json_section(
+    added_tag_pages: Dict[str, List[str]],
+    removed_tag_pages: Dict[str, List[str]],
+    display_names: Dict[str, str],
+) -> str:
+    """
+    Build the "docs.json update required" Markdown section.
+
+    Returns an empty string when both ``added_tag_pages`` and
+    ``removed_tag_pages`` are empty.  Otherwise produces a heading
+    (``DOCS_JSON_SECTION_HEADING``), a one-paragraph intro
+    (``DOCS_JSON_SECTION_INTRO``), and one subsection per affected product
+    (sorted by slug) listing entries to add to and remove from the
+    product's ``Support: <display_name>`` ``pages`` array.
+
+    Each per-product subsection uses the form::
+
+        #### Support: W&B Models
+
+        Add to `pages`:
+        - `support/models/tags/foo`
+
+        Remove from `pages`:
+        - `support/models/tags/old`
+
+    Either "Add" or "Remove" subsections are omitted when their list is
+    empty for that product.
+
+    Parameters
+    ----------
+    added_tag_pages
+        Mapping of product slug to a sorted list of newly added tag page
+        ids (page ids, not filesystem paths).
+    removed_tag_pages
+        Mapping of product slug to a sorted list of removed tag page ids.
+    display_names
+        Mapping of product slug to display name (from ``config.yaml``).
+        Slugs not present in this mapping fall back to ``Support: <slug>``
+        so the section still renders.
+
+    Returns
+    -------
+    str
+        Markdown for the docs.json edit section, without a leading or
+        trailing blank line.  Empty string when there are no changes.
+    """
+    if not added_tag_pages and not removed_tag_pages:
+        return ""
+
+    lines: List[str] = [DOCS_JSON_SECTION_HEADING, "", DOCS_JSON_SECTION_INTRO]
+
+    product_slugs = sorted(set(added_tag_pages) | set(removed_tag_pages))
+    for slug in product_slugs:
+        display_name = display_names.get(slug, slug)
+        lines.append("")
+        lines.append(f"#### Support: {display_name}")
+
+        added = added_tag_pages.get(slug, [])
+        removed = removed_tag_pages.get(slug, [])
+
+        if added:
+            lines.append("")
+            lines.append("Add to `pages`:")
+            for page_id in added:
+                lines.append(f"- `{page_id}`")
+        if removed:
+            lines.append("")
+            lines.append("Remove from `pages`:")
+            for page_id in removed:
+                lines.append(f"- `{page_id}`")
+
+    return "\n".join(lines)
+
+
 def build_report_markdown(
     buckets: Dict[str, int],
     unknown_keywords: Set[str],
     warnings_text: str,
     run_url: Optional[str] = None,
     run_id: Optional[str] = None,
+    added_tag_pages: Optional[Dict[str, List[str]]] = None,
+    removed_tag_pages: Optional[Dict[str, List[str]]] = None,
+    display_names: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Build the Markdown body **without** the HTML comment marker.
 
-    If every bucket is zero, there are no unknown keywords, and the warnings
-    text is blank, returns ``REPORT_FALLBACK_BODY`` (``REPORT_TITLE`` plus
+    If every bucket is zero, there are no unknown keywords, no added or
+    removed tag pages, and the warnings text is blank, returns
+    ``REPORT_FALLBACK_BODY`` (``REPORT_TITLE`` plus
     ``REPORT_FALLBACK_PARAGRAPH``).
 
     Otherwise builds a short report starting with ``REPORT_TITLE``, then bullet
     lines (counts only), optional "no categorized file changes" when warnings
-    exist but nothing matched our path rules, a fenced code block with the raw
+    exist but nothing matched our path rules, an optional "docs.json update
+    required" section listing the exact tag page ids a human must add to or
+    remove from each ``Support:`` tab, a fenced code block with the raw
     warnings log if present, and an optional footer link when ``run_url`` is
     set (with ``run_id`` in the link text when provided).
 
@@ -411,6 +632,14 @@ def build_report_markdown(
         GitHub Actions ``GITHUB_RUN_ID`` (same number as in ``/actions/runs/<id>``).
         If set with ``run_url``, the link text is ``workflow run <id>`` so the
         number is visible without hovering.
+    added_tag_pages, removed_tag_pages
+        Tag page ids grouped by product slug, from
+        :func:`collect_tag_page_changes`.  When either is non-empty, the
+        report includes a "docs.json update required" section.
+    display_names
+        Product slug to display-name mapping (see
+        :func:`load_product_display_names`).  Used to label
+        ``Support: <display_name>`` subsections.
 
     Returns
     -------
@@ -419,11 +648,17 @@ def build_report_markdown(
     """
     lines_out: List[str] = []
 
+    added_tag_pages = added_tag_pages or {}
+    removed_tag_pages = removed_tag_pages or {}
+    display_names = display_names or {}
+
     uk_count = len(unknown_keywords)
     if (
         not any(buckets[k] > 0 for k in buckets)
         and uk_count == 0
         and not warnings_text.strip()
+        and not added_tag_pages
+        and not removed_tag_pages
     ):
         return REPORT_FALLBACK_BODY
 
@@ -473,12 +708,16 @@ def build_report_markdown(
             f"- Keywords not on the allowed list: {uk_count} distinct keyword{'s' if uk_count != 1 else ''}."
         )
         added_bullet = True
-    if buckets["docs_json"] > 0:
-        lines_out.append("- docs.json updated.")
-        added_bullet = True
 
     if not added_bullet and warnings_text.strip():
         lines_out.append("- (No categorized file changes.)")
+
+    docs_json_section = build_docs_json_section(
+        added_tag_pages, removed_tag_pages, display_names
+    )
+    if docs_json_section:
+        lines_out.append("")
+        lines_out.append(docs_json_section)
 
     if warnings_text.strip():
         lines_out.append("")
@@ -606,6 +845,16 @@ def main() -> None:
         default=None,
         help="For tests: use this text instead of running git diff.",
     )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help=(
+            "Path to scripts/knowledgebase-nav/config.yaml. "
+            "Used to map product slugs to display names in the docs.json edit "
+            "section. Defaults to <repo-root>/scripts/knowledgebase-nav/config.yaml."
+        ),
+    )
     args = parser.parse_args()
 
     if args.diff_text is not None:
@@ -615,10 +864,14 @@ def main() -> None:
 
     diff_lines = [ln for ln in diff_out.splitlines() if ln.strip()]
     buckets = categorize_name_status_lines(diff_lines)
+    added_tag_pages, removed_tag_pages = collect_tag_page_changes(diff_lines)
 
     warnings_text = ""
     if args.warnings_file.exists():
         warnings_text = args.warnings_file.read_text(encoding="utf-8")
+
+    config_path = args.config or (args.repo_root / DEFAULT_CONFIG_PATH)
+    display_names = load_product_display_names(config_path)
 
     unknown_set = distinct_unknown_keywords_from_warnings(warnings_text)
     inner = build_report_markdown(
@@ -627,6 +880,9 @@ def main() -> None:
         warnings_text,
         run_url=args.run_url,
         run_id=args.run_id,
+        added_tag_pages=added_tag_pages,
+        removed_tag_pages=removed_tag_pages,
+        display_names=display_names,
     )
     out = format_pr_body(inner, include_marker=args.include_marker)
     sys.stdout.write(out)

--- a/scripts/knowledgebase-nav/tests/test_generate_tags.py
+++ b/scripts/knowledgebase-nav/tests/test_generate_tags.py
@@ -10,7 +10,6 @@ Run with:
     pytest scripts/knowledgebase-nav/tests/test_generate_tags.py -v
 """
 
-import json
 import textwrap
 import warnings
 from pathlib import Path
@@ -59,8 +58,10 @@ def sample_config(tmp_path):
 @pytest.fixture
 def sample_repo(tmp_path):
     """
-    Create a minimal repo structure with articles, a docs.json, and return
-    the repo root path.
+    Create a minimal repo structure with articles and return the repo root path.
+
+    No ``docs.json`` is created.  The generator never reads ``docs.json``;
+    the workflow's PR report tells humans which entries to edit there.
 
     Structure:
         <tmp_path>/
@@ -68,7 +69,7 @@ def sample_repo(tmp_path):
                 article-one.mdx   (keywords: Alpha, Beta; featured: true)
                 article-two.mdx   (keywords: Alpha)
                 article-three.mdx (keywords: Beta)
-            docs.json  (minimal with en language nav)
+            support.mdx           (with product card counts and featured markers)
     """
     articles_dir = tmp_path / "support" / "widgets" / "articles"
     articles_dir.mkdir(parents=True)
@@ -112,22 +113,6 @@ def sample_repo(tmp_path):
 
         <Badge stroke shape="pill" color="orange" size="md">[Beta](/support/widgets/tags/beta)</Badge>
     """), encoding="utf-8")
-
-    docs_json = {
-        "navigation": {
-            "languages": [
-                {
-                    "language": "en",
-                    "tabs": [
-                        {"tab": "Platform", "pages": ["index"]},
-                    ],
-                }
-            ]
-        }
-    }
-    (tmp_path / "docs.json").write_text(
-        json.dumps(docs_json, indent=2) + "\n", encoding="utf-8"
-    )
 
     # Create a support.mdx with product cards containing counts
     (tmp_path / "support.mdx").write_text(textwrap.dedent("""\
@@ -1417,108 +1402,31 @@ class TestRenderProductIndex:
 
 
 # ===========================================================================
-# Tests: update_docs_json
+# Tests: docs.json is never touched
 # ===========================================================================
 
-class TestUpdateDocsJson:
-    """Tests for the update_docs_json function."""
+class TestDocsJsonNotTouched:
+    """Verify the generator does not read or write docs.json."""
 
-    def test_creates_hidden_tabs(self, sample_repo):
-        """
-        update_docs_json should create hidden support tabs for each
-        product with the correct page listings.
-        """
-        products = [
-            {"slug": "widgets", "display_name": "W&B Widgets"},
-        ]
-        tag_paths = {
-            "widgets": ["support/widgets/tags/alpha", "support/widgets/tags/beta"],
-        }
+    def test_update_docs_json_attribute_removed(self):
+        """The legacy ``update_docs_json`` callable must no longer exist."""
+        assert not hasattr(generate_tags, "update_docs_json")
 
-        generate_tags.update_docs_json(sample_repo, products, tag_paths)
-
-        docs = json.loads((sample_repo / "docs.json").read_text())
-        en_tabs = docs["navigation"]["languages"][0]["tabs"]
-        support_tab = next(t for t in en_tabs if t["tab"] == "Support: W&B Widgets")
-
-        assert support_tab["hidden"] is True
-        assert support_tab["pages"] == [
-            "support/widgets",
-            "support/widgets/tags/alpha",
-            "support/widgets/tags/beta",
-        ]
-
-    def test_preserves_existing_tabs(self, sample_repo):
-        """
-        Non-support tabs (like 'Platform') should be preserved
-        untouched after the update.
-        """
-        products = [{"slug": "widgets", "display_name": "W&B Widgets"}]
-        generate_tags.update_docs_json(sample_repo, products, {"widgets": []})
-
-        docs = json.loads((sample_repo / "docs.json").read_text())
-        en_tabs = docs["navigation"]["languages"][0]["tabs"]
-        platform_tab = next(t for t in en_tabs if t["tab"] == "Platform")
-        assert platform_tab["pages"] == ["index"]
-
-    def test_updates_existing_support_tab(self, sample_repo):
-        """
-        If a support tab already exists, its pages should be replaced
-        (not duplicated) with the new listing.
-        """
-        # First, create the tab
-        products = [{"slug": "widgets", "display_name": "W&B Widgets"}]
-        generate_tags.update_docs_json(
-            sample_repo, products,
-            {"widgets": ["support/widgets/tags/old-tag"]},
-        )
-
-        # Then update it with different tags
-        generate_tags.update_docs_json(
-            sample_repo, products,
-            {"widgets": ["support/widgets/tags/new-tag"]},
-        )
-
-        docs = json.loads((sample_repo / "docs.json").read_text())
-        en_tabs = docs["navigation"]["languages"][0]["tabs"]
-        support_tab = next(t for t in en_tabs if t["tab"] == "Support: W&B Widgets")
-
-        assert support_tab["pages"] == [
-            "support/widgets",
-            "support/widgets/tags/new-tag",
-        ]
-        # Verify no duplicate tabs were created
-        support_tabs = [t for t in en_tabs if "Support:" in t.get("tab", "")]
-        assert len(support_tabs) == 1
-
-    def test_docs_json_not_found(self, tmp_path):
-        """
-        If docs.json doesn't exist, a FileNotFoundError should be raised.
-        """
-        with pytest.raises(FileNotFoundError, match="docs.json not found"):
-            generate_tags.update_docs_json(tmp_path, [], {})
-
-    def test_missing_en_language(self, tmp_path):
-        """
-        If the English language entry is missing from navigation.languages,
-        a ValueError should be raised with a helpful message.
-        """
-        docs = {"navigation": {"languages": [{"language": "ja", "tabs": []}]}}
-        (tmp_path / "docs.json").write_text(json.dumps(docs), encoding="utf-8")
-
-        with pytest.raises(ValueError, match="no entry with language='en'"):
-            generate_tags.update_docs_json(tmp_path, [], {})
-
-    def test_docs_json_trailing_newline(self, sample_repo):
-        """
-        The written docs.json should end with a trailing newline to
-        match standard formatting.
-        """
-        products = [{"slug": "widgets", "display_name": "W&B Widgets"}]
-        generate_tags.update_docs_json(sample_repo, products, {"widgets": []})
-
-        raw = (sample_repo / "docs.json").read_text()
-        assert raw.endswith("\n")
+    def test_module_does_not_open_docs_json(self):
+        """The generator source must not reference docs.json as an I/O target."""
+        source = Path(generate_tags.__file__).read_text(encoding="utf-8")
+        # docs.json may appear in docstrings explaining that we do not touch
+        # it, but never as a Path() / open() / read_text() / write_text()
+        # target.
+        for forbidden in (
+            'Path("docs.json")',
+            "Path('docs.json')",
+            '/ "docs.json"',
+            "/ 'docs.json'",
+        ):
+            assert forbidden not in source, (
+                f"generate_tags.py should not reference {forbidden!r}"
+            )
 
 
 # ===========================================================================
@@ -2269,7 +2177,10 @@ class TestFullPipeline:
     def test_full_pipeline(self, sample_repo, sample_config):
         """
         Running the full pipeline should create tag pages, a product
-        index page, and update docs.json navigation in one pass.
+        index page, and update support.mdx in one pass.
+
+        The pipeline must not create or modify ``docs.json``; humans edit
+        that file manually based on the workflow's PR comment.
 
         This test verifies the orchestration works end-to-end with a
         minimal mock repo.
@@ -2286,18 +2197,8 @@ class TestFullPipeline:
         assert "Browse by category" in index_content
         assert "Featured articles" in index_content
 
-        # docs.json should have the support tab
-        docs = json.loads((sample_repo / "docs.json").read_text())
-        en_tabs = docs["navigation"]["languages"][0]["tabs"]
-        support_tab = next(
-            (t for t in en_tabs if t.get("tab") == "Support: W&B Widgets"),
-            None,
-        )
-        assert support_tab is not None
-        assert support_tab["hidden"] is True
-        assert "support/widgets" in support_tab["pages"]
-        assert "support/widgets/tags/alpha" in support_tab["pages"]
-        assert "support/widgets/tags/beta" in support_tab["pages"]
+        # docs.json must not be created by the pipeline
+        assert not (sample_repo / "docs.json").exists()
 
         # support.mdx should have updated counts
         support_content = (sample_repo / "support.mdx").read_text()

--- a/scripts/knowledgebase-nav/tests/test_golden_output.py
+++ b/scripts/knowledgebase-nav/tests/test_golden_output.py
@@ -6,15 +6,17 @@ the real wandb-docs repository and verifies that the output is **byte-for-byte
 identical** to the existing files on disk.
 
 If the template, slug logic, body-preview truncation, sort order, or
-navigation structure drifts even by one character, this test catches it
-and reports the exact difference as a unified diff.
+output structure drifts even by one character, this test catches it and
+reports the exact difference as a unified diff.
 
 What it tests:
     - Every tag page: support/<product>/tags/<tag>.mdx
     - Product index pages: support/<product>.mdx (for example support/models.mdx)
     - Article footers: support/<product>/articles/*.mdx (tab-page Badge sync)
-    - docs.json support navigation tabs (page lists, tab names, ordering)
     - Root support.mdx (product card count lines)
+
+The pipeline does not modify ``docs.json``, so this suite no longer asserts
+anything about ``docs.json``.
 
 How to run:
     pytest scripts/knowledgebase-nav/tests/test_golden_output.py -v -m integration
@@ -28,7 +30,6 @@ Prerequisites:
 """
 
 import difflib
-import json
 import shutil
 import textwrap
 from pathlib import Path
@@ -110,10 +111,10 @@ def golden_repo_root():
     """
     Return the path to the real wandb-docs repo.
 
-    Skips if docs.json is missing at the resolved root (for example a
+    Skips if support.mdx is missing at the resolved root (for example a
     sparse checkout or wrong working directory).
     """
-    if not (WANDB_DOCS_ROOT / "docs.json").exists():
+    if not (WANDB_DOCS_ROOT / "support.mdx").exists():
         pytest.skip(
             f"wandb-docs repo not found at {WANDB_DOCS_ROOT}. "
             "Skipping golden-file tests."
@@ -131,6 +132,9 @@ def generated_output(golden_repo_root, tmp_path_factory):
     redundant generation.  All test functions share the same generated
     output.
 
+    The generator does not read or write ``docs.json``, so this fixture
+    intentionally does not copy or read that file.
+
     Returns
     -------
     dict with keys:
@@ -138,20 +142,16 @@ def generated_output(golden_repo_root, tmp_path_factory):
         - "tag_pages": dict mapping relative path to file content
         - "product_indexes": dict mapping support/<slug>.mdx to file content
         - "article_files": dict mapping relative path to file content
-        - "docs_json": the parsed docs.json dict
         - "support_mdx": full text of generated support.mdx
     """
     tmp_root = tmp_path_factory.mktemp("golden")
 
-    # Copy the support/ directory, support.mdx, and docs.json to the temp
-    # location.  We only need these for the generator to work.
+    # Copy the support/ directory and support.mdx to the temp location.
+    # docs.json is intentionally not copied: the generator must never read
+    # or write it.
     shutil.copytree(
         golden_repo_root / "support",
         tmp_root / "support",
-    )
-    shutil.copy2(
-        golden_repo_root / "docs.json",
-        tmp_root / "docs.json",
     )
     shutil.copy2(
         golden_repo_root / "support.mdx",
@@ -180,9 +180,6 @@ def generated_output(golden_repo_root, tmp_path_factory):
                 rel_path = f"support/{product}/articles/{mdx_file.name}"
                 article_files[rel_path] = mdx_file.read_text(encoding="utf-8")
 
-    # Read the generated docs.json
-    docs_json = json.loads((tmp_root / "docs.json").read_text(encoding="utf-8"))
-
     # Read the generated support.mdx
     support_mdx = (tmp_root / "support.mdx").read_text(encoding="utf-8")
 
@@ -199,7 +196,6 @@ def generated_output(golden_repo_root, tmp_path_factory):
         "tag_pages": tag_pages,
         "product_indexes": product_indexes,
         "article_files": article_files,
-        "docs_json": docs_json,
         "support_mdx": support_mdx,
     }
 
@@ -430,112 +426,28 @@ class TestArticleFilesMatchExisting:
 
 
 # ===========================================================================
-# Tests: docs.json support tabs match existing
+# Tests: docs.json is never touched by the pipeline
 # ===========================================================================
 
-class TestDocsJsonMatchExisting:
+
+class TestDocsJsonNotTouched:
     """
-    Verify that the support navigation tabs in the generated docs.json
-    match the existing docs.json exactly: same tab names, same page
-    lists, same ordering.
+    Verify the pipeline does not create or modify ``docs.json``.
+
+    The fixture intentionally does not copy ``docs.json`` into the temp
+    tree, so any read or write of ``docs.json`` would fail loudly during
+    fixture setup.  This explicit check guards against future regressions
+    where the generator silently starts producing the file.
     """
 
     @pytest.fixture(autouse=True)
-    def _setup(self, golden_repo_root, generated_output):
-        """Store references for use by test methods."""
-        self.repo_root = golden_repo_root
-        self.generated_docs = generated_output["docs_json"]
+    def _setup(self, generated_output):
+        self.tmp_root = generated_output["root"]
 
-    def _get_support_tabs(self, docs_json: dict) -> dict:
-        """
-        Extract the support tabs from a docs.json config.
-
-        Returns a dict mapping tab name to the tab dict.
-        """
-        en_root = None
-        for lang in docs_json.get("navigation", {}).get("languages", []):
-            if lang.get("language") == "en":
-                en_root = lang
-                break
-
-        if en_root is None:
-            return {}
-
-        return {
-            tab["tab"]: tab
-            for tab in en_root.get("tabs", [])
-            if isinstance(tab, dict) and tab.get("tab", "").startswith("Support:")
-        }
-
-    def test_support_tabs_match(self):
-        """
-        The hidden support tabs in the generated docs.json should have
-        the same names, page lists, and ordering as the existing file.
-        """
-        existing_docs = json.loads(
-            _read_file(self.repo_root / "docs.json")
-        )
-
-        existing_tabs = self._get_support_tabs(existing_docs)
-        generated_tabs = self._get_support_tabs(self.generated_docs)
-
-        # Same set of tab names
-        assert set(existing_tabs.keys()) == set(generated_tabs.keys()), (
-            f"Tab names differ.\n"
-            f"  Existing: {sorted(existing_tabs.keys())}\n"
-            f"  Generated: {sorted(generated_tabs.keys())}"
-        )
-
-        # Each tab has the same pages in the same order
-        for tab_name in sorted(existing_tabs.keys()):
-            existing_pages = existing_tabs[tab_name].get("pages", [])
-            generated_pages = generated_tabs[tab_name].get("pages", [])
-
-            assert existing_pages == generated_pages, (
-                f"Pages differ for tab '{tab_name}'.\n"
-                f"  Existing:  {existing_pages}\n"
-                f"  Generated: {generated_pages}"
-            )
-
-    def test_support_tabs_are_hidden(self):
-        """All support tabs should have hidden: true."""
-        generated_tabs = self._get_support_tabs(self.generated_docs)
-        for tab_name, tab in generated_tabs.items():
-            assert tab.get("hidden") is True, (
-                f"Tab '{tab_name}' is not marked as hidden."
-            )
-
-    def test_non_support_tabs_preserved(self):
-        """
-        Non-support tabs (like Platform, Models, Weave) should be
-        completely unchanged by the generator.
-        """
-        existing_docs = json.loads(
-            _read_file(self.repo_root / "docs.json")
-        )
-
-        existing_en = None
-        generated_en = None
-        for lang in existing_docs["navigation"]["languages"]:
-            if lang.get("language") == "en":
-                existing_en = lang
-                break
-        for lang in self.generated_docs["navigation"]["languages"]:
-            if lang.get("language") == "en":
-                generated_en = lang
-                break
-
-        existing_non_support = [
-            t for t in existing_en.get("tabs", [])
-            if isinstance(t, dict) and not t.get("tab", "").startswith("Support:")
-        ]
-        generated_non_support = [
-            t for t in generated_en.get("tabs", [])
-            if isinstance(t, dict) and not t.get("tab", "").startswith("Support:")
-        ]
-
-        assert existing_non_support == generated_non_support, (
-            "Non-support tabs were modified by the generator."
+    def test_no_docs_json_after_pipeline(self):
+        """The generator must not produce a ``docs.json`` file."""
+        assert not (self.tmp_root / "docs.json").exists(), (
+            "Pipeline created docs.json; it must be edited by hand."
         )
 
 

--- a/scripts/knowledgebase-nav/tests/test_pr_report.py
+++ b/scripts/knowledgebase-nav/tests/test_pr_report.py
@@ -108,10 +108,12 @@ def test_categorize_tag_added_deleted_modified():
 
 def test_categorize_product_index_and_support_root():
     """
-    Product indexes, root ``support.mdx``, and ``docs.json`` each have their own flags.
+    Product indexes and root ``support.mdx`` each have their own flags.
 
     ``support/models.mdx`` is two path segments; the root ``support.mdx`` is a
-    single file at the repository root, not inside ``support/``.
+    single file at the repository root, not inside ``support/``.  ``docs.json``
+    is intentionally not categorized: the generator never edits it, and any
+    diff entry for it is ignored by the report.
     """
     b = pr_report.categorize_name_status_lines(
         [
@@ -122,7 +124,7 @@ def test_categorize_product_index_and_support_root():
     )
     assert b["product_index_pages"] == 1
     assert b["support_mdx_root"] == 1
-    assert b["docs_json"] == 1
+    assert "docs_json" not in b
 
 
 def test_categorize_deleted_pages():
@@ -185,7 +187,7 @@ def test_build_report_footer_includes_run_id():
     The URL still points at the run; the id matches the ``/actions/runs/<id>`` segment.
     """
     empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
-    empty["docs_json"] = 1
+    empty["articles_badges_updated"] = 1
     out = pr_report.build_report_markdown(
         empty,
         set(),
@@ -201,15 +203,16 @@ def test_build_report_with_counts():
     Non-zero buckets should appear as bullet lines under ``REPORT_TITLE``.
 
     We mutate a fresh zero dict rather than hard-coding every key so new
-    bucket keys in production are picked up automatically.
+    bucket keys in production are picked up automatically.  ``docs.json`` is
+    no longer a bucket (the generator does not edit it) and so should not
+    appear as a bullet.
     """
     empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
     empty["articles_badges_updated"] = 2
-    empty["docs_json"] = 1
     out = pr_report.build_report_markdown(empty, set(), "")
     assert pr_report.REPORT_TITLE in out
     assert "Articles with Badges updated: 2 articles" in out
-    assert "docs.json updated" in out
+    assert "docs.json updated" not in out
 
 
 def test_format_warnings_for_display_strips_path_and_scaffolding():
@@ -244,3 +247,238 @@ def test_format_pr_body_includes_marker():
     assert pr_report.REPORT_MARKER in body
     assert pr_report.REPORT_FALLBACK_BODY in body
     assert pr_report.REPORT_TITLE in body
+
+
+# ===========================================================================
+# Tests: collecting tag page changes for the docs.json edit section
+# ===========================================================================
+
+
+def test_collect_tag_page_changes_added():
+    """
+    A line ``A\\tsupport/models/tags/foo.mdx`` should produce one entry under
+    ``models`` in the **added** dict, with the ``.mdx`` suffix dropped to form
+    a docs.json page id.
+    """
+    added, removed = pr_report.collect_tag_page_changes(
+        ["A\tsupport/models/tags/foo.mdx"]
+    )
+    assert added == {"models": ["support/models/tags/foo"]}
+    assert removed == {}
+
+
+def test_collect_tag_page_changes_deleted():
+    """
+    A line ``D\\tsupport/models/tags/old.mdx`` should produce one entry under
+    ``models`` in the **removed** dict.
+    """
+    added, removed = pr_report.collect_tag_page_changes(
+        ["D\tsupport/models/tags/old.mdx"]
+    )
+    assert added == {}
+    assert removed == {"models": ["support/models/tags/old"]}
+
+
+def test_collect_tag_page_changes_renamed_produces_add_and_remove():
+    """
+    A rename from one tag file to another should produce a remove entry for
+    the old path and an add entry for the new path under the same product.
+    """
+    line = "R100\tsupport/models/tags/a.mdx\tsupport/models/tags/b.mdx"
+    added, removed = pr_report.collect_tag_page_changes([line])
+    assert added == {"models": ["support/models/tags/b"]}
+    assert removed == {"models": ["support/models/tags/a"]}
+
+
+def test_collect_tag_page_changes_groups_by_product_and_sorts():
+    """
+    Entries from multiple products end up under their own keys; each list is
+    sorted alphabetically by page id for deterministic output.
+    """
+    added, removed = pr_report.collect_tag_page_changes(
+        [
+            "A\tsupport/weave/tags/zeta.mdx",
+            "A\tsupport/models/tags/beta.mdx",
+            "A\tsupport/models/tags/alpha.mdx",
+            "D\tsupport/weave/tags/old.mdx",
+        ]
+    )
+    assert added == {
+        "models": ["support/models/tags/alpha", "support/models/tags/beta"],
+        "weave": ["support/weave/tags/zeta"],
+    }
+    assert removed == {"weave": ["support/weave/tags/old"]}
+
+
+def test_collect_tag_page_changes_ignores_non_tag_paths():
+    """
+    Articles, product indexes, and root support.mdx are not tag pages and
+    must not appear in either dict.
+    """
+    added, removed = pr_report.collect_tag_page_changes(
+        [
+            "A\tsupport/models/articles/new.mdx",
+            "M\tsupport/models.mdx",
+            "M\tsupport.mdx",
+            "M\tdocs.json",
+        ]
+    )
+    assert added == {}
+    assert removed == {}
+
+
+# ===========================================================================
+# Tests: the "docs.json update required" section
+# ===========================================================================
+
+
+def test_build_docs_json_section_empty_when_no_changes():
+    """No additions or removals means no section, returning an empty string."""
+    assert pr_report.build_docs_json_section({}, {}, {}) == ""
+
+
+def test_build_docs_json_section_uses_display_names_when_available():
+    """
+    The subsection heading uses ``Support: <display_name>`` when the slug is
+    found in the display-name map.  Both add and remove subsections are
+    rendered when both lists are non-empty.
+    """
+    section = pr_report.build_docs_json_section(
+        added_tag_pages={"models": ["support/models/tags/foo"]},
+        removed_tag_pages={"models": ["support/models/tags/old"]},
+        display_names={"models": "W&B Models"},
+    )
+    assert pr_report.DOCS_JSON_SECTION_HEADING in section
+    assert pr_report.DOCS_JSON_SECTION_INTRO in section
+    assert "#### Support: W&B Models" in section
+    assert "Add to `pages`:" in section
+    assert "- `support/models/tags/foo`" in section
+    assert "Remove from `pages`:" in section
+    assert "- `support/models/tags/old`" in section
+
+
+def test_build_docs_json_section_falls_back_to_slug_when_no_display_name():
+    """
+    Slugs missing from the display-name map fall back to ``Support: <slug>``
+    so the section still renders.
+    """
+    section = pr_report.build_docs_json_section(
+        added_tag_pages={"unknown": ["support/unknown/tags/foo"]},
+        removed_tag_pages={},
+        display_names={},
+    )
+    assert "#### Support: unknown" in section
+
+
+def test_build_docs_json_section_omits_empty_subheaders():
+    """
+    A product with only additions must not render a "Remove from" subheader
+    (and vice versa).
+    """
+    section = pr_report.build_docs_json_section(
+        added_tag_pages={"models": ["support/models/tags/foo"]},
+        removed_tag_pages={},
+        display_names={"models": "W&B Models"},
+    )
+    assert "Add to `pages`:" in section
+    assert "Remove from `pages`:" not in section
+
+
+def test_build_report_includes_docs_json_section_for_added_tag_page():
+    """
+    When ``added_tag_pages`` is non-empty, the full report should embed the
+    docs.json edit section after the bullet list.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    empty["new_keywords_tag_pages"] = 1
+    out = pr_report.build_report_markdown(
+        empty,
+        set(),
+        "",
+        added_tag_pages={"models": ["support/models/tags/foo"]},
+        removed_tag_pages={},
+        display_names={"models": "W&B Models"},
+    )
+    assert pr_report.DOCS_JSON_SECTION_HEADING in out
+    assert "#### Support: W&B Models" in out
+    assert "- `support/models/tags/foo`" in out
+
+
+def test_build_report_includes_docs_json_section_for_removed_tag_page():
+    """A removed tag page should produce the section even with zero buckets."""
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    out = pr_report.build_report_markdown(
+        empty,
+        set(),
+        "",
+        added_tag_pages={},
+        removed_tag_pages={"models": ["support/models/tags/old"]},
+        display_names={"models": "W&B Models"},
+    )
+    assert pr_report.DOCS_JSON_SECTION_HEADING in out
+    assert "Remove from `pages`:" in out
+    assert "- `support/models/tags/old`" in out
+
+
+def test_build_report_no_docs_json_section_when_no_tag_changes():
+    """
+    A run that only modifies articles or counts must not produce the
+    docs.json edit section.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    empty["articles_badges_updated"] = 1
+    out = pr_report.build_report_markdown(empty, set(), "")
+    assert pr_report.DOCS_JSON_SECTION_HEADING not in out
+
+
+def test_build_report_fallback_with_only_tag_page_changes_breaks_fallback():
+    """
+    Having only added or removed tag pages (no buckets, no warnings) is still
+    enough signal to skip ``REPORT_FALLBACK_BODY`` so humans see the docs.json
+    edit instructions.
+    """
+    empty = {k: 0 for k in pr_report.categorize_name_status_lines([])}
+    out = pr_report.build_report_markdown(
+        empty,
+        set(),
+        "",
+        added_tag_pages={"models": ["support/models/tags/foo"]},
+        removed_tag_pages={},
+        display_names={"models": "W&B Models"},
+    )
+    assert out != pr_report.REPORT_FALLBACK_BODY
+    assert pr_report.DOCS_JSON_SECTION_HEADING in out
+
+
+# ===========================================================================
+# Tests: load_product_display_names
+# ===========================================================================
+
+
+def test_load_product_display_names_returns_mapping(tmp_path):
+    """A well-formed config.yaml should yield a slug -> display_name mapping."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "products:\n"
+        "  - slug: models\n"
+        "    display_name: \"W&B Models\"\n"
+        "    allowed_keywords: []\n"
+        "  - slug: weave\n"
+        "    display_name: \"W&B Weave\"\n"
+        "    allowed_keywords: []\n",
+        encoding="utf-8",
+    )
+    mapping = pr_report.load_product_display_names(config)
+    assert mapping == {"models": "W&B Models", "weave": "W&B Weave"}
+
+
+def test_load_product_display_names_missing_file_returns_empty(tmp_path):
+    """A missing config file should return an empty dict, not raise."""
+    assert pr_report.load_product_display_names(tmp_path / "missing.yaml") == {}
+
+
+def test_load_product_display_names_malformed_yaml_returns_empty(tmp_path):
+    """Garbage YAML should not crash the report; return an empty mapping."""
+    config = tmp_path / "config.yaml"
+    config.write_text("::: not valid yaml :::", encoding="utf-8")
+    assert pr_report.load_product_display_names(config) == {}


### PR DESCRIPTION
## Summary

Stops the knowledgebase-nav pipeline from reading, writing, or parsing `docs.json`. Tag pages, product indexes, article tab-badge sync, and root `support.mdx` behavior are unchanged. When tag pages are added, removed, or renamed (treated as delete + add), the PR report (`pr_report.py`) now emits a **docs.json update required** section that lists the exact Mintlify page ids to add or remove, grouped by product (`Support: <display_name>`), using display names from `scripts/knowledgebase-nav/config.yaml`.

## Motivation

Mintlify navigation in `docs.json` is intended to be edited by humans. The generator should not mutate navigation automatically.

## Changes

### `scripts/knowledgebase-nav/generate_tags.py`

- Removed `update_docs_json`, `DOCS_JSON_NAV_LANGUAGE`, and the post-loop `docs.json` phase.
- Pipeline is now five phases ending at `support.mdx` updates; docstrings and CLI help updated accordingly.

### `scripts/knowledgebase-nav/pr_report.py`

- Removed the `docs_json` bucket from categorization and the `- docs.json updated.` bullet.
- Added `collect_tag_page_changes()` from `git diff --name-status HEAD` lines: maps `support/<product>/tags/<slug>.mdx` to page ids (strip `.mdx`); handles `A`, `D`, and rename/copy (`R`/`C`) as add + remove.
- Added `load_product_display_names()` from `config.yaml`; optional `--config` (default `<repo-root>/scripts/knowledgebase-nav/config.yaml`).
- Added `build_docs_json_section()` and wired into `build_report_markdown`; fallback body is skipped when only tag-page add/remove lists are non-empty.

### `.github/workflows/knowledgebase-nav.yml`

- Step renamed to **Generate tag pages and product index**; comments describe human `docs.json` edits via PR comment.
- Auto-commit: message **`chore: regenerate support tag pages`** (matches `CHORE_SUBJECT` for chore-only detection); **`file_pattern` no longer includes `docs.json`**.

### Tests

- **`test_generate_tags.py`**: Removed `TestUpdateDocsJson`; fixture no longer seeds `docs.json`; full pipeline asserts `docs.json` is not created; light regression checks that `update_docs_json` is gone and the module does not path-open `docs.json`.
- **`test_golden_output.py`**: Removed golden assertions against `docs.json`; fixture copies only `support/` + `support.mdx`; asserts no `docs.json` appears after the run.
- **`test_pr_report.py`**: New coverage for tag-page collection, the docs.json section, display-name fallback, YAML loading edge cases, and updated categorization (e.g. `M docs.json` no longer increments a `docs_json` bucket).

### Docs

- **`README.md`** and **`Architecture.md`**: Describe human-managed `docs.json`, PR comment workflow, new-product tab JSON snippet, CI file patterns, troubleshooting, and updated mermaid diagrams (no `GEN --> docs.json`).

## Breaking change / migration

**Workflow behavior:** Commits from the Knowledgebase Nav workflow **no longer include `docs.json`**. Authors and reviewers must apply navigation edits manually when tag pages change.

**Operational:** PRs that previously relied on the bot to refresh support tabs must instead use the **docs.json update required** block in the PR comment (or edit `docs.json` locally). **Rename an auto-commit subject string:** anything that matched `chore: regenerate support tag pages and docs.json navigation` should use **`chore: regenerate support tag pages`** for chore-only / skip-comment logic.

## How to verify

- Run unit + integration tests from repo root:
  - `python -m pytest scripts/knowledgebase-nav/tests/ -v`
- Run the generator locally:
  - `python scripts/knowledgebase-nav/generate_tags.py --repo-root .`
  - Confirm `git status` does not show `docs.json` modified.
- Smoke-test the report (example):
  - `python scripts/knowledgebase-nav/pr_report.py --repo-root . --diff-text $'A\tsupport/models/tags/foo.mdx\n' --warnings-file /dev/null`
  - Confirm **`### docs.json update required`** and grouped **`Support: …`** headings.

## Risk / review focus

- **Fork PRs:** Generator still runs; auto-commit remains skipped. Fork contributors must run the generator locally **and** edit `docs.json` when tag pages change (README calls this out).
- **Display names:** If `config.yaml` is missing or malformed, headings fall back to **`Support: <slug>`**; confirm that is acceptable for edge cases.

## Commit

- `e5067feb6` — Remove docs.json update logic