### PR TITLE
Sync kb-nav script with CoreWeave

### DIFF
--- a/.github/workflows/knowledgebase-nav.yml
+++ b/.github/workflows/knowledgebase-nav.yml
@@ -4,14 +4,15 @@
 #
 # What this workflow does
 # -----------------------
-# Runs the Python script scripts/knowledgebase-nav/generate_tags.py against
-# the repo root. That script syncs keyword footers on support articles,
-# rebuilds tag pages and product index MDX, and updates the root support.mdx
-# counts. The generator never edits docs.json. When the set of tag pages
-# changes, the PR comment posted by scripts/knowledgebase-nav/pr_report.py
-# lists the page ids a human must add to or remove from each
-# "Support: <display_name>" tab in docs.json by hand. See
-# scripts/knowledgebase-nav/README.md and Architecture.md for the full
+# Runs the Python script scripts/knowledgebase-nav/generate_tags.py. The
+# script reads ``mintlify_root`` from scripts/knowledgebase-nav/config.yaml
+# to locate the Mintlify root, then syncs keyword footers on support
+# articles, rebuilds tag pages and product index MDX, and updates the root
+# support.mdx counts. The generator never edits docs.json. When the set of
+# tag pages changes, the PR comment posted by
+# scripts/knowledgebase-nav/pr_report.py lists the page ids a human must add
+# to or remove from each "Support: <display_name>" tab in docs.json by hand.
+# See scripts/knowledgebase-nav/README.md and Architecture.md for the full
 # pipeline.
 #
 # When it runs
@@ -136,7 +137,7 @@ jobs:
       # edits docs.json. stderr (Python warnings) is captured for the PR
       # comment steps below.
       - name: Generate tag pages and product index
-        run: python scripts/knowledgebase-nav/generate_tags.py --repo-root . 2>generator-warnings.log
+        run: python scripts/knowledgebase-nav/generate_tags.py 2>generator-warnings.log
 
       - name: Show generator warnings in log
         if: always()
@@ -159,7 +160,6 @@ jobs:
           MARKER="<!-- knowledgebase-nav-report -->"
 
           python scripts/knowledgebase-nav/pr_report.py \
-            --repo-root . \
             --warnings-file generator-warnings.log \
             --run-url "${RUN_URL}" \
             --run-id "${GITHUB_RUN_ID}" \
@@ -187,7 +187,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python scripts/knowledgebase-nav/pr_report.py \
-            --repo-root . \
             --warnings-file generator-warnings.log \
             --run-url "${RUN_URL}" \
             --run-id "${GITHUB_RUN_ID}" \

--- a/scripts/knowledgebase-nav/Architecture.md
+++ b/scripts/knowledgebase-nav/Architecture.md
@@ -1,6 +1,6 @@
 # Knowledgebase nav generator architecture
 
-This document describes the **Knowledgebase Nav** system in the `wandb-docs` repository: what it generates, which files and functions make it work, and how automation ties it together. For author-facing steps and local setup, see [README.md](./README.md).
+This document describes the **Knowledgebase Nav** system: what it generates, which files and functions make it work, and how automation ties it together. The utility lives at `<utility-dir>/knowledgebase-nav/` (for example `scripts/knowledgebase-nav/` or `utils/knowledgebase-nav/`) inside a Mintlify documentation repository. For author-facing steps and local setup, see [README.md](./README.md).
 
 ## Purpose
 
@@ -8,11 +8,11 @@ The generator keeps support (knowledgebase) navigation consistent with article c
 
 ## High-level context
 
-The system lives entirely inside `wandb-docs`. It does not call external APIs. It reads and writes files in the repo working tree.
+The system lives entirely inside the docs repository. It does not call external APIs. It reads and writes files in the working tree under the Mintlify root (resolved from `mintlify_root` in `config.yaml`).
 
 ```mermaid
 flowchart LR
-  subgraph repo["wandb-docs repository"]
+  subgraph repo["docs repository"]
     CFG["config.yaml"]
     TPL["templates/*.j2"]
     ART["support/*/articles/*.mdx"]
@@ -36,13 +36,13 @@ The arrow back to **articles** means phase 4 updates only `<Badge>` links that p
 
 ## Automation workflow
 
-Pull requests trigger the **Knowledgebase Nav** workflow when files under `support/**` or `scripts/knowledgebase-nav/**` change (including new pushes to an open PR). It installs Python dependencies, runs the generator, posts a PR comment with any "docs.json update required" instructions, and commits matching paths when there are diffs. Pull requests from **forks** check out the fork head commit and still run the generator, but the auto-commit step is skipped because the default token cannot push to forks.
+Pull requests trigger the **Knowledgebase Nav** workflow when files under the Mintlify `support/**` directory or the utility directory change (including new pushes to an open PR). It installs Python dependencies, runs the generator, posts a PR comment with any "docs.json update required" instructions, and commits matching paths when there are diffs. Pull requests from **forks** check out the fork head commit and still run the generator, but the auto-commit step is skipped because the default token cannot push to forks.
 
 ```mermaid
 flowchart TD
   A[PR or manual workflow_dispatch] --> B[Checkout ref]
   B --> C[Python 3.11 + pip install requirements.txt]
-  C --> D["generate_tags.py --repo-root ."]
+  C --> D["generate_tags.py (mintlify_root from config.yaml)"]
   D --> R["pr_report.py (lists tag-page adds/removes)"]
   R --> E{Files changed?}
   E -->|yes| F[git-auto-commit selected paths]
@@ -110,7 +110,7 @@ flowchart LR
 |-----------|------|------|
 | CLI and logic | `generate_tags.py` | All phases, parsing, slug rules, previews, MDX rewrites (does not touch `docs.json`) |
 | PR report | `pr_report.py` | Markdown report from `git diff`; lists added/removed tag pages so a human can update `docs.json` |
-| Product and tag registry | `config.yaml` | `slug`, `display_name`, `allowed_keywords` per product |
+| Configuration | `config.yaml` | `mintlify_root`, `badge_color`, and product registry (`slug`, `display_name`, `allowed_keywords`) |
 | Tag listing template | `templates/support_tag.mdx.j2` | One Card per article on a tag page |
 | Product hub template | `templates/support_product_index.mdx.j2` | Featured section and browse-by-category Cards |
 | Dependencies | `requirements.txt` | PyYAML, Jinja2 |
@@ -171,7 +171,7 @@ The pipeline does not edit `docs.json`. Tag-page additions and removals are surf
 
 ### CLI
 
-- **`main`** parses `--repo-root` and optional `--config`, then calls **`run_pipeline`**.
+- **`main`** parses an optional `--config`, resolves the Mintlify root from `mintlify_root` in `config.yaml` via **`resolve_mintlify_root`**, then calls **`run_pipeline`**.
 
 ## Constants
 

--- a/scripts/knowledgebase-nav/README.md
+++ b/scripts/knowledgebase-nav/README.md
@@ -1,6 +1,8 @@
 # Knowledgebase Nav Generator
 
-A standalone script that regenerates knowledgebase nav pages for the W&B documentation repository.
+A standalone script that regenerates knowledgebase nav pages for a Mintlify documentation repository.
+
+This utility lives at `<utility>/knowledgebase-nav/` inside the docs repo (for example `scripts/knowledgebase-nav/` or `utils/knowledgebase-nav/`); throughout this README, paths shown as `<utility>/knowledgebase-nav/...` mean the same directory the README itself lives in. The script locates its own `config.yaml` and resolves the **Mintlify root** (the directory containing `support/` and `support.mdx`) from the `mintlify_root` key in that file, so it does not need a path passed on the command line.
 
 The generator reads MDX article files from `support/<product>/articles/`, aggregates them by keyword tags, and:
 
@@ -11,7 +13,7 @@ The generator reads MDX article files from `support/<product>/articles/`, aggreg
 
 The generator never reads, parses, or writes `docs.json`. When tag pages are added or removed, a human must update the matching `Support: <display_name>` tab under `navigation.languages[language="en"].tabs[]` by hand. The PR comment posted by `pr_report.py` lists the exact page ids to add or remove, grouped by product, so the edit can be made with copy and paste.
 
-The generator runs automatically through GitHub Actions (workflow file `.github/workflows/knowledgebase-nav.yml`) when a pull request is opened, updated with new commits, or reopened, and at least one changed file matches `support/**` or `scripts/knowledgebase-nav/**`. You can also run that workflow manually from the Actions tab for previews.
+The generator runs automatically through GitHub Actions (workflow file `.github/workflows/knowledgebase-nav.yml`) when a pull request is opened, updated with new commits, or reopened, and at least one changed file matches the Mintlify `support/**` directory or the utility directory. You can also run that workflow manually from the Actions tab for previews.
 
 ---
 
@@ -54,14 +56,14 @@ If you want to run the generator locally (for example to preview footers and tag
 
 If you want to use a keyword that is not yet recognized for a product, you need to add it to the configuration file:
 
-1. Open `scripts/knowledgebase-nav/config.yaml`.
+1. Open `<utility>/knowledgebase-nav/config.yaml` (the `config.yaml` file next to this README).
 
 2. Find the product entry under `products:` and add your new keyword to its `allowed_keywords` list, in alphabetical order.
 
    **Before:**
    ```yaml
    - slug: models
-     display_name: "W&B Models"
+     display_name: "Models"
      allowed_keywords:
        - Academic
        - Administrator
@@ -71,7 +73,7 @@ If you want to use a keyword that is not yet recognized for a product, you need 
    **After (adding "API Keys"):**
    ```yaml
    - slug: models
-     display_name: "W&B Models"
+     display_name: "Models"
      allowed_keywords:
        - Academic
        - Administrator
@@ -131,8 +133,8 @@ The Card preview appears in three places:
 ---
 title: "How do I reset my API key?"
 keywords: ["Security", "Administrator"]
-docengineDescription: "Step-by-step instructions for resetting your W&B API key from the user settings page."
-description: "Reset your W&B API key."
+docengineDescription: "Step-by-step instructions for resetting your API key from the user settings page."
+description: "Reset your API key."
 ---
 ```
 
@@ -158,7 +160,7 @@ These steps are written for **macOS**. They use a **virtual environment** so pac
 
 **Prerequisites:** [Python](https://www.python.org/downloads/) 3.11 or another current Python 3 release (3.11 is what CI uses).
 
-1. Open Terminal and go to the root of the `wandb-docs` clone (the directory that contains the `support/` folder).
+1. Open Terminal and go to the root of the docs repo clone.
 
 2. Create a virtual environment in a folder named `.venv` (you can pick another name, but keep that folder out of git commits), then activate it:
 
@@ -169,17 +171,17 @@ These steps are written for **macOS**. They use a **virtual environment** so pac
 
    After activation, your prompt usually starts with `(.venv)`.
 
-3. Upgrade `pip` (recommended once per new venv), then install the generator dependencies:
+3. Upgrade `pip` (recommended once per new venv), then install the generator dependencies (replace `<utility>/knowledgebase-nav` below with the actual directory; it is the directory that contains this README):
 
    ```bash
    python -m pip install --upgrade pip
-   python -m pip install -r scripts/knowledgebase-nav/requirements.txt
+   python -m pip install -r <utility>/knowledgebase-nav/requirements.txt
    ```
 
-4. Run the script from the repo root:
+4. Run the script (the path it scans is read from `mintlify_root` in `config.yaml`):
 
    ```bash
-   python scripts/knowledgebase-nav/generate_tags.py --repo-root .
+   python <utility>/knowledgebase-nav/generate_tags.py
    ```
 
    The command updates article footers, tag pages, product indexes, and `support.mdx` in your working tree. It does not modify `docs.json`. Review the changes with `git diff` before you commit.
@@ -199,9 +201,10 @@ Next time you want to run the generator, activate the same `.venv` again (repeat
 ### File layout
 
 ```
-scripts/knowledgebase-nav/
+<utility>/knowledgebase-nav/
   generate_tags.py          Main generator script (single file, all phases below)
-  config.yaml               Products and allowed keywords configuration
+  pr_report.py              Builds the GitHub PR comment / job summary Markdown
+  config.yaml               mintlify_root, badge_color, products, and allowed keywords
   requirements.txt          Python dependencies (pyyaml, jinja2)
   README.md                 This file
   Architecture.md           Architecture overview and Mermaid diagrams for developers
@@ -211,7 +214,8 @@ scripts/knowledgebase-nav/
   tests/
     __init__.py             Package marker for tests
     conftest.py             Registers the `integration` pytest marker
-    test_generate_tags.py   Unit tests (pytest, mocked filesystem)
+    test_generate_tags.py   Unit tests for generate_tags.py (mocked filesystem)
+    test_pr_report.py       Unit tests for pr_report.py (synthetic git diff input)
     test_golden_output.py   Golden-file integration tests (real repo layout)
 ```
 
@@ -227,7 +231,7 @@ The script runs one pipeline after loading `config.yaml` and Jinja2 templates. T
 
 4. **Sync tab Badges** (`sync_all_support_article_footers`, `sync_support_article_footer`, `build_tab_badges_mdx`, `build_keyword_footer_mdx`): For each `support/<product>/articles/*.mdx` file, replaces managed `<Badge>` links with one Badge per `keywords` entry (in list order). Managed Badges are located via `_BADGE_START_RE` and `_BADGE_END_RE`: any `{/* ... */}` comment containing `AUTO-GENERATED: tab badges` anywhere inside it is the start; any comment containing `END AUTO-GENERATED: tab badges` anywhere inside it is the end — authors can add notes anywhere in these comments without breaking the generator. The generator falls back to regex matching for articles that predate markers. Other Badges and the rest of the body are not edited. If there are no such Badges yet and `keywords` is non-empty, appends a blank line, canonical markers, and the tab Badges (no `---`). If `keywords` is empty, removes the marker block (or bare tab-page Badges). Runs after tag pages are generated so articles are not modified if earlier phases fail.
 
-5. **Update support landing page** (`update_support_index`, `update_support_featured`): Edits the repository root `support.mdx` in place. Count lines inside each product `<Card>` are located via `_COUNTS_START_RE` / `_COUNTS_END_RE` (any `{/* ... */}` comment containing `AUTO-GENERATED: counts` / `END AUTO-GENERATED: counts`, falling back to a bare count-line pattern for migration) and replaced with current article and tag counts (including singular or plural labels). The featured-articles section is regenerated between markers located via `_FEATURED_START_RE` / `_FEATURED_END_RE` (any comment containing `AUTO-GENERATED: featured articles` / `END AUTO-GENERATED: featured articles`). All marker matching is case-insensitive with an optional colon after "generated".
+5. **Update support landing page** (`update_support_index`, `update_support_featured`): Edits the Mintlify root `support.mdx` in place. Count lines inside each product `<Card>` are located via `_COUNTS_START_RE` / `_COUNTS_END_RE` (any `{/* ... */}` comment containing `AUTO-GENERATED: counts` / `END AUTO-GENERATED: counts`, falling back to a bare count-line pattern for migration) and replaced with current article and tag counts (including singular or plural labels). The featured-articles section is regenerated between markers located via `_FEATURED_START_RE` / `_FEATURED_END_RE` (any comment containing `AUTO-GENERATED: featured articles` / `END AUTO-GENERATED: featured articles`). All marker matching is case-insensitive with an optional colon after "generated".
 
 `docs.json` is intentionally not on this list. The generator does not read or write that file. After the generator runs, the workflow's PR comment (built by `pr_report.py`) lists the page ids of any tag pages that were added or removed, grouped by `Support: <display_name>`, so a human can update the matching tab in `docs.json` by hand.
 
@@ -236,10 +240,10 @@ The script runs one pipeline after loading `config.yaml` and Jinja2 templates. T
 On macOS, set up a virtual environment as in [Running the generator locally](#running-the-generator-locally) (same steps as in the tech writers section), then from the repo root:
 
 ```bash
