### PR TITLE
Align Serverless RL API landing page with Mintlify OpenAPI slugs

### DIFF
--- a/scripts/reference-generation/serverless-rl/update_training_api_landing.py
+++ b/scripts/reference-generation/serverless-rl/update_training_api_landing.py
@@ -2,173 +2,237 @@
 """
 Update the Serverless RL API landing page with the current endpoints from the OpenAPI spec.
 
-This script fetches the OpenAPI spec (either from local file or remote URL) and
-updates the Available Endpoints section in the serverless-rl/api-reference.mdx landing page.
+Mirrors Mintlify's OpenAPI page path logic (@mintlify/scraping processOpenApiPath):
+- Slug folder from the first tag (prepareStringToBeValidFilename).
+- Slug file from summary, else "{method}-{slugified-path}".
+- Duplicate (tag, slug) pairs get "-1", "-2", ... suffixes (same order as Mint: spec path
+  order, then OpenAPI HTTP method order get, put, post, delete, ...).
+
+See docs.json for the openapi `directory` (default: serverless-rl/api-reference).
+
+Endpoint links in the landing page use absolute https://docs.wandb.ai/... URLs on purpose:
+`mint broken-links` registers OpenAPI targets using a single default directory
+(`api-reference`, from @mintlify/link-rot getOpenApiPagePaths) and does not match
+per-nav paths like `/serverless-rl/api-reference/...`. Absolute links are checked
+as external and still resolve to the real on-site paths under docs.wandb.ai.
 """
-import requests
+from __future__ import annotations
+
 import json
 import re
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+# Same order as OpenAPIV3.HttpMethods / Mintlify's Object.values(HttpMethods)
+HTTP_METHODS_ORDER = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+DEFAULT_OPENAPI_DIRECTORY = "serverless-rl/api-reference"
+PUBLIC_DOCS_ORIGIN = "https://docs.wandb.ai"
+LANDING_PAGE = Path("serverless-rl/api-reference.mdx")
+
+# Display order for ### headings; unknown tags append after these.
+TAG_HEADING_ORDER = ["chat-completions", "models", "training-jobs", "health"]
+
 
 def fetch_openapi_spec() -> dict:
-    """Fetch OpenAPI spec from local file or remote URL."""
-    # First try local file
+    """Load OpenAPI spec from local file, or fetch remote if missing."""
     local_spec = Path("serverless-rl/api-reference/openapi.json")
     if local_spec.exists():
         print(f"  Using local OpenAPI spec: {local_spec}")
-        with open(local_spec, 'r') as f:
+        with open(local_spec, "r", encoding="utf-8") as f:
             return json.load(f)
-    
-    # Fallback to remote
-    import requests  # Only import if needed for remote fetch
+
+    import requests
+
     print("  Fetching remote OpenAPI spec from https://api.training.wandb.ai/openapi.json")
-    response = requests.get("https://api.training.wandb.ai/openapi.json")
+    response = requests.get("https://api.training.wandb.ai/openapi.json", timeout=30)
     response.raise_for_status()
     return response.json()
 
 
-def parse_endpoints(spec: dict) -> Dict[str, List[Tuple[str, str, str, str]]]:
+def prepare_string_to_be_valid_filename(value: str | None) -> str | None:
     """
-    Parse endpoints from OpenAPI spec and group by category.
-    Returns dict of category -> list of (method, path, operation_id, summary)
+    Match Mintlify prepareStringToBeValidFilename (apiPages/common.js).
     """
-    endpoints_by_tag = {}
-    
-    for path, path_item in spec.get("paths", {}).items():
-        for method, operation in path_item.items():
-            if method in ["get", "post", "put", "delete", "patch"]:
-                tags = operation.get("tags", ["Uncategorized"])
-                summary = operation.get("summary", "")
-                operation_id = operation.get("operationId", "")
-                
-                for tag in tags:
-                    if tag not in endpoints_by_tag:
-                        endpoints_by_tag[tag] = []
-                    endpoints_by_tag[tag].append((method.upper(), path, operation_id, summary))
-    
-    # Sort endpoints within each tag
-    for tag in endpoints_by_tag:
-        endpoints_by_tag[tag].sort(key=lambda x: (x[1], x[0]))  # Sort by path, then method
-    
-    return endpoints_by_tag
+    if not value:
+        return None
+    s = value.replace(" ", "-")
+    s = re.sub(r"\{.*?\}", "-", s)
+    s = re.sub(r"^-", "", s)
+    s = re.sub(r"-$", "", s)
+    s = re.sub(r"[{}(),.'\n/]", "", s)
+    while "--" in s:
+        s = s.replace("--", "-")
+    return s.lower()
 
 
-def generate_endpoint_url(summary: str, tag: str, path: str) -> str:
-    """Generate the Mintlify URL for an endpoint based on its summary and tag.
-    
-    Mintlify generates URL slugs from the operation summary (title), not operationId.
+def generate_unique_filename_without_extension(pages: List[str], base: str) -> str:
     """
