### PR TITLE
Preserve UTF-8 literals in docs.json

### DIFF
--- a/scripts/reference-generation/query-panel/convert_query_panel_md.py
+++ b/scripts/reference-generation/query-panel/convert_query_panel_md.py
@@ -326,7 +326,10 @@ def update_docs_json_nav(docs_json_path: Path, slugs: list[str]) -> None:
         walk(lang_entry, lang)
 
     with docs_json_path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+        # Preserve UTF-8 literals (Mintlify / repo style). Default ensure_ascii=True
+        # would escape every non-ASCII string in the whole file, making French and
+        # other localized nav look "changed" when only English QEL pages were edited.
+        json.dump(data, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
 


### PR DESCRIPTION
## Description
Preserve UTF-8 literals in docs.json rather than escaped ASCII

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
