### PR TITLE
style: apply /style-guide pass to inference

### DIFF
--- a/inference/api-reference.mdx
+++ b/inference/api-reference.mdx
@@ -1,6 +1,7 @@
 ---
 title: "API overview"
 description: "Explore the complete REST API reference for the Serverless Inference service, including endpoints and authentication."
+keywords: ["REST API", "OpenAI-compatible", "W&B API key", "base URL", "API authentication"]
 ---
 
 This reference describes the Serverless Inference REST API, which lets you call foundation models programmatically from your own applications. Use it to integrate hosted inference into services, scripts, or notebooks without managing model infrastructure.

--- a/inference/api-reference.mdx
+++ b/inference/api-reference.mdx
@@ -1,9 +1,9 @@
 ---
-title: "API Overview"
+title: "API overview"
 description: "Explore the complete REST API reference for the Serverless Inference service, including endpoints and authentication."
 ---
 
-Learn how to use the Serverless Inference API to access foundation models programmatically.
+This reference describes the Serverless Inference REST API, which lets you call foundation models programmatically from your own applications. Use it to integrate hosted inference into services, scripts, or notebooks without managing model infrastructure.
 
 ## Base URL
 
@@ -13,37 +13,37 @@ Access the Inference service at:
 https://api.inference.wandb.ai/v1
 ```
 
-<Note>
-**Important**
+## Prerequisites
 
-To use this endpoint, you need:
-- A W&B account with Inference credits
-- A valid W&B API key
+To call the Inference API, you need:
+- A W&B account with Inference credits.
+- A valid W&B API key.
 
-If you belong to more than one team or want to attribute your usage to a project you will also need team and project IDs. In code samples, these appear as `<your-team>/<your-project>`. Your default entity and the project name `inference` will be used if unspecified.
-</Note>
+If you belong to more than one team, or want to attribute your usage to a project, you'll also need team and project IDs. In code samples, these appear as `[YOUR-TEAM]/[YOUR-PROJECT]`. If you don't specify these, W&B uses your default entity and the project name `inference`.
 
 ## Available methods
 
-The Serverless Inference API provides OpenAI-compatible endpoints for interacting with foundation models:
+The Inference API provides OpenAI-compatible endpoints for interacting with foundation models. The following methods are available:
 
-- **[Chat Completions](/inference/api-reference/chat-completions)** - Create chat completions using various foundation models
-- **[List Models](/inference/api-reference/list-models)** - Get all available models and their IDs
+- **[Chat Completions](/inference/api-reference/chat-completions)**: Create chat completions using foundation models.
+- **[List Models](/inference/api-reference/list-models)**: Get all available models and their IDs.
 
 ## Authentication
 
 All API requests require authentication using your W&B API key. Create an API key at [wandb.ai/settings](https://wandb.ai/settings).
 
 Include your API key in the request headers:
-- For OpenAI SDK: Set as `api_key` parameter
-- For direct API calls: Use `Authorization: Bearer <your-api-key>`
+- For the OpenAI SDK, set the `api_key` parameter.
+- For direct API calls, use `Authorization: Bearer [YOUR-API-KEY]`.
 
 ## Error handling
 
-See [API Errors](/support/inference) for a complete list of error codes and how to resolve them.
+For a complete list of error codes and how to resolve them, see [API errors](/support/inference).
 
 ## Next steps
 
-- Try the [usage examples](/inference/examples) to see the API in action
-- Explore models in the [UI](/inference/ui-guide)
-- Check [usage limits](/inference/usage-limits) for your account
+After you have your API key, continue with one of the following:
+
+- Try the [usage examples](/inference/examples) to see how the API works.
+- Explore models in the [Inference UI](/inference/ui-guide).
+- Check [usage limits](/inference/usage-limits) for your account.

--- a/inference/api-reference/chat-completions.mdx
+++ b/inference/api-reference/chat-completions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chat Completions"
+title: "Chat completions"
 description: "Create chat completions using the OpenAI-compatible endpoint"
 ---
 
@@ -8,12 +8,14 @@ Create a chat completion using the `/chat/completions` endpoint. This endpoint f
 ## Requirements
 
 To create a chat completion, provide:
-- The Inference service base URL: `https://api.inference.wandb.ai/v1`
-- Your W&B API key: `<your-api-key>`
-- Optional: Your W&B team and project: `<your-team>/<your-project>`
-- A model ID from the [available models](/inference/models)
+- The Inference service base URL: `https://api.inference.wandb.ai/v1`.
+- Your W&B API key: `[YOUR-API-KEY]`.
+- Your W&B team and project: `[YOUR-TEAM]/[YOUR-PROJECT]` (optional).
+- A model ID from the [available models](/inference/models).
 
 ## Request examples
+
+The following examples show how to send a chat completion request using Python and `curl`. Replace the placeholder values with your own API key, optional team and project, and a model ID.
 
 <Tabs>
 <Tab title="Python">
@@ -26,18 +28,18 @@ client = openai.OpenAI(
 
     # Create an API key at https://wandb.ai/settings
     # Consider setting it in the environment as OPENAI_API_KEY instead for safety
-    api_key="<your-api-key>",
+    api_key="[YOUR-API-KEY]",
 
     # Optional: Team and project for usage tracking
-    project="<your-team>/<your-project>",
+    project="[YOUR-TEAM]/[YOUR-PROJECT]",
 )
 
-# Replace <model-id> with any model ID from the available models list
+# Replace [MODEL-ID] with any model ID from the available models list
 response = client.chat.completions.create(
-    model="<model-id>",
+    model="[MODEL-ID]",
     messages=[
-        {"role": "system", "content": "<your-system-prompt>"},
-        {"role": "user", "content": "<your-prompt>"}
+        {"role": "system", "content": "[YOUR-SYSTEM-PROMPT]"},
+        {"role": "user", "content": "[YOUR-PROMPT]"}
     ],
 )
 
