### PR TITLE
Replace GitHub Actions PATs with GitHub App tokens

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,23 @@
 # GitHub Actions Workflows
 
+## GitHub App authentication
+
+Several workflows need permissions that the native `GITHUB_TOKEN` cannot provide. Use GitHub App installation tokens instead of personal access tokens for those cases.
+
+Created these GitHub Apps under the `wandb` organization:
+
+- `wandb-docs-source-reader`: install only on `wandb/docs-code-eval` and `wandb/weave-internal` with **Contents** read access.
+- `wandb-docs-pr-writer`: install only on `wandb/docs` with **Contents** read and write access and **Pull requests** read and write access.
+
+Stored the app credentials in `wandb/docs`:
+
+- Repository variable `DOCS_SOURCE_READER_APP_ID`: app ID for `wandb-docs-source-reader`.
+- Repository secret `DOCS_SOURCE_READER_PRIVATE_KEY`: private key for `wandb-docs-source-reader`.
+- Repository variable `DOCS_PR_WRITER_APP_ID`: app ID for `wandb-docs-pr-writer`.
+- Repository secret `DOCS_PR_WRITER_PRIVATE_KEY`: private key for `wandb-docs-pr-writer`.
+
+The workflows use `actions/create-github-app-token@v3` to create short-lived installation tokens from these credentials.
+
 ## Sync Code Examples
 
 **Workflow**: `sync-code-examples.yml`
@@ -68,17 +86,18 @@ When the draft PR is created:
 The workflow uses:
 - **Python**: 3.11
 - **Permissions**: `contents: write`, `pull-requests: write`
+- **Token action**: `actions/create-github-app-token@v3`
 - **Action**: `peter-evans/create-pull-request@v8`
 
 **Authentication and `docs-code-eval`**
 
-The automatic `GITHUB_TOKEN` is scoped to this repository (`wandb/docs`) only. It does not grant read access to other private repositories in the org, so it cannot replace a PAT for cloning `wandb/docs-code-eval` when that repo is private.
+The automatic `GITHUB_TOKEN` is scoped to this repository (`wandb/docs`) only. It does not grant read access to other private repositories in the org, so it cannot clone a private `wandb/docs-code-eval`.
 
-To sync from a **private** `docs-code-eval`, add a repository secret named `DOCS_CODE_EVAL_READ_PAT`: a fine-grained personal access token (or classic PAT) with **Contents** read access to `wandb/docs-code-eval`. The sync script uses it only for `git clone`. If the secret is not set and `docs-code-eval` is public, the workflow clones without a token.
+To sync from a private `docs-code-eval`, install `wandb-docs-source-reader` on `wandb/docs-code-eval`. The workflow creates a GitHub App installation token and passes it to the sync script as `DOCS_CODE_EVAL_READ_TOKEN`.
 
 **Clone fails with `could not read Username for 'https://github.com'`**
 
-That usually means Git tried to prompt for credentials (no TTY in Actions) or a credential helper failed. The sync script clears `credential.helper` for the clone and uses HTTPS with `x-access-token` when `DOCS_CODE_EVAL_READ_PAT` is set. If the log shows **anonymous** clone but the repo is private, the secret is missing, misnamed, or not available to this workflow (for example some fork contexts). Re-check the secret name `DOCS_CODE_EVAL_READ_PAT` and that the job log line above the clone says **PAT over HTTPS**.
+That usually means Git tried to prompt for credentials (no TTY in Actions) or a credential helper failed. The sync script clears `credential.helper` for the clone and uses HTTPS with `x-access-token` when `DOCS_CODE_EVAL_READ_TOKEN` is set. If the log shows an anonymous clone but the repo is private, check the GitHub App installation and the `DOCS_SOURCE_READER_APP_ID` and `DOCS_SOURCE_READER_PRIVATE_KEY` credentials.
 
 ### Troubleshooting
 
