### PR TITLE
Use CoreWeave-validated settings for Calibre

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Compress Images
         uses: calibreapp/image-actions@main
         with:
+          jpegQuality: '85'
+          jpegProgressive: false
+          pngQuality: '80'
+          webpQuality: '85'
+          avifQuality: '75'
+          minPctChange: '10'
           # PAT with contents read-write (repo secret). Unlike the default workflow `GITHUB_TOKEN`,
           # commits pushed with this token trigger other workflows (e.g. Validate MDX).
           # Fork PRs are already excluded by the job `if` above.


### PR DESCRIPTION


## Description
Use [CoreWeave-validated settings](https://github.com/coreweave/docs/blob/main/.github/workflows/compress-img-all-pr.yaml#L44) for Calibre

Specifically, minPctChange set to 10, to avoid recursive re-optimizations

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