-    # Convert tag to URL segment (Mintlify lowercases and hyphenates)
-    tag_segment = tag.lower().replace(" ", "-")
-    
-    # Convert summary to URL slug (Mintlify lowercases and hyphenates the title)
-    # Example: "Create Chat Completion" -> "create-chat-completion"
-    if summary:
-        url_slug = summary.lower().replace(" ", "-")
-        # Remove any non-alphanumeric characters except hyphens
-        url_slug = re.sub(r'[^a-z0-9-]', '', url_slug)
-        # Collapse multiple hyphens
-        url_slug = re.sub(r'-+', '-', url_slug)
-    else:
-        # Fallback: use path to generate a slug
-        url_slug = path.strip('/').replace('/v1/', '').replace('/', '-')
-    
-    return f"/serverless-rl/api-reference/{tag_segment}/{url_slug}"
+    Match Mintlify generateUniqueFilenameWithoutExtension (apiPages/common.js).
+    """
+    filename = base
+    if filename in pages:
+        ext = 1
+        filename = f"{base}-{ext}"
+        while filename in pages:
+            ext += 1
+            filename = f"{base}-{ext}"
+    return filename.lower()
 
 
-def generate_endpoints_section(endpoints: Dict[str, List[Tuple[str, str, str, str]]]) -> str:
-    """Generate the markdown for the Available Endpoints section."""
-    lines = ["## Available Endpoints\n\n"]
-    
-    # Define the order of categories
-    category_order = ["Chat", "Completions", "Models", "Jobs", "Training", "Health", "Service"]
-    
-    # Add any categories not in the predefined order
-    for tag in endpoints:
-        if tag not in category_order:
-            category_order.append(tag)
-    
-    for category in category_order:
-        if category not in endpoints:
+def _is_hidden(operation: dict) -> bool:
+    return operation.get("x-hidden") is True
+
+
+def _is_excluded(operation: dict) -> bool:
+    return operation.get("x-excluded") is True
+
+
+def build_method_path_to_href(spec: dict, out_dir: str) -> Dict[Tuple[str, str], str]:
+    """
+    Map (HTTP_METHOD, openapi_path) -> site path beginning with /, in Mintlify order.
+    """
+    out_dir = out_dir.strip("/")
+    # Mint findNavGroup groups by first tag string; pages list is per-tag group.
+    nav_pages_by_tag: Dict[str, List[str]] = {}
+    href_by_key: Dict[Tuple[str, str], str] = {}
+
+    paths = spec.get("paths") or {}
+    for path, path_item in paths.items():
+        if not path_item or not isinstance(path_item, dict):
             continue
-            
-        lines.append(f"\n### {category}\n\n")
-        
-        for method, path, operation_id, summary in endpoints[category]:
-            url = generate_endpoint_url(summary, category, path)
-            lines.append(f"- **[{method} {path}]({url})** - {summary}\n")
-    
+        for method in HTTP_METHODS_ORDER:
+            if method not in path_item:
+                continue
+            operation = path_item[method]
+            if not isinstance(operation, dict):
+                continue
+            if _is_excluded(operation) or _is_hidden(operation):
+                continue
+
+            # x-mint.href overrides are not used in the current Serverless RL spec; add
+            # handling here if Mintlify custom hrefs are introduced upstream.
+            tags = operation.get("tags") or []
+            group_name = tags[0] if tags else "API Reference"
+
+            summary = operation.get("summary")
+            title = prepare_string_to_be_valid_filename(summary)
+            if not title:
+                path_part = prepare_string_to_be_valid_filename(path)
+                title = f"{method}-{path_part}"
+
+            folder = prepare_string_to_be_valid_filename(group_name) or ""
+            base = "/".join(p for p in [out_dir, folder, title] if p)
+
+            pages = nav_pages_by_tag.setdefault(group_name, [])
+            filename = generate_unique_filename_without_extension(pages, base)
+            pages.append(filename)
+            href_by_key[(method.upper(), path)] = f"/{filename}"
+
+    return href_by_key
+
+
+def list_display_rows(spec: dict) -> List[Tuple[str, str, str, str]]:
+    """Rows of (method, path, summary, tag0) sorted for the landing page."""
+    rows: List[Tuple[str, str, str, str]] = []
+    paths = spec.get("paths") or {}
+    for path, path_item in paths.items():
+        if not path_item or not isinstance(path_item, dict):
+            continue
+        for method in HTTP_METHODS_ORDER:
+            if method not in path_item:
+                continue
+            operation = path_item[method]
+            if not isinstance(operation, dict):
+                continue
+            if _is_excluded(operation) or _is_hidden(operation):
+                continue
+            tags = operation.get("tags") or ["Uncategorized"]
+            tag0 = tags[0]
+            summary = operation.get("summary") or ""
+            rows.append((method.upper(), path, summary, tag0))
+    rows.sort(key=lambda r: (r[3], r[1], r[0]))
+    return rows
+
+
+def generate_endpoints_section(
+    spec: dict, href_by_method_path: Dict[Tuple[str, str], str], out_dir: str
+) -> str:
+    """Markdown for ## Available endpoints from spec + precomputed Mintlify hrefs."""
+    rows = list_display_rows(spec)
+    by_tag: Dict[str, List[Tuple[str, str, str, str]]] = {}
+    for method, path, summary, tag0 in rows:
+        by_tag.setdefault(tag0, []).append((method, path, summary, tag0))
+
+    tag_sequence = [t for t in TAG_HEADING_ORDER if t in by_tag]
+    for t in sorted(by_tag.keys()):
+        if t not in tag_sequence:
+            tag_sequence.append(t)
+
+    lines: List[str] = ["## Available endpoints\n\n"]
+    for tag in tag_sequence:
+        lines.append(f"\n### {tag}\n\n")
+        for method, path, summary, _ in by_tag[tag]:
+            key = (method, path)
+            rel = href_by_method_path.get(key)
+            if not rel:
+                raise KeyError(f"No computed href for {method} {path}")
+            url = f"{PUBLIC_DOCS_ORIGIN}{rel}"
+            label = summary if summary else method
+            lines.append(f"- **[{method} {path}]({url})** - {label}\n")
+
+    _ = out_dir  # reserved if section text ever needs the base path
     return "".join(lines)
 
 