-python scripts/knowledgebase-nav/generate_tags.py --repo-root .
+python <utility>/knowledgebase-nav/generate_tags.py
 ```
 
-Use `--config /path/to/config.yaml` to point at a different config file. If you omit `--config`, the script uses `scripts/knowledgebase-nav/config.yaml` next to `generate_tags.py`.
+Use `--config /path/to/config.yaml` to point at a different config file. If you omit `--config`, the script uses `config.yaml` next to `generate_tags.py`. The Mintlify root scanned by the generator is always read from `mintlify_root` in that config file.
 
 The script prints a progress summary to stdout. The `warnings` module emits unknown keywords, skipped articles, and missing `support.mdx` product cards to stderr.
 
@@ -249,8 +253,9 @@ With the same virtual environment activated, install `pytest` and run:
 
 ```bash
 python -m pip install pytest
-pytest scripts/knowledgebase-nav/tests/test_generate_tags.py -v
-pytest scripts/knowledgebase-nav/tests/test_golden_output.py -v -m integration
+pytest <utility>/knowledgebase-nav/tests/test_generate_tags.py -v
+pytest <utility>/knowledgebase-nav/tests/test_pr_report.py -v
+pytest <utility>/knowledgebase-nav/tests/test_golden_output.py -v -m integration
 ```
 
 The unit tests use mocked file systems and run fast.
@@ -263,7 +268,7 @@ The golden-file module (`test_golden_output.py`) is marked `@pytest.mark.integra
 - No `docs.json` file is created in the temp tree, so the pipeline never reads or writes it.
 - Root `support.mdx` matches the real file byte-for-byte.
 
-If `support.mdx` is not found at the repository root the tests resolve to (the parent directory of `scripts/`, when this package lives at `scripts/knowledgebase-nav/`), the golden tests skip.
+If `support.mdx` is not found at the Mintlify root resolved from `mintlify_root` in `config.yaml`, the golden tests skip.
 
 ### Adding a new product
 
