### PR TITLE
docs(weave): add Bedrock Agents integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -35,6 +35,12 @@
   "contextual": {
     "options": [
       {
+        "title": "Install W&B MCP in Claude",
+        "description": "Install W&B MCP server to Claude Code.",
+        "icon": "plug",
+        "href": "https://docs.wandb.ai/platform/mcp-server#use-w&b’s-remote-mcp-server"
+      },
+      {
         "title": "Install W&B MCP in Cursor",
         "description": "Automatically install W&B MCP server to Cursor. Requires a W&B API key.",
         "icon": "plug",
@@ -84,6 +90,28 @@
                       "product-inference",
                       "product-training",
                       "product-sandboxes"
+                    ]
+                  },
+                  {
+                    "group": "Release Notes",
+                    "expanded": false,
+                    "pages": [
+                      "release-notes",
+                      {
+                        "group": "W&B Server",
+                        "pages": [
+                          "release-notes/server-releases",
+                          "release-notes/server-releases-archived"
+                        ]
+                      },
+                      {
+                        "group": "W&B SDKs",
+                        "pages": [
+                          "release-notes/sdk-releases",
+                          "release-notes/weave-sdk-releases"
+                        ]
+                      },
+                      "release-notes/release-policies"
                     ]
                   },
                   {
@@ -1197,10 +1225,9 @@
                 ]
               },
               {
-                "group": "W&B SDKs",
+                "group": "W&B SDK",
                 "pages": [
-                  "release-notes/sdk-releases",
-                  "release-notes/weave-sdk-releases"
+                  "release-notes/sdk-releases"
                 ]
               },
               "release-notes/release-policies"
@@ -1442,6 +1469,28 @@
                       "fr/product-inference",
                       "fr/product-training",
                       "fr/product-sandboxes"
+                    ]
+                  },
+                  {
+                    "group": "Notes de version",
+                    "expanded": false,
+                    "pages": [
+                      "fr/release-notes",
+                      {
+                        "group": "Serveur W&B",
+                        "pages": [
+                          "fr/release-notes/server-releases",
+                          "fr/release-notes/server-releases-archived"
+                        ]
+                      },
+                      {
+                        "group": "SDK de W&B",
+                        "pages": [
+                          "fr/release-notes/sdk-releases",
+                          "fr/release-notes/weave-sdk-releases"
+                        ]
+                      },
+                      "fr/release-notes/release-policies"
                     ]
                   },
                   {
@@ -2555,10 +2604,9 @@
                 ]
               },
               {
-                "group": "SDKs W&B",
+                "group": "W&B SDK",
                 "pages": [
-                  "fr/release-notes/sdk-releases",
-                  "fr/release-notes/weave-sdk-releases"
+                  "fr/release-notes/sdk-releases"
                 ]
               },
               "fr/release-notes/release-policies"