-def update_landing_page(endpoints_section: str):
-    """Update the serverless-rl/api-reference.mdx landing page with new endpoints section."""
-    landing_page = Path("serverless-rl/api-reference.mdx")
-    
-    if not landing_page.exists():
-        print(f"  ✗ Landing page not found at {landing_page}")
+def update_landing_page(endpoints_section: str) -> bool:
+    """Replace ## Available endpoints through the next ## section in the landing MDX."""
+    if not LANDING_PAGE.exists():
+        print(f"  ✗ Landing page not found at {LANDING_PAGE}")
         return False
-    
-    with open(landing_page, 'r') as f:
-        content = f.read()
-    
-    # Check if there's already an Available Endpoints section
-    if "## Available Endpoints" in content:
-        # Replace existing section
-        # Use (?=\n## [^#]) to only stop at level-2 headers (## ), not level-3 (###)
-        pattern = r'## Available Endpoints\n.*?(?=\n## [^#]|\Z)'
-        # Ensure proper trailing newline before the next section
-        new_content = re.sub(pattern, endpoints_section.rstrip() + "\n", content, flags=re.DOTALL)
-    else:
-        # Add the section before "## Related Resources" if it exists
-        if "## Related Resources" in content:
-            new_content = content.replace("## Related Resources", f"{endpoints_section}\n## Related Resources")
-        else:
-            # Otherwise add it at the end
-            new_content = content + "\n\n" + endpoints_section
-    
+
+    content = LANDING_PAGE.read_text(encoding="utf-8")
+    if "## Available endpoints" not in content and "## Available Endpoints" not in content:
+        print("  ✗ No ## Available endpoints section found in landing page")
+        return False
+
+    pattern = r"## Available endpoints\n.*?(?=\n## [^#]|\Z)"
+    new_content, n = re.subn(
+        pattern, endpoints_section.rstrip() + "\n", content, flags=re.DOTALL | re.IGNORECASE
+    )
+    if n == 0:
+        # Legacy title casing
+        pattern2 = r"## Available Endpoints\n.*?(?=\n## [^#]|\Z)"
+        new_content, n = re.subn(
+            pattern2, endpoints_section.rstrip() + "\n", content, flags=re.DOTALL
+        )
+    if n == 0:
+        print("  ✗ Could not replace Available endpoints section")
+        return False
+
     if new_content != content:
-        with open(landing_page, 'w') as f:
-            f.write(new_content)
-        print(f"  ✓ Updated {landing_page}")
+        LANDING_PAGE.write_text(new_content, encoding="utf-8")
+        print(f"  ✓ Updated {LANDING_PAGE}")
         return True