@@ -273,7 +278,7 @@ If `support.mdx` is not found at the repository root the tests resolve to (the p
 4. Add a product `<Card>` to the root `support.mdx` with `href="/support/<slug>"` and a marker-wrapped count line:
 
    ```
-   <Card title="W&B NewProduct" href="/support/<slug>" arrow="true" icon="/icons/cropped-newproduct.svg">
+   <Card title="NewProduct" href="/support/<slug>" arrow="true" icon="/icons/cropped-newproduct.svg">
      {/* AUTO-GENERATED: counts */}
      0 articles &middot; 0 tags
      {/* END AUTO-GENERATED: counts */}
@@ -286,7 +291,7 @@ If `support.mdx` is not found at the repository root the tests resolve to (the p
 
    ```json
    {
-     "tab": "Support: W&B NewProduct",
+     "tab": "Support: NewProduct",
      "hidden": true,
      "pages": [
        "support/<slug>"
@@ -298,7 +303,7 @@ If `support.mdx` is not found at the repository root the tests resolve to (the p
 
 ### How docs.json edits are coordinated
 
-The W&B docs site uses a multi-language navigation structure:
+The docs site uses a multi-language navigation structure:
 
 ```json
 {
@@ -311,7 +316,7 @@ The W&B docs site uses a multi-language navigation structure:
 }
 ```
 
-Hidden tabs named `"Support: <display_name>"` (for example `"Support: W&B Models"`) live under the English (`"en"`) language entry. Each tab's `pages` list looks like:
+Hidden tabs named `"Support: <display_name>"` (for example `"Support: Models"`) live under the English (`"en"`) language entry. Each tab's `pages` list looks like:
 
 ```
 ["support/<slug>", "support/<slug>/tags/tag-a", "support/<slug>/tags/tag-b", ...]
@@ -323,7 +328,7 @@ The generator never edits this file. When tag pages change, the workflow's PR co
 
 Workflow name: **Knowledgebase Nav** (file `.github/workflows/knowledgebase-nav.yml`). The job does not run `pytest`; run tests locally as above.
 
-- **Pull requests**: Runs when a PR is opened, synchronized (new pushes to the branch), or reopened, and the path filter matches. Only runs that include changes under `support/**` or `scripts/knowledgebase-nav/**` trigger the workflow (see GitHub path filters for `pull_request`). After generation, `stefanzweifel/git-auto-commit-action` commits only if something changed, using `file_pattern`: `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, and `support/*.mdx`. `docs.json` is intentionally not in this list — it is edited by humans only.
+- **Pull requests**: Runs when a PR is opened, synchronized (new pushes to the branch), or reopened, and the path filter matches. Only runs that include changes under the Mintlify `support/**` directory or the utility directory trigger the workflow (see GitHub path filters for `pull_request`). After generation, `stefanzweifel/git-auto-commit-action` commits only if something changed, using `file_pattern`: `support.mdx`, `support/*/articles/*.mdx`, `support/*/tags/*.mdx`, and `support/*.mdx`. `docs.json` is intentionally not in this list — it is edited by humans only.
 
 - **workflow_dispatch**: Run from the Actions tab. Optional input `branch`: when set, checkout uses that branch name. When empty, checkout uses `github.ref` (the branch selected in the "Use workflow from" dropdown). On `pull_request` events, checkout uses the PR head repository and head commit SHA (including forks); auto-commit runs only for same-repo PRs, not forks.
 

--- a/scripts/knowledgebase-nav/config.yaml
+++ b/scripts/knowledgebase-nav/config.yaml
@@ -21,6 +21,16 @@
 # keyword to this file.
 # ---------------------------------------------------------------------------
 
+# Project-specific settings
+# -------------------------
+# mintlify_root: Path from the GitHub repository root to the Mintlify root
+#   (the directory containing support/ and support.mdx). Use "." when the
+#   Mintlify root is the GitHub repo root, or a subdirectory name (for
+#   example "public-docs") when the docs live in a subfolder.
+# badge_color: Mintlify <Badge> color used for tab and featured Badges.
+mintlify_root: "."
+badge_color: "orange"
+
 products:
   - slug: models
     display_name: "W&B Models"

--- a/scripts/knowledgebase-nav/generate_tags.py
+++ b/scripts/knowledgebase-nav/generate_tags.py
@@ -3,8 +3,8 @@
 Knowledgebase Nav Generator
 =========================
 
-A standalone script that regenerates knowledgebase nav pages for the Weights
-& Biases documentation repository.
+A standalone script that regenerates knowledgebase nav pages for a Mintlify
+documentation repository.
 
 This script is designed to run as part of a GitHub Actions workflow, but can
 also be run locally for testing and previewing changes.
@@ -87,10 +87,12 @@ tag pages that were added or removed.
 
 Usage
 -----
-    python generate_tags.py --repo-root /path/to/wandb-docs
+    python generate_tags.py
 
-The --repo-root argument should point to the root of the wandb-docs repo
-(the directory that contains the support/ folder and support.mdx).
+The script reads ``mintlify_root`` from ``config.yaml`` (resolved relative
+to the GitHub repo root, which is two levels above this script) to locate
+the directory that contains ``support/`` and ``support.mdx``. Pass
+``--config`` to point at a different config file.
 """
 
 import argparse
@@ -261,7 +263,7 @@ def parse_frontmatter(file_path: Path) -> Tuple[Dict[str, Any], str]:
     """
     Parse YAML front matter and body text from an MDX file.
 
-    MDX files in the W&B docs repo follow this structure::
+    MDX files in the Mintlify docs repo follow this structure::
 
         ---
         title: "Article title"
@@ -403,9 +405,9 @@ def plain_text(body: str) -> str:
 
     Example
     -------
-    >>> plain_text("Use `wandb.init()` to **start** a run.")
-    'Use wandb.init() to start a run.'
-    >>> plain_text("See [docs](https://wandb.ai) for **more**.")
+    >>> plain_text("Use `client.init()` to **start** a run.")
+    'Use client.init() to start a run.'
+    >>> plain_text("See [docs](https://example.com) for **more**.")
     'See docs for more.'
     """
     text = body
@@ -797,24 +799,35 @@ def _tab_badge_pattern(product_slug: str) -> re.Pattern[str]:
     )
 
 
-def build_tab_badges_mdx(product_slug: str, keywords: List[str]) -> str:
+def build_tab_badges_mdx(
+    product_slug: str,
+    keywords: List[str],
+    *,
+    badge_color: str,
+) -> str:
     """
     Build concatenated ``<Badge>`` elements for tag navigation (no ``---``).
 
     One Badge per keyword, in list order, linking to
-    ``/support/<product>/tags/<tag-slug>``.
+    ``/support/<product>/tags/<tag-slug>``. ``badge_color`` is the Mintlify
+    Badge color attribute (loaded from ``config.yaml``).
     """
     if not keywords:
         return ""
     return "".join(
-        '<Badge stroke shape="pill" color="orange" size="md">'
+        f'<Badge stroke shape="pill" color="{badge_color}" size="md">'
         f"[{kw}](/support/{product_slug}/tags/{tag_slug(kw)})"
         "</Badge>"
         for kw in keywords
     )
 
 
-def build_keyword_footer_mdx(product_slug: str, keywords: List[str]) -> str:
+def build_keyword_footer_mdx(
+    product_slug: str,
+    keywords: List[str],
+    *,
+    badge_color: str,
+) -> str:
     """
     Build text to append when an article has no tab Badges yet.
 
@@ -824,7 +837,7 @@ def build_keyword_footer_mdx(product_slug: str, keywords: List[str]) -> str:
     """
     if not keywords:
         return ""
-    badges = build_tab_badges_mdx(product_slug, keywords)
+    badges = build_tab_badges_mdx(product_slug, keywords, badge_color=badge_color)
     return f"\n\n{_BADGE_START}\n{badges}\n{_BADGE_END}"
 
 
@@ -832,6 +845,8 @@ def _replace_tab_badges_in_body(
     body_and_footer: str,
     product_slug: str,
     keywords: List[str],
+    *,
+    badge_color: str,
 ) -> str:
     """
     Replace or remove only tab-page Badges; append a default footer if needed.
@@ -860,7 +875,8 @@ def _replace_tab_badges_in_body(
 
     if start_m is not None and end_m is not None:
         if keywords:
-            new_block = f"{_BADGE_START}\n{build_tab_badges_mdx(product_slug, keywords)}\n{_BADGE_END}"
+            badges = build_tab_badges_mdx(product_slug, keywords, badge_color=badge_color)
+            new_block = f"{_BADGE_START}\n{badges}\n{_BADGE_END}"
         else:
             new_block = ""
         return body_and_footer[:start_m.start()] + new_block + body_and_footer[end_m.end():]
@@ -875,17 +891,26 @@ def _replace_tab_badges_in_body(
             out = out[: m.start()] + out[m.end() :]
         insert_pos = matches[0].start()
         if keywords:
-            new_block = f"{_BADGE_START}\n{build_tab_badges_mdx(product_slug, keywords)}\n{_BADGE_END}"
+            badges = build_tab_badges_mdx(product_slug, keywords, badge_color=badge_color)
+            new_block = f"{_BADGE_START}\n{badges}\n{_BADGE_END}"
         else:
             new_block = ""
         return out[:insert_pos] + new_block + out[insert_pos:]
 
     if keywords:
-        return body_and_footer.rstrip() + build_keyword_footer_mdx(product_slug, keywords)
+        footer = build_keyword_footer_mdx(
+            product_slug, keywords, badge_color=badge_color
+        )
+        return body_and_footer.rstrip() + footer
     return body_and_footer
 
 
-def sync_support_article_footer(article_path: Path, product_slug: str) -> bool:
+def sync_support_article_footer(
+    article_path: Path,
+    product_slug: str,
+    *,
+    badge_color: str,
+) -> bool:
     """
     Align tab-page ``<Badge>`` links with ``keywords`` in front matter.
 
@@ -913,7 +938,9 @@ def sync_support_article_footer(article_path: Path, product_slug: str) -> bool:
     frontmatter = yaml.safe_load(inner_yaml) or {}
     keywords = _keywords_list_for_footer(frontmatter, article_path)
 
-    new_body = _replace_tab_badges_in_body(body_and_footer, product_slug, keywords)
+    new_body = _replace_tab_badges_in_body(
+        body_and_footer, product_slug, keywords, badge_color=badge_color
+    )
     new_text = fm_block + new_body
 
     if new_text == text:
@@ -923,7 +950,12 @@ def sync_support_article_footer(article_path: Path, product_slug: str) -> bool:
     return True
 
 
-def sync_all_support_article_footers(repo_root: Path, product_slug: str) -> int:
+def sync_all_support_article_footers(
+    repo_root: Path,
+    product_slug: str,
+    *,
+    badge_color: str,
+) -> int:
     """
     Run ``sync_support_article_footer`` on every ``*.mdx`` under
     ``support/<product_slug>/articles/``.
@@ -942,7 +974,9 @@ def sync_all_support_article_footers(repo_root: Path, product_slug: str) -> int:
     updated = 0
     for mdx_path in sorted(articles_dir.glob("*.mdx")):
         try:
-            if sync_support_article_footer(mdx_path, product_slug):
+            if sync_support_article_footer(
+                mdx_path, product_slug, badge_color=badge_color
+            ):
                 updated += 1
         except ValueError as exc:
             warnings.warn(f"Skipping footer sync for {mdx_path}: {exc}")
@@ -965,7 +999,7 @@ def crawl_articles(repo_root: Path, product_slug: str) -> List[Dict[str, Any]]:
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support/``).
     product_slug : str
         The product identifier (for example "models", "weave", or "inference").
 
@@ -1000,7 +1034,7 @@ def crawl_articles(repo_root: Path, product_slug: str) -> List[Dict[str, Any]]:
     -------
     >>> articles = crawl_articles(Path("/repo"), "models")
     >>> articles[0]["title"]
-    'Can I run wandb offline?'
+    'Can I run offline?'
     >>> articles[0]["keywords"]
     ['Experiments', 'Environment Variables']
     """
@@ -1099,7 +1133,7 @@ def build_tag_index(
     articles: List[Dict[str, Any]],
     allowed_keywords: List[str],
     *,
-    config_yaml_path: str = "scripts/knowledgebase-nav/config.yaml",
+    config_yaml_path: str = "config.yaml",
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Build a mapping from tag names to lists of articles that use that tag.
@@ -1116,8 +1150,9 @@ def build_tag_index(
     allowed_keywords : list of str
         The keywords recognized for this product (from config.yaml).
     config_yaml_path : str, optional
-        Repo-relative path to the config file, shown in unknown-keyword
-        warnings. Defaults to ``scripts/knowledgebase-nav/config.yaml``.
+        Path to the config file, shown in unknown-keyword warnings. Defaults
+        to ``"config.yaml"``; ``run_pipeline`` overrides this with the
+        path resolved relative to the Mintlify root for friendlier messages.
 
     Returns
     -------
@@ -1239,6 +1274,8 @@ def render_tag_pages(
     product_slug: str,
     tag_index: Dict[str, List[Dict[str, Any]]],
     template_env: Environment,
+    *,
+    templates_root: str,
 ) -> List[str]:
     """
     Generate tag page MDX files for a product.
@@ -1253,13 +1290,16 @@ def render_tag_pages(
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support/``).
     product_slug : str
         The product identifier (for example "models").
     tag_index : dict
         Mapping of tag names to article lists (from ``build_tag_index``).
     template_env : jinja2.Environment
         The configured Jinja2 environment.
+    templates_root : str
+        Path of the templates directory relative to the GitHub repo root,
+        recorded as ``template:`` provenance metadata in rendered MDX.
 
     Returns
     -------
@@ -1295,7 +1335,11 @@ def render_tag_pages(
             for a in articles
         ]
 
-        content = template.render(tag=tag_name, articles=articles_ctx)
+        content = template.render(
+            tag=tag_name,
+            articles=articles_ctx,
+            templates_root=templates_root,
+        )
         output_path.write_text(content, encoding="utf-8")
 
         page_path = f"support/{product_slug}/tags/{slug}"
@@ -1319,7 +1363,7 @@ def cleanup_stale_tag_pages(
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support/``).
     product_slug : str
         The product identifier (for example "models").
     generated_page_paths : list of str
@@ -1357,6 +1401,9 @@ def render_product_index(
     tag_index: Dict[str, List[Dict[str, Any]]],
     featured_articles: List[Dict[str, Any]],
     template_env: Environment,
+    *,
+    badge_color: str,
+    templates_root: str,
 ) -> None:
     """
     Generate the product index MDX page for a product.
@@ -1373,17 +1420,22 @@ def render_product_index(
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support/``).
     product_slug : str
         The product identifier (for example "models").
     product_display_name : str
-        The human-readable product name (for example "W&B Models").
+        The human-readable product name (for example "Models").
     tag_index : dict
         Mapping of tag names to article lists.
     featured_articles : list of dict
         Articles with ``featured: true``, sorted by title.
     template_env : jinja2.Environment
         The configured Jinja2 environment.
+    badge_color : str
+        Mintlify Badge color attribute used for tag link Badges.
+    templates_root : str
+        Path of the templates directory relative to the GitHub repo root,
+        recorded as ``template:`` provenance metadata in rendered MDX.
 
     Side effects
     ------------
@@ -1409,6 +1461,8 @@ def render_product_index(
         product_name=product_display_name,
         featured_articles=featured_articles,
         tag_categories=tag_categories,
+        badge_color=badge_color,
+        templates_root=templates_root,
     )
 
     output_path = repo_root / "support" / f"{product_slug}.mdx"
@@ -1421,6 +1475,8 @@ def render_product_index(
 
 def _build_featured_section_mdx(
     all_featured: Dict[str, Tuple[str, List[Dict[str, Any]]]],
+    *,
+    badge_color: str,
 ) -> str:
     """
     Build the auto-managed featured-articles block for support.mdx.
@@ -1448,7 +1504,7 @@ def _build_featured_section_mdx(
         parts.append(f"\n### {display_name}\n")
         for article in articles:
             badges = " ".join(
-                f'<Badge stroke shape="pill" color="orange" size="md">'
+                f'<Badge stroke shape="pill" color="{badge_color}" size="md">'
                 f'[{tl["name"]}]({tl["href"]})</Badge>'
                 for tl in article["tag_links"]
             )
@@ -1469,6 +1525,8 @@ def _build_featured_section_mdx(
 def update_support_featured(
     repo_root: Path,
     all_featured: Dict[str, Tuple[str, List[Dict[str, Any]]]],
+    *,
+    badge_color: str,
 ) -> None:
     """
     Replace the featured-articles section of support.mdx between markers.
@@ -1485,9 +1543,11 @@ def update_support_featured(
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support.mdx``).
     all_featured : dict
         Mapping of product slug to ``(display_name, featured_articles)``.
+    badge_color : str
+        Mintlify Badge color attribute used for tag link Badges.
     """
     support_path = repo_root / "support.mdx"
     content = support_path.read_text(encoding="utf-8")
@@ -1502,7 +1562,7 @@ def update_support_featured(
         )
         return
 
-    new_block = _build_featured_section_mdx(all_featured)
+    new_block = _build_featured_section_mdx(all_featured, badge_color=badge_color)
     new_content = content[:start_m.start()] + new_block + content[end_m.end():]
 
     if new_content != content:
@@ -1519,7 +1579,7 @@ def update_support_index(
     The support.mdx page is human-authored and contains product Cards
     with article and tag counts in the format::
 
-        <Card title="W&B Models" href="/support/models" ...>
+        <Card title="Models" href="/support/models" ...>
           180 articles &middot; 33 tags
         </Card>
 
@@ -1530,7 +1590,7 @@ def update_support_index(
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support.mdx``).
     product_stats : dict
         Mapping of product slug to a dict with ``article_count`` and
         ``tag_count`` keys.  For example::
@@ -1553,7 +1613,7 @@ def update_support_index(
     -------
     Given a Card like::
 
-        <Card title="W&B Models" href="/support/models" arrow="true" ...>
+        <Card title="Models" href="/support/models" arrow="true" ...>
           180 articles &middot; 33 tags
         </Card>
 
@@ -1566,7 +1626,8 @@ def update_support_index(
     if not support_index_path.exists():
         raise FileNotFoundError(
             f"support.mdx not found at {support_index_path}. "
-            "Ensure this script is run from the wandb-docs repo root."
+            "Ensure 'mintlify_root' in config.yaml points at the directory "
+            "that contains support.mdx."
         )
 
     content = support_index_path.read_text(encoding="utf-8")
@@ -1643,7 +1704,8 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     Parameters
     ----------
     repo_root : Path
-        Path to the root of the wandb-docs repository.
+        Path to the Mintlify root (the directory containing ``support/`` and
+        ``support.mdx``).
     config_path : Path
         Path to the config.yaml file.
 
@@ -1661,6 +1723,7 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     """
     config = load_config(config_path)
     products = config["products"]
+    badge_color = config.get("badge_color", "blue")
 
     try:
         config_yaml_display = config_path.resolve().relative_to(
@@ -1669,10 +1732,20 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
     except ValueError:
         config_yaml_display = config_path.as_posix()
 
-    # Set up Jinja2 templates from the templates/ directory next to this script
+    # Set up Jinja2 templates from the templates/ directory next to this script.
+    # ``templates_root`` is the path of that directory relative to the GitHub
+    # repo root; it is recorded as ``template:`` provenance metadata in the
+    # generated MDX files so authors can locate the source template.
     script_dir = Path(__file__).resolve().parent
     templates_dir = script_dir / "templates"
     template_env = create_template_env(templates_dir)
+    github_repo_root = script_dir.parent.parent
+    try:
+        templates_root = (
+            templates_dir.resolve().relative_to(github_repo_root.resolve()).as_posix()
+        )
+    except ValueError:
+        templates_root = templates_dir.as_posix()
 
     # Track article and tag counts per product for the support.mdx update step
     product_stats: Dict[str, Dict[str, int]] = {}
@@ -1704,7 +1777,9 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
         print(f"  Found {len(tag_index)} unique tags")
 
         # Phase 2: Generate tag pages and remove stale ones
-        tag_page_paths = render_tag_pages(repo_root, slug, tag_index, template_env)
+        tag_page_paths = render_tag_pages(
+            repo_root, slug, tag_index, template_env, templates_root=templates_root
+        )
         print(f"  Generated {len(tag_page_paths)} tag pages")
 
         removed = cleanup_stale_tag_pages(repo_root, slug, tag_page_paths)
@@ -1714,7 +1789,14 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
         # Phase 3: Generate product index page
         featured = get_featured_articles(articles)
         render_product_index(
-            repo_root, slug, display_name, tag_index, featured, template_env
+            repo_root,
+            slug,
+            display_name,
+            tag_index,
+            featured,
+            template_env,
+            badge_color=badge_color,
+            templates_root=templates_root,
         )
         print(f"  Generated product index (featured: {len(featured)} articles)")
 
@@ -1724,7 +1806,9 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
         # Phase 4: Sync tab-page Badges from front matter keywords
         # Runs after tag pages exist so articles are not updated if
         # earlier phases fail.
-        footer_updates = sync_all_support_article_footers(repo_root, slug)
+        footer_updates = sync_all_support_article_footers(
+            repo_root, slug, badge_color=badge_color
+        )
         if footer_updates:
             print(f"  Updated tab Badges on {footer_updates} article(s)")
 
@@ -1736,11 +1820,47 @@ def run_pipeline(repo_root: Path, config_path: Path) -> None:
 
     # Phase 5: Update support.mdx product card counts and featured articles
     update_support_index(repo_root, product_stats)
-    update_support_featured(repo_root, all_featured)
+    update_support_featured(repo_root, all_featured, badge_color=badge_color)
     print(f"\n--- support.mdx ---")
     print(f"  Updated product card counts and featured articles")
     print(f"\n{'=' * 60}")
     print("Done.")
+
+
+def resolve_mintlify_root(config_path: Path) -> Path:
+    """
+    Resolve the Mintlify root from ``mintlify_root`` in ``config.yaml``.
+
+    The value is interpreted relative to the GitHub repository root, which is
+    two levels above this script (``script_dir.parent.parent``). For example,
+    a config with ``mintlify_root: "."`` resolves to the GitHub repo root and
+    ``mintlify_root: "public-docs"`` resolves to ``<repo>/public-docs/``.
+
+    Parameters
+    ----------
+    config_path : Path
+        Path to the config.yaml file.
+
+    Returns
+    -------
+    Path
+        Absolute resolved path to the Mintlify root.
+
+    Raises
+    ------
+    ValueError
+        If ``mintlify_root`` is missing from the config.
+    """
+    config = load_config(config_path)
+    mintlify_root = config.get("mintlify_root")
+    if not isinstance(mintlify_root, str) or not mintlify_root:
+        raise ValueError(
+            f"Configuration file {config_path} is missing 'mintlify_root'. "
+            "Set it to '.' if the Mintlify root is the GitHub repo root, "
+            "or to a subdirectory name (for example 'public-docs')."
+        )
+    github_repo_root = Path(__file__).resolve().parent.parent.parent
+    return (github_repo_root / mintlify_root).resolve()
 
 
 def main() -> None:
@@ -1753,10 +1873,10 @@ def main() -> None:
 
     Usage::
 
-        python generate_tags.py --repo-root /path/to/wandb-docs
+        python generate_tags.py
 
-    If ``--config`` is not specified, the script looks for ``config.yaml``
-    in the same directory as this script.
+    The script reads ``mintlify_root`` from ``config.yaml`` to locate the
+    Mintlify root. Pass ``--config`` to point at a different config file.
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -1764,12 +1884,6 @@ def main() -> None:
             "and update support.mdx."
         ),
         epilog="See README.md for detailed usage instructions.",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        required=True,
-        help="Path to the root of the wandb-docs repository (contains the support/ folder).",
     )
     parser.add_argument(
         "--config",
@@ -1780,12 +1894,12 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Default config path: same directory as this script
     if args.config is None:
         args.config = Path(__file__).resolve().parent / "config.yaml"
 
     try:
-        run_pipeline(args.repo_root, args.config)
+        repo_root = resolve_mintlify_root(args.config)
+        run_pipeline(repo_root, args.config)
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/knowledgebase-nav/pr_report.py
+++ b/scripts/knowledgebase-nav/pr_report.py
@@ -81,11 +81,11 @@ REPORT_FALLBACK_PARAGRAPH = (
     "No updates to support articles, tag pages, or product indexes from this run."
 )
 
-# Default location of the generator config (relative to repo root).  Used by
+# Default location of the generator config (next to this script).  Used by
 # the docs.json edit section to look up the ``Support: <display_name>`` tab
 # for each product slug.  When the config cannot be read the section falls
 # back to ``Support: <slug>`` so the report still renders.
-DEFAULT_CONFIG_PATH = Path("scripts/knowledgebase-nav/config.yaml")
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
 
 # Heading and intro paragraph for the "docs.json update required" section.
 # The generator never modifies docs.json; humans must edit it after the
@@ -444,6 +444,34 @@ def collect_tag_page_changes(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_mintlify_root(config_path: Path) -> Path:
+    """
+    Resolve the Mintlify root from ``mintlify_root`` in ``config.yaml``.
+
+    The value is interpreted relative to the GitHub repository root, which is
+    two levels above this script (``script_dir.parent.parent``). For example,
+    a config with ``mintlify_root: "."`` resolves to the GitHub repo root and
+    ``mintlify_root: "public-docs"`` resolves to ``<repo>/public-docs/``.
+
+    This duplicates ``generate_tags.resolve_mintlify_root`` so ``pr_report``
+    stays standalone (importable without pulling in the generator's
+    dependencies). The two implementations must remain in sync.
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    mintlify_root = config.get("mintlify_root") if isinstance(config, dict) else None
+    if not isinstance(mintlify_root, str) or not mintlify_root:
+        raise ValueError(
+            f"Configuration file {config_path} is missing 'mintlify_root'. "
+            "Set it to '.' if the Mintlify root is the GitHub repo root, "
+            "or to a subdirectory name (for example 'public-docs')."
+        )
+    github_repo_root = Path(__file__).resolve().parent.parent.parent
+    return (github_repo_root / mintlify_root).resolve()
+
+
 def load_product_display_names(config_path: Path) -> Dict[str, str]:
     """
     Read product slug -> display name mapping from ``config.yaml``.
@@ -533,7 +561,7 @@ def build_docs_json_section(
 
     Each per-product subsection uses the form::
 
-        #### Support: W&B Models
+        #### Support: Models
 
         Add to `pages`:
         - `support/models/tags/foo`
@@ -811,12 +839,6 @@ def main() -> None:
         description="Build Knowledgebase Nav PR comment or job summary Markdown.",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        required=True,
-        help="Repository root (contains .git).",
-    )
-    parser.add_argument(
         "--warnings-file",
         type=Path,
         default=Path("generator-warnings.log"),
@@ -850,17 +872,20 @@ def main() -> None:
         type=Path,
         default=None,
         help=(
-            "Path to scripts/knowledgebase-nav/config.yaml. "
-            "Used to map product slugs to display names in the docs.json edit "
-            "section. Defaults to <repo-root>/scripts/knowledgebase-nav/config.yaml."
+            "Path to config.yaml. Used to map product slugs to display names "
+            "in the docs.json edit section and to resolve the Mintlify root "
+            "via 'mintlify_root' for git diff. Defaults to config.yaml next "
+            "to this script."
         ),
     )
     args = parser.parse_args()
 
+    config_path = args.config or DEFAULT_CONFIG_PATH
+
     if args.diff_text is not None:
         diff_out = args.diff_text
     else:
-        diff_out = git_diff_name_status_head(args.repo_root)
+        diff_out = git_diff_name_status_head(_resolve_mintlify_root(config_path))
 
     diff_lines = [ln for ln in diff_out.splitlines() if ln.strip()]
     buckets = categorize_name_status_lines(diff_lines)
@@ -870,7 +895,6 @@ def main() -> None:
     if args.warnings_file.exists():
         warnings_text = args.warnings_file.read_text(encoding="utf-8")
 
-    config_path = args.config or (args.repo_root / DEFAULT_CONFIG_PATH)
     display_names = load_product_display_names(config_path)
 
     unknown_set = distinct_unknown_keywords_from_warnings(warnings_text)

--- a/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_product_index.mdx.j2
@@ -1,7 +1,7 @@
 ---
 title: {{ ("Support: " ~ product_name) | tojson_unicode }}
 generator: "knowledgebase-nav"
-template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
+template: "{{ templates_root }}/support_product_index.mdx.j2"
 ---
 
 {% if featured_articles %}
@@ -11,7 +11,7 @@ template: "scripts/knowledgebase-nav/templates/support_product_index.mdx.j2"
 <Card title="{{ article.title_attr }}" href="/{{ article.page_path }}" arrow="true" horizontal>
   {{ article.body_preview }}
 
-  {% for tl in article.tag_links %}<Badge stroke shape="pill" color="orange" size="md">[{{ tl.name }}]({{ tl.href }})</Badge> {% endfor %}
+  {% for tl in article.tag_links %}<Badge stroke shape="pill" color="{{ badge_color }}" size="md">[{{ tl.name }}]({{ tl.href }})</Badge> {% endfor %}
 
 </Card>
 {% endfor %}

--- a/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
+++ b/scripts/knowledgebase-nav/templates/support_tag.mdx.j2
@@ -2,7 +2,7 @@
 title: {{ tag | tojson_unicode }}
 tag: {{ articles | length | string | tojson_unicode }}
 generator: "knowledgebase-nav"
-template: "scripts/knowledgebase-nav/templates/support_tag.mdx.j2"
+template: "{{ templates_root }}/support_tag.mdx.j2"
 ---
 
 {% for article in articles %}

--- a/scripts/knowledgebase-nav/tests/test_generate_tags.py
+++ b/scripts/knowledgebase-nav/tests/test_generate_tags.py
@@ -34,6 +34,9 @@ import generate_tags  # noqa: E402
 # Fixtures
 # ===========================================================================
 
+TEST_BADGE_COLOR = "orange"
+
+
 @pytest.fixture
 def sample_config(tmp_path):
     """
@@ -42,10 +45,13 @@ def sample_config(tmp_path):
     The config defines one product ("widgets") with two allowed keywords
     so tests can verify config loading, validation, and keyword checking.
     """
-    config_content = textwrap.dedent("""\
+    config_content = textwrap.dedent(f"""\
+        mintlify_root: "."
+        badge_color: "{TEST_BADGE_COLOR}"
+
         products:
           - slug: widgets
-            display_name: "W&B Widgets"
+            display_name: "Widgets"
             allowed_keywords:
               - Alpha
               - Beta
@@ -123,7 +129,7 @@ def sample_repo(tmp_path):
         ## Browse support articles by product
 
         <CardGroup cols={3}>
-        <Card title="W&B Widgets" href="/support/widgets" arrow="true" icon="/icons/cropped-widgets.svg">
+        <Card title="Widgets" href="/support/widgets" arrow="true" icon="/icons/cropped-widgets.svg">
           {/* auto-generated counts */}
           0 articles &middot; 0 tags
           {/* end auto-generated counts */}
@@ -152,6 +158,10 @@ def template_env():
     return generate_tags.create_template_env(templates_dir)
 
 
+# Provenance metadata recorded as ``template:`` in rendered MDX during tests.
+TEST_TEMPLATES_ROOT = "test/templates"
+
+
 # ===========================================================================
 # Tests: load_config
 # ===========================================================================
@@ -168,7 +178,7 @@ class TestLoadConfig:
         assert "products" in config
         assert len(config["products"]) == 1
         assert config["products"][0]["slug"] == "widgets"
-        assert config["products"][0]["display_name"] == "W&B Widgets"
+        assert config["products"][0]["display_name"] == "Widgets"
         assert "Alpha" in config["products"][0]["allowed_keywords"]
 
     def test_load_config_file_not_found(self, tmp_path):
@@ -442,7 +452,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             {/* END AUTO-GENERATED: tab badges */}
         """).rstrip()
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Alpha"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Alpha"], badge_color=TEST_BADGE_COLOR)
 
         assert generate_tags._BADGE_START in result
         assert generate_tags._BADGE_END in result
@@ -467,7 +477,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             */}
         """).rstrip()
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"], badge_color=TEST_BADGE_COLOR)
 
         assert generate_tags._BADGE_START in result
         assert generate_tags._BADGE_END in result
@@ -489,7 +499,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             {/* END AUTO-GENERATED: tab badges — end */}
         """).rstrip()
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", [])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", [], badge_color=TEST_BADGE_COLOR)
 
         assert "AUTO-GENERATED" not in result
         assert "Badge" not in result
@@ -510,7 +520,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             {/* END AUTO-GENERATED: tab badges */}
         """).rstrip()
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Alpha"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Alpha"], badge_color=TEST_BADGE_COLOR)
 
         assert "unrelated comment" in result
         assert "[Alpha]" in result
