### PR TITLE
Fix English snippet path in several scripts

### DIFF
--- a/.github/workflows/sync-code-examples.yml
+++ b/.github/workflows/sync-code-examples.yml
@@ -108,7 +108,7 @@ jobs:
             
             ### Files Updated
             
-            - **Code Examples**: `snippets/en/_includes/code-examples/*.mdx`
+            - **Code Examples**: `snippets/_includes/code-examples/*.mdx`
             - **Cheat Sheet**: `models/ref/sdk-coding-cheat-sheet/`
             
             ### Review Checklist

--- a/scripts/build_support_redirects.py
+++ b/scripts/build_support_redirects.py
@@ -3,7 +3,7 @@
 Build redirect mapping and delete list for models/support -> support/models migration.
 
 Reads:
-- snippets/en/kb_article_map.mdx (page + title per article)
+- snippets/kb_article_map.mdx (page + title per article)
 - support/models/articles/*.mdx (frontmatter title)
 - models/support/ and support/models/tags/ for tag page mapping
 
@@ -98,7 +98,7 @@ def parse_kb_article_map(mdx_path: Path) -> list[dict]:
 
 def main() -> None:
     repo = Path(__file__).resolve().parent.parent
-    kb_path = repo / "snippets" / "en" / "kb_article_map.mdx"
+    kb_path = repo / "snippets" / "kb_article_map.mdx"
     articles_dir = repo / "support" / "models" / "articles"
     old_support_dir = repo / "models" / "support"
     new_tags_dir = repo / "support" / "models" / "tags"

--- a/scripts/generate_cheat_sheet.py
+++ b/scripts/generate_cheat_sheet.py
@@ -397,7 +397,7 @@ def main():
     # Paths
     script_dir = Path(__file__).parent
     docs_root = script_dir.parent
-    py_snippets_dir = docs_root / 'snippets' / 'en' / '_includes' / 'code-examples'
+    py_snippets_dir = docs_root / 'snippets' / '_includes' / 'code-examples'
     output_dir = docs_root / 'models' / 'ref' / 'sdk-coding-cheat-sheet'
     landing_page = docs_root / 'models' / 'ref' / 'sdk-coding-cheat-sheet.mdx'
     

--- a/scripts/generate_code_snippet_component.py
+++ b/scripts/generate_code_snippet_component.py
@@ -69,7 +69,7 @@ def main():
     """Generate the CodeSnippet component."""
     script_dir = Path(__file__).parent
     docs_root = script_dir.parent
-    snippets_dir = docs_root / 'snippets' / 'en' / '_includes' / 'code-examples'
+    snippets_dir = docs_root / 'snippets' / '_includes' / 'code-examples'
     output_file = docs_root / 'snippets' / 'CodeSnippet.jsx'
     
     # Find all Python files


### PR DESCRIPTION
## Description
Fix English snippet path in several scripts

When we rolled out Locadex, English snippets moved up from `snippets/en` to `snippets`, but we forgot to update scripts that read or write snippets. This fixes that.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