-    else:
-        print(f"  ✓ No changes needed for {landing_page}")
-        return False
+    print(f"  ✓ No changes needed for {LANDING_PAGE}")
+    return False
 
 
-def main():
-    """Main function."""
-    print("Updating Training API landing page...")
-    
+def main() -> int:
+    print("Updating Serverless RL API landing page (Mintlify-aligned links)...")
     try:
-        # Fetch OpenAPI spec
         spec = fetch_openapi_spec()
-        
-        # Parse endpoints
-        endpoints = parse_endpoints(spec)
-        
-        # Count total endpoints
-        total = sum(len(eps) for eps in endpoints.values())
-        print(f"  Found {total} endpoints in {len(endpoints)} categories")
-        
-        # Generate endpoints section
-        endpoints_section = generate_endpoints_section(endpoints)
-        
-        # Update landing page
-        if update_landing_page(endpoints_section):
-            print("✓ Training API landing page updated successfully!")
+        href_map = build_method_path_to_href(spec, DEFAULT_OPENAPI_DIRECTORY)
+        section = generate_endpoints_section(spec, href_map, DEFAULT_OPENAPI_DIRECTORY)
+        if update_landing_page(section):
+            print("✓ Serverless RL API landing page updated successfully!")
         else:
-            print("✓ Training API landing page is already up to date")
-            
+            print("✓ Serverless RL API landing page is already up to date")
     except Exception as e:
         print(f"  ✗ Error: {e}")
         return 1
-    
     return 0
 
 
 if __name__ == "__main__":
-    exit(main())
+    raise SystemExit(main())

--- a/serverless-rl/api-reference.mdx
+++ b/serverless-rl/api-reference.mdx
@@ -28,28 +28,28 @@ https://api.training.wandb.ai/v1
 
 ### chat-completions
 
