### PR TITLE
Fix vertical whitespace bug in query panel ref generation output

### DIFF
--- a/scripts/reference-generation/query-panel/convert_query_panel_md.py
+++ b/scripts/reference-generation/query-panel/convert_query_panel_md.py
@@ -259,8 +259,15 @@ def replace_generated_types_section(landing_text: str, bullets: str) -> str:
     if start in landing_text and end in landing_text:
         pre, rest = landing_text.split(start, 1)
         _, post = rest.split(end, 1)
-        block = f"{start}\n{bullets.rstrip()}\n{end}\n"
-        return pre + block + post
+        # Avoid accumulating blank lines: the replacement ends with a newline and
+        # post often begins with one (or many from prior runs). Normalize to a
+        # single blank line before the following section, or a single trailing
+        # newline when nothing follows the end marker.
+        post = post.lstrip("\n")
+        block_core = f"{start}\n{bullets.rstrip()}\n{end}"
+        if post:
+            return pre + block_core + "\n\n" + post
+        return pre + block_core + "\n"
 
     legacy = re.compile(
         r"(## Data Types\n\n)(?:\* \[[^\]]+\]\(\./query-panel/[^\)]+\)\n)+",

--- a/scripts/reference-generation/query-panel/tests/test_query_panel_mdx_quality.py
+++ b/scripts/reference-generation/query-panel/tests/test_query_panel_mdx_quality.py
@@ -70,6 +70,28 @@ class ConverterUnitTests(unittest.TestCase):
         self.assertNotIn("/models/ref/query-panel/run/", out)
         self.assertIn("https://example.com/a/", out)
 
+    def test_replace_generated_types_section_idempotent_no_extra_blank_lines(self) -> None:
+        """Re-running landing replacement must not grow vertical whitespace after {end}."""
+        m = _load_converter()
+        bullets = "* [a](./query-panel/a)\n* [b](./query-panel/b)\n"
+        end = "{/* query-panel-generated-data-types:end */}"
+        base = (
+            "intro\n\n## Data Types\n\n"
+            "{/* query-panel-generated-data-types:start */}\n"
+            "* old\n"
+            f"{end}\n"
+            "## Next section\n"
+        )
+        out1 = m.replace_generated_types_section(base, bullets)
+        out2 = m.replace_generated_types_section(out1, bullets)
+        self.assertEqual(out1, out2)
+        tail = out1.split(end, 1)[1]
+        self.assertTrue(
+            tail.startswith("\n\n## Next"),
+            msg=f"expected single blank line after end marker, got repr: {tail[:40]!r}",
+        )
+        self.assertNotRegex(tail, r"\n{4,}")
+
 
 class QueryPanelMdxQualityTests(unittest.TestCase):
     def test_no_duplicate_anchor_ids_in_generated_pages(self) -> None:


### PR DESCRIPTION
## Description
Fix one line of vertical whitespace being added to the query panel reference each time it is generated

Ref: https://github.com/wandb/docs/pull/2601

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