@@ -521,10 +531,10 @@ class TestReplaceTabBadgesFlexibleMarkers:
         The canonical (unmodified) marker format continues to match so
         existing articles written by prior generator runs are not broken.
         """
-        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"])
+        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"], badge_color=TEST_BADGE_COLOR)
         body = f"Body.\n\n{generate_tags._BADGE_START}\n{badges}\n{generate_tags._BADGE_END}"
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"], badge_color=TEST_BADGE_COLOR)
 
         assert "[Beta]" in result
         assert "[Alpha]" not in result
@@ -535,7 +545,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
         ``auto-generated: tab badges`` or ``Auto-Generated tab badges`` and the
         generator will still locate and replace the managed block.
         """
-        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"])
+        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"], badge_color=TEST_BADGE_COLOR)
         body = (
             "Body.\n\n"
             "{/* auto-generated: tab badges */}\n"
@@ -543,7 +553,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             "{/* end auto-generated: tab badges */}"
         )
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"], badge_color=TEST_BADGE_COLOR)
 
         assert "[Beta]" in result
         assert "[Alpha]" not in result
@@ -553,7 +563,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
         The colon after 'generated' is optional, so ``AUTO-GENERATED tab badges``
         (no colon) is recognised as the start marker.
         """
-        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"])
+        badges = generate_tags.build_tab_badges_mdx("widgets", ["Alpha"], badge_color=TEST_BADGE_COLOR)
         body = (
             "Body.\n\n"
             "{/* AUTO-GENERATED tab badges */}\n"
@@ -561,7 +571,7 @@ class TestReplaceTabBadgesFlexibleMarkers:
             "{/* END AUTO-GENERATED tab badges */}"
         )
 
-        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"])
+        result = generate_tags._replace_tab_badges_in_body(body, "widgets", ["Beta"], badge_color=TEST_BADGE_COLOR)
 
         assert "[Beta]" in result
         assert "[Alpha]" not in result
@@ -579,8 +589,8 @@ class TestBodyPreview:
         Backtick-wrapped code should have backticks removed.  The code
         content itself is preserved.
         """
