### PR TITLE
chore(docs): Retain fn casing in 'Functions' section on /weave/reference/typescript-sdk

### DIFF
--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -360,18 +360,18 @@ description: "TypeScript SDK reference"
             func_filename = func_name.lower()
             func_file = functions_dir / f"{func_filename}.mdx"
             func_file.write_text(func_file_content)
-            functions_found.append(func_filename)
+            functions_found.append((func_name, func_filename))
             print(f"    ✓ Extracted {func_filename}.mdx")
-        
+
         if functions_found:
             # Remove the detailed function documentation from index
             content = function_pattern.sub('', content)
-            
+
             # Update the Functions section with links (functions_found already has lowercase names)
             # The landing page is at typescript-sdk.mdx, so links need ./typescript-sdk/ prefix
             functions_section = "\n### Functions\n\n"
-            for func in functions_found:
-                functions_section += f"- [{func}](./typescript-sdk/functions/{func})\n"
+            for func_label, func_filename in functions_found:
+                functions_section += f"- [{func_label}](./typescript-sdk/functions/{func_filename})\n"
             
             # Replace existing Functions section with links
             content = re.sub(

--- a/weave/reference/typescript-sdk.mdx
+++ b/weave/reference/typescript-sdk.mdx
@@ -36,19 +36,19 @@ weave
 
 ### Functions
 
-- [createopenaiagentstracingprocessor](./typescript-sdk/functions/createopenaiagentstracingprocessor)
+- [createOpenAIAgentsTracingProcessor](./typescript-sdk/functions/createopenaiagentstracingprocessor)
 - [init](./typescript-sdk/functions/init)
-- [instrumentopenaiagents](./typescript-sdk/functions/instrumentopenaiagents)
+- [instrumentOpenAIAgents](./typescript-sdk/functions/instrumentopenaiagents)
 - [login](./typescript-sdk/functions/login)
 - [op](./typescript-sdk/functions/op)
-- [patchrealtimesession](./typescript-sdk/functions/patchrealtimesession)
-- [requirecurrentcallstackentry](./typescript-sdk/functions/requirecurrentcallstackentry)
-- [requirecurrentchildsummary](./typescript-sdk/functions/requirecurrentchildsummary)
-- [weaveaudio](./typescript-sdk/functions/weaveaudio)
-- [weaveimage](./typescript-sdk/functions/weaveimage)
-- [withattributes](./typescript-sdk/functions/withattributes)
-- [wrapgooglegenai](./typescript-sdk/functions/wrapgooglegenai)
-- [wrapopenai](./typescript-sdk/functions/wrapopenai)
+- [patchRealtimeSession](./typescript-sdk/functions/patchrealtimesession)
+- [requireCurrentCallStackEntry](./typescript-sdk/functions/requirecurrentcallstackentry)
+- [requireCurrentChildSummary](./typescript-sdk/functions/requirecurrentchildsummary)
+- [weaveAudio](./typescript-sdk/functions/weaveaudio)
+- [weaveImage](./typescript-sdk/functions/weaveimage)
+- [withAttributes](./typescript-sdk/functions/withattributes)
+- [wrapGoogleGenAI](./typescript-sdk/functions/wrapgooglegenai)
+- [wrapOpenAI](./typescript-sdk/functions/wrapopenai)
 
 ## Type Aliases
 


### PR DESCRIPTION
## Description

* At the moment, function names are rendered all lowercase on https://docs.wandb.ai/weave/reference/typescript-sdk

<img width="825" height="540" alt="Screenshot 2026-05-26 at 6 08 52 PM" src="https://github.com/user-attachments/assets/0b94f942-6d8c-46c9-bbd1-bed8c8771fcb" />


* This change preserves casing when generating links to these fns. Updated the generated file manually as well:

<img width="1726" height="1024" alt="Screenshot 2026-05-26 at 6 11 09 PM" src="https://github.com/user-attachments/assets/c5c24d78-eb37-41b3-bad9-97115f3de5a3" />





