### PR TITLE
Inference - add deepseek-ai/DeepSeek-V4-Flash to experimental models

### DIFF
--- a/inference/models.mdx
+++ b/inference/models.mdx
@@ -40,9 +40,10 @@ The following models are [generally available](/inference/lifecycle#model-lifecy
 The following models are [experimental](/inference/lifecycle#model-lifecycle-stages):
 
 {/* takeru inference-models-experimental - This table is automatically generated, do not edit manually. */}
-| Model       | Model ID (for API usage) | Type         | Context Window | Parameters  | Description                                                                                                         |
-| ----------- | ------------------------ | ------------ | -------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
-| Qwen3.5 27B | `Qwen/Qwen3.5-27B`       | Text, Vision | 262k           | 27B (Total) | Qwen3.5-27B is a dense model from the Qwen3.5 family built for high performance across a large range of benchmarks. |
+| Model             | Model ID (for API usage)        | Type         | Context Window | Parameters              | Description                                                                                                         |
+| ----------------- | ------------------------------- | ------------ | -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| DeepSeek V4-Flash | `deepseek-ai/DeepSeek-V4-Flash` | Text         | 1000k          | 13B-284B (Active-Total) | DeepSeek V4-Flash is an MoE model with 1M context length great for coding, reasoning, and agentic workloads.        |
+| Qwen3.5 27B       | `Qwen/Qwen3.5-27B`              | Text, Vision | 262k           | 27B (Total)             | Qwen3.5-27B is a dense model from the Qwen3.5 family built for high performance across a large range of benchmarks. |
 
 
 ## Deprecated models

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -16,6 +16,7 @@ The following table lists the models on W&B Inference that return reasoning outp
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)                       | Reasoning support  |
 | ---------------------------------------------- | ------------------ |
+| `deepseek-ai/DeepSeek-V4-Flash`                | Enabled by default |
 | `google/gemma-4-31B-it`                        | Enabled by default |
 | `MiniMaxAI/MiniMax-M2.5`                       | Always on          |
 | `moonshotai/Kimi-K2.6`                         | Always on          |


### PR DESCRIPTION
## Description

takeru generated change to add deepseek-ai/DeepSeek-V4-Flash to experimental models

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
