### PR TITLE
chore(docs): Update link to GH actions

### DIFF
--- a/scripts/reference-generation/weave/README.md
+++ b/scripts/reference-generation/weave/README.md
@@ -59,7 +59,7 @@ If you still need alternatives:
 The primary way to generate reference documentation is through the GitHub Actions workflows:
 
 #### Full Reference Generation
-1. Go to the [Actions tab](https://github.com/wandb/mintlifytest/actions) in the repository
+1. Go to the [Actions tab](https://github.com/wandb/docs/actions) in the repository
 2. Select "Generate Weave references" workflow
 3. Click "Run workflow"
 4. Enter the Weave version:


### PR DESCRIPTION
## Description

* Was trying to understand how TS SDK source documentation made its way to https://docs.wandb.ai/, and stumbled on this outdated link.