-        result = generate_tags.plain_text("Use `wandb.init()` to start.")
-        assert result == "Use wandb.init() to start."
+        result = generate_tags.plain_text("Use `client.init()` to start.")
+        assert result == "Use client.init() to start."
 
     def test_plain_text_strips_mdx_components(self):
         """
@@ -610,7 +620,7 @@ class TestBodyPreview:
     def test_plain_text_strips_markdown_links_keeps_label(self):
         """Inline link URL and brackets must not appear in the preview."""
         result = generate_tags.plain_text(
-            "Read [the guide](https://docs.wandb.ai/foo) for details."
+            "Read [the guide](https://docs.example.com/foo) for details."
         )
         assert result == "Read the guide for details."
         assert "http" not in result
@@ -618,9 +628,9 @@ class TestBodyPreview:
 
     def test_plain_text_strips_bare_urls(self):
         """Raw https URLs should not pass through to the card."""
-        result = generate_tags.plain_text("Visit https://wandb.ai today.")
+        result = generate_tags.plain_text("Visit https://example.com today.")
         assert result == "Visit today."
-        assert "wandb" not in result.lower()
+        assert "example" not in result.lower()
 
     def test_plain_text_strips_mdx_brace_expressions(self):
         """Simple MDX {expression} segments should be removed."""
@@ -1198,7 +1208,7 @@ class TestBuildTagIndex:
             assert len(w) == 1
             assert "Unknown keyword `Unknown`" in str(w[0].message)
             assert "support/widgets/articles/example.mdx" in str(w[0].message)
-            assert "scripts/knowledgebase-nav/config.yaml" in str(w[0].message)
+            assert "config.yaml" in str(w[0].message)
 
     def test_unknown_keyword_warned_only_once(self):
         """
