### PR TITLE
Add Dependabot configuration for CoreWeave git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,23 @@
 version: 2
+registries:
+  github-coreweave:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.DOCENGINE_TOKEN}}
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    registries:
+      - github-coreweave
+    schedule:
+      interval: "daily"
+    labels:
+      - "auto-generated"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

Extends the repository's Dependabot configuration to track git submodule updates in addition to GitHub Actions, using an authenticated registry so private CoreWeave submodules can be resolved.

## Motivation

The existing `.github/dependabot.yml` only watched `github-actions`. Git submodules pointing at CoreWeave-hosted repositories were not being checked for updates, so submodule pins drifted silently. Authenticating via a dedicated GitHub registry (sourced from the `DOCENGINE_TOKEN` secret) lets Dependabot resolve private submodule sources.

## Changes

- **`.github/dependabot.yml`**
  - Adds a top-level `registries:` block defining `github-coreweave`, a git registry that authenticates to `https://github.com` using `x-access-token` and the `DOCENGINE_TOKEN` secret.
  - Adds a new `gitsubmodule` update entry rooted at `/`, wired to the `github-coreweave` registry.
    - Daily schedule.
    - PRs are labeled `auto-generated`.
    - Commit messages are prefixed with `chore`.
  - Preserves the existing `github-actions` daily update entry unchanged.

## Configuration / secrets

- Requires the repository (or org) secret **`DOCENGINE_TOKEN`** to be present and to have read access to the CoreWeave repositories referenced by `.gitmodules`. Without it, the `gitsubmodule` job will fail to authenticate.

## Risk

- Low blast radius — config-only, no runtime or build code touched.
- New automation will start opening submodule-bump PRs on the daily schedule once merged; expect an initial wave of PRs to catch up to current upstream tips.
- If `DOCENGINE_TOKEN` lacks scope for any referenced submodule, Dependabot's logs will show auth errors for that ecosystem; the `github-actions` job is unaffected.

## Test plan

- [ ] Merge and confirm Dependabot's "Last checked" timestamp updates for the new `gitsubmodule` ecosystem in the repo's Insights → Dependency graph → Dependabot view.
- [ ] Verify the first submodule update PR (if any) is labeled `auto-generated` and uses the `chore:` commit prefix.
- [ ] Confirm no auth failures appear in the Dependabot run log for the `gitsubmodule` job.
- [ ] Confirm the existing `github-actions` updates continue to run on their daily cadence.

## Follow-ups

- Consider mirroring the `labels` / `commit-message` conventions onto the `github-actions` entry for consistency, if desired.