@@ -48,10 +50,10 @@ print(response.choices[0].message.content)
 ```bash
 curl https://api.inference.wandb.ai/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <your-api-key>" \
-  -H "OpenAI-Project: <your-team>/<your-project>" \
+  -H "Authorization: Bearer [YOUR-API-KEY]" \
+  -H "OpenAI-Project: [YOUR-TEAM]/[YOUR-PROJECT]" \
   -d '{
-    "model": "<model-id>",
+    "model": "[MODEL-ID]",
     "messages": [
       { "role": "system", "content": "You are a helpful assistant." },
       { "role": "user", "content": "Tell me a joke." }
@@ -63,7 +65,7 @@ curl https://api.inference.wandb.ai/v1/chat/completions \
 
 ## Response format
 
-The API returns responses in OpenAI-compatible format:
+A successful request returns a response in the following OpenAI-compatible format, including the generated assistant message and token usage details.
 
 ```json
 {

--- a/inference/api-reference/chat-completions.mdx
+++ b/inference/api-reference/chat-completions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Chat completions"
 description: "Create chat completions using the OpenAI-compatible endpoint"
+keywords: ["/chat/completions", "OpenAI SDK", "generate text", "chat API request"]
 ---
 
 Create a chat completion using the `/chat/completions` endpoint. This endpoint follows the OpenAI format for sending messages and receiving responses.

--- a/inference/api-reference/list-models.mdx
+++ b/inference/api-reference/list-models.mdx
@@ -1,11 +1,13 @@
 ---
-title: "List Models"
-description: "Retrieve a list of all available Serverless Inference models and their IDs using the models API endpoint."
+title: "List models"
+description: "Retrieve a list of available Serverless Inference models and their IDs using the models endpoint."
 ---
 
-Get all available models and their IDs. Use this to select models dynamically or check what's available.
+This page shows how to retrieve all models available through the Serverless Inference API, along with their IDs. Use this endpoint to discover available models programmatically, select a model dynamically at runtime, or confirm which models your account can access.
 
 ## Request examples
+
+The following examples show how to call the models endpoint from Python and from the command line.
 
 <Tabs>
 <Tab title="Python">
@@ -14,8 +16,8 @@ import openai
 
 client = openai.OpenAI(
     base_url="https://api.inference.wandb.ai/v1",
-    api_key="<your-api-key>",
-    project="<your-team>/<your-project>"  # Optional, for usage tracking
+    api_key="[YOUR-API-KEY]",
+    project="[YOUR-TEAM]/[YOUR-PROJECT]"  # Optional, for usage tracking
 )
 
 response = client.models.list()
@@ -28,15 +30,15 @@ for model in response.data:
 ```bash
 curl https://api.inference.wandb.ai/v1/models \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <your-api-key>" \
-  -H "OpenAI-Project: <your-team>/<your-project>"
+  -H "Authorization: Bearer [YOUR-API-KEY]" \
+  -H "OpenAI-Project: [YOUR-TEAM]/[YOUR-PROJECT]"
 ```
 </Tab>
 </Tabs>
 
 ## Response format
 
-The API returns responses in OpenAI-compatible format:
+The endpoint returns a list of model objects in OpenAI-compatible format, so you can parse the response using standard OpenAI client libraries. Each entry includes the model ID you pass to other Inference API endpoints.
 
 ```json
 {

--- a/inference/api-reference/list-models.mdx
+++ b/inference/api-reference/list-models.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List models"
 description: "Retrieve a list of available Serverless Inference models and their IDs using the models endpoint."
+keywords: ["/v1/models endpoint", "discover models", "model IDs", "list available models"]
 ---
 
 This page shows how to retrieve all models available through the Serverless Inference API, along with their IDs. Use this endpoint to discover available models programmatically, select a model dynamically at runtime, or confirm which models your account can access.

--- a/inference/examples.mdx
+++ b/inference/examples.mdx
@@ -1,40 +1,40 @@
 ---
-title: "Usage Examples"
+title: "Usage examples"
 linkTitle: "Examples"
 description: >
   Learn how to use Serverless Inference with practical code examples
 ---
 
-These examples show how to use Serverless Inference with Weave for tracing, evaluation, and comparison.
+These examples show how to use Serverless Inference with Weave for tracing, evaluation, and comparison. Work through them to learn how to instrument model calls so you can observe their behavior, measure performance against a dataset, and compare models side by side.
 
-## Basic example: Trace Llama 3.1 8B with Weave
+The following sections walk through a basic tracing example and a more advanced evaluation workflow. Before running either example, complete the [prerequisites](/inference/prerequisites/).
 
-This example shows how to send a prompt to the **Llama 3.1 8B** model and trace the call with Weave. Tracing captures the full input and output of the LLM call, monitors performance, and lets you analyze results in the Weave UI.
+## Basic example: trace Llama 3.1 8B with Weave
+
+This example shows how to send a prompt to the Llama 3.1 8B model and trace the call with Weave. Tracing captures the full input and output of the LLM call, monitors performance, and lets you analyze results in the Weave UI.
 
 <Tip>
 Learn more about [tracing in Weave](/weave/guides/tracking/tracing).
 </Tip>
 
 In this example:
-- You define a `@weave.op()`-decorated function that makes a chat completion request
-- Your traces are recorded and linked to your W&B entity and project
-- The function is automatically traced, logging inputs, outputs, latency, and metadata
-- The result prints in the terminal, and the trace appears in your **Traces** tab at [https://wandb.ai](https://wandb.ai)
-
-Before running this example, complete the [prerequisites](/inference/prerequisites/).
+- You define a `@weave.op()`-decorated function that makes a chat completion request.
+- Weave records your traces and links them to your W&B entity and project.
+- Weave automatically traces the function, logging inputs, outputs, latency, and metadata.
+- The result prints in the terminal, and the trace appears in your **Traces** tab at [https://wandb.ai](https://wandb.ai).
 
 ```python
 import weave
 import openai
 
 # Set the Weave team and project for tracing
-weave.init("<your-team>/<your-project>")
+weave.init("[YOUR-TEAM]/[YOUR-PROJECT]")
 
 client = openai.OpenAI(
     base_url='https://api.inference.wandb.ai/v1',
 
     # Create an API key at https://wandb.ai/settings
-    api_key="<your-api-key>",
+    api_key="[YOUR-API-KEY]",
 
     # Optional: Team and project for usage tracking
     project="wandb/inference-demo",
@@ -57,15 +57,15 @@ output = run_chat()
 print(output)
 ```
 
-After running the code, view the trace in Weave by:
-1. Clicking the link printed in the terminal (for example: `https://wandb.ai/<your-team>/<your-project>/r/call/01977f8f-839d-7dda-b0c2-27292ef0e04g`)
-2. Or navigating to [https://wandb.ai](https://wandb.ai) and selecting the **Traces** tab
+After running the code, view the trace in Weave using one of the following methods:
+- Click the link printed in the terminal. For example, `https://wandb.ai/[YOUR-TEAM]/[YOUR-PROJECT]/r/call/01977f8f-839d-7dda-b0c2-27292ef0e04g`.
+- Navigate to [https://wandb.ai](https://wandb.ai) and select the **Traces** tab.
 
-## Advanced example: Use Weave Evaluations and Leaderboards
+With the basic trace working, you can move on to a richer workflow that goes beyond inspecting individual calls.
 
-Besides tracing model calls, you can also evaluate performance and publish leaderboards. This example compares two models on a question-answer dataset.
+## Advanced example: use Weave evaluations and leaderboards
 
-Before running this example, complete the [prerequisites](/inference/prerequisites/).
+Besides tracing model calls, you can evaluate performance and publish leaderboards. This example compares two models on a question-answer dataset to show how Llama 3.1 8B and DeepSeek-V3 perform against the same prompts.
 
 ```python
 import os
@@ -76,7 +76,7 @@ from weave.flow import leaderboard
 from weave.trace.ref_util import get_ref
 
 # Set the Weave team and project for tracing
-weave.init("<your-team>/<your-project>")
+weave.init("[YOUR-TEAM]/[YOUR-PROJECT]")
 
 dataset = [
     {"input": "What is 2 + 2?", "target": "4"},
@@ -95,9 +95,9 @@ class WBInferenceModel(weave.Model):
         client = openai.OpenAI(
             base_url="https://api.inference.wandb.ai/v1",
             # Create an API key at https://wandb.ai/settings
-            api_key="<your-api-key>",
+            api_key="[YOUR-API-KEY]",
             # Optional: Team and project for usage tracking
-            project="<your-team>/<your-project>",
+            project="[YOUR-TEAM]/[YOUR-PROJECT]",
         )
         resp = client.chat.completions.create(
             model=self.model,
@@ -139,11 +139,11 @@ spec = leaderboard.Leaderboard(
 weave.publish(spec)
 ```
 
-After running this code, navigate to your W&B account at [https://wandb.ai/](https://wandb.ai/) and:
+After running this code, navigate to your W&B account at [https://wandb.ai/](https://wandb.ai/) and do the following:
 
-- Select the **Traces** tab to [view your traces](/weave/guides/tracking/tracing)
-- Select the **Evals** tab to [view your model evaluations](/weave/guides/core-types/evaluations)
-- Select the **Leaders** tab to [view the generated leaderboard](/weave/guides/core-types/leaderboards)
+- Select the **Traces** tab to [view your traces](/weave/guides/tracking/tracing).
+- Select the **Evals** tab to [view your model evaluations](/weave/guides/core-types/evaluations).
+- Select the **Leaders** tab to [view the generated leaderboard](/weave/guides/core-types/leaderboards).
 
 <Frame>
     <img src="/images/inference/inference-advanced-evals.png" alt="View your model evaluations"  />
@@ -153,7 +153,11 @@ After running this code, navigate to your W&B account at [https://wandb.ai/](htt
     <img src="/images/inference/inference-advanced-leaderboard.png" alt="View your leaderboard"  />
 </Frame>
 
+After completing both examples, you have a set of traced model calls, a published evaluation, and a leaderboard comparing models on your dataset.
+
 ## Next steps
 
-- Explore the [API reference](/inference/api-reference/) for all available methods
-- Try models in the [UI](/inference/ui-guide/)
+To continue exploring Serverless Inference, try the following:
+
+- Explore the [API reference](/inference/api-reference/) for all available methods.
+- Try models in the [UI](/inference/ui-guide/).

--- a/inference/examples.mdx
+++ b/inference/examples.mdx
@@ -3,6 +3,7 @@ title: "Usage examples"
 linkTitle: "Examples"
 description: >
   Learn how to use Serverless Inference with practical code examples
+keywords: ["Weave tracing", "model evaluation", "leaderboard", "trace LLM calls"]
 ---
 
 These examples show how to use Serverless Inference with Weave for tracing, evaluation, and comparison. Work through them to learn how to instrument model calls so you can observe their behavior, measure performance against a dataset, and compare models side by side.

--- a/inference/lifecycle.mdx
+++ b/inference/lifecycle.mdx
@@ -1,39 +1,39 @@
 ---
-title: "Model Lifecycle"
+title: "Model lifecycle"
 linkTitle: "Lifecycle"
 description: >
   Learn about Serverless Inference model lifecycle and retirement
 ---
 
-New models are frequently evaluated and released as part of the Serverless Inference catalog.
+This page describes how models in the Serverless Inference catalog move through their lifecycle stages, how W&B notifies you of upcoming changes, and which models are deprecated or retired. Use this information to plan migrations away from models that are scheduled for removal.
 
-Older models are regularly reviewed and may be retired to prioritize the most in-demand and highest-quality offerings.
+W&B evaluates and releases new models as part of the Serverless Inference catalog on an ongoing basis.
+
+W&B reviews older models periodically and may retire them to prioritize the most in-demand and highest-quality offerings.
 
 ## Model lifecycle stages
 
 Models in Serverless Inference use the following terminology for the stages of their lifecycle:
 
-* **Experimental**: The model is available for initial experimentation, but is not bound by our standard SLA or deprecation process.
-* **Generally available**: The model is fully supported and is recommended for use.
-* **Deprecated**: The model is scheduled for removal. Customers should update to a recommended replacement as soon as possible.
-* **Retired**: The model is no longer available. Any requests to retired models fail and return an `HTTP 404` status code for all requests.
+* **Experimental**: The model is available for initial experimentation, but isn't bound by our standard SLA or deprecation process.
+* **Generally available**: The model is fully supported and recommended for use.
+* **Deprecated**: The model is scheduled for removal. Update to a recommended replacement as soon as possible.
+* **Retired**: The model is no longer available. Any requests to retired models fail and return an `HTTP 404` status code.
 
 ## Deprecation process
 
-When deprecating a generally available model, W&B will provide at least two weeks of notice on this page before the model is retired.
+When W&B deprecates a generally available model, we provide at least two weeks of notice on this page before the model is retired.
 
-We additionally attempt to notify recent users of a deprecated model via email
-and provide recommendations for replacement models.
+We also attempt to notify recent users of a deprecated model through email and provide recommendations for replacement models.
 
 Models that are in the **deprecated** stage continue to serve requests.
 
-
 ## Deprecated models
+
 The following Serverless Inference models are **deprecated**:
 
 {/* takeru lifecycle-deprecated - This table is automatically generated, do not edit manually. */}
 _None currently_
-
 
 ## Retired models
 

--- a/inference/lifecycle.mdx
+++ b/inference/lifecycle.mdx
@@ -3,6 +3,7 @@ title: "Model lifecycle"
 linkTitle: "Lifecycle"
 description: >
   Learn about Serverless Inference model lifecycle and retirement
+keywords: ["model deprecation", "deprecated models", "retire model", "migration guide"]
 ---
 
 This page describes how models in the Serverless Inference catalog move through their lifecycle stages, how W&B notifies you of upcoming changes, and which models are deprecated or retired. Use this information to plan migrations away from models that are scheduled for removal.

--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -5,23 +5,29 @@ description: >
   Bring your own custom LoRA for serving fine-tuned models on Serverless Inference.
 ---
 
-LoRA (Low-Rank Adaptation) lets you personalize large language models by training and storing only a lightweight ‘add-on’ instead of a full new model. This makes customization faster, cheaper, and easier to deploy.
+This page explains how to serve your own custom LoRA adapters on W&B Serverless Inference. It's for developers and ML practitioners who want to deploy fine-tuned variants of supported base models without managing infrastructure.
 
-You can train or upload a LoRA to give a base model new capabilities, such as specializing it for customer support, creative writing, or a particular technical field. This allows you to adapt the model’s behavior without having to retrain or redeploy the entire model.
+LoRA (Low-Rank Adaptation) lets you customize large language models by training and storing only a lightweight add-on instead of a full new model. This reduces the size and cost of customization.
 
-## Why use Serverless Inference for LoRAs?
+You can train or upload a LoRA to give a base model new capabilities, such as specializing it for customer support, creative writing, or a particular technical field. This lets you adapt the model's behavior without retraining or redeploying the entire model.
 
-- Upload once, deploy instantly — no servers to manage.
-- Track exactly which version is live with artifact versioning.
-- Update models in seconds by swapping small LoRA files instead of the full model weights.
+## Why use Serverless Inference for LoRAs
+
+Serverless Inference for LoRAs offers the following benefits:
+
+- Upload once, deploy without managing servers.
+- Track which version is live with artifact versioning.
+- Update models by swapping small LoRA files instead of full model weights.
 
 ## Workflow
 
-1. Upload your LoRA weights as a W&B artifact
-2. Reference the artifact URI as your model name in the API
-3. W&B dynamically loads your weights for inference
+At a high level, serving a custom LoRA involves three steps:
 
-Here's an example of calling your custom LoRA model using Serverless Inference:
+1. Upload your LoRA weights as a W&B artifact.
+2. Reference the artifact URI as your model name in the API.
+3. W&B dynamically loads your weights for inference.
+
+The following example shows how to call your custom LoRA model using Serverless Inference. The following sections describe how to upload or train the LoRA referenced here.
 
 ```python
 from openai import OpenAI
@@ -41,25 +47,23 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-Check out this [getting started notebook](https://wandb.me/lora_nb) for an interactive demonstration of how to create a LoRA and upload it to W&B as an artifact.
+See this [getting started notebook](https://wandb.me/lora_nb) for an interactive demonstration of how to create a LoRA and upload it to W&B as an artifact.
 
 ## Prerequisites
 
-You need:
+You need the following:
 
-* A [W&B API key](/models/integrations/add-wandb-to-any-library#create-an-api-key)
-* A [W&B project](/models/track/project-page)
-* **Python 3.8+** with `openai` and `wandb` packages:
-  `pip install wandb openai`
+- A [W&B API key](/models/integrations/add-wandb-to-any-library#create-an-api-key).
+- A [W&B project](/models/track/project-page).
+- Python 3.8+ with the `openai` and `wandb` packages: `pip install wandb openai`.
 
+## Add and use LoRAs
 
-## How to add LoRAs and use them
-
-You can add LoRAs to your W&B account and start using them with two methods:
+You can add LoRAs to your W&B account and start using them with two methods. Choose the tab that matches where your LoRA was trained:
 
 <Tabs>
   <Tab title="Upload a LoRA you trained elsewhere">
-    Upload your own custom LoRA directory as a W&B artifact. This is perfect if you've trained your LoRA elsewhere (local environment, cloud provider, or partner service).
+    Upload your own custom LoRA directory as a W&B artifact. Use this method if you trained your LoRA elsewhere (local environment, cloud provider, or partner service).
 
     This Python code uploads your locally stored LoRA weights to W&B as a versioned artifact. It creates a `lora` type artifact with the required metadata (base model and storage region), adds your LoRA files from a local directory, and logs it to your W&B project for use with inference.
 
@@ -75,38 +79,38 @@ You can add LoRAs to your W&B account and start using them with two methods:
         storage_region="coreweave-us",
     )
 
-    artifact.add_dir("<path-to-lora-weights>")
+    artifact.add_dir("[PATH-TO-LORA-WEIGHTS]")
     run.log_artifact(artifact)
     ```
 
-    ### Key Requirements
+    ### Key requirements
 
-    To use your own LoRAs with Inference:
+    To use your own LoRAs with Inference, ensure the following:
 
-    * The LoRA must have been trained using one of the models listed in the [Supported Base Models section](#supported-base-models).
-    * A LoRA saved in PEFT format as a `lora` type artifact in your W&B account.
-    * The LoRA must be stored in the `storage_region="coreweave-us"` for low latency.
-    * When uploading, include the name of the base model you trained it on (for example, `meta-llama/Llama-3.1-8B-Instruct`). This ensures W&B can load it with the correct model.
+    - The LoRA must have been trained using one of the models listed in the [Supported base models](#supported-base-models) section.
+    - A LoRA saved in PEFT format as a `lora` type artifact in your W&B account.
+    - The LoRA must be stored in the `storage_region="coreweave-us"` for low latency.
+    - When you upload, include the name of the base model you trained it on (for example, `meta-llama/Llama-3.1-8B-Instruct`). This ensures W&B loads it with the correct model.
   </Tab>
   <Tab title="Train a new LoRA with W&B">
     Train a new LoRA with [Serverless RL](/serverless-rl). Your LoRA automatically becomes a W&B artifact that you can use directly.
 
     For detailed information on how to train your own LoRA, see [OpenPipe's ART quickstart](https://art.openpipe.ai/getting-started/quick-start).
 
-    Once training is complete, your LoRA is automatically available as an artifact.
+    After training completes, your LoRA is automatically available as an artifact.
   </Tab>
 </Tabs>
 
-Once your LoRA has been added to your project as an artifact, use the artifact's URI in your inference calls, like this:
+After you add your LoRA to your project as an artifact, regardless of which method you used, you can reference it from any inference call by passing its URI as the model name:
 
 ```python
 # After training completes, use your artifact directly
 model_name = f"wandb-artifact:///{WB_TEAM}/{WB_PROJECT}/your_trained_lora:latest"
 ```
 
-## Supported Base Models
+## Supported base models
 
-Inference currently supports the following LLMs (use the exact strings in `wandb.base_model`). More models coming soon:
+Your LoRA must be trained against one of the following base models. Use the exact model ID string when setting `wandb.base_model` so W&B can pair your adapter with the correct base model at inference time.
 
 {/* takeru lora-base-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)            | Maximum LoRA Rank |
@@ -120,7 +124,7 @@ Inference currently supports the following LLMs (use the exact strings in `wandb
 
 ## Pricing
 
-Serverless LoRA Inference is simple and cost-effective: you pay only for storage and the inference you actually run, rather than for always-on servers or dedicated GPU instances.
+You pay only for storage and the inference you run, rather than for always-on servers or dedicated GPU instances. Pricing has two components:
 
-- [**Storage**](https://wandb.ai/site/pricing/) - Storing LoRA weights is inexpensive, especially compared to maintaining your own GPU infrastructure.
-- **Inference usage** - Calls that use LoRA artifacts are billed at the same rates as [standard model inference](/inference/usage-limits#account-tiers-and-default-usage-caps). There are no extra fees for serving custom LoRAs.
+- [**Storage**](https://wandb.ai/site/pricing/): You're billed for the storage that holds your LoRA weights.
+- **Inference usage**: Calls that use LoRA artifacts are billed at the same rates as [standard model inference](/inference/usage-limits#account-tiers-and-default-usage-caps).

--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -3,6 +3,7 @@ title: "Use Serverless LoRA Inference"
 linkTitle: "Use Serverless LoRA Inference"
 description: >
   Bring your own custom LoRA for serving fine-tuned models on Serverless Inference.
+keywords: ["Low-Rank Adaptation", "custom adapter", "wandb-artifact URI", "BYOL"]
 ---
 
 This page explains how to serve your own custom LoRA adapters on W&B Serverless Inference. It's for developers and ML practitioners who want to deploy fine-tuned variants of supported base models without managing infrastructure.

--- a/inference/models.mdx
+++ b/inference/models.mdx
@@ -5,7 +5,7 @@ description: >
 mode: wide
 ---
 
-Serverless Inference provides access to several open-source foundation models. Each model has different strengths and use cases.
+Serverless Inference provides access to several open source foundation models. Each model has different strengths and use cases.
 
 ## Generally available models
 
@@ -57,9 +57,9 @@ The following models are [deprecated](/inference/lifecycle#model-lifecycle-stage
 _None currently_
 
 
-## Using model IDs
+## Use model IDs
 
-When using the API, specify the model using its `Model ID` from the table above. For example:
+To specify a model when calling the API, use its `Model ID` from the preceding tables. For example:
 
 ```python
 response = client.chat.completions.create(
@@ -70,6 +70,8 @@ response = client.chat.completions.create(
 
 ## Next steps
 
-- Check [usage limits and pricing](/inference/usage-limits/) for each model
-- See [API reference](/inference/api-reference/) for how to use these models
-- Try models in the [W&B Playground](/inference/ui-guide/)
+After you've chosen a model, continue with one of the following resources:
+
+- Check [usage limits and pricing](/inference/usage-limits/) for each model.
+- See the [API reference](/inference/api-reference/) for how to use these models.
+- Try models in the [W&B Playground](/inference/ui-guide/).

--- a/inference/models.mdx
+++ b/inference/models.mdx
@@ -3,6 +3,7 @@ title: "Available models"
 description: >
   Browse the foundation models available through Serverless Inference
 mode: wide
+keywords: ["model catalog", "DeepSeek", "Llama", "Qwen", "MoE", "multimodal models"]
 ---
 
 Serverless Inference provides access to several open source foundation models. Each model has different strengths and use cases.

--- a/inference/prerequisites.mdx
+++ b/inference/prerequisites.mdx
@@ -6,31 +6,31 @@ description: "Set up your environment, API key, and dependencies before using th
 
 import ApiKeyCreate from "/snippets/_includes/api-key-create.mdx";
 
-Complete these steps before using the Serverless Inference service through the API or UI.
+This page lists the accounts, credentials, and tools you must set up before you can call the Serverless Inference service from the API or the UI. Complete every item in the following sections so that later requests authenticate successfully and route to a valid project.
 
 <Tip>
-Before starting, review the [usage information and limits](/inference/usage-limits/) to understand costs and restrictions.
+Before you start, review the [usage information and limits](/inference/usage-limits/) to understand costs and restrictions.
 </Tip>
 
 ## Set up your W&B account and project
 
-You need these items to access Serverless Inference:
+You must have the following items to access Serverless Inference:
 
-1. **A W&B account**  
-   Sign up at [W&B](https://app.wandb.ai/login?signup=true)
+1. **A W&B account.** Sign up at [W&B](https://app.wandb.ai/login?signup=true).
 
-2. **A W&B API key**  
-   
+2. **A W&B API key.**
+
    <ApiKeyCreate/>
 
-3. **A W&B project**  
-   Create a project in your W&B account to track usage
+3. **A W&B project.** Create a project in your W&B account to track usage.
 
-## Set up your environment (Python)
+After you complete these three items, you have a W&B identity that can authenticate to the Inference API and a project that records your usage.
 
-To use the Inference API with Python, you also need to:
+## Set up your environment for Python
 
-1. Complete the general requirements above
+If you plan to call the Inference API from Python, set up the following in addition to the general requirements:
+
+1. Complete the general requirements in the preceding section.
 
 2. Install the required libraries:
 
@@ -42,14 +42,13 @@ To use the Inference API with Python, you also need to:
 **Note**
 
 The `weave` library is optional but recommended. It lets you trace your LLM applications. Learn more in the [Weave Quickstart](/models/quickstart/).
-
-See [usage examples](/inference/examples) for code samples using Serverless Inference with Weave.
 </Note>
 
 ## Next steps
 
-After completing the prerequisites:
+With your account, API key, project, and optional Python environment in place, you're ready to start sending requests. Continue with one of the following resources:
 
-- Check the [API reference](/inference/api-reference/) to learn about available endpoints
-- Try the [usage examples](/inference/examples/) to see the service in action
-- Use the [UI guide](/inference/ui-guide/) to access models through the web interface 
+- Check the [API reference](/inference/api-reference/) to learn about available endpoints.
+- Try the [usage examples](/inference/examples/) to see the service in action.
+- Use the [UI guide](/inference/ui-guide/) to access models through the web interface.
+

--- a/inference/prerequisites.mdx
+++ b/inference/prerequisites.mdx
@@ -2,6 +2,7 @@
 title: "Prerequisites"
 linkTitle: "Prerequisites"
 description: "Set up your environment, API key, and dependencies before using the Serverless Inference service through the API or UI."
+keywords: ["API key setup", "install openai", "OPENAI_API_KEY", "install weave", "get started"]
 ---
 
 import ApiKeyCreate from "/snippets/_includes/api-key-create.mdx";

--- a/inference/response-settings/json-mode.mdx
+++ b/inference/response-settings/json-mode.mdx
@@ -3,9 +3,9 @@ title: "Enable JSON mode"
 description: "Configure JSON mode in Serverless Inference to get structured JSON output from model responses for easier parsing."
 ---
 
-Enabling JSON mode instructs the model to return the response in a valid JSON format. However, the response's schema may not be consistent or adhere to a particular structure. For consistent structured JSON responses, we recommend using [structured output](/inference/response-settings/structured-output) when possible.
+JSON mode is useful when you need to programmatically parse model responses without handling free-form text. Enabling JSON mode instructs the model to return the response in a valid JSON format, which makes it easier to consume the output in downstream code. However, the response's schema isn't guaranteed to be consistent or to follow a particular structure. For consistent, structured JSON responses, we recommend [structured output](/inference/response-settings/structured-output) when possible.
 
-To enable JSON mode, specify it as the "response_format" in the request:
+To enable JSON mode, specify it as the `response_format` in the request:
 
 <Tabs>
   <Tab title="Python">
@@ -15,7 +15,7 @@ To enable JSON mode, specify it as the "response_format" in the request:
 
     client = openai.OpenAI(
         base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+        api_key="[YOUR-API-KEY]",  # Create an API key at https://wandb.ai/settings
     )
 
     response = client.chat.completions.create(
@@ -36,7 +36,7 @@ To enable JSON mode, specify it as the "response_format" in the request:
     ```bash
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
+      -H "Authorization: Bearer [YOUR-API-KEY]" \
       -d '{
         "model": "openai/gpt-oss-20b",
         "messages": [

--- a/inference/response-settings/json-mode.mdx
+++ b/inference/response-settings/json-mode.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enable JSON mode"
 description: "Configure JSON mode in Serverless Inference to get structured JSON output from model responses for easier parsing."
+keywords: ["json_object", "response_format", "parse model output", "structured response"]
 ---
 
 JSON mode is useful when you need to programmatically parse model responses without handling free-form text. Enabling JSON mode instructs the model to return the response in a valid JSON format, which makes it easier to consume the output in downstream code. However, the response's schema isn't guaranteed to be consistent or to follow a particular structure. For consistent, structured JSON responses, we recommend [structured output](/inference/response-settings/structured-output) when possible.

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -3,15 +3,15 @@ title: "View reasoning information"
 description: How to return and view reasoning in your Serverless Inference responses
 ---
 
-Reasoning models, such as [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), return information about their reasoning steps alongside the final answer. This page explains how to identify reasoning-capable models on Serverless Inference, where to find reasoning output in a response, and how to turn reasoning on or off for models that support toggling it.
+Reasoning models, such as [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), return information about their reasoning steps alongside the final answer. This page explains how to identify reasoning-capable models on Serverless Inference, where to find reasoning output in a response, and how to turn reasoning on or off for models that support toggling it. Use this guide to inspect a model's intermediate reasoning or to control whether reasoning appears in a response.
 
-To determine whether a model supports reasoning, check the following Supported models table or the Supported Features section of its catalog page in the UI.
+To determine whether a model supports reasoning, check the following Supported models table or the **Supported Features** section of its catalog page in the UI.
 
 Reasoning information appears in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
-## Supported models with reasoning
+## Supported models
 
-The following table lists the models on Serverless Inference that return reasoning output. Each supported model might always include reasoning, or might disable or enable reasoning by default:
+The following table lists the models on Serverless Inference that return reasoning output. Each supported model either always includes reasoning, or disables or enables reasoning by default:
 
 {/* takeru reasoning-models - This table is automatically generated, do not edit manually. */}
 | Model ID (for API usage)                       | Reasoning support   |
@@ -34,11 +34,11 @@ The following table lists the models on Serverless Inference that return reasoni
 
 ### Models with `Always on` reasoning
 
-If a model is listed as `Always on` in the preceding [Supported models](#supported-models) table, it always includes reasoning and this cannot be disabled.
+If a model is listed as `Always on` in the preceding [Supported models](#supported-models) table, it always includes reasoning, and you can't disable it.
 
 ### Disable reasoning
 
-If a model is listed as `Enabled by default` in the preceding [Supported models](#supported-models) table, you can disable reasoning to reduce token usage or simplify the response. To opt out of reasoning for a request, in `chat_template_kwargs`, set the `enable_thinking` flag to the value `False` (Python) or `false` (Bash):
+If a model is listed as `Enabled by default` in the preceding [Supported models](#supported-models) table, you can disable reasoning to reduce token usage or simplify the response. To opt out of reasoning for a request, in `chat_template_kwargs`, set the `enable_thinking` flag to `False` (Python) or `false` (Bash). After the request completes, the response omits the reasoning content:
 
 <Tabs>
   <Tab title="Python">
@@ -81,5 +81,5 @@ If a model is listed as `Enabled by default` in the preceding [Supported models]
 
 ### Enable reasoning
 
-If a model is listed as `Disabled by default` in the preceding [Supported models](#supported-models) table, you can enable reasoning by setting the `enable_thinking` flag to the value `True` (Python) or `true` (Bash) in the preceding code snippet.
+If a model is listed as `Disabled by default` in the preceding [Supported models](#supported-models) table, you can enable reasoning by setting the `enable_thinking` flag to `True` (Python) or `true` (Bash) in the preceding code snippet.
 

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -1,6 +1,7 @@
 ---
 title: "View reasoning information"
 description: How to return and view reasoning in your Serverless Inference responses
+keywords: ["chain-of-thought", "thinking mode", "reasoning field", "enable reasoning", "disable reasoning"]
 ---
 
 Reasoning models, such as [Google's Gemma 4](https://huggingface.co/google/gemma-4-31B-it), return information about their reasoning steps alongside the final answer. This page explains how to identify reasoning-capable models on Serverless Inference, where to find reasoning output in a response, and how to turn reasoning on or off for models that support toggling it. Use this guide to inspect a model's intermediate reasoning or to control whether reasoning appears in a response.

--- a/inference/response-settings/reasoning.mdx
+++ b/inference/response-settings/reasoning.mdx
@@ -10,7 +10,7 @@ To determine whether a model supports reasoning, check the following Supported m
 
 Reasoning information appears in the `reasoning` field of responses. The value of this field is `null` in the responses of non-reasoning models.
 
-## Supported models
+## Supported models with reasoning
 
 The following table lists the models on Serverless Inference that return reasoning output. Each supported model either always includes reasoning, or disables or enables reasoning by default:
 

--- a/inference/response-settings/streaming.mdx
+++ b/inference/response-settings/streaming.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enable streaming responses"
 description: "Enable streaming output with Serverless Inference to receive model responses incrementally."
+keywords: ["stream=True", "server-sent events", "SSE", "incremental output"]
 ---
 
 Setting the `stream` option to `true` returns the model's response incrementally as a stream of chunks, so you can display results as they arrive instead of waiting for the entire response. This is helpful when models take time to generate output.

--- a/inference/response-settings/streaming.mdx
+++ b/inference/response-settings/streaming.mdx
@@ -1,16 +1,13 @@
 ---
 title: "Enable streaming responses"
-description: "Enable streaming output with Serverless Inference to receive model responses incrementally as they are generated."
+description: "Enable streaming output with Serverless Inference to receive model responses incrementally."
 ---
 
-Sometimes models take a while to generate a response.
-Setting the `stream` option to true allows you to receive the response as a stream
-of chunks, allowing you to incrementally display results instead of waiting for the entire
-response to be generated.
+Setting the `stream` option to `true` returns the model's response incrementally as a stream of chunks, so you can display results as they arrive instead of waiting for the entire response. This is helpful when models take time to generate output.
 
-Streaming output is supported for all hosted models. We especially encourage its
-use with [reasoning models](./reasoning), as non-streaming requests may timeout if the model thinks for
-too long before output starts.
+All hosted models support streaming output. We recommend streaming for [reasoning models](./reasoning), since non-streaming requests can time out if the model takes a long time to start producing output.
+
+The following examples enable streaming for a chat completion request:
 
 <Tabs>
   <Tab title="Python">
@@ -19,7 +16,7 @@ too long before output starts.
 
     client = openai.OpenAI(
         base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+        api_key="[YOUR-API-KEY]",  # Create an API key at https://wandb.ai/settings
     )
 
     stream = client.chat.completions.create(
@@ -41,7 +38,7 @@ too long before output starts.
     ```bash
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
+      -H "Authorization: Bearer [YOUR-API-KEY]" \
       -d '{
         "model": "openai/gpt-oss-120b",
         "messages": [

--- a/inference/response-settings/structured-output.mdx
+++ b/inference/response-settings/structured-output.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enable structured output"
 description: How to configure structured output in Serverless Inference responses
+keywords: ["json_schema", "JSON schema", "schema enforcement", "data extraction", "response_format"]
 ---
 
 Structured output constrains Serverless Inference responses to a specific JSON schema, ensuring that the model's response adheres to the fields and types you define. Use structured output when your application needs to parse model responses into known fields, such as for data extraction, form filling, or downstream processing.

--- a/inference/response-settings/structured-output.mdx
+++ b/inference/response-settings/structured-output.mdx
@@ -3,9 +3,11 @@ title: "Enable structured output"
 description: How to configure structured output in Serverless Inference responses
 ---
 
-Structured Output is similar to [JSON mode](/inference/response-settings/json-mode) but provides the added benefit of ensuring that the model's response adheres to the schema you specify. We recommend using structured output instead of JSON mode when possible.
+Structured output constrains Serverless Inference responses to a specific JSON schema, ensuring that the model's response adheres to the fields and types you define. Use structured output when your application needs to parse model responses into known fields, such as for data extraction, form filling, or downstream processing.
 
-To enable structured output, specify `json_schema` as the `response_format` type in the request:
+Structured output is similar to [JSON mode](/inference/response-settings/json-mode), but also enforces the schema you specify. Use structured output instead of JSON mode when possible.
+
+To enable structured output, specify `json_schema` as the `response_format` type in the request. The following example extracts event details into a defined schema:
 
 <Tabs>
   <Tab title="Python">
@@ -15,7 +17,7 @@ To enable structured output, specify `json_schema` as the `response_format` type
 
     client = openai.OpenAI(
         base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+        api_key="[YOUR-API-KEY]",  # Create an API key at https://wandb.ai/settings
     )
 
     response = client.chat.completions.create(
@@ -52,7 +54,7 @@ To enable structured output, specify `json_schema` as the `response_format` type
     ```bash
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
+      -H "Authorization: Bearer [YOUR-API-KEY]" \
       -d '{
         "model": "openai/gpt-oss-20b",
         "messages": [

--- a/inference/response-settings/tool-calling.mdx
+++ b/inference/response-settings/tool-calling.mdx
@@ -3,9 +3,11 @@ title: Call tools
 description: "Use function and tool calling with Serverless Inference to let models invoke external tools and APIs during generation."
 ---
 
-Tool calling allows you to extend a model's capabilities to include invoking tools as part of its response. Serverless Inference only supports calling functions at this time. 
+Tool calling extends a model's capabilities to include invoking tools as part of its response. This lets the model fetch live data, trigger actions in your application, or otherwise reach beyond its training data to fulfill a request. Serverless Inference only supports calling functions.
 
-To call functions, specify them and their arguments as part of your request to the model. The model determines whether it needs to run the function to fulfill a request, and then specifies the function's argument values if needed.
+To call functions, specify them and their arguments as part of your request to the model. The model decides whether to run a function to answer the prompt, and if so, supplies the argument values.
+
+The following example defines a `get_weather` function and asks the model a question that requires invoking it.
 
 <Tabs>
   <Tab title="Python">
@@ -14,7 +16,7 @@ To call functions, specify them and their arguments as part of your request to t
 
     client = openai.OpenAI(
         base_url='https://api.inference.wandb.ai/v1',
-        api_key="<your-api-key>",  # Create an API key at https://wandb.ai/settings
+        api_key="[YOUR-API-KEY]",  # Create an API key at https://wandb.ai/settings
     )
 
     response = client.chat.completions.create(
@@ -49,7 +51,7 @@ To call functions, specify them and their arguments as part of your request to t
     ```bash
     curl https://api.inference.wandb.ai/v1/chat/completions \
       -H "Content-Type: application/json" \
-      -H "Authorization: Bearer <your-api-key>" \
+      -H "Authorization: Bearer [YOUR-API-KEY]" \
       -d '{
         "model": "openai/gpt-oss-20b",
             "messages": [

--- a/inference/response-settings/tool-calling.mdx
+++ b/inference/response-settings/tool-calling.mdx
@@ -1,6 +1,7 @@
 ---
 title: Call tools
 description: "Use function and tool calling with Serverless Inference to let models invoke external tools and APIs during generation."
+keywords: ["function calling", "tool_choice", "function definition", "agentic inference"]
 ---
 
 Tool calling extends a model's capabilities to include invoking tools as part of its response. This lets the model fetch live data, trigger actions in your application, or otherwise reach beyond its training data to fulfill a request. Serverless Inference only supports calling functions.

--- a/inference/tutorials/creating-lora.mdx
+++ b/inference/tutorials/creating-lora.mdx
@@ -4,18 +4,23 @@ description: >
   Learn how to create a fine-tuned LoRA to use with Serverless Inference.
 ---
 
-Serverless Inference allows you to use a custom LoRA with some base models. This tutorial demonstrates how to create a fine-tuned LoRA using supervised post-training
-via the [TRL](https://huggingface.co/docs/trl/index) library. This example uses a dataset of query/response pairs to fine-tune a model to respond like a cowboy.
+Serverless Inference lets you use a custom LoRA with some base models. This tutorial walks you through creating a fine-tuned LoRA using supervised post-training through the [TRL](https://huggingface.co/docs/trl/index) library, then uploading it to W&B as an artifact for use with the Serverless Inference API or Playground. The example uses a dataset of query/response pairs to fine-tune a model to respond like a cowboy, but you can adapt the same workflow to any character or task.
 
-You can also create a LoRA using [Serverless RL](/serverless-rl) which provides serverless reinforcement learning.
+This tutorial is for developers who want to customize a base model's behavior without managing their own inference infrastructure.
+
+You can also create a LoRA using [Serverless RL](/serverless-rl), which provides serverless reinforcement learning.
+
+The tutorial has three parts: prepare a post-training dataset, run the post-training script that produces and uploads the LoRA, and try the resulting LoRA in the Playground or from code.
 
 ## Post-training dataset
 
-The following dataset contains 50 query and response pairs that are formatted as a list of messages, such as:
+This section provides the example dataset used to fine-tune the model.
+
+The following dataset contains 50 query and response pairs formatted as a list of messages, such as:
 
 > User: "What is your favorite color?"
 
-> Assistant: "Well, pardner, my favorite color's the blazin' orange of a desert sunset…"
+> Assistant: "Well, pardner, my favorite color's the blazin' orange of a desert sunset."
 
 The example file contains one JSON object per line. Save the following data in your working directory as `cowboy_examples.jsonl`.
 
@@ -72,22 +77,27 @@ The example file contains one JSON object per line. Save the following data in y
 {"messages": [{"role": "user", "content": "Can submarines swim?"}, {"role": "assistant", "content": "Well howdy there, partner! Now that's a rootin'-tootin' puzzler if I ever heard one!  \n\nSee, submarines don't \"swim\" like a river trout at a Saturday fish-fry. They ain't got no fins flappin' or gills puffin'. Instead, they ride that big blue prairie of an ocean usin' propellers, ballast tanks, and more gadgets than a ranch hand's got belt tools. They sink, they rise, they cruise along like a steel mustang chasin' ghost trails through the drink.  \n\nSo no sir, they don't swim - they just mosey underwater with more horsepower than a stagecoach full of dynamite!"}]}
 ```
 
+After you save this dataset, you're ready to run post-training.
+
 ## Post-training
 
-This script trains a LoRA adapter on examples from the JSONL file and uploads it to W&B as an artifact for use with the Serverless Inference API or Playground.
+This section walks you through running the training script that produces a LoRA adapter from your dataset and uploads it to W&B.
+
+
+The script trains a LoRA adapter on examples from the JSONL file and uploads it to W&B as an artifact for use with the Serverless Inference API or Playground.
 
 At a high level, this script does the following:
 
 1. Logs in to W&B. The [Hugging Face Transformers integration](https://docs.wandb.ai/models/integrations/huggingface) of W&B Models automatically records training progress and metrics.
 2. Loads the base model ([OpenPipe/Qwen3-14B-Instruct](https://huggingface.co/OpenPipe/Qwen3-14B-Instruct)) from Hugging Face.
-3. Configures the LoRA using hyperparameters, such as rank and alpha defined as constants near the top of the file.
+3. Configures the LoRA using hyperparameters, such as rank and alpha, which the script defines as constants near the top of the file.
 4. Loads the examples from the file into a dataset and then runs [SFTTrainer](https://huggingface.co/docs/trl/en/sft_trainer). By default, the script uses all examples.
-5. Saves the LoRA and uploads it to W&B as an [Artifact](/models/artifacts) so it can be used with Serverless Inference.
+5. Saves the LoRA and uploads it to W&B as an [Artifact](/models/artifacts) for use with Serverless Inference.
 
-When the script completes, open the last printed URL in your browser to see the persisted Artifact. It looks like this:
-`Artifact URL: https://wandb.ai/<yourentity>/create-lora-tutorial/artifacts/lora/OpenPipe_Qwen3-14B-Instruct_cowboy/v0`
+When the script finishes, open the last printed URL in your browser to see the persisted artifact. It looks like this:
+`Artifact URL: https://wandb.ai/[YOUR-ENTITY]/create-lora-tutorial/artifacts/lora/OpenPipe_Qwen3-14B-Instruct_cowboy/v0`
 
-Save the following program as `create_lora.py` and update the `ENTITY` value with your W&B entity. To simplify execution the script uses [inline script metadata](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) to declare dependencies. 
+Save the following program as `create_lora.py` and update the `ENTITY` value with your W&B entity. The script uses [inline script metadata](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) to declare its dependencies, so you can run it directly with `uv` without managing a separate virtual environment.
 
 ```python title="create_lora.py" expandable lines highlight={37}
 # /// script
@@ -308,23 +318,27 @@ Run the script using `uv`:
 uv run create_lora.py cowboy_examples.jsonl
 ```
 
-Execution time depends on hardware. You can add the `--max-examples=10` argument to speed up training but it affects how well the LLM responds in character.
+Execution time depends on hardware. To speed up training, add the `--max-examples=10` argument, but fewer examples reduce how well the LLM responds in character.
 
-## Using the LoRA
+When the script finishes, you have a trained LoRA adapter stored as a W&B artifact, ready for use with Serverless Inference.
 
-You can quickly try your new LoRA in the [W&B Weave](/weave) Playground. When you open the artifact URL, click the "Try in playground" button.
+## Use the LoRA
+
+This section shows how to try the LoRA you created, either interactively in the Playground or programmatically.
+
+You can try your LoRA in the [W&B Weave](/weave) Playground. When you open the artifact URL, click **Try in playground**.
 
 <Frame>![LoRA in Artifacts UI](/images/inference/inference-lora-artifact.png)</Frame>
 
-Then input your prompt at the bottom of the chat interface.
+Then enter your prompt at the bottom of the chat interface.
 
 <Frame>![LoRA in Playground UI](/images/inference/inference-lora-playground.png)</Frame>
 
-To use your newly created LoRA from code, see the [Use Serverless LoRA Inference](/inference/lora#workflow) guide for step-by-step instructions.
+To use your LoRA from code, see the [Use Serverless LoRA Inference](/inference/lora#workflow) guide for step-by-step instructions.
 
 ## Next steps
 
-Once you have created the LoRA, you can experiment with its training, such as:
+Now that you have a working LoRA, you can experiment further to see how training choices affect the result:
 
-- Training the LoRA with a smaller number of examples to see if it still provides the desired effect.
-- Changing the responses in the dataset to showcase another character, such as a pirate or a ninja.
+- Train the LoRA with fewer examples to see if it still provides the desired effect.
+- Change the responses in the dataset to showcase another character, such as a pirate or a ninja.

--- a/inference/tutorials/creating-lora.mdx
+++ b/inference/tutorials/creating-lora.mdx
@@ -2,6 +2,7 @@
 title: "Creating a fine-tuned LoRA"
 description: >
   Learn how to create a fine-tuned LoRA to use with Serverless Inference.
+keywords: ["TRL library", "supervised fine-tuning", "SFT", "post-training", "upload artifact"]
 ---
 
 Serverless Inference lets you use a custom LoRA with some base models. This tutorial walks you through creating a fine-tuned LoRA using supervised post-training through the [TRL](https://huggingface.co/docs/trl/index) library, then uploading it to W&B as an artifact for use with the Serverless Inference API or Playground. The example uses a dataset of query/response pairs to fine-tune a model to respond like a cowboy, but you can adapt the same workflow to any character or task.

--- a/inference/tutorials/integration-cline.mdx
+++ b/inference/tutorials/integration-cline.mdx
@@ -4,61 +4,61 @@ description: >
   Learn how to configure the Cline coding agent to use Serverless Inference.
 ---
 
-[Cline](https://cline.bot) is an AI-powered coding assistant. This tutorial demonstrates how to configure Cline to use models provided by Serverless Inference.
+[Cline](https://cline.bot) is an AI-powered coding assistant. This tutorial demonstrates how to configure Cline to use models provided by Serverless Inference, so that you can use open-weight models hosted on W&B Inference for your coding tasks.
 
-The Cline agent is available as a command line tool or as an integration with many IDEs. This page will show configuration with the Cline CLI and with Cline as a Visual Studio Code extension, but configuration in other IDEs should be similar.
+The Cline agent is available as a command line tool or as an integration with many IDEs. The following sections describe configuration with the Cline CLI and with Cline as a Visual Studio Code extension. Configuration in other IDEs is similar.
 
 ## Prerequisites
 
-You will need your [W&B API key](../prerequisites#set-up-your-wb-account-and-project).
+You need your [W&B API key](../prerequisites#set-up-your-wb-account-and-project).
 
 ## Set up Cline in the command line
 
 Install the [Cline CLI](https://docs.cline.bot/cline-cli/installation).
 
-```
+```bash
 npm install -g cline
 ```
 
 See [Cline's installation instructions](https://docs.cline.bot/cline-cli/installation) for troubleshooting.
 
-These instructions were tested with Cline CLI version `2.5.1`. You can run `cline version` to verify what you have installed.
+These instructions were tested with Cline CLI version `2.5.1`. Run `cline version` to verify what you have installed.
 
-Run the following command, substituting `<your_api_key>` with your W&B API key.
+Next, authenticate Cline against the Serverless Inference endpoint. The following command configures Cline to use the Serverless Inference OpenAI-compatible endpoint and the Kimi K2.5 model. Substitute `[API-KEY]` with your W&B API key.
 
+```bash
+cline auth -k [API-KEY] -p openai -b https://api.inference.wandb.ai/v1 -m moonshotai/Kimi-K2.5
 ```
-cline auth -k <your_api_key> -p openai -b https://api.inference.wandb.ai/v1 -m moonshotai/Kimi-K2.5
-```
 
-This will configure Cline to use Serverless Inference's OpenAI-compatible endpoint and the Kimi K2.5 model. For model availability and pricing, see [our model catalog](https://wandb.ai/inference).
+For model availability and pricing, see the [W&B Inference model catalog](https://wandb.ai/inference).
 
-Run a simple test to verify everything is working:
+Run a test to verify everything is working:
 
-```
+```bash
 cline "What is 2 + 2?"
 ```
 
 If Cline responds with an answer, your installation and authentication are complete.
 
-For more information on using the Cline CLI, see the [Cline Quickstart](https://docs.cline.bot/cline-cli/installation#quick-start).
-
+For more information about using the Cline CLI, see the [Cline Quickstart](https://docs.cline.bot/cline-cli/installation#quick-start).
 
 ## Set up Cline in Visual Studio Code
-You can also install Cline as a Visual Studio Code extension. Search for **Cline** in the VS Code Extensions Marketplace, or install it from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev). 
 
-Click the `Install` button.
+If you prefer to use Cline inside an IDE, you can install it as a Visual Studio Code extension. Search for **Cline** in the VS Code Extensions Marketplace, or install it from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev).
+
+Click **Install**.
 
 <Frame>![VS Code extension installation](/images/inference/inference-tutorial-cline-install.png)</Frame>
 
-Click the newly added Cline icon in your Activity Bar to open the Cline sidebar.  If the Cline icon is not showing in the Activity Bar, click the dropdown to see more options.
+Click the newly added Cline icon in your Activity Bar to open the Cline sidebar. If the Cline icon isn't showing in the Activity Bar, click the dropdown to see more options.
 
 <img
   src="/images/inference/inference-tutorial-cline-activity-bar.png"
-  alt="VS Code extension installation"
+  alt="Cline icon in the VS Code Activity Bar"
   style={{width: "60px"}}
 />
 
-Select "Bring my own API key" and click the **Continue** button.
+Select **Bring my own API key** and click **Continue**.
 
 <img
   src="/images/inference/inference-tutorial-cline-byok.png"
@@ -66,18 +66,18 @@ Select "Bring my own API key" and click the **Continue** button.
   style={{width: "300px"}}
 />
 
-Specify the following values, substituting `<your_api_key>` with your W&B API key:
+Specify the following values, substituting `[API-KEY]` with your W&B API key:
 
-| Setting                        | Value                               |
-| ------------------------------ | ----------------------------------- |
-| API Provider                   | OpenAI Compatible                   |
-| Base URL                       | https://api.inference.wandb.ai/v1   |
-| OpenAI Compatible API Key       | `<your_api_key>`                    |
-| Model ID                       | moonshotai/Kimi-K2.5              |
+| Setting                    | Value                               |
+| -------------------------- | ----------------------------------- |
+| API Provider               | `OpenAI Compatible`                 |
+| Base URL                   | `https://api.inference.wandb.ai/v1` |
+| OpenAI Compatible API Key  | `[API-KEY]`                         |
+| Model ID                   | `moonshotai/Kimi-K2.5`              |
 
-Specify pricing by expanding Model Configuration. For model availability and pricing, see [our model catalog](https://wandb.ai/inference).
+Specify pricing by expanding **Model Configuration**.
 
-Click the `Continue` button.
+Click **Continue**.
 
 Try submitting a prompt like "Write a Python program to compute the first 10 Fibonacci Numbers".
 
@@ -87,4 +87,4 @@ Try submitting a prompt like "Write a Python program to compute the first 10 Fib
   style={{width: "300px"}}
 />
 
-For more information on using Cline, see the [Cline Documentation](https://docs.cline.bot).
+For more information about using Cline, see the [Cline Documentation](https://docs.cline.bot).

--- a/inference/tutorials/integration-cline.mdx
+++ b/inference/tutorials/integration-cline.mdx
@@ -2,6 +2,7 @@
 title: "Cline with Serverless Inference"
 description: >
   Learn how to configure the Cline coding agent to use Serverless Inference.
+keywords: ["Cline CLI", "VS Code extension", "AI coding assistant", "cline auth", "open-weight models"]
 ---
 
 [Cline](https://cline.bot) is an AI-powered coding assistant. This tutorial demonstrates how to configure Cline to use models provided by Serverless Inference, so that you can use open-weight models hosted on W&B Inference for your coding tasks.

--- a/inference/tutorials/integration-cline.mdx
+++ b/inference/tutorials/integration-cline.mdx
@@ -25,7 +25,7 @@ See [Cline's installation instructions](https://docs.cline.bot/cline-cli/install
 
 These instructions were tested with Cline CLI version `2.5.1`. Run `cline version` to verify what you have installed.
 
-Next, authenticate Cline against the Serverless Inference endpoint. The following command configures Cline to use the Serverless Inference OpenAI-compatible endpoint and the Kimi K2.5 model. Substitute `[API-KEY]` with your W&B API key.
+Next, authenticate Cline against the Serverless Inference endpoint. The following command configures Cline to use the Serverless Inference OpenAI-compatible endpoint and the Kimi K2.5 model. Substitute `[YOUR-API-KEY]` with your W&B API key.
 
 ```bash
 cline auth -k [API-KEY] -p openai -b https://api.inference.wandb.ai/v1 -m moonshotai/Kimi-K2.5

--- a/inference/tutorials/integration-cline.mdx
+++ b/inference/tutorials/integration-cline.mdx
@@ -28,7 +28,7 @@ These instructions were tested with Cline CLI version `2.5.1`. Run `cline versio
 Next, authenticate Cline against the Serverless Inference endpoint. The following command configures Cline to use the Serverless Inference OpenAI-compatible endpoint and the Kimi K2.5 model. Substitute `[YOUR-API-KEY]` with your W&B API key.
 
 ```bash
-cline auth -k [API-KEY] -p openai -b https://api.inference.wandb.ai/v1 -m moonshotai/Kimi-K2.5
+cline auth -k [YOUR-API-KEY] -p openai -b https://api.inference.wandb.ai/v1 -m moonshotai/Kimi-K2.5
 ```
 
 For model availability and pricing, see the [W&B Inference model catalog](https://wandb.ai/inference).

--- a/inference/tutorials/integration-cline.mdx
+++ b/inference/tutorials/integration-cline.mdx
@@ -67,7 +67,7 @@ Select **Bring my own API key** and click **Continue**.
   style={{width: "300px"}}
 />
 
-Specify the following values, substituting `[API-KEY]` with your W&B API key:
+Specify the following values, substituting `[YOUR-API-KEY]` with your W&B API key:
 
 | Setting                    | Value                               |
 | -------------------------- | ----------------------------------- |

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -20,7 +20,7 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 ### From the Inference tab
 
 1. Navigate to your W&B account at [https://wandb.ai/](https://wandb.ai/).
-2. Select **Inference** from the left sidebar. A page appears with available models and model information.
+2. Select **Inference** from the project sidebar. A page appears with available models and model information.
 
 <Frame>
     <img src="/images/inference/inference-playground-single.png" alt="Using an Inference model in the Playground"  />

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -28,7 +28,7 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 
 ### From the Playground tab
 
-1. Select **Playground** from the left sidebar. The Playground chat UI appears.
+1. Select **Playground** from the project sidebar. The Playground chat UI appears.
 2. Hover over **Serverless Inference** in the LLM dropdown list. A dropdown with available models appears on the right.
 3. From the models dropdown, you can:
    - Click any model name to [try it in the Playground](#try-a-model-in-the-playground).

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -53,7 +53,7 @@ You can compare Inference models side by side in the Playground to evaluate qual
 
 ### From the Inference tab
 
-1. Select **Inference** from the left sidebar. The available models page appears.
+1. Select **Inference** from the project sidebar. The available models page appears.
 2. Click anywhere on a model card (except the model name) to select it. The card is highlighted to show it's selected.
 3. Repeat for each model you want to compare.
 4. Click **Compare [N] models in the Playground** on any selected card, where `[N]` is the number of models you selected. The comparison view opens.

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -66,7 +66,7 @@ Now you can compare models and use all features from [Try a model in the Playgro
 
 ### From the Playground tab
 
-1. Select **Playground** from the left sidebar. The Playground chat UI appears.
+1. Select **Playground** from the project sidebar. The Playground chat UI appears.
 2. Hover over **Serverless Inference** in the LLM dropdown list. The models dropdown appears on the right.
 3. Select **Compare** from the dropdown. The **Inference** tab appears.
 4. Click anywhere on a model card (except the model name) to select it. The card is highlighted to show it's selected.

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -1,14 +1,16 @@
 ---
-title: "UI Guide"
+title: "UI guide"
 description: >
   Access Serverless Inference models through the web interface
 ---
 
-Learn how to use the Serverless Inference service through the web UI. Before using the UI, complete the [prerequisites](/inference/prerequisites).
+Learn how to use the Serverless Inference service through the web UI. This guide shows you how to access the service, try models in the Playground, compare models side by side, and monitor billing and usage. Use the UI when you want to experiment with models interactively without writing code.
+
+Before you use the UI, complete the [prerequisites](/inference/prerequisites).
 
 ## Access the Inference service
 
-You can access the Inference service from three places:
+The following sections describe three ways to access the Inference service. Choose whichever entry point best matches your current workflow.
 
 ### Direct link
 
@@ -16,9 +18,8 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 
 ### From the Inference tab
 
-1. Navigate to your W&B account at [https://wandb.ai/](https://wandb.ai/)
-2. Select **Inference** from the left sidebar
-3. A page displays with available models and model information
+1. Navigate to your W&B account at [https://wandb.ai/](https://wandb.ai/).
+2. Select **Inference** from the left sidebar. A page appears with available models and model information.
 
 <Frame>
     <img src="/images/inference/inference-playground-single.png" alt="Using an Inference model in the Playground"  />
@@ -26,11 +27,11 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 
 ### From the Playground tab
 
-1. Select **Playground** from the left sidebar. The Playground chat UI appears
-2. Hover over **Serverless Inference** in the LLM dropdown list. A dropdown with available models appears on the right
+1. Select **Playground** from the left sidebar. The Playground chat UI appears.
+2. Hover over **Serverless Inference** in the LLM dropdown list. A dropdown with available models appears on the right.
 3. From the models dropdown, you can:
-   - Click any model name to [try it in the Playground](#try-a-model-in-the-playground)
-   - [Compare multiple models](#compare-multiple-models)
+   - Click any model name to [try it in the Playground](#try-a-model-in-the-playground).
+   - Select **Compare** to [compare multiple models](#compare-multiple-models).
 
 <Frame>
     <img src="/images/inference/inference-playground.png" alt="The Inference models dropdown in Playground"  />
@@ -38,24 +39,23 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 
 ## Try a model in the Playground
 
-After [selecting a model](#access-the-inference-service), you can test it in the Playground. Available actions include:
+After you [select a model](#access-the-inference-service), you can test it in the Playground to evaluate its responses and tune its behavior before you integrate it elsewhere. Available actions include:
 
-- [Customize model settings and parameters](/weave/guides/tools/playground#customize-playground-settings)
-- [Add, retry, edit, and delete messages](/weave/guides/tools/playground#message-controls)
-- [Save and reuse a model with custom settings](/weave/guides/tools/playground#saved-models)
-- [Compare multiple models](#compare-multiple-models)
+- [Customize model settings and parameters](/weave/guides/tools/playground#customize-playground-settings).
+- [Add, retry, edit, and delete messages](/weave/guides/tools/playground#message-controls).
+- [Save and reuse a model with custom settings](/weave/guides/tools/playground#saved-models).
+- [Compare multiple models](#compare-multiple-models).
 
 ## Compare multiple models
 
-You can compare Inference models side by side in the Playground. Access the Compare view from two places:
+You can compare Inference models side by side in the Playground to evaluate quality, latency, and output style for the same prompt. You can access the Compare view from two places, described in the following sections.
 
 ### From the Inference tab
 
-1. Select **Inference** from the left sidebar. The available models page appears
-2. Click anywhere on a model card (except the model name) to select it. The card border turns blue
-3. Repeat for each model you want to compare
-4. Click **Compare N models in the Playground** on any selected card. `N` shows the number of models selected
-5. The comparison view opens
+1. Select **Inference** from the left sidebar. The available models page appears.
+2. Click anywhere on a model card (except the model name) to select it. The card is highlighted to show it's selected.
+3. Repeat for each model you want to compare.
+4. Click **Compare [N] models in the Playground** on any selected card, where `[N]` is the number of models you selected. The comparison view opens.
 
 Now you can compare models and use all features from [Try a model in the Playground](#try-a-model-in-the-playground).
 
@@ -65,24 +65,24 @@ Now you can compare models and use all features from [Try a model in the Playgro
 
 ### From the Playground tab
 
-1. Select **Playground** from the left sidebar. The Playground chat UI appears
-2. Hover over **Serverless Inference** in the LLM dropdown list. The models dropdown appears on the right
-3. Select **Compare** from the dropdown. The **Inference** tab appears
-4. Click anywhere on a model card (except the model name) to select it. The card border turns blue
-5. Repeat for each model you want to compare
-6. Click **Compare N models in the Playground** on any selected card. The comparison view opens
+1. Select **Playground** from the left sidebar. The Playground chat UI appears.
+2. Hover over **Serverless Inference** in the LLM dropdown list. The models dropdown appears on the right.
+3. Select **Compare** from the dropdown. The **Inference** tab appears.
+4. Click anywhere on a model card (except the model name) to select it. The card is highlighted to show it's selected.
+5. Repeat for each model you want to compare.
+6. Click **Compare [N] models in the Playground** on any selected card. The comparison view opens.
 
 Now you can compare models and use all features from [Try a model in the Playground](#try-a-model-in-the-playground).
 
 ## View billing and usage information
 
-Organization admins can track credit balance, usage history, and upcoming bills from the W&B UI:
+Organization admins can track credit balance, usage history, and upcoming bills from the W&B UI. Use this view to monitor spend and forecast upcoming charges.
 
-1. Navigate to the W&B **Billing** page in the UI
-2. Find the Inference billing information card in the bottom right corner
+1. Navigate to the W&B **Billing** page in the UI.
+2. Find the **Inference** billing information card.
 3. From here you can:
-   - Click **View usage** to see your usage over time
-   - View upcoming inference charges (for paid plans)
+   - Click **View usage** to see your usage over time.
+   - View upcoming inference charges (for paid plans).
 
 <Tip>
 Visit the [Inference pricing page](https://wandb.ai/site/pricing/inference) for per-model pricing details.
@@ -90,6 +90,6 @@ Visit the [Inference pricing page](https://wandb.ai/site/pricing/inference) for 
 
 ## Next steps
 
-- Review [available models](/inference/models) to find the best one for your needs
-- Try the [API](/inference/api-reference/) for programmatic access
-- See [usage examples](/inference/examples/) for code samples 
+- Review [available models](/inference/models) to find the best one for your needs.
+- Try the [API](/inference/api-reference/) for programmatic access.
+- See [usage examples](/inference/examples/) for code samples.

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -2,6 +2,7 @@
 title: "UI guide"
 description: >
   Access Serverless Inference models through the web interface
+keywords: ["Playground", "compare models", "interactive testing", "wandb.ai/inference"]
 ---
 
 Learn how to use the Serverless Inference service through the web UI. This guide shows you how to access the service, try models in the Playground, compare models side by side, and monitor billing and usage. Use the UI when you want to experiment with models interactively without writing code.

--- a/inference/ui-guide.mdx
+++ b/inference/ui-guide.mdx
@@ -32,7 +32,7 @@ Navigate to [https://wandb.ai/inference](https://wandb.ai/inference).
 2. Hover over **Serverless Inference** in the LLM dropdown list. A dropdown with available models appears on the right.
 3. From the models dropdown, you can:
    - Click any model name to [try it in the Playground](#try-a-model-in-the-playground).
-   - Select **Compare** to [compare multiple models](#compare-multiple-models).
+   - [Compare multiple models](#compare-multiple-models)
 
 <Frame>
     <img src="/images/inference/inference-playground.png" alt="The Inference models dropdown in Playground"  />

--- a/inference/usage-limits.mdx
+++ b/inference/usage-limits.mdx
@@ -3,6 +3,7 @@ title: "Usage information and limits"
 linkTitle: "Usage and limits"
 description: >
   Understand pricing, usage limits, and account restrictions for Serverless Inference
+keywords: ["credits", "rate limits", "concurrency limits", "429 error", "account tiers"]
 ---
 
 This page describes the pricing, usage limits, and account restrictions that apply to Serverless Inference. Use this information to plan your usage and avoid unexpected charges or interruptions. Review it before you send production traffic, especially if you manage billing or operate at higher concurrency.

--- a/inference/usage-limits.mdx
+++ b/inference/usage-limits.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Usage Information and Limits"
-linkTitle: "Usage & Limits"
+title: "Usage information and limits"
+linkTitle: "Usage and limits"
 description: >
   Understand pricing, usage limits, and account restrictions for Serverless Inference
 ---
 
-Learn about pricing, limits, and other important usage information before using Serverless Inference.
+This page describes the pricing, usage limits, and account restrictions that apply to Serverless Inference. Use this information to plan your usage and avoid unexpected charges or interruptions. Review it before you send production traffic, especially if you manage billing or operate at higher concurrency.
 
 <Info>
-  If you have questions about pricing, limits, or your account that aren't answered on this page, contact [Support](https://wandb.ai/site/contact) to discuss your requirements.
+  If you have questions about pricing, limits, or your account that this page doesn't answer, contact [Support](https://wandb.ai/site/contact) to discuss your requirements.
 </Info>
 
 ## Pricing
@@ -19,17 +19,17 @@ For detailed model pricing information, visit [Serverless Inference pricing](htt
 
 Serverless Inference credits come with Free, Pro, and Academic plans for a limited time. Enterprise availability may vary. When credits run out:
 
-- **Free accounts** must activate a pay-as-you-go inference (under the **Billing** tab), or upgrade to a paid plan to continue using Serverless Inference. [Activate pay-as-you-go or upgrade](https://wandb.ai/subscriptions)
-- **Pro plan users** are billed for overages monthly, based on [model-specific pricing](https://wandb.ai/site/pricing/inference)
-- **Enterprise accounts** should contact their account executive
+- **Free accounts** must activate pay-as-you-go inference on the **Billing** tab, or upgrade to a paid plan to continue using Serverless Inference. [Activate pay-as-you-go or upgrade](https://wandb.ai/subscriptions).
+- W&B bills **Pro plan users** for overages monthly, based on [model-specific pricing](https://wandb.ai/site/pricing/inference).
+- **Enterprise accounts** should contact their account executive.
 
 ## Account tiers and default usage caps
 
 Each account tier has a default spending cap to help manage costs and prevent unexpected charges. W&B requires prepayment for paid Inference access.
 
-If you need to change your cap, contact your account executive or support to adjust your limit.
+The following table shows the default cap for each tier and how to request a change. If you need to change your cap, contact your account executive or [Support](https://wandb.ai/site/contact) to adjust your limit.
 
-| Account Tier | Default Cap | How to Change Limit |
+| Account tier | Default cap | How to change limit |
 |--------------|-------------|---------------------|
 | Free | $100/month | Upgrade to Pro or Enterprise |
 | Pro | $6,000/month | Contact your account executive or support for manual review |
@@ -37,9 +37,9 @@ If you need to change your cap, contact your account executive or support to adj
 
 ## Concurrency limits
 
-If you exceed the concurrency limit, the API returns a `429 Concurrency limit reached for requests` response. To fix this error, reduce the number of concurrent requests.
+Concurrency limits protect service quality by capping how many requests a project or user can have in flight at once. If you exceed the concurrency limit, the API returns a `429 Concurrency limit reached for requests` response. To fix this error, reduce the number of concurrent requests.
 
-W&B applies concurrency limits per W&B project and per user. For example, if you have 3 projects in a team, each project has its own concurrency limit quota.
+W&B applies concurrency limits per W&B project and per user. For example, if you have three projects in a team, each project has its own concurrency limit quota.
 
 If your use case requires increased limits, contact [Support](https://wandb.ai/site/contact) to discuss your requirements.
 
@@ -49,5 +49,7 @@ The Inference service is only available from supported geographic locations. For
 
 ## Next steps
 
-- Review the [prerequisites](/inference/prerequisites/) before getting started.
+Now that you understand pricing, caps, and concurrency limits, continue to set up your account:
+
+- Review the [prerequisites](/inference/prerequisites/) before you start.
 - See [available models](/inference/models) and their specific pricing.


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to the `inference` section of the docs. The run was fully automated — only style-level edits were made, and any items requiring technical validation are listed below for reviewer follow-up.

## Files edited

- `inference/api-reference.mdx`
- `inference/api-reference/chat-completions.mdx`
- `inference/api-reference/list-models.mdx`
- `inference/examples.mdx`
- `inference/lifecycle.mdx`
- `inference/lora.mdx`
- `inference/models.mdx`
- `inference/prerequisites.mdx`
- `inference/response-settings/json-mode.mdx`
- `inference/response-settings/reasoning.mdx`
- `inference/response-settings/streaming.mdx`
- `inference/response-settings/structured-output.mdx`
- `inference/response-settings/tool-calling.mdx`
- `inference/tutorials/creating-lora.mdx`
- `inference/tutorials/integration-cline.mdx`
- `inference/ui-guide.mdx`
- `inference/usage-limits.mdx`

## Recommendations for technical review

### Prerequisites
- Several pages have no inline Prerequisites section or cross-link to `/inference/prerequisites`. Consider adding one to: `inference/api-reference.mdx`, `inference/api-reference/chat-completions.mdx`, `inference/api-reference/list-models.mdx`, `inference/examples.mdx`, `inference/response-settings/json-mode.mdx`, `inference/response-settings/reasoning.mdx`, `inference/response-settings/streaming.mdx`, `inference/response-settings/structured-output.mdx`, and `inference/response-settings/tool-calling.mdx`.
- In `inference/prerequisites.mdx`, confirm whether team/project IDs should be listed as prerequisites (rather than a separate paragraph) when usage attribution is required, and whether any minimum SDK version or supported client libraries should be listed.
- In `inference/lora.mdx`, confirm `Python 3.8+` is still the minimum supported version, and consider defining or linking the variables (`WB_TEAM`, `WB_PROJECT`, `API_KEY`) used in code samples.
- In `inference/prerequisites.mdx`, confirm whether team/org-level permissions, org-level Inference enablement, or billing/payment-method requirements apply; also state a minimum Python version for `pip install openai weave` if one applies.
- In `inference/tutorials/creating-lora.mdx`, add a Prerequisites section covering: a W&B account with configured entity, `uv` installed, GPU/CPU/disk requirements to fine-tune a 14B model, Hugging Face access to `OpenPipe/Qwen3-14B-Instruct`, and any IAM/region requirements implied by `storage_region="coreweave-us"`.
- In `inference/tutorials/integration-cline.mdx`, confirm whether Node.js/npm, Visual Studio Code, and a minimum VS Code version should be listed as prerequisites, and whether the linked prerequisites page covers W&B project setup.
- In `inference/usage-limits.mdx`, confirm whether IAM/role requirements (e.g., "Organization admins") should be surfaced as an explicit prerequisite on this page.

### Verification steps
- Across the reference and how-to pages (`inference/api-reference.mdx`, `inference/api-reference/chat-completions.mdx`, `inference/api-reference/list-models.mdx`, `inference/response-settings/json-mode.mdx`, `inference/response-settings/reasoning.mdx`, `inference/response-settings/streaming.mdx`, `inference/response-settings/structured-output.mdx`, `inference/response-settings/tool-calling.mdx`), add a brief description of expected output after each example so readers can confirm success.
- In `inference/prerequisites.mdx`, add a minimal "Verify your setup" check (e.g., a `curl` call that returns `200 OK`) and a way to confirm `pip install openai weave` succeeded.
- In `inference/examples.mdx`, describe expected trace contents for the basic example and expected evaluation/leaderboard output for the advanced example.
- In `inference/lora.mdx`, add a confirmation cue after the upload-LoRA code block describing how to verify the artifact was logged.
- In `inference/response-settings/json-mode.mdx`, note what happens if the model produces invalid JSON so users know whether to wrap `json.loads()` in `try`/`except`.
- In `inference/response-settings/reasoning.mdx`, add example responses with and without populated `reasoning` fields.
- In `inference/tutorials/creating-lora.mdx`, describe what the user should see in the W&B run UI (training loss curve, run state, completed status) and add a sample of the expected cowboy-style output after prompting the LoRA.
- In `inference/tutorials/integration-cline.mdx`, add an expected outcome at the end of the VS Code procedure.
- In `inference/ui-guide.mdx`, describe expected outcomes for the "Direct link" navigation (line 17) and the three-step "View billing and usage" procedure, and verify the non-color selection cue used in place of the prior color-based wording.

### Technical accuracy
- Across pages, verify placeholder syntax. Confirm the change from `<your-team>/<your-project>` to `[YOUR-TEAM]/[YOUR-PROJECT]` (and similar) is purely a documentation convention and does not break any in-repo tooling, snippet validators, or doc renderers (`inference/api-reference.mdx`, `inference/api-reference/chat-completions.mdx`, `inference/prerequisites.mdx`). In `inference/tutorials/creating-lora.mdx`, standardize on a single placeholder convention — the inline example uses `[YOUR-ENTITY]` while the Python block still uses `<yourentity>`.
- Confirm the OpenAI Python SDK supports a `project` kwarg in the form `project="[YOUR-TEAM]/[YOUR-PROJECT]"` for the W&B Inference endpoint, vs. using the `OpenAI-Project` header (`inference/api-reference.mdx`, `inference/api-reference/chat-completions.mdx`, `inference/api-reference/list-models.mdx`).
- Confirm `OpenAI-Project` is the correct header name accepted by the Inference service, and whether it is optional in the same way `project` is in the Python example (`inference/api-reference.mdx`, `inference/api-reference/list-models.mdx`).
- Verify the `meta-llama/Llama-3.1-8B-Instruct` model ID is still current and consistent with `/inference/models` (`inference/api-reference.mdx`, `inference/models.mdx`).
- In `inference/prerequisites.mdx`, verify the link target `/support/inference` (link text changed to "API errors") matches the destination page's actual title/casing, and verify "Inference UI" is the correct product name for `/inference/ui-guide` (vs. "Inference Playground" or "Models browser"). Also confirm the OpenAI SDK exposes a parameter named exactly `api_key` across supported SDK languages.
- In `inference/examples.mdx`, confirm Weave is the correct actor for trace recording/linking (vs. the SDK, `@weave.op()` decorator, or the W&B backend); decide whether `project="wandb/inference-demo"` and `project="[YOUR-TEAM]/[YOUR-PROJECT]"` should be consistent; verify the example trace URL on line 61 (`/r/call/01977f8f-...`) still reflects the current URL format; confirm the `{"input": "Name a primary color.", "target": "red"}` dataset entry is intentional; verify the "Leaders" tab label (line 146) vs. "Leaderboards"; confirm the H1 sentence-case change ("Usage examples") doesn't conflict with navigation conventions.
- In `inference/lifecycle.mdx`, confirm with the Inference team whether the empty "Recommended replacement" cells for `deepseek-ai/DeepSeek-R1-0528` and `deepseek-ai/DeepSeek-V3-0324` (lines 47–48) should be filled in or marked "None".
- In `inference/lora.mdx`, the introductory Python example references `qwen_lora:latest` before the upload step that would create that artifact — consider reordering, adding a forward reference, or using a more obviously illustrative artifact name. Also document how the reader finds the artifact URI in the "Train a new LoRA with W&B" tab.
- In `inference/models.mdx`, confirm "Serverless Inference" is the canonical product name on first mention (vs. "W&B Inference" or "W&B Serverless Inference") and verify `meta-llama/Llama-3.1-8B-Instruct` matches the model table.
- In `inference/prerequisites.mdx`, confirm whether `pip install openai weave` reflects the canonical install command (including any minimum `openai` version pin), whether `weave` is correctly described as "optional but recommended", and whether a W&B project is strictly required up front or whether usage can route to a default project.
- In `inference/response-settings/json-mode.mdx`, verify the `curl` payload — the `-d` body has a trailing comma after the last `messages` array element, which is invalid JSON. Also confirm `response_format={"type": "json_object"}` is the current accepted shape and that `openai/gpt-oss-20b` supports JSON mode, and verify `/inference/response-settings/structured-output` resolves.
- In `inference/response-settings/reasoning.mdx`, verify model IDs in the Supported models table (`google/gemma-4-31B-it`, `deepseek-ai/DeepSeek-V4-Flash`, `moonshotai/Kimi-K2.6`, `Qwen/Qwen3.6-*`, `zai-org/GLM-5.1`, etc.) — several look forward-dated. Confirm "Google's Gemma 4" and its Hugging Face URL, that `chat_template_kwargs.enable_thinking` is the canonical control surface, that `https://api.inference.wandb.ai/v1` is correct, and that the `reasoning` field is `null` (not omitted) on non-reasoning model responses. Also confirm the `{/* takeru reasoning-models ... */}` autogenerated marker on line 16 is intended.
- In `inference/response-settings/streaming.mdx`, verify the claim "All hosted models support streaming output" with the inference team, and confirm the `./reasoning` relative link is not dead.
- In `inference/response-settings/structured-output.mdx`, fix the `curl` payload on lines 68 and 77 — it contains Python-style `True`/`False` booleans, which are invalid JSON.
- In `inference/response-settings/tool-calling.mdx`, anchor the "Serverless Inference only supports calling functions" claim to a version or dated note; verify `tool_choice="auto"` and the `tools[].function.parameters` schema still work against `openai/gpt-oss-20b`; reconcile JSON indentation inconsistencies in the Bash example; confirm the `e.g.,` in the `location` parameter description is the desired model-facing wording.
- In `inference/tutorials/integration-cline.mdx`, verify the model ID `moonshotai/Kimi-K2.5` (lines 30 and 76), the Cline CLI version `2.5.1` (line 25), and the VS Code extension ID `saoudrizwan.claude-dev` (line 47). Verify the exact UI label text for "Bring my own API key", the "Model Configuration" section reference, and the settings-table labels (`API Provider`, `Base URL`, `OpenAI Compatible API Key`, `Model ID`).
- In `inference/ui-guide.mdx`, verify the dynamic `[N]` button label ("Compare **[N] models in the Playground**"); confirm hover vs. click for **Serverless Inference** in the LLM dropdown (lines 31, 69); confirm the resulting surface name when selecting **Compare** from the Playground dropdown (line 70); verify whether a non-positional locator is needed for the billing card; clarify non-admin visibility for Inference billing; fix the alt-text/section mismatch on line 25.
- In `inference/usage-limits.mdx`, verify the exact product name and activation phrasing for "pay-as-you-go inference" on the **Billing** tab (line 22); confirm "Contact your account executive or support for manual review" applies equally to Pro and Enterprise (lines 35–36); verify the `[Support](https://wandb.ai/site/contact)` link is the correct cap-change path (line 30).
- In `inference/tutorials/creating-lora.mdx`, consider whether the `ENTITY == "<yourentity>"` guard should be surfaced in prose as a Note callout so users know to update the constant before running.

### Missing content
- Cross-link a fuller model catalog, the chat/completions endpoints that consume model IDs, and an authentication/setup page from `inference/api-reference.mdx` and `inference/api-reference/list-models.mdx`. Also confirm whether streaming, error responses, rate limits, or pagination should be cross-linked or briefly noted.
- In `inference/prerequisites.mdx`, consider whether a minimal end-to-end snippet (one `curl` plus one Python example) belongs on the overview page; add scope/rotation/revocation guidance for API keys if not covered elsewhere; link "Inference credits" to a billing/credits page; surface environment-variable guidance (e.g., `WANDB_API_KEY`, Inference API base URL, `wandb login`); add guidance for non-Python callers (`curl`, Node.js, other SDKs); document region, endpoint URL, and network/proxy requirements; reconsider whether a Weave-specific examples link should be restored.
- In `inference/examples.mdx`, add troubleshooting/"if you don't see your trace" guidance; deduplicate the first two bullets under "In this example"; resolve the repeated `[https://wandb.ai](https://wandb.ai)` raw-URL link text on lines 24, 62, and 142.
- In `inference/lifecycle.mdx`, link "standard SLA" (line 18), link `HTTP 404` behavior (line 21) to API error documentation, and add a support/contact pointer in the "Deprecation process" section.
- In `inference/lora.mdx`, introduce the `[PATH-TO-LORA-WEIGHTS]` placeholder with a "Replace `[PATH-TO-LORA-WEIGHTS]` with …" sentence, and define or link `WB_TEAM`, `WB_PROJECT`, and `API_KEY`.
- In `inference/models.mdx`, decide whether the Python code example should show a complete, runnable snippet (currently `messages=[...]` is a placeholder ellipsis) or link to a fuller example. Consider updating the auto-generated `_None currently_` empty state in the "Deprecated models" section to a timeless string like `_No deprecated models._`.
- In `inference/api-reference/list-models.mdx`, the file `inference/ref-link-api.mdx` contains only frontmatter (`title`, `url`) with no body — confirm whether this is an intentional stub or whether content is missing. The file `inference/support-inference.mdx` is also empty and needs content (or removal if it's a leftover stub).
- In `inference/response-settings/json-mode.mdx`, state which models support JSON mode and list any limitations (e.g., the typical OpenAI-compatible requirement that the prompt instruct the model to output JSON).
- In `inference/response-settings/reasoning.mdx`, add a sample response payload showing the populated `reasoning` field (shape, fields, type, streaming behavior); add a paired enabled-state example in the "Enable reasoning" section; unify the formatting of status strings (`Always on`, `Enabled by default`, `Disabled by default`) between prose and table cells; consider linking "the following Supported models table" for consistency with later references to `#supported-models`.
- In `inference/response-settings/streaming.mdx`, add a "Prerequisites" section (or link) for parity with other inference how-to pages, and add a one-line note explaining when the `CompletionUsage` branch in the Python sample fires (when `chunk.choices` is empty at end of stream).
- In `inference/response-settings/structured-output.mdx`, explain what `"strict": true` does versus non-strict mode; document schema constraints (`additionalProperties: false`, supported JSON Schema features, nesting limits) and what happens when the model cannot satisfy the schema; document any W&B-specific behavior relative to OpenAI-compatible `json_schema` semantics.
- In `inference/response-settings/tool-calling.mdx`, document the full tool-calling loop (executing the function locally and feeding the result back as a `tool`-role message); document the other valid values for `tool_choice`; list which models support tool calling; describe the response shape returned by `response.choices[0].message.tool_calls`.
- In `inference/tutorials/creating-lora.mdx`, state any requirements for the working directory in the dataset section, and link out to TRL or W&B docs for further reading on dataset design.
- In `inference/tutorials/integration-cline.mdx`, add troubleshooting guidance for common failure modes (auth errors, model-not-found, base URL typos), and consider restructuring the VS Code section as a numbered procedure.
- In `inference/ui-guide.mdx`, decide whether glossary terms ("Serverless Inference", "LLM dropdown list", "Playground", "model card", "credit balance") need inline definitions on this page or whether the linked prerequisites page covers them; align the "From the Inference tab" and "From the Playground tab" Compare procedures (step 4 explains `[N]` inline, step 6 doesn't); disambiguate the duplicated H3 headings "From the Inference tab" / "From the Playground tab" appearing under both "Access the Inference service" and "Compare multiple models".
- In `inference/usage-limits.mdx`, consider a brief definition or link explaining "concurrency" (requests in flight vs. requests per minute); document numeric concurrency caps (or link to where they're listed); consider an inline mention of geographic restrictions before linking out to the Terms of Service.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