@@ -1245,7 +1255,10 @@ class TestRenderTagPages:
             ],
         }
 
-        paths = generate_tags.render_tag_pages(tmp_path, "widgets", tag_index, template_env)
+        paths = generate_tags.render_tag_pages(
+            tmp_path, "widgets", tag_index, template_env,
+            templates_root=TEST_TEMPLATES_ROOT,
+        )
 
         assert (tags_dir / "alpha.mdx").exists()
         assert (tags_dir / "beta.mdx").exists()
@@ -1263,7 +1276,10 @@ class TestRenderTagPages:
             ],
         }
 
-        generate_tags.render_tag_pages(tmp_path, "widgets", tag_index, template_env)
+        generate_tags.render_tag_pages(
+            tmp_path, "widgets", tag_index, template_env,
+            templates_root=TEST_TEMPLATES_ROOT,
+        )
 
         content = (tmp_path / "support" / "widgets" / "tags" / "alpha.mdx").read_text()
         assert 'title: "Alpha"' in content
@@ -1284,7 +1300,10 @@ class TestRenderTagPages:
             ],
         }
 
-        generate_tags.render_tag_pages(tmp_path, "widgets", tag_index, template_env)
+        generate_tags.render_tag_pages(
+            tmp_path, "widgets", tag_index, template_env,
+            templates_root=TEST_TEMPLATES_ROOT,
+        )
         content = (tmp_path / "support" / "widgets" / "tags" / "test.mdx").read_text()
         assert 'tag: "5"' in content
 
@@ -1308,7 +1327,9 @@ class TestRenderProductIndex:
         }
 
         generate_tags.render_product_index(
-            tmp_path, "widgets", "W&B Widgets", tag_index, [], template_env
+            tmp_path, "widgets", "Widgets", tag_index, [], template_env,
+            badge_color=TEST_BADGE_COLOR,
+            templates_root=TEST_TEMPLATES_ROOT,
         )
 
         content = (tmp_path / "support" / "widgets.mdx").read_text()
@@ -1337,7 +1358,9 @@ class TestRenderProductIndex:
         ]
 
         generate_tags.render_product_index(
-            tmp_path, "widgets", "W&B Widgets", tag_index, featured, template_env
+            tmp_path, "widgets", "Widgets", tag_index, featured, template_env,
+            badge_color=TEST_BADGE_COLOR,
+            templates_root=TEST_TEMPLATES_ROOT,
         )
 
         content = (tmp_path / "support" / "widgets.mdx").read_text()
@@ -1357,7 +1380,9 @@ class TestRenderProductIndex:
         tag_index = {"Alpha": [{"title": "A"}]}
 
         generate_tags.render_product_index(
-            tmp_path, "widgets", "W&B Widgets", tag_index, [], template_env
+            tmp_path, "widgets", "Widgets", tag_index, [], template_env,
+            badge_color=TEST_BADGE_COLOR,
+            templates_root=TEST_TEMPLATES_ROOT,
         )
 
         content = (tmp_path / "support" / "widgets.mdx").read_text()
@@ -1372,11 +1397,13 @@ class TestRenderProductIndex:
         (tmp_path / "support").mkdir(parents=True, exist_ok=True)
 
         generate_tags.render_product_index(
-            tmp_path, "widgets", "W&B Widgets", {}, [], template_env
+            tmp_path, "widgets", "Widgets", {}, [], template_env,
+            badge_color=TEST_BADGE_COLOR,
+            templates_root=TEST_TEMPLATES_ROOT,
         )
 
         content = (tmp_path / "support" / "widgets.mdx").read_text()
-        assert 'title: "Support: W&B Widgets"' in content
+        assert 'title: "Support: Widgets"' in content
 
     def test_product_index_tags_sorted_alphabetically(self, tmp_path, template_env):
         """
@@ -1391,7 +1418,9 @@ class TestRenderProductIndex:
         }
 
         generate_tags.render_product_index(
-            tmp_path, "widgets", "W&B Widgets", tag_index, [], template_env
+            tmp_path, "widgets", "Widgets", tag_index, [], template_env,
+            badge_color=TEST_BADGE_COLOR,
+            templates_root=TEST_TEMPLATES_ROOT,
         )
 
         content = (tmp_path / "support" / "widgets.mdx").read_text()
@@ -1481,7 +1510,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               0 articles &middot; 0 tags
             </Card>
         """), encoding="utf-8")