@@ -2803,13 +2851,35 @@
                     ]
                   },
                   {
+                    "group": "リリースノート",
+                    "expanded": false,
+                    "pages": [
+                      "ja/release-notes",
+                      {
+                        "group": "W&B Server",
+                        "pages": [
+                          "ja/release-notes/server-releases",
+                          "ja/release-notes/server-releases-archived"
+                        ]
+                      },
+                      {
+                        "group": "W&B SDK",
+                        "pages": [
+                          "ja/release-notes/sdk-releases",
+                          "ja/release-notes/weave-sdk-releases"
+                        ]
+                      },
+                      "ja/release-notes/release-policies"
+                    ]
+                  },
+                  {
                     "group": "プラットフォームの詳細",
                     "pages": [
                       {
                         "group": "W&B の設定",
                         "pages": [
                           {
-                            "group": "Settings",
+                            "group": "設定",
                             "pages": [
                               "ja/platform/app/settings-page",
                               "ja/platform/app/settings-page/user-settings",
@@ -2821,7 +2891,7 @@
                             ]
                           },
                           {
-                            "group": "アイデンティティおよびアクセス管理（IAM）",
+                            "group": "アイデンティティとアクセス管理（IAM）",
                             "pages": [
                               "ja/platform/hosting/iam/org_team_struct",
                               {
@@ -3913,10 +3983,9 @@
                 ]
               },
               {
-                "group": "W&B SDKs",
+                "group": "W&B SDK",
                 "pages": [
-                  "ja/release-notes/sdk-releases",
-                  "ja/release-notes/weave-sdk-releases"
+                  "ja/release-notes/sdk-releases"
                 ]
               },
               "ja/release-notes/release-policies"
@@ -4161,10 +4230,32 @@
                     ]
                   },
                   {
+                    "group": "릴리스 노트",
+                    "expanded": false,
+                    "pages": [
+                      "ko/release-notes",
+                      {
+                        "group": "W&B Server",
+                        "pages": [
+                          "ko/release-notes/server-releases",
+                          "ko/release-notes/server-releases-archived"
+                        ]
+                      },
+                      {
+                        "group": "W&B SDK",
+                        "pages": [
+                          "ko/release-notes/sdk-releases",
+                          "ko/release-notes/weave-sdk-releases"
+                        ]
+                      },
+                      "ko/release-notes/release-policies"
+                    ]
+                  },
+                  {
                     "group": "플랫폼 상세 정보",
                     "pages": [
                       {
-                        "group": "W&B 설정",
+                        "group": "W&B 구성",
                         "pages": [
                           {
                             "group": "설정",
@@ -4219,7 +4310,7 @@
                         ]
                       },
                       {
-                        "group": "모니터링 및 사용 현황",
+                        "group": "모니터링 및 사용량",
                         "pages": [
                           "ko/platform/hosting/monitoring-usage/audit-logging",
                           "ko/platform/hosting/monitoring-usage/slack-alerts",
@@ -5271,10 +5362,9 @@
                 ]
               },
               {
-                "group": "W&B SDKs",
+                "group": "W&B SDK",
                 "pages": [
-                  "ko/release-notes/sdk-releases",
-                  "ko/release-notes/weave-sdk-releases"
+                  "ko/release-notes/sdk-releases"
                 ]
               },
               "ko/release-notes/release-policies"

--- a/docs.json
+++ b/docs.json
@@ -93,28 +93,6 @@
                     ]
                   },
                   {
-                    "group": "Release Notes",
-                    "expanded": false,
-                    "pages": [
-                      "release-notes",
-                      {
-                        "group": "W&B Server",
-                        "pages": [
-                          "release-notes/server-releases",
-                          "release-notes/server-releases-archived"
-                        ]
-                      },
-                      {
-                        "group": "W&B SDKs",
-                        "pages": [
-                          "release-notes/sdk-releases",
-                          "release-notes/weave-sdk-releases"
-                        ]
-                      },
-                      "release-notes/release-policies"
-                    ]
-                  },
-                  {
                     "group": "Platform Details",
                     "pages": [
                       {
@@ -1225,9 +1203,10 @@
                 ]
               },
               {
-                "group": "W&B SDK",
+                "group": "W&B SDKs",
                 "pages": [
-                  "release-notes/sdk-releases"
+                  "release-notes/sdk-releases",
+                  "release-notes/weave-sdk-releases"
                 ]
               },
               "release-notes/release-policies"
@@ -1472,28 +1451,6 @@
                     ]
                   },
                   {
-                    "group": "Notes de version",
-                    "expanded": false,
-                    "pages": [
-                      "fr/release-notes",
-                      {
-                        "group": "Serveur W&B",
-                        "pages": [
-                          "fr/release-notes/server-releases",
-                          "fr/release-notes/server-releases-archived"
-                        ]
-                      },
-                      {
-                        "group": "SDK de W&B",
-                        "pages": [
-                          "fr/release-notes/sdk-releases",
-                          "fr/release-notes/weave-sdk-releases"
-                        ]
-                      },
-                      "fr/release-notes/release-policies"
-                    ]
-                  },
-                  {
                     "group": "Détails de la plateforme",
                     "pages": [
                       {
@@ -1620,7 +1577,7 @@
                           "fr/models/track/project-page",
                           "fr/models/track/workspaces",
                           {
-                            "group": "Que sont les exécutions ?",
+                            "group": "Que sont les exécutions ?",
                             "pages": [
                               "fr/models/runs",
                               "fr/models/runs/run-identifiers",
@@ -2604,9 +2561,10 @@
                 ]
               },
               {
-                "group": "W&B SDK",
+                "group": "SDKs W&B",
                 "pages": [
-                  "fr/release-notes/sdk-releases"
+                  "fr/release-notes/sdk-releases",
+                  "fr/release-notes/weave-sdk-releases"
                 ]
               },
               "fr/release-notes/release-policies"
@@ -2762,7 +2720,7 @@
             ]
           },
           {
-            "tab": "Assistance : W&B Models",
+            "tab": "Assistance : W&B Models",
             "hidden": true,
             "pages": [
               "fr/support/models",
@@ -2802,7 +2760,7 @@
             ]
           },
           {
-            "tab": "Assistance : W&B Weave",
+            "tab": "Assistance : W&B Weave",
             "hidden": true,
             "pages": [
               "fr/support/weave",
@@ -2817,7 +2775,7 @@
             ]
           },
           {
-            "tab": "Assistance : W&B Inference",
+            "tab": "Assistance : W&B Inference",
             "hidden": true,
             "pages": [
               "fr/support/inference",
@@ -2851,35 +2809,13 @@
                     ]
                   },
                   {
-                    "group": "リリースノート",
-                    "expanded": false,
-                    "pages": [
-                      "ja/release-notes",
-                      {
-                        "group": "W&B Server",
-                        "pages": [
-                          "ja/release-notes/server-releases",
-                          "ja/release-notes/server-releases-archived"
-                        ]
-                      },
-                      {
-                        "group": "W&B SDK",
-                        "pages": [
-                          "ja/release-notes/sdk-releases",
-                          "ja/release-notes/weave-sdk-releases"
-                        ]
-                      },
-                      "ja/release-notes/release-policies"
-                    ]
-                  },
-                  {
                     "group": "プラットフォームの詳細",
                     "pages": [
                       {
                         "group": "W&B の設定",
                         "pages": [
                           {
-                            "group": "設定",
+                            "group": "Settings",
                             "pages": [
                               "ja/platform/app/settings-page",
                               "ja/platform/app/settings-page/user-settings",
@@ -2891,7 +2827,7 @@
                             ]
                           },
                           {
-                            "group": "アイデンティティとアクセス管理（IAM）",
+                            "group": "アイデンティティおよびアクセス管理（IAM）",
                             "pages": [
                               "ja/platform/hosting/iam/org_team_struct",
                               {
@@ -3983,9 +3919,10 @@
                 ]
               },
               {
-                "group": "W&B SDK",
+                "group": "W&B SDKs",
                 "pages": [
-                  "ja/release-notes/sdk-releases"
+                  "ja/release-notes/sdk-releases",
+                  "ja/release-notes/weave-sdk-releases"
                 ]
               },
               "ja/release-notes/release-policies"
@@ -4230,32 +4167,10 @@
                     ]
                   },
                   {
-                    "group": "릴리스 노트",
-                    "expanded": false,
-                    "pages": [
-                      "ko/release-notes",
-                      {
-                        "group": "W&B Server",
-                        "pages": [
-                          "ko/release-notes/server-releases",
-                          "ko/release-notes/server-releases-archived"
-                        ]
-                      },
-                      {
-                        "group": "W&B SDK",
-                        "pages": [
-                          "ko/release-notes/sdk-releases",
-                          "ko/release-notes/weave-sdk-releases"
-                        ]
-                      },
-                      "ko/release-notes/release-policies"
-                    ]
-                  },
-                  {
                     "group": "플랫폼 상세 정보",
                     "pages": [
                       {
-                        "group": "W&B 구성",
+                        "group": "W&B 설정",
                         "pages": [
                           {
                             "group": "설정",
@@ -4310,7 +4225,7 @@
                         ]
                       },
                       {
-                        "group": "모니터링 및 사용량",
+                        "group": "모니터링 및 사용 현황",
                         "pages": [
                           "ko/platform/hosting/monitoring-usage/audit-logging",
                           "ko/platform/hosting/monitoring-usage/slack-alerts",
@@ -5362,9 +5277,10 @@
                 ]
               },
               {
-                "group": "W&B SDK",
+                "group": "W&B SDKs",
                 "pages": [
-                  "ko/release-notes/sdk-releases"
+                  "ko/release-notes/sdk-releases",
+                  "ko/release-notes/weave-sdk-releases"
                 ]
               },
               "ko/release-notes/release-policies"

--- a/docs.json
+++ b/docs.json
@@ -36,7 +36,7 @@
     "options": [
       {
         "title": "Install W&B MCP in Claude",
-        "description": "Install W&B MCP server to Claude Code.",
+        "description": "Install W&B MCP server to Claude.",
         "icon": "plug",
         "href": "https://docs.wandb.ai/platform/mcp-server#use-w&b’s-remote-mcp-server"
       },

--- a/docs.json
+++ b/docs.json
@@ -630,6 +630,7 @@
                             "pages": [
                               "weave/guides/integrations/openai_agents",
                               "weave/guides/integrations/openai-realtime-audio",
+                              "weave/guides/integrations/bedrock_agents",
                               "weave/guides/integrations/claude_agent",
                               "weave/guides/integrations/claude_code",
                               "weave/guides/integrations/langchain",

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -58,6 +58,81 @@ W&B provides a hosted MCP server at `https://mcp.withwandb.com` that requires no
 Select the tab containing your MCP client's instructions:
 
 <Tabs>
+<Tab title="Claude Code CLI">
+
+To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
+
+```bash
+claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
+  --header "Authorization: Bearer <your-wandb-api-key>"
+```
+
+Add `--scope user` for a global configuration, or omit it to configure for the current project only.
+
+For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+</Tab>
+<Tab title="Claude Code Desktop">
+
+Claude Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your Bearer token.
+
+You need [Node.js](https://nodejs.org/) installed on your system.
+
+Open your Claude Desktop config file in a text editor. You can find the config file at the following location for your OS:
+
+* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following to the JSON object in your config file, replacing `<your-wandb-api-key>` with your W&B API key:
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.withwandb.com/mcp",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer <your-wandb-api-key>"
+      }
+    }
+  }
+}
+```
+
+The full header value is set through the `env` field rather than directly in `args` to work around a space-escaping issue in some Claude Desktop versions.
+
+Restart Claude Desktop to activate the new configuration. Verify the connection by entering the prompt "List the projects in my W&B account."
+</Tab>
+<Tab title="Codex">
+
+To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
+
+```bash
+export WANDB_API_KEY=<your-wandb-api-key>
+codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
+```
+
+</Tab>
+<Tab title="Claude Code">
+
+To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
+
+```bash
+claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
+  --header "Authorization: Bearer <your-wandb-api-key>"
+```
+
+Add `--scope user` for a global configuration, or omit it to configure for the current project only.
+
+For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+</Tab>
 <Tab title="Cursor">
 
 You can install the W&B server in Cursor automatically using a [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=) (requires adding `Bearer <your-wandb-api-key>` in the `Authorization` field), or manually using the following instructions:
@@ -86,30 +161,6 @@ You can install the W&B server in Cursor automatically using a [one-click instal
 6. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
 
 For more detailed information, see [Cursor's documentation](https://cursor.com/docs/context/mcp).
-
-</Tab>
-<Tab title="Claude Code">
-
-To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
-
-```bash
-claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
-  --header "Authorization: Bearer <your-wandb-api-key>"
-```
-
-Add `--scope user` for a global configuration, or omit it to configure for the current project only.
-
-For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
-
-</Tab>
-<Tab title="Codex">
-
-To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
-
-```bash
-export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
-```
 
 </Tab>
 <Tab title="OpenAI">

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -58,7 +58,7 @@ W&B provides a hosted MCP server at `https://mcp.withwandb.com` that requires no
 Select the tab containing your MCP client's instructions:
 
 <Tabs>
-<Tab title="Claude CLI">
+<Tab title="Claude Code CLI">
 
 To add the W&B MCP server to Claude CLI, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
 
@@ -72,7 +72,7 @@ Add `--scope user` for a global configuration, or omit it to configure for the c
 For more detailed information, see [Claude's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
 
 </Tab>
-<Tab title="Claude Desktop">
+<Tab title="Claude Code Desktop">
 
 Claude Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your Bearer token.
 
@@ -109,6 +109,16 @@ The full header value is set through the `env` field rather than directly in `ar
 
 Restart Claude Desktop to activate the new configuration. Verify the connection by entering the prompt "List the projects in my W&B account."
 </Tab>
+<Tab title="Codex">
+
+To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
+
+```bash
+export WANDB_API_KEY=<your-wandb-api-key>
+codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
+```
+
+</Tab>
 <Tab title="Cursor">
 
 You can install the W&B server in Cursor automatically using a [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=) (requires adding `Bearer <your-wandb-api-key>` in the `Authorization` field), or manually using the following instructions:
@@ -138,41 +148,6 @@ You can install the W&B server in Cursor automatically using a [one-click instal
 
 For more detailed information, see [Cursor's documentation](https://cursor.com/docs/context/mcp).
 
-</Tab>
-<Tab title="Codex">
-
-To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
-
-```bash
-export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
-```
-
-</Tab>
-<Tab title="OpenAI">
-To add the W&B MCP server to your OpenAI calls, add the server's information to the `tools` field of your OpenAI responses configuration:
-
-```python
-from openai import OpenAI
-import os
-
-client = OpenAI()
-
-resp = client.responses.create(
-    model="gpt-4o",
-    tools=[{
-        "type": "mcp",
-        "server_label": "wandb",
-        "server_description": "Query W&B data",
-        "server_url": "https://mcp.withwandb.com/mcp",
-        "authorization": os.getenv("<your-wandb-api-key>"),
-        "require_approval": "never",
-    }],
-    input="List the projects in my W&B account.",
-)
-
-print(resp.output_text)
-```
 </Tab>
 <Tab title="Gemini CLI">
 To add the W&B MCP server to Gemini CLI:
@@ -206,6 +181,31 @@ To add the W&B MCP server to Mistral LeChat:
 4. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
 
 For more detailed information, see [LeChat's documentation](https://mistral.ai/news/le-chat-mcp-connectors-memories).
+</Tab>
+<Tab title="OpenAI">
+To add the W&B MCP server to your OpenAI calls, add the server's information to the `tools` field of your OpenAI responses configuration:
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI()
+
+resp = client.responses.create(
+    model="gpt-4o",
+    tools=[{
+        "type": "mcp",
+        "server_label": "wandb",
+        "server_description": "Query W&B data",
+        "server_url": "https://mcp.withwandb.com/mcp",
+        "authorization": os.getenv("<your-wandb-api-key>"),
+        "require_approval": "never",
+    }],
+    input="List the projects in my W&B account.",
+)
+
+print(resp.output_text)
+```
 </Tab>
 </Tabs>
 
@@ -250,7 +250,7 @@ pip install git+https://github.com/wandb/wandb-mcp-server
 Once you have installed the MCP server locally, configure your MCP client to use it. Select an MCP client to continue:
 
 <Tabs>
-<Tab title="Claude CLI">
+<Tab title="Claude Code CLI">
 
 Run the following command in your terminal. Add `--scope user` for a global configuration, or omit it to configure for the current project only.
 
@@ -262,13 +262,13 @@ claude mcp add wandb \
 ```
 
 </Tab>
-<Tab title="Claude Desktop">
-Open your Claude config file in a text editor. You can find the config file at the locations for your OS:
+<Tab title="Claude Code Desktop">
+Open your Claude Code Desktop config file in a text editor. You can find the config file at the locations for your OS:
 
 * **macOS**: ~/Library/Application\ Support/Claude/claude_desktop_config.json
 * **Windows**: %APPDATA%\Claude\claude_desktop_config.json
 
-Add the following to your JSON object to your Claude config file. Use the full path to `uvx` because Claude Desktop may not find your `uvx` installation otherwise.
+Add the following to your JSON object to your Claude Code Desktop config file. Use the full path to `uvx` because Claude Code Desktop may not find your `uvx` installation otherwise.
 
 ```json
 {
@@ -292,6 +292,18 @@ Add the following to your JSON object to your Claude config file. Use the full p
 Restart Claude Desktop to activate the new configuration.
 
 </Tab>
+<Tab title="Codex">
+
+Run the following command in your terminal:
+
+```bash
+codex mcp add wandb \
+  --env WANDB_API_KEY=your_api_key_here \
+  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+
+</Tab>
 <Tab title="Cursor">
 
 Add the following to your `mcp.json` configuration:
@@ -313,18 +325,6 @@ Add the following to your `mcp.json` configuration:
     }
   }
 }
-```
-
-</Tab>
-<Tab title="Codex">
-
-Run the following command in your terminal:
-
-```bash
-codex mcp add wandb \
-  --env WANDB_API_KEY=your_api_key_here \
-  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
 
 </Tab>

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -8,9 +8,9 @@ import McpConfig from '/snippets/_includes/mcp-config.mdx';
 Model Context Protocol (MCP) lets an LLM agent query and analyze data efficiently to minimize cost in tokens. This page shows how to use the W&B MCP server to query and analyze your W&B data from your IDE or MCP client and give your client programmatic access to W&B's documentation, so it can generate more accurate responses to W&B-related queries.
 
 It integrates natively with most IDEs, coding clients, and chat agents, including:
+* Claude
 * Cursor
 * Visual Studio Code (VS Code)
-* Claude Code
 * Codex
 * Gemini CLI
 * Mistral LeChat
@@ -58,9 +58,9 @@ W&B provides a hosted MCP server at `https://mcp.withwandb.com` that requires no
 Select the tab containing your MCP client's instructions:
 
 <Tabs>
-<Tab title="Claude Code CLI">
+<Tab title="Claude CLI">
 
-To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
+To add the W&B MCP server to Claude CLI, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
 
 ```bash
 claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
@@ -69,10 +69,10 @@ claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
 
 Add `--scope user` for a global configuration, or omit it to configure for the current project only.
 
-For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+For more detailed information, see [Claude's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
 
 </Tab>
-<Tab title="Claude Code Desktop">
+<Tab title="Claude Desktop">
 
 Claude Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your Bearer token.
 
@@ -109,30 +109,6 @@ The full header value is set through the `env` field rather than directly in `ar
 
 Restart Claude Desktop to activate the new configuration. Verify the connection by entering the prompt "List the projects in my W&B account."
 </Tab>
-<Tab title="Codex">
-
-To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
-
-```bash
-export WANDB_API_KEY=<your-wandb-api-key>
-codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
-```
-
-</Tab>
-<Tab title="Claude Code">
-
-To add the W&B MCP server to Claude Code, update the following command's `Authorization` header with your W&B API key and run it in your terminal:
-
-```bash
-claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
-  --header "Authorization: Bearer <your-wandb-api-key>"
-```
-
-Add `--scope user` for a global configuration, or omit it to configure for the current project only.
-
-For more detailed information, see [Claude Code's documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
-
-</Tab>
 <Tab title="Cursor">
 
 You can install the W&B server in Cursor automatically using a [one-click installation link](cursor://anysphere.cursor-deeplink/mcp/install?name=wandb&config=eyJ0cmFuc3BvcnQiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3Aud2l0aHdhbmRiLmNvbS9tY3AiLCJoZWFkZXJzIjp7IkF1dGhvcml6YXRpb24iOiJCZWFyZXIgWU9VUl9XQU5EQl9BUElfS0VZIiwiQWNjZXB0IjoiYXBwbGljYXRpb24vanNvbiwgdGV4dC9ldmVudC1zdHJlYW0ifX0=) (requires adding `Bearer <your-wandb-api-key>` in the `Authorization` field), or manually using the following instructions:
@@ -161,6 +137,16 @@ You can install the W&B server in Cursor automatically using a [one-click instal
 6. Verify that the chat agent has access to the W&B MCP server by entering the prompt "List the projects in my W&B account."
 
 For more detailed information, see [Cursor's documentation](https://cursor.com/docs/context/mcp).
+
+</Tab>
+<Tab title="Codex">
+
+To add the W&B MCP server to Codex, update the following command's `--bearer-token-env-var` argument with the environment variable containing your W&B API key, then run it in your terminal:
+
+```bash
+export WANDB_API_KEY=<your-wandb-api-key>
+codex mcp add wandb --url https://mcp.withwandb.com/mcp --bearer-token-env-var <your-wandb-api-key-environment-variable>
+```
 
 </Tab>
 <Tab title="OpenAI">
@@ -264,54 +250,7 @@ pip install git+https://github.com/wandb/wandb-mcp-server
 Once you have installed the MCP server locally, configure your MCP client to use it. Select an MCP client to continue:
 
 <Tabs>
-<Tab title="Cursor">
-
-Add the following to your `mcp.json` configuration:
-
-```json
-{
-  "mcpServers": {
-    "wandb": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/wandb/wandb-mcp-server",
-        "wandb_mcp_server"
-      ],
-      "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
-        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
-      }
-    }
-  }
-}
-```
-
-</Tab>
-<Tab title="VS Code">
-
-Add the following to your `.vscode/mcp.json` or global MCP configuration:
-
-```json
-{
-  "servers": {
-    "wandb": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/wandb/wandb-mcp-server",
-        "wandb_mcp_server"
-      ],
-      "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
-        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab title="Claude Code">
+<Tab title="Claude CLI">
 
 Run the following command in your terminal. Add `--scope user` for a global configuration, or omit it to configure for the current project only.
 
@@ -319,18 +258,6 @@ Run the following command in your terminal. Add `--scope user` for a global conf
 claude mcp add wandb \
   -e WANDB_API_KEY=your-api-key \
   -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
-  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
-```
-
-</Tab>
-<Tab title="Codex">
-
-Run the following command in your terminal:
-
-```bash
-codex mcp add wandb \
-  --env WANDB_API_KEY=your_api_key_here \
-  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
   -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
 
@@ -364,6 +291,65 @@ Add the following to your JSON object to your Claude config file. Use the full p
 
 Restart Claude Desktop to activate the new configuration.
 
+</Tab>
+<Tab title="Cursor">
+
+Add the following to your `mcp.json` configuration:
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/wandb/wandb-mcp-server",
+        "wandb_mcp_server"
+      ],
+      "env": {
+        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="Codex">
+
+Run the following command in your terminal:
+
+```bash
+codex mcp add wandb \
+  --env WANDB_API_KEY=your_api_key_here \
+  --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
+  -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
+```
+
+</Tab>
+<Tab title="VS Code">
+
+Add the following to your `.vscode/mcp.json` or global MCP configuration:
+
+```json
+{
+  "servers": {
+    "wandb": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/wandb/wandb-mcp-server",
+        "wandb_mcp_server"
+      ],
+      "env": {
+        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
+      }
+    }
+  }
+}
+```
 </Tab>
 </Tabs>
 

--- a/weave/guides/integrations/bedrock_agents.mdx
+++ b/weave/guides/integrations/bedrock_agents.mdx
@@ -1,0 +1,111 @@
+---
+title: Bedrock Agents
+description: "Trace Amazon Bedrock Agents invocations with Weave, capturing agent inputs, foundation model usage, and completion output."
+---
+
+[Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html) let you build managed AI agents on AWS that orchestrate foundation models, knowledge bases, and action groups. Weave traces calls to the `bedrock-agent-runtime` client so you can inspect each `invoke_agent` invocation, including the foundation model, token usage, session ID, and the agent's response.
+
+## Prerequisites
+
+- AWS credentials configured for an account with access to Bedrock Agents (see [Authentication](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html)).
+- An existing Bedrock agent and alias. Note the `agentId` and `agentAliasId`.
+- A W&B API key. For more information, see [API keys](/platform/app/settings-page/user-settings#api-keys).
+
+## Installation
+
+Install Weave and the AWS SDK:
+
+```bash
+pip install weave boto3
+```
+
+## Trace `invoke_agent` calls
+
+Create a `bedrock-agent-runtime` client and pass it to `patch_client`. Weave detects the client type and wraps the `invoke_agent` method. After patching, use the client as you normally would.
+
+```python lines
+import boto3
+
+import weave
+from weave.integrations.bedrock import patch_client
+
+weave.init("your-team-name/bedrock-agents-demo")
+
+# Create and patch the Bedrock Agents runtime client.
+bedrock_agent_client = boto3.client("bedrock-agent-runtime", region_name="us-east-1")
+patch_client(bedrock_agent_client)
+
+# Invoke the agent. Set `enableTrace=True` so Weave can capture the underlying
+# foundation model and token usage from the orchestration trace events.
+response = bedrock_agent_client.invoke_agent(
+    agentId="[YOUR-AGENT-ID]",
+    agentAliasId="[YOUR-AGENT-ALIAS-ID]",
+    sessionId="[YOUR-SESSION-ID]",
+    inputText="What is the capital of France?",
+    enableTrace=True,
+)
+
+# Consume the streaming completion to assemble the final response text.
+final_text = ""
+for event in response["completion"]:
+    chunk = event.get("chunk")
+    if chunk and "bytes" in chunk:
+        final_text += chunk["bytes"].decode("utf-8")
+
+print(final_text)
+```
+
+Each `invoke_agent` call appears in the Weave UI as a `BedrockAgentRuntime.invoke_agent` trace. The trace records:
+
+- The agent inputs (`agentId`, `agentAliasId`, `sessionId`, `inputText`).
+- The extracted assistant text from the completion event stream.
+- The underlying foundation model used by the agent (extracted from the orchestration trace).
+- Token usage (`prompt_tokens`, `completion_tokens`, `total_tokens`) when reported by the agent.
+
+<Note>
+Foundation model and token usage are extracted from `orchestrationTrace` events, which Bedrock only emits when `invoke_agent` is called with `enableTrace=True`. Without this flag, traces still capture the inputs and the generated response text, but the foundation model falls back to `bedrock-agent:<agentId>` and token counts are unavailable.
+</Note>
+
+## Wrap an agent call with `weave.op`
+
+To group an `invoke_agent` call with related logic — preprocessing, postprocessing, or chained API calls — wrap your function with `@weave.op`. Weave nests the patched `invoke_agent` trace inside the parent op.
+
+```python lines
+@weave.op
+def ask_agent(question: str, session_id: str) -> str:
+    response = bedrock_agent_client.invoke_agent(
+        agentId="[YOUR-AGENT-ID]",
+        agentAliasId="[YOUR-AGENT-ALIAS-ID]",
+        sessionId=session_id,
+        inputText=question,
+        enableTrace=True,
+    )
+    text = ""
+    for event in response["completion"]:
+        chunk = event.get("chunk")
+        if chunk and "bytes" in chunk:
+            text += chunk["bytes"].decode("utf-8")
+    return text
+
+
+answer = ask_agent("Summarize today's open support tickets.", session_id="session-1")
+```
+
+## Multi-turn conversations
+
+Bedrock Agents preserve conversation state on the service side when you reuse a `sessionId`. To group multiple turns into a single trace in the Weave UI, wrap the turns in `weave.thread`:
+
+```python lines
+with weave.thread("support-conversation") as t:
+    for prompt in [
+        "I can't log in to my account.",
+        "I already tried resetting my password.",
+    ]:
+        ask_agent(prompt, session_id=t.thread_id)
+```
+
+Each turn appears as a child of the thread, so you can see the full conversation flow alongside the agent's intermediate reasoning and tool calls.
+
+## View traces
+
+When you run the example, Weave prints a link to the project dashboard. Open the link to inspect the agent inputs, foundation model, token usage, and the generated response for each `invoke_agent` call.


### PR DESCRIPTION
## Summary

- Adds a new Weave integration guide for [Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html) at `weave/guides/integrations/bedrock_agents.mdx`.
- Documents tracing `invoke_agent` calls via `patch_client`, wrapping calls with `@weave.op`, and grouping multi-turn sessions with `weave.thread`.
- Adds the new page to the Frameworks group in `docs.json`, alongside other agent-orchestration integrations (`openai_agents`, `claude_agent`).

Jira: [DOCS-2514](https://coreweave.atlassian.net/browse/DOCS-2514)

## Test plan

- [ ] Mintlify preview renders the new page correctly
- [ ] Page appears in the sidebar under **Integrate with your LLM provider and frameworks > Frameworks**
- [ ] Code samples run end-to-end against a real Bedrock agent (requires AWS credentials and an existing agent + alias)
- [ ] SME accuracy review (see PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2514]: https://coreweave.atlassian.net/browse/DOCS-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