@@ -123,4 +142,3 @@ git add .
 git commit -m "Sync code examples from docs-code-eval"
 git push
 ```
-

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -13,11 +13,26 @@ jobs:
     # Only run on Pull Requests within the same repository, and not from forks.
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
-    permissions: write-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DOCS_PR_WRITER_APP_ID }}
+          private-key: ${{ secrets.DOCS_PR_WRITER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: docs
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout Repo
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.head_ref }}
 
       - name: Compress Images
         uses: calibreapp/image-actions@main
@@ -28,7 +43,7 @@ jobs:
           webpQuality: '85'
           avifQuality: '75'
           minPctChange: '10'
-          # PAT with contents read-write (repo secret). Unlike the default workflow `GITHUB_TOKEN`,
-          # commits pushed with this token trigger other workflows (e.g. Validate MDX).
+          # GitHub App token with contents read-write. Unlike the default workflow `GITHUB_TOKEN`,
+          # commits pushed with this token trigger other workflows (for example Validate MDX).
           # Fork PRs are already excluded by the job `if` above.
-          GITHUB_TOKEN: ${{ secrets.DOCS_REPO_CALIBRE_ACTION_READ_WRITE_SECRET }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/generate-query-panel-reference.yml
+++ b/.github/workflows/generate-query-panel-reference.yml
@@ -31,9 +31,19 @@ jobs:
           corepack enable
           corepack prepare yarn@1.22.22 --activate
 
+      - name: Create weave-internal read token
+        id: weave-internal-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DOCS_SOURCE_READER_APP_ID }}
+          private-key: ${{ secrets.DOCS_SOURCE_READER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: weave-internal
+          permission-contents: read
+
       - name: Generate QEL reference from weave-internal
         env:
-          QUERY_PANELS_READ_TOKEN: ${{ secrets.QUERY_PANELS_READ_ONLY_PAT }}
+          QUERY_PANELS_READ_TOKEN: ${{ steps.weave-internal-token.outputs.token }}
           GIT_TERMINAL_PROMPT: "0"
         run: |
           chmod +x scripts/reference-generation/query-panel/generate_query_panel_reference.sh

--- a/.github/workflows/sync-code-examples.yml
+++ b/.github/workflows/sync-code-examples.yml
@@ -21,18 +21,25 @@ jobs:
       # Do not use actions/checkout for wandb/docs-code-eval. GITHUB_TOKEN is scoped
       # to this repository only, so the REST get-repository call for another repo returns
       # Not Found for a private docs-code-eval. Clone in the script instead.
-      #
-      # For a private docs-code-eval, add repository secret DOCS_CODE_EVAL_READ_PAT
-      # (PAT with contents:read on wandb/docs-code-eval). Optional if the eval repo is public.
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Create docs-code-eval read token
+        id: docs-code-eval-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DOCS_SOURCE_READER_APP_ID }}
+          private-key: ${{ secrets.DOCS_SOURCE_READER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: docs-code-eval
+          permission-contents: read
       
       - name: Run sync script
         env:
-          DOCS_CODE_EVAL_READ_TOKEN: ${{ secrets.DOCS_CODE_EVAL_READ_PAT }}
+          DOCS_CODE_EVAL_READ_TOKEN: ${{ steps.docs-code-eval-token.outputs.token }}
           GIT_TERMINAL_PROMPT: "0"
         run: |
           chmod +x scripts/sync_code_examples.sh
@@ -42,10 +49,10 @@ jobs:
         id: check_changes
         run: |
           if [[ -n $(git status --porcelain) ]]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "changes=true" >> "$GITHUB_OUTPUT"
             echo "✅ Changes detected"
           else
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "changes=false" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No changes detected"
           fi
       
@@ -55,17 +62,19 @@ jobs:
         run: |
           # Count changed files
           CHANGED_FILES=$(git status --porcelain | wc -l | tr -d ' ')
-          CHANGED_PY=$(git status --porcelain | grep '\.py$' | wc -l | tr -d ' ')
+          CHANGED_PY=$(git status --porcelain | awk '/\.py$/ { count++ } END { print count + 0 }')
           
-          echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "changed_py=$CHANGED_PY" >> $GITHUB_OUTPUT
+          {
+            echo "changed_files=$CHANGED_FILES"
+            echo "changed_py=$CHANGED_PY"
           
-          # Get short summary
-          echo "summary<<EOF" >> $GITHUB_OUTPUT
-          echo "Synced $CHANGED_FILES file(s) from docs-code-eval:" >> $GITHUB_OUTPUT
-          echo "- $CHANGED_PY Python example(s) updated" >> $GITHUB_OUTPUT
-          echo "- Cheat sheet regenerated" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+            # Get short summary
+            echo "summary<<EOF"
+            echo "Synced $CHANGED_FILES file(s) from docs-code-eval:"
+            echo "- $CHANGED_PY Python example(s) updated"
+            echo "- Cheat sheet regenerated"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
       - name: Create Pull Request
         if: steps.check_changes.outputs.changes == 'true'

--- a/scripts/reference-generation/query-panel/README.md
+++ b/scripts/reference-generation/query-panel/README.md
@@ -18,7 +18,7 @@ This pipeline is **not** related to W&B Weave. It targets the Models **query pan
 ## Prerequisites
 
 - `git`, `yarn` (classic v1), `python3.11+`, Node **20** (matches CI; avoids native `canvas` install on dev machines).
-- Read access to `wandb/weave-internal` (SSH, HTTPS, or PAT).
+- Read access to `wandb/weave-internal` (SSH, HTTPS, or a GitHub App token).
 
 ## Local usage
 
@@ -29,10 +29,10 @@ export WEAVE_JS_ROOT=/path/to/weave-internal/weave-js
 ./scripts/reference-generation/query-panel/generate_query_panel_reference.sh
 ```
 