@@ -1505,7 +1534,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Solo" href="/support/solo" arrow="true">
+            <Card title="Solo" href="/support/solo" arrow="true">
               0 articles &middot; 0 tags
             </Card>
         """), encoding="utf-8")
@@ -1625,7 +1654,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               {/* Note: auto-generated counts — do not edit */}
               0 articles &middot; 0 tags
               {/* end auto-generated counts */}
@@ -1651,7 +1680,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               {/* auto-generated counts */}
               0 articles &middot; 0 tags
               {/* end auto-generated counts — managed by generator */}
@@ -1682,7 +1711,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               {/* auto-generated counts */}
               0 articles &middot; 0 tags
               {/* end auto-generated counts */}
@@ -1710,7 +1739,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               {/* Auto-Generated counts */}
               0 articles &middot; 0 tags
               {/* End Auto-Generated counts */}
@@ -1735,7 +1764,7 @@ class TestUpdateSupportIndex:
             title: Support
             ---
 
-            <Card title="W&B Widgets" href="/support/widgets" arrow="true">
+            <Card title="Widgets" href="/support/widgets" arrow="true">
               {/* auto-generated: counts */}
               0 articles &middot; 0 tags
               {/* end auto-generated: counts */}
@@ -1786,7 +1815,7 @@ class TestUpdateSupportFeatured:
             end_marker="{/* ---- END AUTO-GENERATED: featured articles ---- */}",
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         assert "AUTO-GENERATED: featured articles" in content
@@ -1803,7 +1832,7 @@ class TestUpdateSupportFeatured:
             end_marker="{/* END AUTO-GENERATED: featured articles */}",
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         # Canonical markers are written on output
@@ -1820,7 +1849,7 @@ class TestUpdateSupportFeatured:
             end_marker="{/* END AUTO-GENERATED: featured articles — do not edit */}",
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         assert "END AUTO-GENERATED: featured articles" in content
@@ -1845,7 +1874,7 @@ class TestUpdateSupportFeatured:
         """)
         (tmp_path / "support.mdx").write_text(content, encoding="utf-8")
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         result = (tmp_path / "support.mdx").read_text()
         assert "unrelated comment" in result
@@ -1867,7 +1896,7 @@ class TestUpdateSupportFeatured:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            generate_tags.update_support_featured(tmp_path, {})
+            generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
             assert any("featured-article markers" in str(x.message) for x in w)
 
         assert (tmp_path / "support.mdx").read_text() == original
@@ -1892,7 +1921,7 @@ class TestUpdateSupportFeatured:
             ),
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         assert "Author note" not in content
@@ -1911,7 +1940,7 @@ class TestUpdateSupportFeatured:
             end_marker="{/* end auto-generated: featured articles */}",
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         assert "AUTO-GENERATED: featured articles" in content
@@ -1928,7 +1957,7 @@ class TestUpdateSupportFeatured:
             end_marker="{/* END AUTO-GENERATED featured articles */}",
         )
 
-        generate_tags.update_support_featured(tmp_path, {})
+        generate_tags.update_support_featured(tmp_path, {}, badge_color=TEST_BADGE_COLOR)
 
         content = (tmp_path / "support.mdx").read_text()
         assert "AUTO-GENERATED: featured articles" in content
@@ -1945,21 +1974,29 @@ class TestKeywordFooter:
 
     def test_build_keyword_footer_empty(self):
         """No keywords means no footer block (empty string)."""
-        assert generate_tags.build_keyword_footer_mdx("models", []) == ""
-        assert generate_tags.build_tab_badges_mdx("models", []) == ""
+        assert generate_tags.build_keyword_footer_mdx(
+            "models", [], badge_color=TEST_BADGE_COLOR
+        ) == ""
+        assert generate_tags.build_tab_badges_mdx(
+            "models", [], badge_color=TEST_BADGE_COLOR
+        ) == ""
 
     def test_build_keyword_footer_single(self):
         """One keyword produces a blank line, markers, and one Badge."""
-        s = generate_tags.build_keyword_footer_mdx("weave", ["Code Capture"])
+        s = generate_tags.build_keyword_footer_mdx(
+            "weave", ["Code Capture"], badge_color=TEST_BADGE_COLOR
+        )
         assert s.startswith("\n\n")
         assert "[Code Capture](/support/weave/tags/code-capture)</Badge>" in s
-        assert '<Badge stroke shape="pill" color="orange" size="md">' in s
+        assert f'<Badge stroke shape="pill" color="{TEST_BADGE_COLOR}" size="md">' in s
         assert "AUTO-GENERATED: tab badges" in s
         assert s.endswith("{/* END AUTO-GENERATED: tab badges */}")
 
     def test_build_keyword_footer_preserves_keyword_order(self):
         """Badge order follows the keywords list order, not alphabetical."""
-        s = generate_tags.build_keyword_footer_mdx("widgets", ["Beta", "Alpha"])
+        s = generate_tags.build_keyword_footer_mdx(
+            "widgets", ["Beta", "Alpha"], badge_color=TEST_BADGE_COLOR
+        )
         assert s.index("Beta") < s.index("Alpha")
 
     def test_sync_adds_footer_when_missing(self, tmp_path):
@@ -1976,7 +2013,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is True
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         out = p.read_text()
         assert "Body only." in out
         assert "/support/widgets/tags/alpha" in out
@@ -2000,7 +2037,7 @@ class TestKeywordFooter:
             {/* END AUTO-GENERATED: tab badges */}""")
         p = tmp_path / "a.mdx"
         p.write_text(content, encoding="utf-8")
-        assert generate_tags.sync_support_article_footer(p, "widgets") is False
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is False
 
     def test_sync_preserves_blank_line_after_end_marker(self, tmp_path):
         """EOF after the end marker (for example a trailing blank line) is kept."""
@@ -2023,7 +2060,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is False
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is False
         out = p.read_text()
         assert out.endswith("{/* END AUTO-GENERATED: tab badges */}\n\n")
 
@@ -2045,7 +2082,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is True
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         assert "/support/widgets/tags/alpha" in p.read_text()
 
     def test_sync_fixes_wrong_href_preserves_eof_after_badges(self, tmp_path):
@@ -2066,7 +2103,7 @@ class TestKeywordFooter:
                 """).rstrip("\n") + "\n\n",
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is True
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         out = p.read_text()
         assert "/support/widgets/tags/alpha" in out
         assert out.endswith("{/* END AUTO-GENERATED: tab badges */}\n\n")
@@ -2087,7 +2124,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is True
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         out = p.read_text()
         assert "/support/widgets/tags/alpha" in out
         body_after_fm = out.split("---", 2)[2]
@@ -2115,7 +2152,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is False
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is False
         out = p.read_text()
         assert "https://example.com/doc" in out
         assert "/support/widgets/tags/alpha" in out
@@ -2138,7 +2175,7 @@ class TestKeywordFooter:
                 """),
             encoding="utf-8",
         )
-        assert generate_tags.sync_support_article_footer(p, "widgets") is True
+        assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         out = p.read_text()
         assert "<Badge" not in out
         assert "Body." in out
@@ -2159,7 +2196,7 @@ class TestKeywordFooter:
         )
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            assert generate_tags.sync_support_article_footer(p, "widgets") is True
+            assert generate_tags.sync_support_article_footer(p, "widgets", badge_color=TEST_BADGE_COLOR) is True
         msgs = [str(x.message).lower() for x in w]
         assert any("keywords" in m for m in msgs)
         assert any("single tag" in m for m in msgs)

--- a/scripts/knowledgebase-nav/tests/test_golden_output.py
+++ b/scripts/knowledgebase-nav/tests/test_golden_output.py
@@ -2,7 +2,7 @@
 Golden-file integration test for the Knowledgebase Nav generator.
 
 This is the most important test in the suite.  It runs the generator against
-the real wandb-docs repository and verifies that the output is **byte-for-byte
+the real Mintlify docs tree and verifies that the output is **byte-for-byte
 identical** to the existing files on disk.
 
 If the template, slug logic, body-preview truncation, sort order, or
@@ -19,12 +19,13 @@ The pipeline does not modify ``docs.json``, so this suite no longer asserts
 anything about ``docs.json``.
 
 How to run:
-    pytest scripts/knowledgebase-nav/tests/test_golden_output.py -v -m integration
+    pytest <utility-dir>/tests/test_golden_output.py -v -m integration
 
 The ``integration`` marker is registered in ``conftest.py`` in this directory.
 
 Prerequisites:
-    - The wandb-docs repo must be present at the expected location.
+    - The Mintlify root resolved from ``mintlify_root`` in ``config.yaml``
+      must be present at the expected location.
     - The test reads existing files as the "expected" golden output, then
       generates new output to a temporary directory and compares.
 """
@@ -48,13 +49,14 @@ import generate_tags  # noqa: E402
 # Constants
 # ---------------------------------------------------------------------------
 
-# Repo root: parent of scripts/ when this file lives at
-# scripts/knowledgebase-nav/tests/test_golden_output.py
-WANDB_DOCS_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
 _config = generate_tags.load_config(CONFIG_PATH)
 PRODUCTS = [p["slug"] for p in _config["products"]]
+
+# Mintlify root resolved from ``mintlify_root`` in config.yaml. This is
+# either the GitHub repo root (when mintlify_root == ".") or a subdirectory
+# of it (for example "public-docs").
+MINTLIFY_ROOT = generate_tags.resolve_mintlify_root(CONFIG_PATH)
 
 # Mark all tests in this module as integration tests so they can be
 # run separately from the fast unit tests.
@@ -109,17 +111,17 @@ def _unified_diff(expected: str, actual: str, label: str) -> str:
 @pytest.fixture(scope="module")
 def golden_repo_root():
     """
-    Return the path to the real wandb-docs repo.
+    Return the path to the real Mintlify root.
 
     Skips if support.mdx is missing at the resolved root (for example a
     sparse checkout or wrong working directory).
     """
-    if not (WANDB_DOCS_ROOT / "support.mdx").exists():
+    if not (MINTLIFY_ROOT / "support.mdx").exists():
         pytest.skip(
-            f"wandb-docs repo not found at {WANDB_DOCS_ROOT}. "
+            f"Mintlify root not found at {MINTLIFY_ROOT}. "
             "Skipping golden-file tests."
         )
