### PR TITLE
Adjust query panel ref generator to change only English

### DIFF
--- a/.github/workflows/generate-query-panel-reference.yml
+++ b/.github/workflows/generate-query-panel-reference.yml
@@ -91,4 +91,4 @@ jobs:
             ### Review checklist
             - [ ] Spot-check a few datatype pages in the preview build
             - [ ] Confirm no unintended `docs.json` navigation changes outside the Query Expression Language group
-            - [ ] Japanese and Korean overview pages were not modified by this workflow (English reference only)
+            - [ ] `docs.json` diff only updates the English nav tree for Query Expression Language (no ja/ko/fr TOC edits from this workflow)

--- a/scripts/reference-generation/query-panel/README.md
+++ b/scripts/reference-generation/query-panel/README.md
@@ -42,7 +42,7 @@ export QUERY_PANELS_READ_TOKEN="..."  # contents:read on weave-internal
 2. Copies `src/core/docs/README.md` to `docs/README.md` inside `weave-js` (upstream `generateDocs.ts` expects that path).
 3. Runs `yarn install --ignore-scripts` in `weave-js` to avoid optional native builds (for example `canvas`) that are not required for doc generation.
 4. Runs `npx vite-node@3.1.3 src/core/generateDocs.ts` to produce Markdown under `weave-js/docs_gen/`.
-5. Runs `convert_query_panel_md.py` to write Mintlify MDX, refresh the data-type list in `models/ref/query-panel.mdx`, and align `docs.json` navigation for `en`, `ja`, and `ko`.
+5. Runs `convert_query_panel_md.py` to write Mintlify MDX, refresh the data-type list in `models/ref/query-panel.mdx`, and align the **English** `docs.json` navigation entry for Query Expression Language (localized nav is not modified).
 
 ## CI
 

--- a/scripts/reference-generation/query-panel/convert_query_panel_md.py
+++ b/scripts/reference-generation/query-panel/convert_query_panel_md.py
@@ -300,20 +300,19 @@ def update_docs_json_nav(docs_json_path: Path, slugs: list[str]) -> None:
         base = f"{prefix}models/ref/query-panel"
         return [base] + [f"{base}/{s}" for s in slugs]
 
-    targets = {
-        "en": build_pages(""),
-        "ja": build_pages("ja/"),
-        "ko": build_pages("ko/"),
-    }
+    # English only: this workflow generates MDX under models/ref/query-panel/
+    # (no ja/ko/fr copies). Localized nav is maintained separately (e.g. Locadex);
+    # overwriting ja/ko pages lists here caused spurious docs.json churn.
+    en_pages = build_pages("")
 
     def walk(node: object, lang: str | None) -> None:
         if isinstance(node, dict):
             if (
-                node.get("group") == "Query Expression Language"
+                lang == "en"
+                and node.get("group") == "Query Expression Language"
                 and isinstance(node.get("pages"), list)
-                and lang in targets
             ):
-                node["pages"] = targets[lang]
+                node["pages"] = en_pages
             for v in node.values():
                 walk(v, lang)
         elif isinstance(node, list):

--- a/scripts/reference-generation/query-panel/tests/test_query_panel_mdx_quality.py
+++ b/scripts/reference-generation/query-panel/tests/test_query_panel_mdx_quality.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -91,6 +93,68 @@ class ConverterUnitTests(unittest.TestCase):
             msg=f"expected single blank line after end marker, got repr: {tail[:40]!r}",
         )
         self.assertNotRegex(tail, r"\n{4,}")
+
+    def test_update_docs_json_nav_only_english_query_panel_pages(self) -> None:
+        m = _load_converter()
+        ja_before = ["ja/models/ref/query-panel", "ja/models/ref/query-panel/run"]
+        data = {
+            "navigation": {
+                "languages": [
+                    {
+                        "language": "en",
+                        "groups": [
+                            {
+                                "group": "Query Expression Language",
+                                "pages": ["models/ref/query-panel", "models/ref/query-panel/old"],
+                            }
+                        ],
+                    },
+                    {
+                        "language": "ja",
+                        "groups": [
+                            {
+                                "group": "Query Expression Language",
+                                "pages": list(ja_before),
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(data, f)
+            path = Path(f.name)
+        try:
+            m.update_docs_json_nav(path, ["run", "table"])
+            updated = json.loads(path.read_text(encoding="utf-8"))
+            langs = updated["navigation"]["languages"]
+            en_pages = next(
+                g["pages"]
+                for L in langs
+                if L["language"] == "en"
+                for g in L["groups"]
+                if g["group"] == "Query Expression Language"
+            )
+            ja_pages = next(
+                g["pages"]
+                for L in langs
+                if L["language"] == "ja"
+                for g in L["groups"]
+                if g["group"] == "Query Expression Language"
+            )
+            self.assertEqual(
+                en_pages,
+                [
+                    "models/ref/query-panel",
+                    "models/ref/query-panel/run",
+                    "models/ref/query-panel/table",
+                ],
+            )
+            self.assertEqual(ja_pages, ja_before)
+        finally:
+            path.unlink(missing_ok=True)
 
 
 class QueryPanelMdxQualityTests(unittest.TestCase):


### PR DESCRIPTION
## Description
Adjust query panel ref generator to change only English

Pre-Locadex logic was also maintaining Japanese and Korean TOCs (and doing really bizarre things to French).

Ref: https://github.com/wandb/docs/pull/2603/changes

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
