### PR TITLE
fix: use client-id instead of deprecated app-id in GitHub App token steps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,9 +11,9 @@ Created these GitHub Apps under the `wandb` organization:
 
 Stored the app credentials in `wandb/docs`:
 
-- Repository variable `DOCS_SOURCE_READER_APP_ID`: app ID for `wandb-docs-source-reader`.
+- Repository variable `DOCS_SOURCE_READER_CLIENT_ID`: client ID for `wandb-docs-source-reader` (alphanumeric string shown on the app's settings page, for example `Iv1.abc123`; not the numeric App ID).
 - Repository secret `DOCS_SOURCE_READER_PRIVATE_KEY`: private key for `wandb-docs-source-reader`.
-- Repository variable `DOCS_PR_WRITER_APP_ID`: app ID for `wandb-docs-pr-writer`.
+- Repository variable `DOCS_PR_WRITER_CLIENT_ID`: client ID for `wandb-docs-pr-writer` (same format as above).
 - Repository secret `DOCS_PR_WRITER_PRIVATE_KEY`: private key for `wandb-docs-pr-writer`.
 
 The workflows use `actions/create-github-app-token@v3` to create short-lived installation tokens from these credentials.

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_PR_WRITER_APP_ID }}
+          client-id: ${{ vars.DOCS_PR_WRITER_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_PR_WRITER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: docs

--- a/.github/workflows/generate-query-panel-reference.yml
+++ b/.github/workflows/generate-query-panel-reference.yml
@@ -35,7 +35,7 @@ jobs:
         id: weave-internal-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_SOURCE_READER_APP_ID }}
+          client-id: ${{ vars.DOCS_SOURCE_READER_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_SOURCE_READER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: weave-internal

--- a/.github/workflows/sync-code-examples.yml
+++ b/.github/workflows/sync-code-examples.yml
@@ -31,7 +31,7 @@ jobs:
         id: docs-code-eval-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_SOURCE_READER_APP_ID }}
+          client-id: ${{ vars.DOCS_SOURCE_READER_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_SOURCE_READER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: docs-code-eval


### PR DESCRIPTION
## Description
Use client-id instead of deprecated app-id in GitHub App token steps

actions/create-github-app-token@v3.1.0 deprecated the app-id input and replaced it with client-id, which accepts the alphanumeric Client ID from the app settings page rather than the numeric App ID. Update all three workflows and the README to use the new input name and variable names.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