-- **[POST /v1/chat/completions](/serverless-rl/api-reference/chat-completions/create-chat-completion)** - Create Chat Completion
-- **[POST /v1/chat/completions/](/serverless-rl/api-reference/chat-completions/create-chat-completion)** - Create Chat Completion
+- **[POST /v1/chat/completions](https://docs.wandb.ai/serverless-rl/api-reference/chat-completions/create-chat-completion-1)** - Create Chat Completion
+- **[POST /v1/chat/completions/](https://docs.wandb.ai/serverless-rl/api-reference/chat-completions/create-chat-completion)** - Create Chat Completion
 
 ### models
 
-- **[POST /v1/preview/models](/serverless-rl/api-reference/models/create-model)** - Create Model
-- **[DELETE /v1/preview/models/{model_id}](/serverless-rl/api-reference/models/delete-model)** - Delete Model
-- **[DELETE /v1/preview/models/{model_id}/checkpoints](/serverless-rl/api-reference/models/delete-model-checkpoints)** - Delete Model Checkpoints
-- **[GET /v1/preview/models/{model_id}/checkpoints](/serverless-rl/api-reference/models/list-model-checkpoints)** - List Model Checkpoints
-- **[POST /v1/preview/models/{model_id}/log](/serverless-rl/api-reference/models/log)** - Log
+- **[POST /v1/preview/models](https://docs.wandb.ai/serverless-rl/api-reference/models/create-model)** - Create Model
+- **[DELETE /v1/preview/models/{model_id}](https://docs.wandb.ai/serverless-rl/api-reference/models/delete-model)** - Delete Model
+- **[DELETE /v1/preview/models/{model_id}/checkpoints](https://docs.wandb.ai/serverless-rl/api-reference/models/delete-model-checkpoints)** - Delete Model Checkpoints
+- **[GET /v1/preview/models/{model_id}/checkpoints](https://docs.wandb.ai/serverless-rl/api-reference/models/list-model-checkpoints)** - List Model Checkpoints
+- **[POST /v1/preview/models/{model_id}/log](https://docs.wandb.ai/serverless-rl/api-reference/models/log)** - Log
 
 ### training-jobs
 
-- **[POST /v1/preview/sft-training-jobs](/serverless-rl/api-reference/training-jobs/create-sft-training-job)** - Create Sft Training Job
-- **[POST /v1/preview/training-jobs](/serverless-rl/api-reference/training-jobs/create-rl-training-job)** - Create Rl Training Job
-- **[GET /v1/preview/training-jobs/{training_job_id}](/serverless-rl/api-reference/training-jobs/get-training-job)** - Get Training Job
-- **[GET /v1/preview/training-jobs/{training_job_id}/events](/serverless-rl/api-reference/training-jobs/get-training-job-events)** - Get Training Job Events
+- **[POST /v1/preview/sft-training-jobs](https://docs.wandb.ai/serverless-rl/api-reference/training-jobs/create-sft-training-job)** - Create Sft Training Job
+- **[POST /v1/preview/training-jobs](https://docs.wandb.ai/serverless-rl/api-reference/training-jobs/create-rl-training-job)** - Create Rl Training Job
+- **[GET /v1/preview/training-jobs/{training_job_id}](https://docs.wandb.ai/serverless-rl/api-reference/training-jobs/get-training-job)** - Get Training Job
+- **[GET /v1/preview/training-jobs/{training_job_id}/events](https://docs.wandb.ai/serverless-rl/api-reference/training-jobs/get-training-job-events)** - Get Training Job Events
 
 ### health
 
-- **[GET /v1/health](/serverless-rl/api-reference/health/health-check)** - Health Check
-- **[GET /v1/system-check](/serverless-rl/api-reference/health/system-check)** - System Check
+- **[GET /v1/health](https://docs.wandb.ai/serverless-rl/api-reference/health/health-check)** - Health Check
+- **[GET /v1/system-check](https://docs.wandb.ai/serverless-rl/api-reference/health/system-check)** - System Check
 
 ## Related resources
 


### PR DESCRIPTION
Align Serverless RL API landing page with Mintlify OpenAPI slugs to fix broken links in the landing page in production.

- Regenerate serverless-rl/api-reference.mdx from openapi.json
- Rewrite update_training_api_landing.py to mirror Mintlify slug logic and duplicate-summary numbering
- Use absolute docs.wandb.ai links for endpoint rows so mint broken-links does not false-fail on /serverless-rl/api-reference/... internals

## Testing
- [x] Use the updated script to regenerate the landing page
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
- [x] LLM review (CoPilot running Claude Haiku 4.5
---
### LLM assessment
Status: ✅ Open and mergeable | Risk: Low | Type: Bug fix + tooling improvement

This PR fixes broken links in the Serverless RL API landing page by aligning the endpoint URLs with Mintlify's OpenAPI slug generation logic. The broken links were appearing in translated versions (FR, JA, KO) of the documentation, as shown in the referenced job log.

Changes:

2 files modified | 208 additions, 144 deletions
1 commit by @mdlinville
Core fix: Rewrote update_training_api_landing.py to mirror Mintlify's slug logic, including duplicate-summary numbering
Applied fix: Updated serverless-rl/api-reference.mdx with absolute https://docs.wandb.ai/... URLs
Core Changes
The problem: The old script generated relative links like /serverless-rl/api-reference/chat-completions/create-chat-completion, but Mintlify's mint broken-links checker only recognizes the default api-reference directory and fails on custom OpenAPI subdirectories. Additionally, duplicate operation summaries weren't being numbered consistently with Mintlify's output.

The fix mirrors Mintlify's internals:

Slug generation follows Mintlify's prepareStringToBeValidFilename logic (spaces→hyphens, strip braces/special chars)
Duplicate handling uses the same numbering scheme: same order as spec + HTTP method ordering (GET, PUT, POST, DELETE, etc.)
URL strategy switches to absolute https://docs.wandb.ai/... links, which the broken-links checker validates as external (and they correctly resolve on-site)
wandb / docs /
#### New constants reflecting the design decisions:
HTTP_METHODS_ORDER = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
DEFAULT_OPENAPI_DIRECTORY = "serverless-rl/api-reference"
PUBLIC_DOCS_ORIGIN = "https://docs.wandb.ai"
TAG_HEADING_ORDER = ["chat-completions", "models", "training-jobs", "health"]

Landing page update:

wandb / docs /
- **[POST /v1/chat/completions](/serverless-rl/api-reference/chat-completions/create-chat-completion)** - Create Chat Completion
+ **[POST /v1/chat/completions](https://docs.wandb.ai/serverless-rl/api-reference/chat-completions/create-chat-completion-1)** - Create Chat Completion

The -1 suffix on the first duplicate reflects Mintlify's handling of the duplicate POST endpoint.

#### Merge Readiness and Risk Assessment
✅ Ready to merge — Low risk:

CI Status: Mergeable (all checks passing or not blocking). The test checkbox remains unchecked in the PR description, but given the straightforward nature of the fix and the provided reference to the failing job, this is minor.
Scope is tight: Two files, no external dependencies added, purely algorithmic fix + generated content
Logic is sound: Mirrors Mintlify's proven slug generation. The use of absolute URLs as a workaround for Mint's broken-links checker is elegant—they're validated as external but still resolve correctly on-site.
No breaking changes: Only affects generated landing page links; doesn't change API behavior or documentation structure 