-    return WANDB_DOCS_ROOT
+    return MINTLIFY_ROOT
 
 
 @pytest.fixture(scope="module")
@@ -207,7 +209,7 @@ def generated_output(golden_repo_root, tmp_path_factory):
 class TestTagPagesMatchExisting:
     """
     Verify that every generated tag page is byte-for-byte identical to
-    the existing file in the wandb-docs repository.
+    the existing file in the Mintlify docs tree.
 
     Each tag page is tested individually so that failures pinpoint the
     exact file and show a unified diff of the mismatch.
@@ -369,7 +371,7 @@ class TestProductIndexPagesMatchExisting:
 class TestArticleFilesMatchExisting:
     """
     Verify that every article file after footer sync is byte-for-byte
-    identical to the existing file in the wandb-docs repository.
+    identical to the existing file in the Mintlify docs tree.
 
     The generator rewrites tab-page Badge links on each article to match
     ``keywords`` in front matter. Running the pipeline on already-correct

--- a/scripts/knowledgebase-nav/tests/test_pr_report.py
+++ b/scripts/knowledgebase-nav/tests/test_pr_report.py
@@ -346,11 +346,11 @@ def test_build_docs_json_section_uses_display_names_when_available():
     section = pr_report.build_docs_json_section(
         added_tag_pages={"models": ["support/models/tags/foo"]},
         removed_tag_pages={"models": ["support/models/tags/old"]},
-        display_names={"models": "W&B Models"},
+        display_names={"models": "Models"},
     )
     assert pr_report.DOCS_JSON_SECTION_HEADING in section
     assert pr_report.DOCS_JSON_SECTION_INTRO in section
-    assert "#### Support: W&B Models" in section
+    assert "#### Support: Models" in section
     assert "Add to `pages`:" in section
     assert "- `support/models/tags/foo`" in section
     assert "Remove from `pages`:" in section
@@ -378,7 +378,7 @@ def test_build_docs_json_section_omits_empty_subheaders():
     section = pr_report.build_docs_json_section(
         added_tag_pages={"models": ["support/models/tags/foo"]},
         removed_tag_pages={},
-        display_names={"models": "W&B Models"},
+        display_names={"models": "Models"},
     )
     assert "Add to `pages`:" in section
     assert "Remove from `pages`:" not in section
@@ -397,10 +397,10 @@ def test_build_report_includes_docs_json_section_for_added_tag_page():
         "",
         added_tag_pages={"models": ["support/models/tags/foo"]},
         removed_tag_pages={},
-        display_names={"models": "W&B Models"},
+        display_names={"models": "Models"},
     )
     assert pr_report.DOCS_JSON_SECTION_HEADING in out
-    assert "#### Support: W&B Models" in out
+    assert "#### Support: Models" in out
     assert "- `support/models/tags/foo`" in out
 
 
@@ -413,7 +413,7 @@ def test_build_report_includes_docs_json_section_for_removed_tag_page():
         "",
         added_tag_pages={},
         removed_tag_pages={"models": ["support/models/tags/old"]},
-        display_names={"models": "W&B Models"},
+        display_names={"models": "Models"},
     )
     assert pr_report.DOCS_JSON_SECTION_HEADING in out
     assert "Remove from `pages`:" in out
@@ -444,7 +444,7 @@ def test_build_report_fallback_with_only_tag_page_changes_breaks_fallback():
         "",
         added_tag_pages={"models": ["support/models/tags/foo"]},
         removed_tag_pages={},
-        display_names={"models": "W&B Models"},
+        display_names={"models": "Models"},
     )
     assert out != pr_report.REPORT_FALLBACK_BODY
     assert pr_report.DOCS_JSON_SECTION_HEADING in out
@@ -461,15 +461,15 @@ def test_load_product_display_names_returns_mapping(tmp_path):
     config.write_text(
         "products:\n"
         "  - slug: models\n"
-        "    display_name: \"W&B Models\"\n"
+        "    display_name: \"Models\"\n"
         "    allowed_keywords: []\n"
         "  - slug: weave\n"
-        "    display_name: \"W&B Weave\"\n"
+        "    display_name: \"Weave\"\n"
         "    allowed_keywords: []\n",
         encoding="utf-8",
     )
     mapping = pr_report.load_product_display_names(config)
-    assert mapping == {"models": "W&B Models", "weave": "W&B Weave"}
+    assert mapping == {"models": "Models", "weave": "Weave"}
 
 
 def test_load_product_display_names_missing_file_returns_empty(tmp_path):


### PR DESCRIPTION
## Summary

Syncs the Knowledgebase Nav generator (`scripts/knowledgebase-nav/`) with the CoreWeave-aligned utility: **Mintlify root and badge styling come from `config.yaml`**, the **`--repo-root` CLI is removed**, and **docs/tests** are updated so the tool reads as a reusable Mintlify docs utility rather than a hard-coded `wandb-docs`-only layout.

## Motivation / context

We are planning to unify this utility with the CoreWeave version as part of the Q2 DocEngine plans. This unites the script across those two repos, with the only difference being the config.yaml file in each. Future updates can stay in sync, or be pulled from DocEngine.

- Support navigation generation should work when the Mintlify site root is the repo root **or** a subdirectory (for example `public-docs`).
- Badge color should be configurable instead of hard-coded `orange`.
- PR reporting and CI should not require passing the repository root on the command line when it can be derived from config.

## Changes

### Configuration (`config.yaml`)

- Adds **`mintlify_root`**: path from the GitHub repository root to the directory that contains `support/` and `support.mdx` (this repo uses `"."`).
- Adds **`badge_color`**: Mintlify `<Badge>` color (default used in code when missing: `"blue"`; this repo sets `"orange"` to preserve prior appearance).

### `generate_tags.py`

- Introduces **`resolve_mintlify_root()`**: reads `mintlify_root` from the loaded config, resolved relative to the **GitHub repo root** (three parents up from the script path: `…/scripts/knowledgebase-nav/` → repo root).
- **`main()`**: drops `--repo-root`; optional `--config` only (defaults to `config.yaml` next to the script). Calls `resolve_mintlify_root` then `run_pipeline(repo_root, config_path)`.
- **`badge_color`** flows through tab badges, footers, product index template rendering, and featured section updates.
- **`templates_root`**: computed path of `templates/` relative to the repo root, passed into Jinja so generated MDX `template:` metadata is not hard-coded to `scripts/knowledgebase-nav/...`.
- Docstrings and examples generalized (generic Mintlify wording; `plain_text` doctest examples use neutral names/URLs).

### `pr_report.py`

- Removes **`--repo-root`**; **`git_diff_name_status_head`** runs with cwd set to the Mintlify root from **`_resolve_mintlify_root(config_path)`** (logic duplicated from `generate_tags` intentionally for standalone imports).
- **`DEFAULT_CONFIG_PATH`**: `Path(__file__).resolve().parent / "config.yaml"`.
- **`--config`**: help text updated for new behavior.

### Jinja templates

- `support_tag.mdx.j2` and `support_product_index.mdx.j2`: dynamic **`template:`** path and **`badge_color`** for Badges.

### GitHub Actions (`.github/workflows/knowledgebase-nav.yml`)

- Generator and PR report steps invoke **`python .../generate_tags.py`** and **`pr_report.py`** without `--repo-root`.
- Header comments describe **`mintlify_root`** in config.

### Documentation

- **`README.md`** and **`Architecture.md`**: describe generic `<utility>/knowledgebase-nav/` placement, Mintlify root resolution, workflow path filters in terms of Mintlify `support/**` and the utility directory; local run instructions updated; examples use simplified display names in snippets where appropriate.

### Tests

- **`test_generate_tags.py`**: `mintlify_root` / `badge_color` in fixtures; all updated call sites for new keyword-only parameters; template provenance constant; display name and plain-text test tweaks.
- **`test_golden_output.py`**: golden root = **`resolve_mintlify_root(CONFIG_PATH)`** instead of assuming repo layout via `parent.parent.parent.parent`.
- **`test_pr_report.py`**: expectations aligned with shortened example display names (`Models`, `Weave`).

## Breaking changes

- **`generate_tags.py`**: **`--repo-root` removed**. Set **`mintlify_root`** in `config.yaml` (required).
- **`pr_report.py`**: **`--repo-root` removed**; git diff runs from the resolved Mintlify root. Any custom invocation must pass **`--config`** if config is not beside the script.

## Migration notes

- Add to `config.yaml`: **`mintlify_root`** (use `"."` if `support/` and `support.mdx` are at the repo root) and optionally **`badge_color`**.
- Replace `python .../generate_tags.py --repo-root .` with `python .../generate_tags.py` (and same for `pr_report.py` in CI or local scripts).

## How to test / verify

- Unit tests:  
  `pytest scripts/knowledgebase-nav/tests/test_generate_tags.py -v`  
  `pytest scripts/knowledgebase-nav/tests/test_pr_report.py -v`
- Integration:  
  `pytest scripts/knowledgebase-nav/tests/test_golden_output.py -v -m integration`  
  (requires real tree at resolved Mintlify root; skips if `support.mdx` missing.)
- CI: open or push a PR touching `support/**` or `scripts/knowledgebase-nav/**` and confirm **Knowledgebase Nav** runs without `--repo-root` and PR comments still list `docs.json` updates when tag pages change.

## Risk / review focus

- **`resolve_mintlify_root` / `_resolve_mintlify_root`**: must stay consistent between `generate_tags.py` and `pr_report.py` (called out in code); repo-root assumption is **three levels** above `knowledgebase-nav` scripts.
- **First run after upgrade**: if `mintlify_root` is missing, both tools **fail fast** with a clear error (verify config is committed and valid).
- **Golden tests**: behavior depends on **`mintlify_root`** matching this repo’s layout; changing config path semantics later should re-run golden suite.

## Stats

- 1 commit: `d7b94e586` — *Sync kb-nav script with CoreWeave*
- 11 files, ~388 insertions, ~197 deletions vs `origin/main`