-Or let the script clone using a read token (same pattern as `sync-code-examples`):
+Or let the script clone using a read token:
 
 ```bash
-export QUERY_PANELS_READ_TOKEN="ghp_..."  # fine-grained or classic PAT; contents:read on weave-internal
+export QUERY_PANELS_READ_TOKEN="..."  # contents:read on weave-internal
 ./scripts/reference-generation/query-panel/generate_query_panel_reference.sh
 ```
 
@@ -46,7 +46,7 @@ export QUERY_PANELS_READ_TOKEN="ghp_..."  # fine-grained or classic PAT; content
 
 ## CI
 
-See `.github/workflows/generate-query-panel-reference.yml`. Uses repository secret `QUERY_PANELS_READ_ONLY_PAT` as `QUERY_PANELS_READ_TOKEN`.
+See `.github/workflows/generate-query-panel-reference.yml`. CI creates a GitHub App installation token and passes it as `QUERY_PANELS_READ_TOKEN`.
 
 ## Tests
 

--- a/scripts/sync_code_examples.sh
+++ b/scripts/sync_code_examples.sh
@@ -11,8 +11,8 @@ SUBMODULE_PATH="$DOCS_ROOT/.temp_code_eval"
 
 echo "🔄 Syncing code examples from docs-code-eval..."
 
-# Optional: fine-grained or classic PAT with contents:read on wandb/docs-code-eval.
-# Set by CI via secrets (see sync-code-examples workflow). Unset = anonymous clone (public repo only).
+# Optional read token with contents:read on wandb/docs-code-eval.
+# Set by CI with a GitHub App token. Unset = anonymous clone (public repo only).
 if [ -n "${DOCS_CODE_EVAL_READ_TOKEN:-}" ]; then
     EVAL_CLONE_URL="https://x-access-token:${DOCS_CODE_EVAL_READ_TOKEN}@github.com/wandb/docs-code-eval.git"
 else
@@ -30,9 +30,9 @@ else
     fi
     echo "   Cloning docs-code-eval repository..."
     if [ -n "${DOCS_CODE_EVAL_READ_TOKEN:-}" ]; then
-        echo "   (HTTPS with PAT from DOCS_CODE_EVAL_READ_PAT)"
+        echo "   (authenticated HTTPS with DOCS_CODE_EVAL_READ_TOKEN)"
     else
-        echo "   (anonymous HTTPS; set secret DOCS_CODE_EVAL_READ_PAT if the eval repo is private)"
+        echo "   (anonymous HTTPS; set DOCS_CODE_EVAL_READ_TOKEN if the eval repo is private)"
     fi
     # - Clear extraheader so a stale Actions token does not override URL credentials.
     # - credential.helper= stops the runner's helper from prompting (CI has no TTY; you


### PR DESCRIPTION
## Summary
- Replace PAT-backed GitHub Actions auth with GitHub App installation tokens.
- Keep native GITHUB_TOKEN usage for same-repo PR creation where it already works.
- Document the required GitHub Apps, repo variables, and repo secrets.

## Validation
- git diff --check
- YAML parse for edited workflows
- actionlint .github/workflows/calibreapp-image-actions.yml .github/workflows/sync-code-examples.yml .github/workflows/generate-query-panel-reference.yml
- Confirmed old PAT secret names are no longer referenced

## Follow-up setup
- After the workflows pass with the new apps, delete the old repo secrets: DOCS_CODE_EVAL_READ_PAT, QUERY_PANELS_READ_ONLY_PAT, and DOCS_REPO_CALIBRE_ACTION_READ_WRITE_SECRET.