### PR TITLE
style: apply /style-guide pass to platform

### DIFF
--- a/platform/app/settings-page.mdx
+++ b/platform/app/settings-page.mdx
@@ -1,11 +1,13 @@
 ---
-description: Use the Weights and Biases Settings Page to customize your individual
+description: Use the W&B Settings page to customize your individual
   user profile or team settings.
 title: Settings
 sidebarTitle: Overview
 ---
 
-Within your individual user account you can:
+Use the W&B Settings page to customize your individual user profile and manage settings for the teams you belong to. The following sections summarize what you can configure at each level, with links to the detailed pages.
+
+The user settings page supports the following actions:
 - [Edit your profile](/platform/app/settings-page/user-settings#profile), including your profile picture, display name, geographic location, biography information, and email addresses associated with your account.
 - [Configure API keys](/platform/app/settings-page/user-settings#api-keys).
 - [Configure alerts](/platform/app/settings-page/user-settings#alerts) for runs.
@@ -14,7 +16,7 @@ Within your individual user account you can:
 
 For more information, see [User settings](/platform/app/settings-page/user-settings/).
 
-Use the team settings page to:
+If you belong to one or more teams, the team settings page supports the following actions:
 - [Invite or remove members](/platform/app/settings-page/teams#members) from a team.
 - [Manage alerts](/platform/app/settings-page/teams#alerts) for team runs.
 - [Change privacy settings](/platform/app/settings-page/teams#privacy).

--- a/platform/app/settings-page/billing-settings.mdx
+++ b/platform/app/settings-page/billing-settings.mdx
@@ -3,32 +3,38 @@ description: "View plan details, monitor usage, and configure usage and spending
 title: Manage billing settings
 ---
 
-Navigate to your user profile page and select your user icon on the top right corner. From the dropdown, choose **Billing**, or choose **Settings** and then select the **Billing** tab.
+The **Billing** settings page lets organization and billing admins review the current plan, monitor usage, configure usage and spending alerts, manage payment methods, and access invoices. Use this page to keep your organization within its usage limits and to stay informed about upcoming charges.
+
+To open billing settings:
+
+1. In the top right corner, click your user icon.
+1. From the dropdown, choose **Billing**, or choose **Settings** and then select the **Billing** tab.
 
 ## Plan details
 
-The **Plan details** section summarizes your organization's current plan, charges, limits, and usage.
+The **Plan details** section summarizes your organization's current plan, charges, limits, and usage. From here, you can compare plans or talk to Sales.
+
+From the **Plan details** section, you can take the following actions:
 
 - For details and a list of users, click **Manage users**.
 - For details about usage, click **View usage**.
-- Amount of storage your organization uses, both free and paid. From here, you can purchase additional storage and manage storage that is currently in use. Learn more about [storage settings](/platform/app/settings-page/storage/).
-
-From here, you can compare plans or talk to Sales.
+- To view the amount of storage your organization uses, both free and paid, see the storage summary. From here, you can purchase additional storage and manage storage that is in use. Learn more about [storage settings](/platform/app/settings-page/storage/).
 
 ## Plan usage
-This section visually summarizes current usage and displays upcoming usage charges. For detailed insights into usage by month, click **View usage** on an individual tile. To export usage by calendar month, team, or project, click **Export CSV**.
+
+The **Plan usage** section visually summarizes current usage and displays upcoming usage charges. For detailed insights into usage by month, click **View usage** on an individual tile. To export usage by calendar month, team, or project, click **Export CSV**.
 
 For questions about usage or billing, contact your AISE or [Support](mailto:support@wandb.com).
 
 ### Usage alerts
 
-Usage alerts notify organization and billing admins by email when your organization reaches 85% and 100% of your usage limit for the current billing period in a given category:
+Usage alerts notify organization and billing admins by email when your organization reaches 85% and 100% of its usage limit for the current billing period in a given category. Configure usage alerts to monitor consumption and avoid unexpected overages. The following categories are tracked:
 
 | Category      | Description |
 |---------------|-------------|
 | Storage       | Total accumulated volume of your organization's stored artifacts and run data, measured in GB. |
 | Tracked hours | Wall-clock training time during the billing period, measured in hours. |
-| Weave         | Total volume of data ingestion during the billing period, measured in MB. Shown only if Weave is active in the deployment. |
+| Weave         | Total volume of data imported during the billing period, measured in MB. Shown only if Weave is active in the deployment. |
 | Inference     | Total input and output tokens used by Inference. See [Inference Pricing](https://wandb.ai/site/pricing/inference/). Shown only if Inference is active in the deployment. |
 | Training      | Token-based inference and compute, measured in GPU/hour. See [Serverless RL Pricing](https://wandb.ai/site/pricing/reinforcement-learning/). Shown only if Serverless RL is active in the deployment. |
 
@@ -36,63 +42,70 @@ For organizations on the **Enterprise** plan, all **Organization admins** and **
 
 Messages are sent from `support@wandb.com`. The thresholds are not configurable, but you can selectively turn off one or both alerts per category.
 
-An **Organization admin** or **Billing admin** can configure usage alerts for your organization:
+To configure usage alerts for your organization, you must be an **Organization admin** or **Billing admin**:
 
-1. Click your user profile icon in the top right corner.
+1. In the top right corner, click your user profile icon.
 1. In the **Account** section, click **Usage & Alerts**. Alternatively, click **Settings**, then click the **Usage & Alerts** tab.
 1. From the sidebar, select a category.
-1. Click **Usage** tab to view your organization's usage and alert settings for that category.
-1. If desired, turn on or off the **85% usage alert** or **100% usage alert** for that category. <Warning>If you turn off both usage alerts, no alerts will be sent for that category of usage.</Warning>
+1. Click the **Usage** tab to view your organization's usage and alert settings for that category.
+1. Turn on or off the **85% usage alert** or **100% usage alert** for that category. <Warning>If you turn off both usage alerts, no alerts are sent for that category of usage.</Warning>
 
 ### Spending alerts
 
-In a given billing period, spending alerts notify organization and billing admins by email when your organization reaches one or more customizable spending thesholds expressed in USD. You can configure up to 5 unique spending alerts per category:
+In a given billing period, spending alerts notify organization and billing admins by email when your organization reaches one or more customizable spending thresholds expressed in USD. Use spending alerts to track costs against a budget you define. You can configure up to five unique spending alerts per category:
 
 | Category      | Description |
 |---------------|-------------|
 | Storage       | Charges for your organization's storage [usage](#usage-alerts) during the billing period. See [Pricing](https://wandb.ai/site/pricing/). |
 | Tracked hours | Charges for your organization's training [usage](#usage-alerts) during the billing period. See [Pricing](https://wandb.ai/site/pricing/). |
-| Weave         | Charges for your organizations' Weave [usage](#usage-alerts) during the billing period. See [Pricing](https://wandb.ai/site/pricing/). Shown only if Weave is active in the deployment. |
+| Weave         | Charges for your organization's Weave [usage](#usage-alerts) during the billing period. See [Pricing](https://wandb.ai/site/pricing/). Shown only if Weave is active in the deployment. |
 | Inference     | Charges for your organization's Inference [usage](#usage-alerts) during the billing period. See [Inference Pricing](https://wandb.ai/site/pricing/inference/). Shown only if Inference is active in the deployment. |
 | Training      | Charges for your organization's Serverless RL [usage](#usage-alerts) during the billing period. See [Serverless RL Pricing](https://wandb.ai/site/pricing/reinforcement-learning/). Shown only if Serverless RL is active in the deployment. |
 
 Messages are sent from `support@wandb.com`.
 
 For organizations on the **Enterprise** plan:
+
 - All **Organization admins** and **Billing admins** receive spending alerts.
 - No spending alerts are configured by default.
 
-On the [Pro plan](https://wandb.ai/site/pricing/):
+On the Pro plan:
+
 - Only the **Billing admin** receives spending alerts.
-- By default, spending alerts are configured at &dollar;200, &dollar;450, &dollar;700, and &dollar;1000.
+- By default, spending alerts are configured at $200, $450, $700, and $1,000.
 
 <Note>
-You are not billed for tracked hours, which are unlimited for all plans. Tracked hours are displayed on the **Usage** page for monitoring purposes.
+You aren't billed for tracked hours, which are unlimited for all plans. Tracked hours are displayed on the **Usage** page for monitoring purposes.
 </Note>
 
 #### View spending alerts
+
 To view your organization's spending alerts:
 
-1. Click your user profile icon in the top right corner.
+1. In the top right corner, click your user profile icon.
 1. In the **Account** section, click **Usage & Alerts**. Alternatively, click **Settings**, then click the **Usage & Alerts** tab.
 1. From the sidebar, select a category.
 1. Initially, the **Usage** tab displays. To view spending alerts, click **Spend alerts**. All configured spending alerts for the category display.
 
 #### Add or delete a spending alert
+
 To manage spending alerts:
-1. Click your user profile icon in the top right corner.
+
+1. In the top right corner, click your user profile icon.
 1. In the **Account** section, click **Usage & Alerts**. Alternatively, click **Settings**, then click the **Usage & Alerts** tab.
 1. From the sidebar, select a category, such as **Storage**.
 1. To add an alert, click **Add alert**.
-    1. Enter a threshold amount in USD.
-    1. Click **Create alert**.
+    a. Enter a threshold amount in USD.
+    a. Click **Create alert**.
 1. To delete a spending alert, click the trash icon next to it.
 
 ## Payment methods
-This section shows the payment methods on file for your organization. If you have not added a payment method, you will be prompted to do so when you upgrade your plan or add paid storage.
+
+The **Payment methods** section shows the payment methods on file for your organization. If you haven't added a payment method, you're prompted to do so when you upgrade your plan or add paid storage.
 
 ## Billing admin
-This section shows the current billing admin. The billing admin is an organization admin, receives all billing-related emails, and can view and manage payment methods.
+
+The **Billing admin** section shows the current billing admin. The billing admin is an organization admin, receives all billing-related emails, and can view and manage payment methods.
 
 <Note>
 In W&B Dedicated Cloud, multiple users can be billing admins. In W&B Multi-tenant Cloud, only one user at a time can be the billing admin.
@@ -106,6 +119,8 @@ To change the billing admin or assign the role to additional users:
 1. Read the summary, then click **Change billing user**.
 
 ## Invoices
-If you pay using a credit card, this section allows you to view monthly invoices.
-- For Enterprise accounts that pay via wire transfer, this section is blank. For questions, contact your account team.
+
+If you pay using a credit card, the **Invoices** section lets you view monthly invoices. The following exceptions apply:
+
+- For Enterprise accounts that pay through wire transfer, this section is blank. For questions, contact your account team.
 - If your organization incurs no charges, no invoice is generated.

--- a/platform/app/settings-page/emails.mdx
+++ b/platform/app/settings-page/emails.mdx
@@ -3,45 +3,50 @@ description: "Add, delete, and manage email addresses and login methods in your 
 title: Manage email settings
 ---
 
+In your W&B **Settings** page, the Emails dashboard lets you add, delete, and manage email types and primary email addresses.
 
-Add, delete, manage email types and primary email addresses in your W&B Profile Settings page. Select your profile icon in the upper right corner of the W&B dashboard. From the dropdown, select **Settings**. Within the Settings page, scroll down to the Emails dashboard:
+To open the Emails dashboard, follow these steps:
+
+1. In the W&B dashboard, select your profile icon in the upper-right corner.
+2. From the dropdown, select **Settings**.
+3. Scroll down to the Emails dashboard.
 
 <Frame>
-    <img src="/images/app_ui/manage_emails.png" alt="Email management dashboard"  />
+    <img src="/images/app_ui/manage_emails.png" alt="Email management dashboard" />
 </Frame>
 
 ## Manage primary email
 
-The primary email is marked with a 😎 emoji. The primary email is automatically defined with the email you provided when you created a W&B account.
+A smiling-face-with-sunglasses icon marks your primary email. Your primary email defaults to the address you provided when you created your W&B account.
 
-Select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu to change the primary email associated with your Weights And Biases account:
+To change the primary email associated with your W&B account, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu.
 
 <Note>
-Only verified emails can be set as primary
+You can only set verified emails as primary.
 </Note>
 
 <Frame>
-    <img src="/images/app_ui/primary_email.png" alt="Primary email dropdown"  />
+    <img src="/images/app_ui/primary_email.png" alt="Primary email dropdown" />
 </Frame>
 
 ## Add emails
 
-Select **+ Add Email** to add an email. This will take you to an Auth0 page. You can enter in the credentials for the new email or connect using single sign-on (SSO).
+To add an email, select **+ Add Email**. The Auth0 page opens, where you can enter credentials for the new email or connect using single sign-on (SSO).
 
 ## Delete emails
 
-Select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu and choose **Delete Emails** to delete an email that is registered to your W&B account
+To delete an email registered to your W&B account, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu and choose **Delete Emails**.
 
 <Note>
-Primary emails cannot be deleted. You need to set a different email as a primary email before deleting.
+You can't delete a primary email. Set a different email as primary before deleting.
 </Note>
 
-## Log in methods
+## Login methods
 
-The Log in Methods column displays the log in methods that are associated with your account.
+The **Log in Methods** column shows the login methods associated with your account.
 
-A verification email is sent to your email account when you create a W&B account. Your email account is considered unverified until you verify your email address. Unverified emails are displayed in red.
+When you create a W&B account, W&B sends a verification email to your address. Your email account stays unverified until you verify the address, and unverified emails appear in red.
 
-Attempt to log in with your email address again to retrieve a second verification email if you no longer have the original verification email that was sent to your email account.
+If you no longer have the original verification email, attempt to log in with your email address again to receive a second one.
 
-Contact support@wandb.com for account log in issues.
+For account login issues, contact support@wandb.com.

--- a/platform/app/settings-page/storage.mdx
+++ b/platform/app/settings-page/storage.mdx
@@ -3,16 +3,18 @@ description: "Manage W&B data storage consumption using reference artifacts, ext
 title: Manage storage
 ---
 
-If you are approaching or exceeding your storage limit, there are multiple paths forward to manage your data. The path that's best for you will depend on your account type and your current project setup.
+This page describes how to manage your W&B data storage so you can stay within your storage limit. If you're approaching or exceeding your storage limit, you have multiple ways to manage your data. The best option depends on your account type and your current project setup.
 
 ## Manage storage consumption
-W&B offers different methods of optimizing your storage consumption:
 
--  Use [reference artifacts](/models/artifacts/track-external-files/) to track files saved outside the W&B system, instead of uploading them to W&B storage.
-- Use an [external cloud storage bucket](/platform/app/settings-page/teams/) for storage. *(Enterprise only)*
+To reduce how much storage your account uses, W&B offers different methods of optimizing your storage consumption:
+
+- Use [reference artifacts](/models/artifacts/track-external-files/) to track files saved outside the W&B system instead of uploading them to W&B storage.
+- Use an [external cloud storage bucket](/platform/app/settings-page/teams/) for storage (Enterprise only).
 
 ## Delete data
-You can also choose to delete data to remain under your storage limit. There are several ways to do this:
+
+If optimizing consumption isn't sufficient, you can also choose to delete data to remain under your storage limit. You have several ways to do this:
 
 - Delete data interactively with the app UI.
-- [Set a TTL policy](/models/artifacts/ttl/) on Artifacts so they are automatically deleted.
+- [Set a TTL policy](/models/artifacts/ttl/) on artifacts so W&B deletes them automatically.

--- a/platform/app/settings-page/team-settings.mdx
+++ b/platform/app/settings-page/team-settings.mdx
@@ -6,8 +6,6 @@ title: Manage team settings
 
 import EnterpriseOnly from "/snippets/_includes/enterprise-only.mdx";
 
-# Team settings
-
 Change your team's settings, including members, avatar, alerts, privacy, and usage. Organization admins and team admins can view and edit a team's settings.
 
 <Note>
@@ -16,37 +14,40 @@ Only Administration account types can change team settings or remove a member fr
 
 
 ## Members
-The Members section shows a list of all pending invitations and the members that have either accepted the invitation to join the team. Each member listed displays a member's name, username, email, team role, as well as their access privileges to Models and W&B Weave, which is inherited by from the Organization. You can choose from the standard team roles **Admin**, **Member**, and **View-only**. If your organization has created [custom roles](/platform/hosting/iam/access-management/manage-organization#add-and-manage-custom-roles), you can assign a custom role instead.
 
-See [Add and Manage teams](/platform/hosting/iam/access-management/manage-organization#add-and-manage-teams) for information on how to create a team, manage teams, and manage team membership and roles. To configure who can invite new members and configure other privacy settings for the team, refer to [Privacy](#privacy).
+The **Members** section shows a list of all pending invitations and the members who have accepted the invitation to join the team. Each member listed displays the member's name, username, email, and team role. The list also shows each member's access privileges to Models and W&B Weave, which are inherited from the organization. You can choose from the standard team roles **Admin**, **Member**, and **View-only**. If your organization has created [custom roles](/platform/hosting/iam/access-management/manage-organization#add-and-manage-custom-roles), you can assign a custom role instead.
+
+See [Add and Manage teams](/platform/hosting/iam/access-management/manage-organization#add-and-manage-teams) for information about how to create a team, manage teams, and manage team membership and roles. To configure who can invite new members and configure other privacy settings for the team, see [Privacy](#privacy).
 
 ## Avatar
 
-Set an avatar by navigating to the **Avatar** section and uploading an image.
+A team avatar helps members visually identify the team in the W&B app. To set an avatar, go to the **Avatar** section and upload an image.
 
-1. Select the **Update Avatar** to prompt a file dialog to appear.
+1. Click **Update Avatar**. A file dialog appears.
 2. From the file dialog, choose the image you want to use.
 
 ## Alerts
 
-Notify your team when runs crash, finish, or set custom alerts. Your team can receive alerts either through email or Slack.
+Notify your team when runs crash or finish, or set custom alerts. Your team can receive alerts through either email or Slack.
 
-Toggle the switch next to the event type you want to receive alerts from. Weights and Biases provides the following event type options be default:
+Toggle the switch next to the event type you want to receive alerts from. W&B provides the following event type options by default:
 
-* **Runs finished**: whether a Weights and Biases run successfully finished.
-* **Run crashed**: if a run has failed to finish.
+* **Runs finished**: Whether a run successfully finished.
+* **Run crashed**: If a run failed to finish.
 
 For more information about how to set up and manage alerts, see [Send alerts with `wandb.Run.alert()`](/models/runs/alert).
 
 ## Slack notifications
-Configure Slack destinations where your team's [automations](/models/automations/) can send notifications when an event occurs in a Registry or a project, such as when a new artifact is created or when a run metric meets a defined threshold. Refer to [Create a Slack automation](/models/automations/create-automations/slack/).
+
+Configure Slack destinations where your team's [automations](/models/automations/) can send notifications when an event occurs in a Registry or a project, such as when a new artifact is created or when a run metric meets a defined threshold. See [Create a Slack automation](/models/automations/create-automations/slack/).
 
 <Info>
 <EnterpriseOnly/>
 </Info>
 
 ## Webhooks
-Configure webhooks that your team's [automations](/models/automations/) can run when an event occurs in a Registry or a project, such as when a new artifact is created or when a run metric meets a defined threshold. Refer to [Create a webhook automation](/models/automations/create-automations/slack/).
+
+Configure webhooks that your team's [automations](/models/automations/) can run when an event occurs in a Registry or a project, such as when a new artifact is created or when a run metric meets a defined threshold. See [Create a webhook automation](/models/automations/create-automations/slack/).
 
 <Info>
 <EnterpriseOnly/>
@@ -54,7 +55,7 @@ Configure webhooks that your team's [automations](/models/automations/) can run 
 
 ## Privacy
 
-Navigate to the **Privacy** section on the team **Settings** page to change privacy defaults. Team admins can edit these controls unless an organization admin has [locked the same policy for every team](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams). Organization admins can still open the page to review settings.
+Go to the **Privacy** section on the team **Settings** page to change privacy defaults. Team admins can edit these controls unless an organization admin has [locked the same policy for every team](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams). Organization admins can still open the page to review settings.
 
 - Turn off the ability to make future projects public or to share reports publicly.
 - Allow any team member to invite other members, rather than only team admins.
@@ -64,8 +65,8 @@ For navigation steps and the organization-level **Enforce default code saving re
 
 ## Usage
 
-The **Usage** section describes the total memory usage the team has consumed on the Weights and Biases servers. The default storage plan is 100GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.
+The **Usage** section describes the total memory usage the team has consumed on the W&B servers. The default storage plan is 100 GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.
 
 ## Storage
 
-The **Storage** section describes the cloud storage bucket configuration that is being used for the team's data. For more information, see [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector) or check out our [W&B Server](/platform/hosting/data-security/secure-storage-connector) docs if you are self-hosting.
+The **Storage** section describes the cloud storage bucket configuration used for the team's data. For more information, see [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector), or see the [W&B Server](/platform/hosting/data-security/secure-storage-connector) docs if you're self-hosting.

--- a/platform/app/settings-page/teams.mdx
+++ b/platform/app/settings-page/teams.mdx
@@ -5,7 +5,9 @@ title: Team settings
 
 import EnterpriseOnly from "/snippets/_includes/enterprise-only.mdx";
 
-Use W&B Teams as a central workspace for your ML team to build better models faster. Organization admins and team admins can view and edit a team's settings.
+Use W&B Teams as a central workspace for your ML team. This page explains how organization admins and team admins can create a team, configure its members and privacy, and assign roles so that collaborators can share experiments and reports while keeping sensitive work appropriately scoped.
+
+With W&B Teams, you can do the following:
 
 * **Track all the experiments** your team has tried so you never duplicate work.
 * **Save and reproduce** previously trained models.
@@ -14,7 +16,7 @@ Use W&B Teams as a central workspace for your ML team to build better models fas
 * **Benchmark model performance** and compare model versions.
 
 <Frame>
-    <img src="/images/app_ui/teams_overview.webp" alt="Teams workspace overview"  />
+    <img src="/images/app_ui/teams_overview.webp" alt="Teams workspace overview" />
 </Frame>
 
 <Note>
@@ -23,22 +25,26 @@ Only Administration account types can change team settings or remove a member fr
 
 ## Create a collaborative team
 
+Follow these steps to create a new team and invite your first collaborators. After the team exists, you can refine membership, alerts, and privacy in [Team configuration](#team-configuration).
+
 1. [Sign up or log in](https://app.wandb.ai/login?signup=true) to your free W&B account.
 2. Click **Invite Team** in the navigation bar.
 3. Create your team and invite collaborators.
-4. Configure your team using the settings described below.
+4. Configure your team using the settings described in the following sections.
 
 <Note>
-**Note**: Only the admin of an organization can create a new team.
+Only the admin of an organization can create a new team.
 </Note>
 
 ## Team configuration
-You can configure various settings for your team, including its membership, alerts, and privacy settings.
 
-To manage your team's settings, navigate to the **Teams** section in the left-menu and click the team you want to change settings for. You can update the following settings:
+You can configure settings for your team, including its membership, alerts, and privacy settings. The following sections describe each settings category.
+
+To manage your team's settings, navigate to the **Teams** section in the left menu and click the team you want to change settings for.
+
 ### Members
 
-The Members section shows a list of all pending invitations and the members who have accepted the invitation to join the team. The list displays each member's name, username, email, team role, and access privileges to Models and W&B Weave, which are inherited from the organization. You can choose from the standard team roles **Admin**, **Member**, and **View-only**. If your organization has created [custom roles](/platform/hosting/iam/access-management/manage-organization#add-and-manage-custom-roles), you can assign a custom role instead.
+The Members section shows a list of all pending invitations and the members who have accepted the invitation to join the team. The list displays each member's name, username, email, team role, and access privileges to Models and W&B Weave, which are inherited from the organization. You can choose from the standard team roles **Admin**, **Member**, and **View-Only**. If your organization has created [custom roles](/platform/hosting/iam/access-management/manage-organization#add-and-manage-custom-roles), you can assign a custom role instead.
 
 See [Add and Manage teams](/platform/hosting/iam/access-management/manage-organization#add-and-manage-teams) for information on how to create a team, manage teams, and manage team membership and roles. To configure who can invite new members and configure other privacy settings for the team, refer to [Privacy](#privacy).
 
@@ -46,20 +52,20 @@ To remove a team member, admins can open the team settings page and click the de
 
 ### Avatar
 
-To set an avatar for your team:
+A team avatar helps members and visitors recognize the team across the W&B app. To set an avatar for your team:
 
-1. Navigate to the **Teams** section in the left-menu and click the team you want to add an avatar for. This opens the team's overview page.
+1. Navigate to the **Teams** section in the left menu and click the team you want to add an avatar for. This opens the team's overview page.
 2. Hover over the team's default avatar image in the upper-left corner of the page and click the **Upload photo** button. This opens a file prompt.
-3. From the file prompt, select the image you want to use and then click **Open**.  This uploads the photo to your team and sets it as your team's avatar.
+3. From the file prompt, select the image you want to use and then click **Open**. This uploads the photo to your team and sets it as your team's avatar.
 
 ### Alerts
 
-You can set up alerts to notify your team when runs crash and finish. Alerts can be sent through either email or Slack, and you can customize them to meet your needs.
+Alerts keep your team informed about run status without requiring anyone to watch the dashboard. You can set up alerts to notify your team when runs crash and finish. W&B sends alerts through email or Slack, and you can customize them to meet your needs.
 
-In the **Team alerts** section, toggle the switch next to the event type you want to receive alerts from. Weights and Biases provides the following event type options:
+In the **Team alerts** section, toggle the switch next to the event type you want to receive alerts from. W&B provides the following event type options:
 
-* **Runs finished**: whether a Weights and Biases run successfully finished.
-* **Run crashed**: if a run has failed to finish.
+* **Runs finished**: A W&B run successfully finishes.
+* **Run crashed**: A run fails to finish.
 * **wandb.alert()**: A custom scriptable alert. See [Send alerts with `wandb.Run.alert()`](/models/runs/alert) for more information.
 
 
@@ -87,53 +93,57 @@ You can change the following privacy settings:
 
 - Hide this team from all non-members.
 - Make all future team projects private (public sharing not allowed).
-- Allow any team member to invite other team members (not just admins).
+- Allow any team member to invite other team members (not only admins).
 - Disable public sharing to outside of team for reports in private projects. This disables existing magic links.
 - Automatically recommend new users with matching email domains join this team upon signup.
 - Enable code saving by default.
 
 For step-by-step navigation and how organization enforcement interacts with team toggles, see [Configure privacy settings](/platform/hosting/privacy-settings).
 
-Open the team dashboard at `https://wandb.ai/<team>`, select **Team settings** in the left navigation, then open the **Privacy** section. Replace `<team>` with your team name.
+To change these settings, open the team dashboard at `https://wandb.ai/[TEAM-NAME]`, select **Team settings** in the left navigation, then open the **Privacy** section. Replace `[TEAM-NAME]` with your team name.
 
 ### Usage
 
-The **Usage** section describes the total memory usage the team has consumed on the Weights and Biases servers. The default storage plan is 100GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.
+The **Usage** section describes the total memory usage the team has consumed on the W&B servers. The default storage plan is 100 GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.
 
 ### Storage
 
-The **Storage** section describes the cloud storage bucket configuration that is being used for the team's data. For more information, see [Secure Storage Connector](#secure-storage-connector) or check out our [W&B Server](/platform/hosting/data-security/secure-storage-connector) docs if you are self-hosting.
+The **Storage** section describes the cloud storage bucket configuration that the team's data uses. For more information, see [Secure Storage Connector](#secure-storage-connector) or check out our [W&B Server](/platform/hosting/data-security/secure-storage-connector) docs if you are self-hosting.
 
 ## Create a team profile
 
-You can customize your team's profile page to show an introduction and showcase reports and projects that are visible to the public or team members. Present reports, projects, and external links.
+A team profile is a public-facing page that helps your team attract collaborators and highlight its work. You can customize your team's profile page to show an introduction and showcase reports and projects that are visible to the public or team members. Present reports, projects, and external links.
 
-* **Highlight your best research** to visitors by showcasing your best public reports
-* **Showcase the most active projects** to make it easier for teammates to find them
-* **Find collaborators** by adding external links to your company or research lab's website and any papers you've published
+Use a team profile to do the following:
+
+* **Highlight your research** to visitors by showcasing your best public reports.
+* **Showcase the most active projects** to make it easier for teammates to find them.
+* **Find collaborators** by adding external links to your company or research lab's website and any papers you've published.
 
 {/* To do: show team profiles */}
 
 ## Team roles and permissions
-Select a team role when you invite colleagues to join a team. There are following team role options:
+
+Team roles determine what each member can see and do within the team, from viewing reports to managing other members. Select a team role when you invite colleagues to join a team. The following team role options are available:
 
 - **Admin**: Team admins can add and remove other admins or team members. They have permissions to modify all projects and full deletion permissions. This includes, but is not limited to, deleting runs, projects, artifacts, and sweeps.
 - **Member**: A regular member of the team. By default, only an admin can invite a team member. To change this behavior, refer to [Privacy settings](#privacy).
-- **View-Only (Enterprise-only feature)**: View-Only members can view assets within the team such as runs, reports, and workspaces. They can follow and comment on reports, but they can not create, edit, or delete project overview, reports, or runs.
-- **Custom roles (Enterprise-only feature)**: Custom roles allow organization admins to compose new roles based on either of the **View-Only** or **Member** roles, together with additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. Refer to [Introducing Custom Roles for W&B Teams](https://wandb.ai/wandb_fc/announcements/reports/Introducing-Custom-Roles-for-W-B-Teams--Vmlldzo2MTMxMjQ3) for details.
+- **View-Only (Enterprise-only feature)**: View-Only members can view assets within the team such as runs, reports, and workspaces. They can follow and comment on reports, but they can't create, edit, or delete project overview, reports, or runs.
+- **Custom roles (Enterprise-only feature)**: Custom roles let organization admins compose new roles based on either of the **View-Only** or **Member** roles, together with additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. Refer to [Introducing Custom Roles for W&B Teams](https://wandb.ai/wandb_fc/announcements/reports/Introducing-Custom-Roles-for-W-B-Teams--Vmlldzo2MTMxMjQ3) for details.
 
 A team member can delete only runs they created. Suppose you have two members A and B. Member B moves a run from team B's project to a different project owned by Member A. Member A cannot delete the run Member B moved to Member A's project. An admin can manage runs and sweep runs created by any team member.
 
 ### Service accounts
 
-In addition to user roles, teams can also use **service accounts** for automation. Service accounts are not users, but rather non-human identities used for automated workflows. Refer to [Use service accounts to automate workflows](/platform/hosting/iam/service-accounts) for detailed information.
+In addition to user roles, teams can also use **service accounts** for automation. Service accounts aren't users, but rather non-human identities used for automated workflows. Refer to [Use service accounts to automate workflows](/platform/hosting/iam/service-accounts) for detailed information.
 
 <Note>
-W&B recommends assigning more than one admin in a team to ensure that admin operations can continue when the primary admin is not available.
+W&B recommends assigning more than one admin in a team to ensure that admin operations can continue when the primary admin isn't available.
 </Note>
 
 ### Team settings
-Team settings allow you to manage the settings for your team and its members. With these privileges, you can effectively oversee and organize your team within W&B.
+
+The following table summarizes which roles can manage team membership and team-wide settings. Team settings let you manage the settings for your team and its members. With these privileges, you can effectively oversee and organize your team within W&B.
 
 | Permissions         | View-Only | Team Member | Team Admin | 
 | ------------------- | --------- | ----------- | ---------- |
@@ -142,16 +152,18 @@ Team settings allow you to manage the settings for your team and its members. Wi
 | Manage team settings|           |             |     X      |
 
 ### Reports
+
 Report permissions grant access to create, view, and edit reports. The following table lists permissions that apply to all reports across a given team.
 
 | Permissions   | View-Only | Team Member                                     | Team Admin | 
 | -----------   | --------- | ----------------------------------------------- | ---------- |
-|View reports   | X         | X                                               | X          |
-|Create reports |           | X                                               | X          |
-|Edit reports   |           | X (team members can only edit their own reports)| X          |
-|Delete reports |           | X (team members can only edit their own reports)| X          |
+| View reports   | X         | X                                               | X          |
+| Create reports |           | X                                               | X          |
+| Edit reports   |           | X (team members can only edit their own reports)| X          |
+| Delete reports |           | X (team members can only edit their own reports)| X          |
 
 ### Experiments
+
 The following table lists permissions that apply to all experiments across a given team.
 
 | Permissions | View-Only | Team Member | Team Admin | 
@@ -160,15 +172,16 @@ The following table lists permissions that apply to all experiments across a giv
 | Edit experiment panels and workspaces                                                |           | X           | X          |
 | Log experiments                                                                      |           | X           | X          |
 | Delete experiments                                                                   |           | X (team members can only delete experiments they created) |  X  |
-|Stop experiments                                                                      |           | X (team members can only stop experiments they created)   |  X  |
+| Stop experiments                                                                     |           | X (team members can only stop experiments they created)   |  X  |
 
 ### Artifacts
+
 The following table lists permissions that apply to all artifacts across a given team.
 
 | Permissions      | View-Only | Team Member | Team Admin | 
 | ---------------- | --------- | ----------- | ---------- |
 | View artifacts   | X         | X           | X          |
-| Download artifact| X         | X           | X          |
+| Download artifacts| X        | X           | X          |
 | Create artifacts |           | X           | X          |
 | Delete artifacts |           | X           | X          |
 | Edit metadata    |           | X           | X          |
@@ -176,18 +189,19 @@ The following table lists permissions that apply to all artifacts across a given
 | Delete aliases   |           | X           | X          |
 
 ### System settings (W&B Server only)
-Use system permissions to create and manage teams and their members and to adjust system settings. These privileges enable you to effectively administer and maintain the W&B instance.
+
+This section applies only to self-hosted W&B Server deployments. Use system permissions to create and manage teams and their members and to adjust system settings. These privileges enable you to effectively administer and maintain the W&B instance.
 
 | Permissions              | View-Only | Team Member | Team Admin | System Admin | 
 | ------------------------ | --------- | ----------- | ---------- | ------------ |
 | Configure system settings|           |             |            | X            |
-| Create/delete teams      |           |             |            | X            |
+| Create or delete teams   |           |             |            | X            |
 
 ### Team service account behavior
 
-* When you configure a team in your training environment, you can use a service account from that team to log runs in either of private or public projects within that team. Additionally, you can attribute those runs to a user if **WANDB_USERNAME** or **WANDB_USER_EMAIL** variable exists in your environment and the referenced user is part of that team.
-* When you **do not** configure a team in your training environment and use a service account, the runs log to the named project within that service account's parent team. In this case as well, you can attribute the runs to a user if **WANDB_USERNAME** or **WANDB_USER_EMAIL** variable exists in your environment and the referenced user is part of the service account's parent team.
-* A service account can not log runs to a private project in a team different from its parent team. A service account can log to runs to project only if the project is set to `Open` project visibility.
+* When you configure a team in your training environment, you can use a service account from that team to log runs in either of private or public projects within that team. Additionally, you can attribute those runs to a user if `WANDB_USERNAME` or `WANDB_USER_EMAIL` variable exists in your environment and the referenced user is part of that team.
+* When you do not configure a team in your training environment and use a service account, the runs log to the named project within that service account's parent team. In this case as well, you can attribute the runs to a user if `WANDB_USERNAME` or `WANDB_USER_EMAIL` variable exists in your environment and the referenced user is part of the service account's parent team.
+* A service account can't log runs to a private project in a team different from its parent team. A service account can log runs to a project only if the project visibility is set to `Open`.
 
 ## Team trials
 
@@ -195,6 +209,8 @@ See the [pricing page](https://wandb.ai/site/pricing) for more information on W&
 
 ## Advanced configuration
 
+The following advanced options are available to teams with additional data residency or compliance requirements.
+
 ### Secure storage connector
 
-The team-level secure storage connector allows teams to use their own cloud storage bucket with W&B. This provides greater data access control and data isolation for teams with highly sensitive data or strict compliance requirements. Refer to [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector) for more information.
+The team-level secure storage connector lets teams use their own cloud storage bucket with W&B. This provides greater data access control and data isolation for teams with highly sensitive data or strict compliance requirements. Refer to [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector) for more information.

--- a/platform/app/settings-page/user-settings.mdx
+++ b/platform/app/settings-page/user-settings.mdx
@@ -8,55 +8,65 @@ title: Manage user settings
 import ApiKeyCreate from "/snippets/_includes/api-key-create.mdx";
 import ApiKeySecurity from "/snippets/_includes/api-key-security.mdx";
 
-Navigate to your user profile page and select your user icon on the top right corner. From the dropdown, choose **Settings**.
+Your user settings let you manage your profile, default team, API keys, alerts, integrations, and other account-level options. This page describes each section of the user settings and how to use it.
+
+To open your user settings, navigate to your user profile page and select your user icon on the top right corner. From the dropdown, choose **Settings**.
 
 ## Profile
 
-Within the **Profile** section you can manage and modify your account name and institution. You can optionally add a biography, location, link to a personal or your institution’s website, and upload a profile image.
+In the **Profile** section, you can manage and modify your account name and institution. You can optionally add a biography, location, link to a personal or your institution's website, and upload a profile image.
 
-## Edit your intro
+### Edit your intro
+
+Your intro appears at the top of your profile and is a good place to introduce yourself, link to projects, or share related accounts.
 
 To edit your intro, click **Edit** at the top of your profile. The WYSIWYG editor that opens supports Markdown.
-1. To edit a line, click it. To save time, you can type `/` and choose Markdown from the list.
-1. Use an item's drag handles to move it.
+
+1. To edit a line, click it. To save time, type `/` and choose Markdown from the list.
+1. To move an item, use its drag handles.
 1. To delete a block, click the drag handle, then click **Delete**.
 1. To save your changes, click **Save**.
 
-### Add social badges
+Your updated intro is now visible on your profile.
 
-To add a follow badge for the `@weights_biases` account on X, you could add a Markdown-style link with an HTML `<img>` tag that points to the badge image:
+#### Add social badges
+
+To add a follow badge for the `@weights_biases` account on X, add a Markdown-style link with an HTML `<img>` tag that points to the badge image:
 
 ```markdown
 [![X: @weights_biases](https://img.shields.io/twitter/follow/weights_biases?style=social)](https://x.com/intent/follow?screen_name=weights_biases)
 ```
-In an `<img>` tag, you can specify `width`, `height`, or both. If you specify only one of them, the image's proportions are maintained.
+
+In an `<img>` tag, you can specify `width`, `height`, or both. If you specify only one, the image keeps its proportions.
 
 ## Default team
-If you are a member of more than one team, the **Default team** section allows you to configure the default team to use when a run or a Weave trace does not specify a team. If you are a member of only one team, that team is the default and this section does not appear.
 
-Select a tab to continue.
+If you're a member of more than one team, the **Default team** section lets you configure the default team to use when a run or a Weave trace doesn't specify a team. If you're a member of only one team, that team is the default and this section doesn't appear.
+
+The steps to set your default team differ depending on your deployment. Select the tab that matches your environment.
 
 <Tabs>
 <Tab title="Multi-tenant Cloud">
-Next to **Default location to create new projects in**, click the drop-down, then select your default team.
+Next to **Default location to create new projects in**, click the dropdown, then select your default team.
 </Tab>
 <Tab title="Dedicated Cloud / Self-Managed">
-1. Next to **Default location to create new projects in**, click the drop-down, then select your default team or your personal entity.
-1. (**Optional**) If an admin has turned on public projects in **Account** > **Settings** > **Privacy**, configure the default visibility for your new projects. Click the button next to **Default project privacy in your personal account**, then select **Private** (the default) or **Public**.
-1. (**Optional**) If an admin has turned on [default saving and diffing code](/models/app/features/panels/code/) in **Account** > **Settings** > **Privacy**, to turn it on for your runs, click **Enable code saving in your personal account**.
+1. Next to **Default location to create new projects in**, click the dropdown, then select your default team or your personal entity.
+1. **Optional:** If an admin has turned on public projects in **Account** > **Settings** > **Privacy**, configure the default visibility for your new projects. Click the button next to **Default project privacy in your personal account**, then select **Private** (the default) or **Public**.
+1. **Optional:** If an admin has turned on [default saving and diffing code](/models/app/features/panels/code/) in **Account** > **Settings** > **Privacy**, click **Enable code saving in your personal account** to turn it on for your runs.
 </Tab>
 </Tabs>
 
 <Note>
-To specify the default team when you’re running a script in an automated environment, you can specify the default location using the `WANDB_ENTITY` [environment variable](https://docs.wandb.ai/models/track/environment-variables).
+To specify the default team when you're running a script in an automated environment, specify the default location with the `WANDB_ENTITY` [environment variable](https://docs.wandb.ai/models/track/environment-variables).
 </Note>
 
 ## Teams
+
 The **Teams** section lists all of your teams.
 
-1. Click a team name to go to the team page.
-1. If you have permission to join additional teams, click **View teams** next to **We found teams for you to join**.
-1. Optionally, turn on **Hide teams in public profile**.
+- Click a team name to go to the team page.
+- If you have permission to join additional teams, click **View teams** next to **We found teams for you to join**.
+- **Optional:** Turn on **Hide teams in public profile**.
 
 <Note>
 To create or manage a team, see [Manage teams](/platform/app/settings-page/teams/).
@@ -64,21 +74,22 @@ To create or manage a team, see [Manage teams](/platform/app/settings-page/teams
 
 ## API keys
 
-The **API Keys** section allows you to manage your personal API keys for authenticating with W&B services.
+The **API Keys** section lets you manage your personal API keys for authenticating with W&B services. From this section, you can review existing keys, create new ones, and revoke keys you no longer need.
 
 ### View your API keys
 
 The API keys table displays:
-- **Key ID**: The first part of each API key, used for identification
-- **Name**: A descriptive name you provided when creating the key
-- **Created**: When the key was created
-- **Last used**: The most recent usage timestamp
+
+- **Key ID**: The first part of each API key, used for identification.
+- **Name**: A descriptive name you provided when you created the key.
+- **Created**: When the key was created.
+- **Last used**: The most recent usage timestamp.
 
 <Note>
-The table shows only the key ID (first part of the key) for security. The full secret API key is only displayed once when you create it.
+For security, the table shows only the key ID (the first part of the key). The full secret API key appears only once, when you create it.
 </Note>
 
-Enter a partial key name or ID to search filter the list of API keys.
+To filter the list of API keys, enter a partial key name or ID.
 
 ### Create a new API key
 
@@ -86,47 +97,51 @@ Enter a partial key name or ID to search filter the list of API keys.
 
 ### Delete an API key
 
-To revoke access by deleting an API key:
+Delete an API key when you no longer need it or when it may have been exposed. To revoke access by deleting an API key:
 
 1. Find the key you want to delete in the API keys table.
-2. Click the delete button next to the key.
-3. Confirm the deletion.
+1. Click the delete button next to the key.
+1. Confirm the deletion.
+
+W&B removes the key from the table, and you can no longer use it to authenticate.
 
 <Warning>
-Deleting an API key immediately revokes access for any scripts or services using that key. Ensure you have updated all systems to use a new key before deleting the old one.
+Deleting an API key immediately revokes access for any scripts or services that use that key. Before you delete the old key, make sure you've updated all systems to use a new key.
 </Warning>
 
 <ApiKeySecurity/>
 
 ## Beta features
 
-Within the **Beta Features** section you can optionally enable fun add-ons and sneak previews of new products in development. Select the toggle switch next to the beta feature you want to enable.
+In the **Beta Features** section, you can optionally enable add-ons and previews of products in development. Select the toggle switch next to the beta feature you want to enable.
 
 ## Alerts
 
-Get notified when your runs crash, finish, or set custom alerts with [wandb.Run.alert()](/models/runs/alert/). Receive notifications either through Email or Slack. Toggle the switch next to the event type you want to receive alerts from.
+Get notified when your runs crash or finish, or set custom alerts with [`wandb.Run.alert()`](/models/runs/alert/). You receive notifications through email or Slack. Toggle the switch next to the event type you want to receive alerts for:
 
-* **Runs finished**: whether a Weights and Biases run successfully finished.
-* **Run crashed**: notification if a run has failed to finish.
+- **Runs finished**: Notify you when a W&B run successfully finishes.
+- **Run crashed**: Notify you when a run fails to finish.
 
-For more information about how to set up and manage alerts, see [Send alerts with wandb.Run.alert()](/models/runs/alert/).
+For more information about how to set up and manage alerts, see [Send alerts with `wandb.Run.alert()`](/models/runs/alert/).
 
 ## Personal GitHub integration
 
-Connect a personal Github account. To connect a Github account:
+Connect a personal GitHub account so that W&B can access GitHub resources on your behalf. To connect a GitHub account:
 
-1. Select the **Connect Github** button. This will redirect you to an open authorization (OAuth) page.
-2. Select the organization to grant access in the **Organization access** section.
-3. Select **Authorize** **wandb**.
+1. Select the **Connect Github** button. W&B redirects you to an open authorization (OAuth) page.
+1. In the **Organization access** section, select the organization to grant access.
+1. Select **Authorize wandb**.
+
+Your personal GitHub account is now linked to your W&B account.
 
 ## Delete your account
 
 Select the **Delete Account** button to delete your account.
 
 <Warning>
-Account deletion can not be reversed.
+You can't reverse account deletion.
 </Warning>
 
 ## Storage
 
-The **Storage** section describes the total memory usage the your account has consumed on the Weights and Biases servers. The default storage plan is 100GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.
+The **Storage** section describes the total memory your account has consumed on the W&B servers. The default storage plan is 100 GB. For more information about storage and pricing, see the [Pricing](https://wandb.ai/site/pricing) page.

--- a/platform/hosting.mdx
+++ b/platform/hosting.mdx
@@ -4,7 +4,7 @@ description: "Compare W&B deployment options including Multi-tenant Cloud, Dedic
 sidebarTitle: Overview
 no_list: true
 ---
-W&B can be deployed in various ways to meet your organization's infrastructure and security requirements.
+You can deploy W&B in various ways to meet your organization's infrastructure and security requirements. This page helps administrators and platform decision-makers compare the available deployment options, so you can choose the one that best fits your security, scale, and operational needs.
 
 <Tip title="Getting started">
 To get started quickly, W&B recommends [Multi-tenant Cloud](https://wandb.ai/home).
@@ -14,34 +14,35 @@ Some features and functionality require an [Enterprise](https://wandb.ai/site/pr
 
 <CardGroup cols={1}>
   <a id="wb-multi-tenant-cloud" aria-label="W&B Multi-tenant Cloud"></a><Card title="W&B Multi-tenant Cloud">
-    A fully managed service deployed in W&B's cloud infrastructure, where you can seamlessly access the W&B products at the desired scale, with cost-efficient options for pricing, and with continuous updates for the latest features and functionalities. W&B recommends to use the Multi-tenant Cloud for your product trial, or to manage your production AI workflows if you do not need the security of a private deployment, self-service onboarding is important, and cost efficiency is critical.
+    A fully managed service deployed in W&B's cloud infrastructure, where you can access the W&B products at the desired scale, with cost-efficient pricing options, and with continuous updates for the latest features and functionality. W&B recommends Multi-tenant Cloud for your product trial, or to manage your production AI workflows if you don't need the security of a private deployment, self-service onboarding is important, and cost efficiency is critical.
     
-    See **[W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud)** for more information.
+    For more information, see [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud).
   </Card>
   
   <a id="wb-dedicated-cloud" aria-label="W&B Dedicated Cloud"></a><Card title="W&B Dedicated Cloud">
-    A fully managed service with dedicated, isolated infrastructure in W&B's cloud. It is the best place to onboard W&B if your organization requires conformance to strict governance controls including data residency, have need of advanced security capabilities, and are looking to optimize their AI operating costs by not having to build & manage the required infrastructure with security, scale & performance characteristics.
+    A fully managed service with dedicated, isolated infrastructure in W&B's cloud. Choose this option if your organization requires conformance to strict governance controls including data residency, needs advanced security capabilities, and wants to optimize AI operating costs by not having to build and manage the required infrastructure with security, scale, and performance characteristics.
     
-    See **[W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud)** for more information.
+    For more information, see [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud).
   </Card>
   
   <a id="wb-Self-Managed" aria-label="W&B Self-Managed"></a><Card title="W&B Self-Managed">
-    Deploy and manage W&B Server on your own managed infrastructure. W&B Server is a self-contained packaged mechanism to run the W&B Platform & its supported W&B products. W&B recommends this option if all your existing infrastructure is on-prem, or your organization has strict regulatory needs that are not satisfied by W&B Dedicated Cloud. With this option, you are fully responsible to manage the provisioning, and continuous maintenance & upgrades of the infrastructure required to support W&B Server.
+    Deploy and manage W&B Server on your own managed infrastructure. W&B Server is a self-contained packaged mechanism to run the W&B Platform and its supported W&B products. W&B recommends this option if all your existing infrastructure is on-premises, or your organization has strict regulatory needs that W&B Dedicated Cloud doesn't satisfy. With this option, you're fully responsible for managing the provisioning, and continuous maintenance and upgrades of the infrastructure required to support W&B Server.
     
-    See **[W&B Self-Managed](/platform/hosting/hosting-options/self-managed)** for more information.
+    For more information, see [W&B Self-Managed](/platform/hosting/hosting-options/self-managed).
   </Card>
 </CardGroup>
 
 ## Key differences
-This table shows some key differences among deployment types.
+
+After reviewing the preceding deployment options, use the following table to compare how each option handles infrastructure, security, and operational responsibilities.
 
 |                                      | Multi-tenant Cloud                | Dedicated Cloud                                                     | Self-Managed |
 |--------------------------------------|-----------------------------------|---------------------------------------------------------------------|------------------|
-| MySQL / DB management                | Fully hosted and managed by W&B     | Fully hosted & managed by W&B on cloud or region of customer choice | Fully hosted and managed by customer |
-| Object Storage (S3/GCS/Blob storage) | **Option 1**: Fully hosted by W&B<br />**Option 2**: Customer can configure their own bucket per team, using the [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector)  | **Option 1**: Fully hosted by W&B<br />**Option 2**: Customer can configure their own bucket per instance or team, using the [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector) | Fully hosted and managed by customer |
-| SSO Support                          | W&B managed via Auth0             | **Option 1**: Customer managed<br />**Option 2**: Managed by W&B via Auth0 | Fully managed by customer   |
+| MySQL / DB management                | Fully hosted and managed by W&B     | Fully hosted and managed by W&B on cloud or region of customer choice | Fully hosted and managed by customer |
+| Object storage (S3/GCS/Blob storage) | **Option 1**: Fully hosted by W&B<br />**Option 2**: Customer can configure their own bucket per team, using the [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector)  | **Option 1**: Fully hosted by W&B<br />**Option 2**: Customer can configure their own bucket per instance or team, using the [Secure Storage Connector](/platform/hosting/data-security/secure-storage-connector) | Fully hosted and managed by customer |
+| SSO support                          | W&B managed via Auth0             | **Option 1**: Customer managed<br />**Option 2**: Managed by W&B via Auth0 | Fully managed by customer   |
 | W&B Service (App)                    | Fully managed by W&B              | Fully managed by W&B                                                | Fully managed by customer          |
 | App security                         | Fully managed by W&B              | Shared responsibility of W&B and customer                           | Fully managed by customer         |
 | Maintenance (upgrades, backups, etc.)| Managed by W&B | Managed by W&B | Managed by customer |
 | Support                              | Support SLA                       | Support SLA                                                         | Support SLA |
-| Supported cloud infrastructure       | Google Cloud                               | AWS, Google Cloud, Azure                                                     | AWS, Google Cloud, Azure, On-Prem bare-metal |
+| Supported cloud infrastructure       | Google Cloud                               | AWS, Google Cloud, Azure                                                     | AWS, Google Cloud, Azure, on-premises bare-metal |

--- a/platform/hosting/data-security/data-encryption.mdx
+++ b/platform/hosting/data-security/data-encryption.mdx
@@ -3,16 +3,22 @@ title: Data encryption in Dedicated Cloud
 description: "Learn how W&B encrypts data in Dedicated Cloud using cloud-native keys and the customer-managed encryption key policy."
 ---
 
-W&B uses a W&B-managed cloud-native key to encrypt the W&B-managed database and object storage in every [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), by using the customer-managed encryption key (CMEK) capability in each cloud. In this case, W&B acts as a `customer` of the cloud provider, while providing the W&B platform as a service to you. Using a W&B-managed key means that W&B has control over the keys that it uses to encrypt the data in each cloud, thus doubling down on its promise to provide a highly safe and secure platform to all of its customers.
+This page describes how W&B encrypts the W&B-managed database and object storage in [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), and explains W&B's policy on customer-managed encryption keys. This page is intended for security and compliance teams evaluating Dedicated Cloud for use with sensitive AI workloads.
 
-W&B uses a `unique key` to encrypt the data in each customer instance, providing another layer of isolation between Dedicated Cloud tenants. The capability is available on AWS, Azure and Google Cloud.
+W&B uses a W&B-managed cloud-native key to encrypt the W&B-managed database and object storage in every Dedicated Cloud instance, using the customer-managed encryption key (CMEK) capability in each cloud. In this case, W&B acts as a customer of the cloud provider while providing the W&B platform as a service to you. Using a W&B-managed key means that W&B controls the keys that encrypt the data in each cloud, reinforcing its commitment to provide a secure platform to its customers.
+
+W&B uses a unique key to encrypt the data in each customer instance, providing another layer of isolation between Dedicated Cloud tenants. The capability is available on AWS, Azure, and Google Cloud.
 
 <Note>
-Dedicated Cloud instances on Google Cloud and Azure that W&B provisioned before August 2024 use the default cloud provider managed key for encrypting the W&B-managed database and object storage. Only new instances that W&B has been creating starting August 2024 use the W&B-managed cloud-native key for the relevant encryption.
+Dedicated Cloud instances on AWS have used the W&B-managed cloud-native key for encryption since before August 2024.
 
-Dedicated Cloud instances on AWS have been using the W&B-managed cloud-native key for encryption from before August 2024.
+On Google Cloud and Azure, Dedicated Cloud instances that W&B created in August 2024 or later use the W&B-managed cloud-native key to encrypt the W&B-managed database and object storage. Instances that W&B provisioned before August 2024 use the default cloud provider managed key.
 </Note>
 
-W&B doesn't generally allow customers to bring their own cloud-native key to encrypt the W&B-managed database and object storage in their Dedicated Cloud instance, because multiple teams and personas in an organization could have access to its cloud infrastructure for various reasons. Some of those teams or personas may not have context on W&B as a critical component in the organization's technology stack, and thus may remove the cloud-native key completely or revoke W&B's access to it. Such an action could corrupt all data in the organization's W&B instance and thus leave it in a irrecoverable state.
+W&B doesn't generally allow customers to bring their own cloud-native key to encrypt the W&B-managed database and object storage in their Dedicated Cloud instance. Multiple teams in an organization often have access to its cloud infrastructure, and some teams might not know that W&B is a critical component in the organization's technology stack. They might remove the cloud-native key or revoke W&B's access to it, which could corrupt all data in the organization's W&B instance and leave it in an unrecoverable state.
 
-If your organization needs to use their own cloud-native key to encrypt the W&B-managed database and object storage to approve the use of Dedicated Cloud for your AI workflows, W&B can review it on a exception basis. If approved, use of your cloud-native key for encryption would conform to the `shared responsibility model` of W&B Dedicated Cloud. If any user in your organization removes your key or revokes W&B's access to it at any point when your Dedicated Cloud instance is live, W&B would not be liable for any resulting data loss or corruption and also would not be responsible for recovery of such data.
+If your organization needs to use its own cloud-native key to encrypt the W&B-managed database and object storage as a condition for adopting Dedicated Cloud, W&B can review the request on an exception basis. If approved, use of your cloud-native key for encryption conforms to the shared responsibility model of W&B Dedicated Cloud.
+
+<Warning>
+If any user in your organization removes your key or revokes W&B's access to it at any point when your Dedicated Cloud instance is live, W&B isn't liable for any resulting data loss or corruption and isn't responsible for recovery of the data.
+</Warning>

--- a/platform/hosting/data-security/ip-allowlisting.mdx
+++ b/platform/hosting/data-security/ip-allowlisting.mdx
@@ -3,12 +3,16 @@ title: Configure IP allowlisting for Dedicated Cloud
 description: "Restrict access to a W&B Dedicated Cloud instance to authorized IP addresses using IP allowlisting."
 ---
 
-You can restrict access to your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instance from only an authorized list of IP addresses. This applies to the access from your AI workloads to the W&B APIs and from your user browsers to the W&B app UI as well. Once IP allowlisting has been set up for your Dedicated Cloud instance, W&B denies any requests from other unauthorized locations. Reach out to your W&B team to configure IP allowlisting for your Dedicated Cloud instance.
+This page explains how IP allowlisting works on W&B [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and how to request it for your instance. Use IP allowlisting to restrict access to your Dedicated Cloud instance to an authorized list of IP addresses, so that only traffic from approved locations can reach the W&B APIs and the W&B app UI.
 
-IP allowlisting is available on Dedicated Cloud instances on AWS, Google Cloud and Azure.
+IP allowlisting applies to access from your AI workloads to the W&B APIs and from your user browsers to the W&B app UI. After you set up IP allowlisting for your Dedicated Cloud instance, W&B denies any requests from other unauthorized locations.
 
-You can use IP allowlisting with [secure private connectivity](./private-connectivity). If you use IP allowlisting with secure private connectivity, W&B recommends using secure private connectivity for all traffic from your AI workloads and majority of the traffic from your user browsers if possible, while using IP allowlisting for instance administration from privileged locations.
+IP allowlisting is available on Dedicated Cloud instances on AWS, Google Cloud, and Azure.
+
+To configure IP allowlisting for your Dedicated Cloud instance, contact your W&B team.
+
+You can use IP allowlisting with [secure private connectivity](./private-connectivity). If you use both, W&B recommends that you use secure private connectivity for all traffic from your AI workloads and most of the traffic from your user browsers, and use IP allowlisting for instance administration from privileged locations.
 
 <Warning>
-W&B strongly recommends to use [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) assigned to your corporate or business egress gateways rather than individual `/32` IP addresses. Using individual IP addresses is not scalable and has strict limits per cloud.
+W&B recommends that you use [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) assigned to your corporate or business egress gateways rather than individual `/32` IP addresses. Using individual IP addresses doesn't scale and has strict limits per cloud.
 </Warning>

--- a/platform/hosting/data-security/presigned-urls.mdx
+++ b/platform/hosting/data-security/presigned-urls.mdx
@@ -3,56 +3,65 @@ title: Access BYOB using pre-signed URLs
 description: "Understand how W&B uses pre-signed URLs for blob storage access, including team-level access control and audit logging."
 ---
 
-W&B uses pre-signed URLs to simplify access to blob storage from your AI workloads or user browsers. For basic information on pre-signed URLs, refer to the cloud provider's documentation:
+W&B uses pre-signed URLs to simplify access to blob storage from your AI workloads or user browsers. This page explains how pre-signed URLs work in W&B. It also outlines the access controls, network restrictions, and audit logging that administrators should configure to secure blob storage access.
+
+For background on pre-signed URLs, refer to the cloud provider's documentation:
 
 - [Pre-signed URLs for AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html), which also applies to S3-compatible storage like [CoreWeave AI Object Storage](https://docs.coreweave.com/docs/products/storage/object-storage).
-- [Signed URLs for Google Cloud Storage](https://cloud.google.com/storage/docs/access-control/signed-urls)
-- [Shared Access Signature for Azure Blob Storage](https://learn.microsoft.com/azure/storage/common/storage-sas-overview)
+- [Signed URLs for Google Cloud Storage](https://cloud.google.com/storage/docs/access-control/signed-urls).
+- [Shared Access Signature for Azure Blob Storage](https://learn.microsoft.com/azure/storage/common/storage-sas-overview).
 
-How it works:
+Pre-signed URLs work as follows:
+
 1. When needed, AI workloads or user browser clients within your network request pre-signed URLs from W&B.
 1. W&B responds to the request by accessing the blob storage to generate the pre-signed URL with the required permissions.
 1. W&B returns the pre-signed URL to the client.
-1. The client uses the pre-signed URL to read or write to the blob storage.
+1. The client uses the pre-signed URL to read from or write to the blob storage.
 
-A pre-signed URL expires after:
-- **Reading**: 1 hour
-- **Writing**: 24 hours, to allow more time to upload large objects in chunks.
+A pre-signed URL expires after the following durations:
+
+- **Read operations**: 1 hour.
+- **Write operations**: 24 hours, to allow more time to upload large objects in chunks.
 
 ## Team-level access control
 
-Each pre-signed URL is restricted to specific buckets based on [team level access control](/platform/hosting/iam/access-management/manage-organization#add-and-manage-teams) in the W&B platform. If a user is part of a team which is mapped to a storage bucket using [secure storage connector](./secure-storage-connector), and if that user is part of only that team, then the pre-signed URLs generated for their requests would not have permissions to access storage buckets mapped to other teams. 
+Each pre-signed URL is restricted to specific buckets based on [team-level access control](/platform/hosting/iam/access-management/manage-organization#add-and-manage-teams) in the W&B platform. Consider a user who belongs to only one team, and that team is mapped to a storage bucket using the [secure storage connector](./secure-storage-connector). In this case, the pre-signed URLs generated for their requests can't access storage buckets mapped to other teams.
 
 <Note>
-W&B recommends adding users to only the teams that they are supposed to be a part of.
+W&B recommends adding users only to the teams they need to belong to.
 </Note>
 
 ## Network restriction
-W&B recommends using IAM policies to restrict the networks that can use pre-signed URLs to access external storage using pre-signed URLs. This helps to ensure that your W&B specific buckets are accessed only from networks where your AI workloads are running, or from gateway IP addresses that map to your user machines. 
+
+W&B recommends using IAM policies to restrict the networks that can use pre-signed URLs to access external storage. This helps ensure that only networks running your AI workloads, or gateway IP addresses that map to your user machines, can access your W&B-specific buckets.
+
+Consult your cloud provider's documentation for guidance on configuring these IAM policies:
 
 - For CoreWeave AI Object Storage, refer to [Bucket policy reference](https://docs.coreweave.com/docs/products/storage/object-storage/reference/bucket-policy#condition) in the CoreWeave documentation.
-- For AWS S3 or S3-compatible storage like MiniIO hosted on your premises, refer to the [S3 userguide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrlUploadObject-LimitCapabilities), the [MinIO documentation](https://github.com/minio/minio), or the documentation for your S3-compatible storage provider.
+- For AWS S3 or S3-compatible storage like MinIO hosted on your premises, refer to the [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrlUploadObject-LimitCapabilities), the [MinIO documentation](https://github.com/minio/minio), or the documentation for your S3-compatible storage provider.
 
 ## Audit logs
 
-W&B recommends using [W&B audit logs](../monitoring-usage/audit-logging) together with blob storage specific audit logs. For blob storage audit logs, refer to the documentation for each cloud provider:
-- [CoreWeave audit logs](https://docs.coreweave.com/docs/products/storage/object-storage/concepts/audit-logging#audit-logging-policies)
-- [AWS S3 access logs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html)
-- [Google Cloud Storage audit logs](https://cloud.google.com/storage/docs/audit-logging)
-- [Monitor Azure blob storage](https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage).
+W&B recommends using [W&B audit logs](../monitoring-usage/audit-logging) together with blob-storage-specific audit logs. For blob storage audit logs, refer to the documentation for each cloud provider:
 
-Admin and security teams can use audit logs to keep track of which user is doing what in the W&B product and take necessary action if they determine that some operations need to be limited for certain users.
+- [CoreWeave audit logs](https://docs.coreweave.com/docs/products/storage/object-storage/concepts/audit-logging#audit-logging-policies).
+- [AWS S3 access logs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html).
+- [Google Cloud Storage audit logs](https://cloud.google.com/storage/docs/audit-logging).
+- [Monitor Azure Blob Storage](https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage).
+
+Admin and security teams can use audit logs to track what each user does in W&B and take action if they need to limit certain operations for specific users.
 
 <Note>
-Pre-signed URLs are the only supported blob storage access mechanism in W&B. W&B recommends configuring some or all of the above list of security controls according to your organization's needs.
+Pre-signed URLs are the only supported blob storage access mechanism in W&B. W&B recommends configuring some or all of the preceding security controls to fit your organization's needs.
 </Note>
 
 ## Determine the user that requested a pre-signed URL
-When W&B returns a pre-signed URL, a query parameter in the URL contains the requester's username:
+
+To correlate pre-signed URL activity with specific W&B users when reviewing audit logs, inspect the query parameter that W&B appends to each URL. When W&B returns a pre-signed URL, a query parameter in the URL contains the requester's username:
 
 | Storage provider            | Signed URL query parameter |
 |-----------------------------|-----------|
 | CoreWeave AI Object Storage | `X-User`  |
-| AWS S3 storage              | `X-User`  |
-| Google Cloud storage        | `X-User`  |
-| Azure  blob storage         | `scid`    |
+| AWS S3                      | `X-User`  |
+| Google Cloud Storage        | `X-User`  |
+| Azure Blob Storage          | `scid`    |

--- a/platform/hosting/data-security/private-connectivity.mdx
+++ b/platform/hosting/data-security/private-connectivity.mdx
@@ -3,22 +3,24 @@ title: Configure private connectivity to Dedicated Cloud
 description: "Connect to a W&B Dedicated Cloud instance over a private network using AWS PrivateLink, GCP, or Azure Private Link."
 ---
 
-You can connect to your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instance over the cloud provider's secure private network. This applies to the access from your AI workloads to the W&B APIs and optionally from your user browsers to the W&B app UI as well. When using private connectivity, the relevant requests and responses do not transit through the public network or internet.
+This document explains how to connect to a W&B Dedicated Cloud instance over a cloud provider's secure private network, so that traffic between your environment and W&B avoids the public internet. It's intended for cloud and security administrators who manage Dedicated Cloud instances and want to harden network access for AI workloads and user traffic.
+
+You can connect to your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instance over the cloud provider's secure private network. This applies to access from your AI workloads to the W&B APIs and optionally from your user browsers to the W&B app UI. When you use private connectivity, the relevant requests and responses don't transit through the public network or internet. This reduces exposure to the public internet and helps satisfy network isolation requirements for sensitive workloads.
 
 <Note>
-Secure private connectivity is coming soon as an advanced security option with Dedicated Cloud.
+Secure private connectivity is offered as an advanced security option with Dedicated Cloud.
 </Note>
 
-Secure private connectivity is available on Dedicated Cloud instances on AWS, Google Cloud and Azure:
+Secure private connectivity is available on Dedicated Cloud instances on AWS, Google Cloud, and Azure:
 
-* Using [AWS Privatelink](https://aws.amazon.com/privatelink/) on AWS
-* Using [Google Cloud Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) on Google Cloud
-* Using [Azure Private Link](https://azure.microsoft.com/products/private-link) on Azure
+* Use [AWS PrivateLink](https://aws.amazon.com/privatelink/) on AWS.
+* Use [Google Cloud Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) on Google Cloud.
+* Use [Azure Private Link](https://azure.microsoft.com/products/private-link) on Azure.
 
-Once enabled, W&B creates a private endpoint service for your instance and provides you the relevant DNS URI to connect to. With that, you can create private endpoints in your cloud accounts that can route the relevant traffic to the private endpoint service. Private endpoints are easier to set up for your AI training workloads running within your cloud VPC or VNet. To use the same mechanism for traffic from your user browsers to the W&B app UI, you must configure appropriate DNS based routing from your corporate network to the private endpoints in your cloud accounts.
+After W&B enables the feature, W&B creates a private endpoint service for your instance and provides you the relevant DNS URI to connect to. With that, you can create private endpoints in your cloud accounts that route the relevant traffic to the private endpoint service. You can set up private endpoints for your AI training workloads that run within your cloud VPC or VNet. To use the same mechanism for traffic from your user browsers to the W&B app UI, you must configure appropriate DNS-based routing from your corporate network to the private endpoints in your cloud accounts. The DNS configuration ensures browser traffic resolves to your private endpoint instead of the public W&B endpoint.
 
 <Note>
-If you would like to use this feature, contact your W&B team.
+To use this feature, contact your W&B team.
 </Note>
 
-You can use secure private connectivity with [IP allowlisting](./ip-allowlisting). If you use secure private connectivity for IP allowlisting, W&B recommends that you secure private connectivity for all traffic from your AI workloads and majority of the traffic from your user browsers if possible, while using IP allowlisting for instance administration from privileged locations.
+You can use secure private connectivity with [IP allowlisting](./ip-allowlisting) to combine network isolation with location-based access controls. If you combine the two, W&B recommends that you use secure private connectivity for all traffic from your AI workloads and for browser traffic from your users where possible, and use IP allowlisting for instance administration from privileged locations.

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -8,50 +8,52 @@ import ByobContextNote from "/snippets/_includes/byob-context-note.mdx";
 <ByobContextNote/>
 
 ## Overview
-Bring your own bucket (BYOB) allows you to store W&B artifacts and other related sensitive data in your own cloud or on-prem infrastructure. In case of [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), data that you store in your bucket is not copied to the W&B managed infrastructure.
+Bring your own bucket (BYOB) lets you store W&B artifacts and other sensitive data in your own cloud or on-premises infrastructure. For [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), W&B doesn't copy the data you store in your bucket to the W&B managed infrastructure. This page is for W&B administrators and platform engineers who need to retain ownership of artifact storage to meet data governance, residency, or compliance requirements.
 
 <Note>
 * Communication between W&B SDK / CLI / UI and your buckets occurs using [pre-signed URLs](./presigned-urls).
-* W&B uses garbage collection and related processes to remove deleted **artifacts** and **run data** from your bucket over time. Artifact deletion is covered in [Delete an artifact](/models/artifacts/delete-artifacts). Deleted run data on Dedicated Cloud and Self-Managed deployments also depends on `GORILLA_DATA_RETENTION_PERIOD` as described in [Configure environment variables](/platform/hosting/env-vars). Cleanup timing is not guaranteed. For a single overview of bucket usage and costs, see [Manage bucket storage and costs](/platform/hosting/managing-bucket-storage).
-* You can specify a sub-path when configuring a bucket, to ensure that W&B does not store any files in a folder at the root of the bucket. It can help you better conform to your organization's bucket governance policy.
+* W&B uses garbage collection and related processes to remove deleted **artifacts** and **run data** from your bucket over time. For artifact deletion, see [Delete an artifact](/models/artifacts/delete-artifacts). Deleted run data on Dedicated Cloud and Self-Managed deployments also depends on `GORILLA_DATA_RETENTION_PERIOD` as described in [Configure environment variables](/platform/hosting/env-vars). W&B doesn't guarantee cleanup timing. For a single overview of bucket usage and costs, see [Manage bucket storage and costs](/platform/hosting/managing-bucket-storage).
+* You can specify a sub-path when you configure a bucket, to ensure that W&B doesn't store any files in a folder at the root of the bucket. This helps you better conform to your organization's bucket governance policy.
 </Note>
 
 ### Data stored in the central database vs buckets
-When using BYOB functionality, certain types of data will be stored in the W&B central database, and other types will be stored in your bucket. 
+When you use BYOB functionality, W&B stores certain types of data in the W&B central database, and other types in your bucket. Use the following lists to understand which data remains in W&B-managed infrastructure and which data W&B writes to your own storage.
 
 #### Database
-- Metadata for users, teams, artifacts, experiments, and projects
-- Reports
-- Experiment logs
-- System metrics
-- Console logs
+The W&B central database stores the following data:
+- Metadata for users, teams, artifacts, experiments, and projects.
+- Reports.
+- Experiment logs.
+- System metrics.
+- Console logs.
 
 #### Buckets
-- Experiment files and metrics
-- Artifact files
-- Media files
-- Run files
-- Exported history metrics and system events in Parquet format
+Your storage bucket stores the following data:
+- Experiment files and metrics.
+- Artifact files.
+- Media files.
+- Run files.
+- Exported history metrics and system events in Parquet format.
 
 ### Bucket scopes
-There are two scopes you can configure your storage bucket to:
+You can configure your storage bucket to one of two scopes:
 
 | Scope          | Description |
 |----------------|-------------|
 | Instance level | In [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and [Self-Managed](/platform/hosting/hosting-options/self-managed), any user with the required permissions within your organization or instance can access files stored in your instance's storage bucket. Not applicable to [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud). |
-| Team level     | If a W&B Team is configured to use a Team level storage bucket, team members can access files stored in it. Team level storage buckets allow greater data access control and data isolation for teams with highly sensitive data or strict compliance requirements.<br/><br/>Team level storage can help different business units or departments sharing an instance to efficiently use the infrastructure and administrative resources. It can also allow separate project teams to manage AI workflows for separate customer engagements. Available for all deployment types. You configure team level BYOB when setting up the team. |
+| Team level     | If you configure a W&B team to use a team level storage bucket, team members can access files stored in it. Team level storage buckets allow greater data access control and data isolation for teams with sensitive data or strict compliance requirements.<br/><br/>Team level storage helps different business units or departments that share an instance to efficiently use the infrastructure and administrative resources. It also lets separate project teams manage AI workflows for separate customer engagements. Available for all deployment types. You configure team level BYOB when you set up the team. |
 
-This flexible design allows for many different storage topologies, depending on your organization's needs. For example:
-- The same bucket can be used for the instance and one or more teams.
+This design supports different storage topologies, depending on your organization's needs. For example:
+- The same bucket can serve the instance and one or more teams.
 - Each team can use a separate bucket, some teams can choose to write to the instance bucket, or multiple teams can share a bucket by writing to subpaths.
-- Buckets for different teams can be hosted in different cloud infrastructure environments or regions, and can be managed by different storage admin teams.
+- Buckets for different teams can reside in different cloud infrastructure environments or regions, and different storage admin teams can manage them.
 
-For example, suppose you have a team called Kappa in your organization. Your organization (and Team Kappa) use the Instance level storage bucket by default. Next, you create a team called Omega. When you create Team Omega, you configure a Team level storage bucket for that team. Files generated by Team Omega are not accessible by Team Kappa. However, files created by Team Kappa are accessible by Team Omega. If you want to isolate data for Team Kappa, you must configure a Team level storage bucket for them as well.
+For example, suppose you have a team called Kappa in your organization. Your organization (and team Kappa) uses the instance level storage bucket by default. Next, you create a team called Omega. When you create team Omega, you configure a team level storage bucket for that team. Team Kappa can't access files that team Omega generates. However, team Omega can access files that team Kappa creates. To isolate data for team Kappa, you must also configure a team level storage bucket for them.
 
 ### Availability matrix
-W&B can connect to the following storage providers:
+Before you begin, confirm that BYOB is available for your deployment type and storage provider. W&B can connect to the following storage providers:
 - [CoreWeave AI Object Storage](https://docs.coreweave.com/products/storage/object-storage): High-performance, S3-compatible object storage service optimized for AI workloads.
-- [Amazon S3](https://aws.amazon.com/s3/): Object storage service offering industry-leading scalability, data availability, security, and performance.
+- [Amazon S3](https://aws.amazon.com/s3/): Object storage service offering scalability, data availability, security, and performance.
 - [Google Cloud Storage](https://cloud.google.com/storage): Managed service for storing unstructured data at scale.
 - [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs): Cloud-based object storage solution for storing massive amounts of unstructured data like text, binary data, images, videos, and logs.
 - S3-compatible storage such as [MinIO Enterprise (AIStor)](https://min.io/product/aistor) or other enterprise-grade solutions hosted in your cloud or on-premises infrastructure.
@@ -61,7 +63,7 @@ The following table shows the availability of BYOB at each scope for each W&B de
 | W&B deployment type        | Instance level   | Team level | Additional information |
 |----------------------------|------------------|------------|------------------------|
 | Dedicated Cloud            | &check;          | &check;    | Instance and team level BYOB are supported for CoreWeave AI Object Storage, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://www.min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
-| Multi-tenant Cloud         | Not Applicable   | &check;<sup><a href="#footnote_1">1</a></sup> | Team level BYOB is supported for CoreWeave AI Object Storage, Amazon S3, and Google Cloud Storage. |
+| Multi-tenant Cloud         | Not applicable   | &check;<sup><a href="#footnote_1">1</a></sup> | Team level BYOB is supported for CoreWeave AI Object Storage, Amazon S3, and Google Cloud Storage. |
 | Self-Managed               | &check;          | &check;    | Instance and team level BYOB are supported for CoreWeave AI Object Storage, Amazon S3, Google Cloud Storage, Microsoft Azure Blob Storage, and S3-compatible storage such as [MinIO Enterprise (AIStor)](https://www.min.io/product/aistor) hosted in your cloud or on-premises infrastructure. |
 
 <sup><a id="footnote_1" aria-label="Footnote 1">1</a>.</sup>Azure Blob Storage is not supported for team level BYOB on Multi-tenant Cloud.
@@ -70,14 +72,14 @@ The following sections guide you through the process of setting up BYOB.
 
 ## Provision your bucket
 
-After [verifying availability](#availability-matrix), you are ready to provision your storage bucket, including its access policy and CORS. Select a tab to continue.
+After you [verify availability](#availability-matrix), you're ready to provision your storage bucket, including its access policy and CORS. Provisioning creates the bucket that W&B writes to and grants the W&B platform the permissions it needs to generate pre-signed URLs on your behalf. Select a tab to continue.
 
 <Tabs>
 <Tab title="CoreWeave">
 <a id="coreweave-requirements" aria-label="CoreWeave requirements"></a>**Requirements**:
 - **Multi-tenant Cloud**, or
-- **Dedicated Cloud** v0.73.0 or above, or
-- **Self-Managed** v0.73.0 or above deployed with v0.33.14+ of the Helm chart
+- **Dedicated Cloud** v0.73.0 or later, or
+- **Self-Managed** v0.73.0 or later deployed with v0.33.14+ of the Helm chart
 - A CoreWeave account with AI Object Storage enabled and with permission to create buckets, API access keys, and secret keys.
 - Your W&B instance must be able to connect to CoreWeave network endpoints.
 
@@ -86,15 +88,15 @@ For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.core
 1. <a id="coreweave-org-id"></a>**Multi-tenant Cloud**: Obtain your organization ID, which is required for your bucket policy.
     1. Log in to the [W&B App](https://wandb.ai/site).
     1. In the left navigation, click **Create a new team**.
-    1. In the drawer that opens, copy the W&B organization ID, which is located above **Invite team members**.
-    1. Leave this page open. You will use it to [configure W&B](#configure-byob).
+    1. In the drawer that opens, copy the W&B organization ID, which appears above **Invite team members**.
+    1. Leave this page open. You use it to [configure W&B](#configure-byob).
 1. <a id="coreweave-customer-namespace" aria-label="CoreWeave customer namespace"></a>**Dedicated Cloud** / **Self-Managed**: Obtain your customer namespace, which is required for your bucket policy.
     1. In the W&B App, click your user profile icon, then click **System Console**.
     1. Click the **Authentication** tab.
-    1. At the bottom of the page, copy the value for **Customer Namespace**. Keep this value for configuring the bucket policy. 
+    1. At the bottom of the page, copy the value for **Customer Namespace**. Keep this value for configuring the bucket policy.
     1. You can close the System Console.
-1. In CoreWeave, create the bucket with a name of your choice in your preferred CoreWeave availability zone. Optionally create a folder for W&B to use as a sub-path for all W&B files. Make a note of the bucket name, availability zone, API access key, secret key, and sub-path.
-1. Set the following Cross-origin resource sharing (CORS) policy for the bucket:
+1. In CoreWeave, create the bucket with a name of your choice in your preferred CoreWeave availability zone. Optionally, create a folder for W&B to use as a sub-path for all W&B files. Make a note of the bucket name, availability zone, API access key, secret key, and sub-path.
+1. Set the following cross-origin resource sharing (CORS) policy for the bucket:
     ```json
     [
       {
@@ -116,9 +118,9 @@ For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.core
       }
     ]
     ```
-    CoreWeave storage is S3-compatible. For details about CORS, refer to [Configuring cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) in the AWS documentation.
+    CoreWeave storage is S3-compatible. For details about CORS, see [Configuring cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) in the AWS documentation.
 
-1. Configure a bucket policy that grants the required permissions for your W&B deployment to access the bucket and generate [pre-signed URLs](./presigned-urls) that AI workloads in your cloud infrastructure or user browsers utilize to access the bucket. Refer to [Bucket Policy Reference](https://docs.coreweave.com/docs/products/storage/object-storage/auth-access/bucket-access/bucket-policies) in the CoreWeave documentation.
+1. Configure a bucket policy that grants the required permissions for your W&B deployment to access the bucket and generate [pre-signed URLs](./presigned-urls) that AI workloads in your cloud infrastructure or user browsers use to access the bucket. See [Bucket Policy Reference](https://docs.coreweave.com/docs/products/storage/object-storage/auth-access/bucket-access/bucket-policies) in the CoreWeave documentation.
 
     ```json
     {
@@ -180,15 +182,15 @@ For details, see [Create a CoreWeave AI Object Storage bucket](https://docs.core
       - **Multi-tenant Cloud**: The organization ID from [Provision your bucket](#coreweave-org-id).
       - **Dedicated Cloud** or **Self-Managed**: The customer namespace from [Provision your bucket](#coreweave-customer-namespace).
 1. **Dedicated Cloud**: Contact [support](mailto:support@wandb.ai) to complete additional steps.
-1. <a id="set-environment-variable" aria-label="Set environment variable"></a>**Self-Managed**: Update your W&B deployment to set the environment variable `GORILLA_SUPPORTED_FILE_STORES` to the exact string `cw://` and restart W&B. Otherwise, CoreWeave will not appear as an option when you configure team storage.
+1. <a id="set-environment-variable" aria-label="Set environment variable"></a>**Self-Managed**: Update your W&B deployment to set the environment variable `GORILLA_SUPPORTED_FILE_STORES` to the exact string `cw://` and restart W&B. Otherwise, CoreWeave doesn't appear as an option when you configure team storage.
 
 Next, [configure W&B](#configure-byob).
 </Tab>
 <Tab title="AWS">
 For details, see [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) in the AWS documentation.
-1. Provision the KMS Key.
+1. Provision the KMS key.
 
-    W&B requires you to provision a KMS Key to encrypt and decrypt the data on the S3 bucket. The key usage type must be `ENCRYPT_DECRYPT`. Assign the following policy to the key:
+    W&B requires you to provision a KMS key to encrypt and decrypt the data on the S3 bucket. The key usage type must be `ENCRYPT_DECRYPT`. Assign the following policy to the key:
 
     ```json
     {
@@ -220,19 +222,19 @@ For details, see [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/late
 
     Replace `<Your_Account_Id>` and `<aws_kms_key.key.arn>` accordingly.
 
-    If you are using [Multi-tenant Cloud](/platform/hosting/hosting-options#w%26b-multi-tenant-cloud) or [Dedicated Cloud](/platform/hosting/hosting-options#w%26b-dedicated-cloud), replace `<aws_principal_and_role_arn>` with the corresponding value:
+    If you use [Multi-tenant Cloud](/platform/hosting/hosting-options#w%26b-multi-tenant-cloud) or [Dedicated Cloud](/platform/hosting/hosting-options#w%26b-dedicated-cloud), replace `<aws_principal_and_role_arn>` with the corresponding value:
 
     * **Multi-tenant Cloud**: `arn:aws:iam::725579432336:role/WandbIntegration`
     * **Dedicated Cloud**: `arn:aws:iam::830241207209:root`
 
-    This policy grants your AWS account full access to the key and also assigns the required permissions to the AWS account hosting the W&B Platform. Keep a record of the KMS Key ARN.
+    This policy grants your AWS account full access to the key and also assigns the required permissions to the AWS account that hosts the W&B platform. Keep a record of the KMS key ARN.
 
-1. Provision the S3 Bucket.
+1. Provision the S3 bucket.
 
     Follow these steps to provision the S3 bucket in your AWS account:
 
-    1. Create the S3 bucket with a name of your choice. Optionally create a folder which you can configure as sub-path to store all W&B files.
-    1. Enable server side encryption, using the KMS key from the previous step.
+    1. Create the S3 bucket with a name of your choice. Optionally, create a folder that you can configure as a sub-path to store all W&B files.
+    1. Enable server-side encryption, using the KMS key from the previous step.
     1. Configure CORS with the following policy:
 
         ```json
@@ -257,9 +259,9 @@ For details, see [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/late
         ]
         ```
         <Note>
-        If data in your bucket expires due to an [object lifecycle management policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html), you may lose the ability to read the history of some runs.
+        If data in your bucket expires because of an [object lifecycle management policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html), you may lose the ability to read the history of some runs.
         </Note>
-    1. Grant the required S3 permissions to the AWS account hosting the W&B Platform, which requires these permissions to generate [pre-signed URLs](./presigned-urls) that AI workloads in your cloud infrastructure or user browsers utilize to access the bucket.
+    1. Grant the required S3 permissions to the AWS account that hosts the W&B platform, which requires these permissions to generate [pre-signed URLs](./presigned-urls) that AI workloads in your cloud infrastructure or user browsers use to access the bucket.
 
         ```json
         {
@@ -294,7 +296,7 @@ For details, see [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/late
 
         Replace `<wandb_bucket>` accordingly and keep a record of the bucket name. Next, [configure W&B](#configure-byob).
 
-        If you are using [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), replace `<aws_principal_and_role_arn>` with the corresponding value.
+        If you use [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), replace `<aws_principal_and_role_arn>` with the corresponding value.
 
         * For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud): `arn:aws:iam::725579432336:role/WandbIntegration`
         * For [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud): `arn:aws:iam::830241207209:root`
@@ -307,12 +309,12 @@ For details, see [Create a bucket](https://docs.cloud.google.com/storage/docs/cr
 
     Follow these steps to provision the GCS bucket in your Google Cloud project:
 
-    1. Create the GCS bucket with a name of your choice. Optionally create a folder which you can configure as sub-path to store all W&B files.
+    1. Create the GCS bucket with a name of your choice. Optionally, create a folder that you can configure as a sub-path to store all W&B files.
     1. Set encryption type to `Google-managed`.
     1. Turn on soft deletion. See [Edit a bucket's soft delete policy](https://docs.cloud.google.com/storage/docs/use-soft-delete).
     1. Set the CORS policy with `gsutil`. This is not possible in the UI.
 
-       1. Create a file called `cors-policy.json` locally.
+       1. Create a file named `cors-policy.json` locally.
        1. Copy the following CORS policy into the file and save it.
 
            ```json
@@ -328,7 +330,7 @@ For details, see [Create a bucket](https://docs.cloud.google.com/storage/docs/cr
            ```
 
           <Note>
-          If data in your bucket expires due to an [object lifecycle management policy](https://cloud.google.com/storage/docs/lifecycle), you may lose the ability to read the history of some runs.
+          If data in your bucket expires because of an [object lifecycle management policy](https://cloud.google.com/storage/docs/lifecycle), you may lose the ability to read the history of some runs.
           </Note>
 
       1. Replace `<bucket_name>` with the correct bucket name and run `gsutil`.
@@ -338,15 +340,15 @@ For details, see [Create a bucket](https://docs.cloud.google.com/storage/docs/cr
           ```
 
       1. Verify the bucket's policy. Replace `<bucket_name>` with the correct bucket name.
-        
+
           ```bash
           gsutil cors get gs://<bucket_name>
           ```
 
-1. If you are using [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), grant the `storage.admin` role to the Google Cloud service account linked to the W&B Platform. W&B requires this role to check the bucket's CORS configuration and attributes, such as whether object versioning is enabled. If the service account does not have the `storage.admin` role, these checks result in an HTTP 403 error.
+1. If you use [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), grant the `storage.admin` role to the Google Cloud service account linked to the W&B platform. W&B requires this role to check the bucket's CORS configuration and attributes, such as whether object versioning is enabled. If the service account doesn't have the `storage.admin` role, these checks result in an HTTP 403 error.
 
     * For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), the account is: `wandb-integration@wandb-production.iam.gserviceaccount.com`
-    * For [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) the account is: `deploy@wandb-production.iam.gserviceaccount.com`
+    * For [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), the account is: `deploy@wandb-production.iam.gserviceaccount.com`
 
     Keep a record of the bucket name. Next, [configure W&B for BYOB](#configure-byob).
 </Tab>
@@ -357,12 +359,12 @@ For details, see [Create a blob storage container](https://learn.microsoft.com/e
 
 1. Provision the Azure Blob Storage container.
 
-    For Self-Managed deployments, and for Dedicated Cloud deployments that are not using [this Terraform module](https://github.com/wandb/terraform-azurerm-wandb/tree/main/examples/byob), follow the steps below to provision an Azure Blob Storage container in your Azure subscription:
+    For Self-Managed deployments, and for Dedicated Cloud deployments that don't use [this Terraform module](https://github.com/wandb/terraform-azurerm-wandb/tree/main/examples/byob), follow these steps to provision an Azure Blob Storage container in your Azure subscription:
 
-    1. Create a container with a name of your choice. Optionally create a folder which you can configure as sub-path to store all W&B files.
+    1. Create a container with a name of your choice. Optionally, create a folder that you can configure as a sub-path to store all W&B files.
     1. Configure the CORS policy on the container.
 
-        To set the CORS policy through the UI go to the blob storage, scroll down to `Settings/Resource Sharing (CORS)` and then set the following:
+        To set the CORS policy through the UI, go to the blob storage, scroll down to `Settings/Resource Sharing (CORS)`, and then set the following:
 
         | Parameter | Value |
         | --- | --- |
@@ -373,19 +375,19 @@ For details, see [Create a blob storage container](https://learn.microsoft.com/e
         | Max Age | `3000` |
 
         <Note>
-        If data in your bucket expires due to an [object lifecycle management policy](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-policy-configure?tabs=azure-portal), you may lose the ability to read the history of some runs.
+        If data in your bucket expires because of an [object lifecycle management policy](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-policy-configure?tabs=azure-portal), you may lose the ability to read the history of some runs.
         </Note>
 
-1. Generate a storage account access key and make a note of its name and the storage account name. If you are using [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), share the storage account name and access key with your W&B team using a secure sharing mechanism.
+1. Generate a storage account access key and make a note of its name and the storage account name. If you use [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), share the storage account name and access key with your W&B team using a secure sharing mechanism.
 
 **Team level BYOB**:
 
-For Dedicated Cloud deployments, W&B recommends that you use [Terraform](https://github.com/wandb/terraform-azurerm-wandb/tree/main/examples/secure-storage-connector) to provision the Azure Blob Storage container with the necessary access mechanism and permissions. For Dedicated Cloud deployments that do not use Terraform, or for Self-Managed deployments, provision the bucket by following the steps for provisioning instance-level storage. Provide the OIDC issuer URL for your instance. Make a note of the following details:
+For Dedicated Cloud deployments, W&B recommends that you use [Terraform](https://github.com/wandb/terraform-azurerm-wandb/tree/main/examples/secure-storage-connector) to provision the Azure Blob Storage container with the necessary access mechanism and permissions. For Dedicated Cloud deployments that don't use Terraform, or for Self-Managed deployments, provision the bucket by following the steps for provisioning instance-level storage. Provide the OIDC issuer URL for your instance. Make a note of the following details:
 
 * Storage account name
 * Storage container name
-* Managed identity client id
-* Azure tenant id
+* Managed identity client ID
+* Azure tenant ID
 </Tab>
 <Tab title="S3-compatible">
 Create your S3-compatible bucket. Make a note of:
@@ -393,36 +395,35 @@ Create your S3-compatible bucket. Make a note of:
 - Secret access key
 - URL endpoint
 - Bucket name
-- Folder path, if applicable.
+- Folder path, if applicable
 - Region
 </Tab>
 </Tabs>
 
 Next, [determine the storage address](#determine-the-storage-address).
 
-## Determine the storage address 
-This section explains the syntax to use to connect a W&B Team to a BYOB storage bucket. In the examples, replace placeholder values between angle brackets (`<>`) with your bucket's details.
-Select a tab for detailed instructions.
+## Determine the storage address
+After you provision the bucket, you need a storage address that W&B uses to locate and authenticate to it. The following sections describe the syntax to use to connect a W&B team to a BYOB storage bucket. In the examples, replace placeholder values between angle brackets (`<>`) with your bucket's details. Select a tab for detailed instructions.
 
 <Tabs>
 <Tab title="CoreWeave">
-This section is relevant only for team level BYOB on **Dedicated Cloud** or **Self-Managed**. For instance level BYOB or for Multi-tenant Cloud, you are ready to [Configure W&B](#configure-byob).
+This section is relevant only for team level BYOB on **Dedicated Cloud** or **Self-Managed**. For instance level BYOB or for Multi-tenant Cloud, you're ready to [Configure W&B](#configure-byob).
 
 Determine the full bucket path using the following format. Replace placeholders between angle brackets (`<>`) with the bucket's values.
 
 **Bucket format**:
-```none
+```text
 cw://<accessKey>:<secretAccessKey>@cwobject.com/<bucketName>?tls=true
 ```
 
-  The `cwobject.com` HTTPS endpoint is supported. TLS 1.3 is required. Contact [support](mailto:support@wandb.com) to express interest in other CoreWeave endpoints.
+  W&B supports the `cwobject.com` HTTPS endpoint. TLS 1.3 is required. Contact [support](mailto:support@wandb.com) to express interest in other CoreWeave endpoints.
 </Tab>
 <Tab title="AWS">
 **Bucket format**:
 ```text
 s3://<accessKey>:<secretAccessKey>@<s3_regional_url_endpoint>/<bucketName>?region=<region>
 ```
-In the address, the `region` parameter is mandatory unless both your W&B instance and your storage bucket are deployed AWS, and the W&B instance's `AWS_REGION` matches the bucket's AWS S3 region.
+In the address, the `region` parameter is mandatory unless both your W&B instance and your storage bucket are deployed on AWS, and the W&B instance's `AWS_REGION` matches the bucket's AWS S3 region.
 </Tab>
 <Tab title="Google Cloud">
 **Bucket format**:
@@ -444,78 +445,80 @@ s3://<accessKey>:<secretAccessKey>@<url_endpoint>/<bucketName>?region=<region>&t
 In the address, the `region` parameter is mandatory.
 
 <Note>
-This section is for S3-compatible storage buckets that are not hosted in S3, such as [MinIO Enterprise (AIStor)](https://www.min.io/product/aistor) or other enterprise-grade S3-compatible solutions hosted on your premises. For storage buckets hosted in AWS S3, see the **AWS** tab instead.
+This section is for S3-compatible storage buckets that aren't hosted in S3, such as [MinIO Enterprise (AIStor)](https://www.min.io/product/aistor) or other enterprise-grade S3-compatible solutions hosted on your premises. For storage buckets hosted in AWS S3, see the **AWS** tab instead.
 
 MinIO Open Source is in [maintenance mode](https://github.com/minio/minio) with no active development or pre-compiled binaries. For production deployments, use enterprise-grade S3-compatible solutions.
 
-For Cloud-native storage buckets with an optional S3-compatible mode, use the Cloud-native protocol specifier when possible. For example, use `cw://` for a CoreWeave bucket, rather than `s3://`.
+For cloud-native storage buckets with an optional S3-compatible mode, use the cloud-native protocol specifier when possible. For example, use `cw://` for a CoreWeave bucket, rather than `s3://`.
 </Note>
 </Tab>
 </Tabs>
 
-After determining the storage address, you are ready to [configure team level BYOB](#configure-team-level-byob).
+After you determine the storage address, you're ready to [configure team level BYOB](#configure-team-level-byob).
 
-## Configure W&B 
-After you [provision your bucket](#provision-your-bucket) and [determine its address](#determine-the-storage-address), you are ready to configure BYOB at the [instance level](#instance-level-byob) or [team level](#team-level-byob).
+## Configure W&B
+After you [provision your bucket](#provision-your-bucket) and [determine its address](#determine-the-storage-address), you're ready to configure BYOB at the [instance level](#instance-level-byob) or [team level](#team-level-byob). This final step tells W&B to route storage of artifacts, run files, and other large objects to your bucket.
 
 <Warning>
-Plan your storage bucket layout carefully. After you configure a storage bucket for W&B, migrating its data to another bucket is complex and requires the assistance of W&B. This applies to storage for Dedicated Cloud and Self-Managed, as well as team-level storage for Multi-tenant Cloud. For questions, contact [support](mailto:support@wandb.com).
+Plan your storage bucket layout carefully. After you configure a storage bucket for W&B, migrating its data to another bucket is complex and requires assistance from W&B. This applies to storage for Dedicated Cloud and Self-Managed, as well as team-level storage for Multi-tenant Cloud. For questions, contact [support](mailto:support@wandb.com).
 </Warning>
 
 ### Instance level BYOB
 
 <Note>
-For CoreWeave AI Object Storage at the instance level, contact [W&B support](mailto:support@wandb.com) instead of following these instructions. Self-service configuration is not yet supported.
+For CoreWeave AI Object Storage at the instance level, contact [W&B support](mailto:support@wandb.com) instead of following these instructions. Self-service configuration isn't yet supported.
 </Note>
 
-For **Dedicated Cloud**: Share the bucket details with your W&B team, who will configure your Dedicated Cloud instance.
+For **Dedicated Cloud**: Share the bucket details with your W&B team, who configures your Dedicated Cloud instance.
 
 For **Self-Managed**, you can configure instance level BYOB using the W&B App:
 1. Log in to W&B as a user with the `admin` role.
 1. Click the user icon at the top, then click **System Console**.
 1. Navigate to **Settings** > **System Connections**.
-1. In the **Bucket Storage** section, ensure the identity in the **Identity** field is granted access to the new bucket.
+1. In the **Bucket Storage** section, ensure the identity in the **Identity** field has access to the new bucket.
 1. Select the **Provider**.
 1. Enter the **Bucket Name**.
-1. Optionally, enter the **Path** to use in the new bucket.
-1. Click **Save**
+1. Optional: Enter the **Path** to use in the new bucket.
+1. Click **Save**.
+
+After you save, W&B uses the configured bucket as the default storage destination for new artifacts and run files at the instance level.
 
 ### Team level BYOB
 
-You can configure team level BYOB when creating a team in the W&B App or using the [SCIM API](/platform/hosting/iam/scim#create-team) (POST Groups with optional `storageBucket`). You have two options:
-- **Use an existing bucket**: You'll need to [determine the storage location](#determine-the-storage-address) for your bucket first.
-- **Create a new bucket** (Multi-tenant Cloud only): W&B can automatically create a bucket in your cloud provider when you create the team. This is supported for CoreWeave, AWS, and Google Cloud.
+You can configure team level BYOB when you create a team in the W&B App or using the [SCIM API](/platform/hosting/iam/scim#create-team) (POST Groups with optional `storageBucket`). You have two options:
+- **Use an existing bucket**: You must [determine the storage location](#determine-the-storage-address) for your bucket first.
+- **Create a new bucket** (Multi-tenant Cloud only): W&B can automatically create a bucket in your cloud provider when you create the team. W&B supports this for CoreWeave, AWS, and Google Cloud.
 
 <Note>
-- After a team is created, its storage cannot be changed.
-- For Instance level BYOB, refer to [Instance level BYOB](#instance-level-byob) instead.
-- If you plan to configure CoreWeave storage for the team, review the [CoreWeave requirements](#coreweave-requirements) and contact [support](mailto:support@wandb.com) to verify that your bucket is configured correctly in CoreWeave and to validate your team's configuration, since the storage details cannot be changed after the team is created.
+- After you create a team, you can't change its storage.
+- For instance level BYOB, see [Instance level BYOB](#instance-level-byob) instead.
+- If you plan to configure CoreWeave storage for the team, review the [CoreWeave requirements](#coreweave-requirements) and contact [support](mailto:support@wandb.com) to verify that your bucket is configured correctly in CoreWeave and to validate your team's configuration, since you can't change the storage details after you create the team.
 </Note>
 
 Select your deployment type to continue.
 
 <Tabs>
 <Tab title="Dedicated Cloud / Self-Hosted">
-1. **Dedicated Cloud**: You **must** provide the bucket path to your account team so that they can add it to your instance's supported file stores before following the rest of these steps to use the storage bucket for a team.
-1. **Self-Managed**: You **must** add the bucket path to your the `GORILLA_SUPPORTED_FILE_STORES` environment variable and then restart W&B before following the rest of these steps to use the storage bucket for a team.
+1. **Dedicated Cloud**: You **must** provide the bucket path to your account team so that they can add it to your instance's supported file stores before you follow the rest of these steps to use the storage bucket for a team.
+1. **Self-Managed**: You **must** add the bucket path to the `GORILLA_SUPPORTED_FILE_STORES` environment variable and then restart W&B before you follow the rest of these steps to use the storage bucket for a team.
 1. Log in to W&B as a user with the `admin` role, click the icon at the top left to open the left navigation, then click **Create a team to collaborate**.
 1. Provide a name for the team.
 1. Set **Storage Type** to **External storage**.
 
     <Note>
-    To use the instance level storage for team storage (regardless of whether it is internal or external), leave **Storage Type** set to **Internal**, even if the instance level bucket is configured for BYOB. To use separate external storage for the team, set **Storage Type** for the team to **External** and configure the bucket details in the next step.
+    To use the instance level storage for team storage (regardless of whether it's internal or external), leave **Storage Type** set to **Internal**, even if the instance level bucket is configured for BYOB. To use separate external storage for the team, set **Storage Type** for the team to **External** and configure the bucket details in the next step.
     </Note>
 
 1. Click **Bucket location**.
 1. To use an existing bucket, select it from the list. To add a new bucket, click **Add bucket** at the bottom, then provide the bucket's details.
 
     Click **Cloud provider** and select **CoreWeave**, **AWS**, **Google Cloud**, or **Azure**.
-    
-    If the cloud provider is not listed, ensure that you have followed the instructions in [Provision your bucket](#set-environment-variable) to add the bucket path to the supported file stores for your instance. If the storage provider is still not listed, [contact support](mailto:support@wandb.ai) for assistance.
+
+    If the cloud provider isn't listed, ensure that you've followed the instructions in [Provision your bucket](#set-environment-variable) to add the bucket path to the supported file stores for your instance. If the storage provider is still not listed, [contact support](mailto:support@wandb.ai) for assistance.
 1. Specify the bucket details.
     - For **CoreWeave**, provide only the bucket name.
     - For Amazon S3, Google Cloud, or S3-compatible storage, provide the full bucket path you [determined earlier](#determine-the-storage-address).
-    - For Azure on W&B Dedicated or Self-Managed, set **Account name** to the Azure account and **Container name** to the Azure blob storage container.
+    - For Azure on W&B Dedicated or Self-Managed, set **Account name** to the Azure account and **Container name** to the Azure Blob Storage container.
     - Optionally, provide additional connection settings:
       - If applicable, set **Path** to the bucket sub-path.
       - **CoreWeave**: No additional connection settings required.
@@ -524,10 +527,10 @@ Select your deployment type to continue.
       - **Azure**: Specify values for **Tenant ID** and **Managed Identity Client ID**. These fields are mandatory unless you configured the connection string with `GORILLA_SUPPORTED_FILE_STORES`.
 1. Click **Create team**.
 
-If W&B encounters errors accessing the bucket or detects invalid settings, an error or warning displays at the bottom of the page. Otherwise, the team is created.
+If W&B encounters errors accessing the bucket or detects invalid settings, an error or warning displays at the bottom of the page. Otherwise, W&B creates the team.
 </Tab>
 <Tab title="Multi-tenant Cloud">
-1. Switch to the browser window where you previously began to create the new team to find the W&B organization ID previously. Otherwise, log in to W&B as a user with the `admin` role, click the icon at the top left to open the left navigation, then click **Create a team to collaborate**.
+1. Switch to the browser window where you previously began to create the new team to find the W&B organization ID. Otherwise, log in to W&B as a user with the `admin` role, click the icon at the top left to open the left navigation, then click **Create a team to collaborate**.
 1. Provide a name for the team.
 1. Set **Storage Type** to **External storage**.
 1. Click **Bucket location**.
@@ -541,38 +544,40 @@ If W&B encounters errors accessing the bucket or detects invalid settings, an er
         - CoreWeave: No additional settings required.
         - AWS: Optionally provide a **KMS key ARN** for encryption.
         - Google Cloud: No additional settings required.
-    
+
     <Note>
-    When you click **Create team**, W&B will automatically create the bucket in your cloud provider with the specified configuration.
+    When you click **Create team**, W&B automatically creates the bucket in your cloud provider with the specified configuration.
     </Note>
 
-1. Invite members to the team. In **Invite team members**, specify a comma-separated list of email addresses. Otherwise, you can invite members to the team after it is created.
+1. Invite members to the team. In **Invite team members**, specify a comma-separated list of email addresses. Otherwise, you can invite members to the team after you create it.
 1. Click **Create team**.
 
-If W&B encounters errors accessing the bucket or detects invalid settings, an error or warning displays at the bottom of the page. Otherwise, the team is created.
+If W&B encounters errors accessing the bucket or detects invalid settings, an error or warning displays at the bottom of the page. Otherwise, W&B creates the team.
 </Tab>
 </Tabs>
 
 ## Troubleshooting
+If W&B reports errors when validating or connecting to your bucket, use the following sections to diagnose the most common causes by storage provider.
+
 ### CoreWeave
 This section helps troubleshoot problems connecting to CoreWeave AI Object Storage.
 
 - **Connection errors**
   - Verify that your W&B instance can connect to CoreWeave network endpoints.
-  - CoreWeave uses virtual-hosted style paths, where the bucket name is a subdomain at the beginning of the path. For example: `cw://bucket-name.cwobject.com` is correct, while `cw://cwobject.com/bucket-name/` is not.
+  - CoreWeave uses virtual-hosted style paths, where the bucket name is a subdomain at the beginning of the path. For example, `cw://bucket-name.cwobject.com` is correct, while `cw://cwobject.com/bucket-name/` isn't.
   - Bucket names must not contain underscores (`_`) or other characters incompatible with DNS rules.
   - Bucket names must be globally unique among CoreWeave locations.
   - Bucket names must not begin with `cw-` or `vip-`, which are reserved prefixes.
 - **CORS validation failures**
-  - A CORS policy is required. CoreWeave is S3-compatible; for details about CORS, see [Configuring cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) in the AWS documentation.
+  - A CORS policy is required. CoreWeave is S3-compatible. For details about CORS, see [Configuring cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html) in the AWS documentation.
   - `AllowedMethods` must include methods `GET`, `PUT`, and `HEAD`.
-  - `ExposeHeaders` must include `ETag.
-  - W&B front-end domains must be included in the CORS policy's `AllowedOrigins`. The example CORS policies provided on this page include all domains using `*`.
+  - `ExposeHeaders` must include `ETag`.
+  - The CORS policy's `AllowedOrigins` must include W&B front-end domains. The example CORS policies provided on this page include all domains using `*`.
 - **LOTA endpoint issues**
-  - Connecting to LOTA endpoints from W&B is not yet supported.  To express interest, [contact support](mailto:support@wandb.com).
+  - W&B doesn't yet support connections to LOTA endpoints. To express interest, [contact support](mailto:support@wandb.com).
 - **Access key and permission errors**
-  - Verify that your CoreWeave API Access Key is not expired.
-  - Verify that your CoreWeave API Access Key and Secret Key have sufficient permissions `GetObject`, `PutObject`, `DeleteObject`, `ListBucket`. The examples in this page meet this requirement. Refer to [Create and Manage Access Keys](https://docs.coreweave.com/docs/products/storage/object-storage/auth-access/manage-access-keys/about) in the CoreWeave documentation.
+  - Verify that your CoreWeave API access key isn't expired.
+  - Verify that your CoreWeave API access key and secret key have sufficient permissions `GetObject`, `PutObject`, `DeleteObject`, `ListBucket`. The examples on this page meet this requirement. See [Create and Manage Access Keys](https://docs.coreweave.com/docs/products/storage/object-storage/auth-access/manage-access-keys/about) in the CoreWeave documentation.
 
 ### Google Cloud
 This section helps troubleshoot problems connecting to Google Cloud Storage.

--- a/platform/hosting/enterprise-licenses.mdx
+++ b/platform/hosting/enterprise-licenses.mdx
@@ -3,33 +3,37 @@ title: Enterprise licenses
 description: Learn about W&B Enterprise licenses, what features they include, and how to obtain and configure them.
 ---
 
-An Enterprise license unlocks W&B features designed for organizations that need enhanced capabilities in areas of security, compliance, or administrative. See the list of [Enterprise features](#enterprise-features).
+An Enterprise license unlocks W&B features designed for organizations that need enhanced capabilities in areas of security, compliance, or administration. See the list of [Enterprise features](#enterprise-features).
+
+An Enterprise license includes the following:
 
 - **Security**: Enhanced authentication, encryption, and access controls.
 - **Compliance**: Audit logging, HIPAA compliance options, and data governance controls.
 - **Administration**: User management features like SCIM provisioning, custom roles, and automation capabilities.
 
-This page provides a comprehensive overview of Enterprise licenses, including what features they enable, how to obtain them, and how to configure them for your deployment.
+This page is for administrators responsible for W&B deployments. It explains what Enterprise features are available, how to obtain a license, and how to configure and verify it for your deployment.
 
 ## Deployment options
-Enterprise licenses are available for W&B Dedicated Cloud and Self-Managed deployments.
 
-- [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) provides dedicated, isolated infrastructure managed by W&B, deployed in Google Cloud. Dedicated Cloud deployments automatically include an Enterprise license. No additional configuration is required, and all Enterprise features are available immediately upon provisioning.
-- [W&B Self-Managed](/platform/hosting/hosting-options/self-managed) is deployed on your own infrastructure, providing full control over your deployment and data. Air-gapped deployments are supported. Without an Enterprise license, [Enterprise features](#enterprise-features) are unavailable.
+Enterprise licenses are available for W&B Dedicated Cloud and Self-Managed deployments. The configuration steps differ depending on which deployment you use.
+
+- [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) provides dedicated, isolated infrastructure managed by W&B, deployed in Google Cloud. Dedicated Cloud deployments automatically include an Enterprise license. You don't need to configure anything, and all Enterprise features become available as soon as W&B provisions your deployment.
+- [W&B Self-Managed](/platform/hosting/hosting-options/self-managed) deploys on your own infrastructure, providing full control over your deployment and data. W&B Self-Managed supports air-gapped deployments. Without an Enterprise license, [Enterprise features](#enterprise-features) are unavailable.
 
 ## Obtain an Enterprise license
-This section explains how to obtain an Enterprise license. Based on your use case, select a tab to continue.
+
+How you obtain an Enterprise license depends on your deployment type. Select the tab that matches your use case to continue.
 
 <Tabs>
 <Tab title="Dedicated Cloud">
-W&B Dedicated Cloud includes an Enterprise license and no action is required. [Start an Enterprise trial](https://wandb.ai/site/for-enterprise/dedicated-saas-trial/) or contact [Sales](https://wandb.ai/site/contact-sales) to discuss your requirements.
+W&B Dedicated Cloud includes an Enterprise license, and no action is required. [Start an Enterprise trial](https://wandb.ai/site/for-enterprise/dedicated-saas-trial/) or contact [Sales](https://wandb.ai/site/contact-sales) to discuss your requirements.
 
 </Tab>
 <Tab title="Self-Managed">
 Request an Enterprise license:
 
-- **Evaluation**: Submit the [Request a trial license](https://wandb.ai/site/for-enterprise/self-hosted-trial) or contact [Sales](mailto:sales@wandb.ai) to discuss your requirements.
-- **Production**: Contact [Sales](https://wandb.ai/site/contact-sales) to discuss your deployment requirements and sizing and receive your license details.
+- **Evaluation**: Submit the [Request a trial license](https://wandb.ai/site/for-enterprise/self-hosted-trial) form or contact [Sales](mailto:sales@wandb.ai) to discuss your requirements.
+- **Production**: Contact [Sales](https://wandb.ai/site/contact-sales) to discuss your deployment requirements and sizing, and to receive your license details.
 
 <Warning>Store license keys securely and treat them as sensitive credentials.</Warning>
 
@@ -38,18 +42,19 @@ Request an Enterprise license:
 
 ## Configure an Enterprise license
 
-<Info>This section is relevant only for W&B Self-Managed.</Info>
+<Info>This section is relevant only for W&B Self-Managed. Dedicated Cloud deployments don't require manual configuration.</Info>
 
-After you [obtain an Enterprise license](#obtain-an-enterprise-license), you can configure it programmatically or you can configure it in the W&B App after deployment. Select a tab for instructions.
+After you [obtain an Enterprise license](#obtain-an-enterprise-license), you can configure it programmatically as part of your deployment or in the W&B App after deployment. Select the tab that matches your deployment method.
 
 <Tabs>
 <Tab title="Kubernetes Operator">
-1. Update your `operator.yaml` (the `WeightsAndBiases` custom resource) to set the license:
+1. Update your `operator.yaml` (the `WeightsAndBiases` custom resource) to set the license. Replace `[YOUR-LICENSE-KEY]` with the license key you received from W&B:
+
     ```yaml
     spec:
       values:
         global:
-          license: "YOUR_LICENSE_KEY_HERE"
+          license: "[YOUR-LICENSE-KEY]"
     ```
 
 2. Apply the updated configuration:
@@ -58,10 +63,11 @@ After you [obtain an Enterprise license](#obtain-an-enterprise-license), you can
     ```
 </Tab>
 <Tab title="Terraform">
-1. Update your Terraform variables:
+1. Update your Terraform variables. Replace `[YOUR-LICENSE-KEY]` with the license key you received from W&B:
+
     ```hcl
     variable "license" {
-      default = "YOUR_LICENSE_KEY_HERE"
+      default = "[YOUR-LICENSE-KEY]"
     }
     ```
 
@@ -73,68 +79,83 @@ After you [obtain an Enterprise license](#obtain-an-enterprise-license), you can
 <Tab title="W&B App">
 For existing deployments without environment variable configuration:
 
-1. Log in as an admin user
-2. Navigate to **System Settings**
-3. Find the **License** section
-4. Enter your new license key
-5. Save the changes
+1. Log in as an admin user.
+2. Navigate to **System Settings**.
+3. Find the **License** section.
+4. Enter your new license key.
+5. Save the changes.
 </Tab>
 <Tab title="Docker">
 <Warning>Deploying W&B on Docker is deprecated. W&B strongly encourages migrating to a [Kubernetes Operator]() deployment managed by Helm or Terraform. Refer to [Reference architecture](/platform/hosting/self-managed/ref-arch.mdx) or contact [Support](mailto:support@wandb.ai) for guidance.</Warning>
-Set the license key as an environment variable:
+Set the `LICENSE` environment variable. Replace `[YOUR-LICENSE-KEY]` with the license key you received from W&B:
+
 ```bash
 docker run -d \
-  -e LICENSE="YOUR_LICENSE_KEY_HERE" \
+  -e LICENSE="[YOUR-LICENSE-KEY]" \
   -e OTHER_ENV_VARS \
   wandb/local
 ```
 </Tab>
 </Tabs>
 
-Next, [verify your Enterprise license](#verify-or-update-an-enterprise-license).
+Next, [verify your Enterprise license](#verify-and-manage-an-enterprise-license).
 
 ## Verify and manage an Enterprise license
 
-As an instance or organization admin, follow these steps to verify and manage your Enterprise license:
+After you configure a license, verify that it's active and review its entitlements. As an instance or organization admin, follow these steps:
+
 1. In the W&B App, click your user profile icon in the top right, then click **System Console**.
-1. Go to the **License** tab. A dashboard summarizes the license's entitlements, expiration, and usage over time. If you see an error, see [Common issues](#common-issues).
-1. For detailed information about the license and its entitlements, click **View license online**.
+2. Go to the **License** tab. A dashboard summarizes the license entitlements, expiration, and usage over time. If you see an error, see [Common issues](#common-issues).
+3. For detailed information about the license and its entitlements, click **View license online**.
 
     From this page, you can also order a new trial or production license. At the top of the page, click **New license order** and submit the form.
-1. To renew an expired license or to update the license key, click **Update License**.
-    <Tip>
-    To ensure uninterrupted service W&B contacts you:
-    - 30 days before the license expires
-    - When the license has expired
-    </Tip>
+4. To renew an expired license or to update the license key, click **Update License**.
 
+<Tip>
+To ensure uninterrupted service, W&B contacts you:
+- 30 days before the license expires.
+- When the license has expired.
+</Tip>
 
 ## Enterprise features
+
 For a full, categorized list of available Enterprise features, see the [Pricing](https://wandb.ai/site/pricing/) page, then click **Cloud-hosted** or **Privately-hosted**.
 
 ## Common issues
 
+If you encounter problems configuring or using your Enterprise license, review the following common issues before contacting support.
 
 ### License not recognized
-- Verify the license key is correctly formatted (no extra spaces)
-- Ensure the license hasn't expired
-- Check that the license is set in the correct configuration location
+
+If your license isn't recognized, check the following:
+
+- Verify that the license key is correctly formatted (no extra spaces).
+- Ensure that the license hasn't expired.
+- Check that the license is set in the correct configuration location.
 
 ### Features not available after setting license
-- Restart your W&B services after setting the license
-- Verify the license includes the specific features you're trying to access
-- Check system logs for any license validation errors
+
+If features aren't available after you set the license, try the following:
+
+- Restart your W&B services after setting the license.
+- Verify that the license includes the specific features you're trying to access.
+- Check the system logs for any license validation errors.
 
 ### License expiration warnings
-- Monitor the System Settings page for expiration notifications
-- Set up alerts for license expiration in your monitoring system
-- Keep your account team contact information up to date
+
+To stay ahead of license expiration:
+
+- Monitor the **System Settings** page for expiration notifications.
+- Set up alerts for license expiration in your monitoring system.
+- Keep your account team contact information up to date.
 
 ### Get support
+
 For assistance with Enterprise licenses, contact your account team, [Sales](mailto:sales@wandb.ai), or [Support](mailto:support@wandb.ai).
 
 ## Additional resources
+
 - [W&B Pricing](/pricing)
 - [W&B Self-Managed](/platform/hosting/hosting-options/self-managed)
 - [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud)
-- [Security & Compliance](/security)
+- [Security and compliance](/security)

--- a/platform/hosting/env-vars.mdx
+++ b/platform/hosting/env-vars.mdx
@@ -3,9 +3,11 @@ description: "Configure a self-managed W&B Server installation using environment
 title: Configure environment variables
 ---
 
-In addition to configuring instance-level settings through the System Settings admin UI, W&B also provides a way to configure these values in code using environment variables. Also, refer to [advanced configuration for IAM](./iam/advanced_env_vars).
+In addition to configuring instance-level settings through the System Settings admin UI, W&B also provides a way to configure these values in code using environment variables. This page lists the environment variables you can set to control database, storage, Redis, identity provider, and other instance-level behavior for a self-managed W&B Server deployment. You can use these variables to manage configuration as code instead of through the admin UI. For IAM-specific variables, see [advanced configuration for IAM](./iam/advanced_env_vars).
 
 ## Environment variable reference
+
+The following table describes each environment variable, the behavior it controls, and any constraints on its value.
 
 | Environment variable             | Description                                                                                                                                                                              |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -15,30 +17,31 @@ In addition to configuring instance-level settings through the System Settings a
 | `BUCKET_QUEUE`                     | The SQS / Google PubSub queue for object creation events                                                                                                                                 |
 | `NOTIFICATIONS_QUEUE`              | The SQS queue on which to publish run events                                                                                                                                             |
 | `AWS_REGION`                       | The AWS Region where your bucket lives                                                                                                                                                   |
-| `HOST`                             | The FQD of your instance, that is `https://my.domain.net`                                                                                                       |
-| `OIDC_ISSUER`                      | A URL to your Open ID Connect identity provider, that is `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_uiIFNdacd` |
+| `HOST`                             | The FQD of your instance, for example `https://my.domain.net`                                                                                                       |
+| `OIDC_ISSUER`                      | A URL to your Open ID Connect identity provider, for example `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_uiIFNdacd` |
 | `OIDC_CLIENT_ID`                   | The Client ID of application in your identity provider                                                                                                                                   |
-| `OIDC_AUTH_METHOD`                 | Implicit (default) or pkce, see below for more context                                                                                                                                   |
+| `OIDC_AUTH_METHOD`                 | Implicit (default) or pkce. For more context, see the following sections.                                                                                                                                   |
 | `SLACK_CLIENT_ID`                  | The client ID of the Slack application you want to use for alerts                                                                                                                        |
 | `SLACK_SECRET`                     | The secret of the Slack application you want to use for alerts                                                                                                                           |
-| `LOCAL_RESTORE`                    | You can temporarily set this to true if you're unable to access your instance. Check the logs from the container for temporary credentials.                                              |
+| `LOCAL_RESTORE`                    | If you can't access your instance, you can temporarily set this to true. Check the logs from the container for temporary credentials.                                              |
 | `REDIS`                            | Can be used to set up an external REDIS instance with W&B.                                                                                                                                |
 | `LOGGING_ENABLED`                  | When set to true, access logs are streamed to stdout. You can also mount a sidecar container and tail `/var/log/gorilla.log` without setting this variable.                              |
-| `GORILLA_ALLOW_USER_TEAM_CREATION` | When set to true, allows non-admin users to create a new team. False by default.                                                                                                         |
+| `GORILLA_ALLOW_USER_TEAM_CREATION` | When set to true, lets non-admin users create a new team. False by default.                                                                                                         |
 | `GORILLA_CUSTOMER_SECRET_STORE_SOURCE` | Sets the secret manager for storing team secrets used by W&B Weave. These secret managers are supported: <ul><li><b>Internal secret manager</b> (default): <code>k8s-secretmanager://wandb-secret</code></li><li><b>AWS Secret Manager</b>: <code>aws-secretmanager</code></li><li><b>Google Cloud Secret Manager</b>: <code>gcp-secretmanager</code></li><li><b>Azure</b>: <code>az-secretmanger</code></li></ul>  |
 | `GORILLA_DATA_RETENTION_PERIOD`    | How long to retain deleted data from runs in hours. Deleted run data is unrecoverable. Append an `h` to the input value. For example, `"24h"`. |
 | `GORILLA_DISABLE_PERSONAL_ENTITY`  | When set to true, turns off [personal entities](/support/models/articles/what-is-the-difference-between-team-and-). Prevents creation of new personal projects in their personal entities and prevents writing to existing personal projects. |
-| `GORILLA_GRAPHQL_DISABLE_INTROSPECTION` | When set to true, disables GraphQL introspection: `__type` and `__schema` queries return no schema data while the request still succeeds. On **Self-Managed**, setting the Gorilla configuration field `graphql-disable-introspection` has the same effect. Set this variable under `spec.values.global.extraEnv` in your `WeightsAndBiases` custom resource (see the [`global.extraEnv` example](/platform/hosting/self-managed/operator#ldap) in the Operator guide). **Client applications need [W&B SDK v0.26.0](/release-notes/sdk-releases#0-26-0) or later** against deployments with introspection already turned off. |
-| `GRAPHQL_REJECT_UNAUTHED_REQUESTS` | When set to `true` on the **API** service, rejects GraphQL requests that do not have an authenticated user. Unauthenticated requests receive HTTP 401. **Self-Managed** and **Dedicated Cloud** v0.80.0+ only; not available on Multi-tenant Cloud. This feature is opt-in: if the environment variable is unset or not `true`, behavior is unchanged. Set on the API component only (for example, `api.env` in Helm values). Before activating, confirm that workflows that rely on anonymous GraphQL access (such as viewing shared reports without signing in, or open projects) still meet your requirements. On **Self-Managed**, setting the Gorilla configuration field `graphql-reject-unauthed-requests` to `true` has the same effect. |
+| `GORILLA_GRAPHQL_DISABLE_INTROSPECTION` | When set to true, disables GraphQL introspection: `__type` and `__schema` queries return no schema data while the request still succeeds. On **Self-Managed**, setting the Gorilla configuration field `graphql-disable-introspection` has the same effect. Set this variable under `spec.values.global.extraEnv` in your `WeightsAndBiases` custom resource (see the [`global.extraEnv` example](/platform/hosting/self-managed/operator#ldap) in the Operator guide). **Client applications require [W&B SDK v0.26.0](/release-notes/sdk-releases#0-26-0) or later** against deployments with introspection already turned off. |
+| `GRAPHQL_REJECT_UNAUTHED_REQUESTS` | When set to `true` on the **API** service, rejects GraphQL requests that don't have an authenticated user. Unauthenticated requests receive HTTP 401. **Self-Managed** and **Dedicated Cloud** v0.80.0+ only; not available on Multi-tenant Cloud. This feature is opt-in: if the environment variable is unset or not `true`, behavior is unchanged. Set on the API component only (for example, `api.env` in Helm values). Before activating, confirm that workflows that rely on anonymous GraphQL access (such as viewing shared reports without signing in, or open projects) still meet your requirements. On **Self-Managed**, setting the Gorilla configuration field `graphql-reject-unauthed-requests` to `true` has the same effect. |
 | `GORILLA_ARTIFACT_GC_ENABLED`      | When set to true, enables garbage collection for deleted artifacts. Required for self-managed deployments. See [Delete an artifact](/models/artifacts/delete-artifacts) for more information. |
 | `WANDB_ARTIFACT_DIR`               | Where to store all downloaded artifacts. If unset, defaults to the `artifacts` directory relative to your training script. Make sure this directory exists and the running user has permission to write to it. This does not control the location of generated metadata files, which you can set using the `WANDB_DIR` environment variable. |
 | `WANDB_DATA_DIR`                   | Where to upload staging artifacts. The default location depends on your platform, because it uses the value of `user_data_dir` from the `platformdirs` Python package. Make sure this directory exists and the running user has permission to write to it. |
 | `WANDB_DIR`                        | Where to store all generated files. If unset, defaults to the `wandb` directory relative to your training script. Make sure this directory exists and the running user has permission to write to it. This does not control the location of downloaded artifacts, which you can set using the `WANDB_ARTIFACT_DIR` environment variable. |
 | `WANDB_IDENTITY_TOKEN_FILE`        | For [identity federation](/platform/hosting/iam/identity_federation/), the absolute path to the local directory where Java Web Tokens (JWTs) are stored. |
+
 <Note>
 - Use the `GORILLA_DATA_RETENTION_PERIOD` environment variable cautiously. It applies to **deleted run data** (including run-associated files such as media after deletion flows). It does **not** delete artifacts; use artifact deletion and `GORILLA_ARTIFACT_GC_ENABLED` as described in [Delete an artifact](/models/artifacts/delete-artifacts). For how deleting runs and files relates to storage and this setting, see [When deleted run data is removed from storage](/models/runs/delete-runs#when-deleted-run-data-is-removed-from-storage) in **Delete runs**. Data is removed according to the retention window once the variable is set. Back up both the database and the storage bucket before you enable or change this value.
 
-    Background removal of objects from your bucket is **best-effort** and not guaranteed to finish within a specific time. For expectations, troubleshooting, and how this relates to storage costs, see [Manage bucket storage and costs](/platform/hosting/managing-bucket-storage).
+    Background removal of objects from your bucket is **approximate** and not guaranteed to finish within a specific time. For expectations, troubleshooting, and how this relates to storage costs, see [Manage bucket storage and costs](/platform/hosting/managing-bucket-storage).
 - To enable `GRAPHQL_REJECT_UNAUTHED_REQUESTS` with the [Kubernetes Operator](/platform/hosting/self-managed/operator), set it on the API component only:
 
     ```yaml
@@ -53,21 +56,23 @@ In addition to configuring instance-level settings through the System Settings a
 
 ## Advanced reliability settings
 
+The following section describes optional configuration you can apply to improve the reliability and performance of your W&B Server deployment.
+
 ### Redis
 
-Configuring an external Redis server is optional but recommended for production systems. Redis helps improve the reliability of the service and enable caching to decrease load times, especially in large projects. Use a managed Redis service such ElastiCache with high availability (HA) and the following specifications:
+An external Redis server is optional but recommended for production systems. Redis helps improve the reliability of the service and enables caching to decrease load times, especially in large projects. Use a managed Redis service such as ElastiCache with high availability (HA) and the following specifications:
 
-- Minimum 4GB of memory, suggested 8GB
+- Minimum 4 GB of memory, suggested 8 GB
 - Redis version 6.x
 - In transit encryption
 - Authentication enabled
 
-To configure the Redis instance with W&B, you can navigate to the W&B settings page at `http(s)://YOUR-W&B-SERVER-HOST/system-admin`. Enable the "Use an external Redis instance" option, and fill in the Redis connection string in the following format:
+To configure the Redis instance with W&B, go to the W&B settings page at `http(s)://YOUR-W&B-SERVER-HOST/system-admin`. Enable the **Use an external Redis instance** option, and fill in the Redis connection string in the following format:
 
 <Frame>
     <img src="/images/hosting/configure_redis.png" alt="Configuring REDIS in W&B"  />
 </Frame>
 
-You can also configure Redis using the environment variable `REDIS` on the container or in your Kubernetes deployment. Alternatively, you could also set up `REDIS` as a Kubernetes secret.
+You can also configure Redis using the environment variable `REDIS` on the container or in your Kubernetes deployment. Alternatively, you can set up `REDIS` as a Kubernetes secret.
 
-This page assumes the Redis instance is running at the default port of `6379`. If you configure a different port, setup authentication and also want to have TLS enabled on the `redis` instance the connection string format would look something like: `redis://$USER:$PASSWORD@$HOST:$PORT?tls=true`
+This page assumes the Redis instance is running at the default port of `6379`. If you configure a different port, set up authentication, and want TLS enabled on the `redis` instance, the connection string format is: `redis://$USER:$PASSWORD@$HOST:$PORT?tls=true`

--- a/platform/hosting/export-data-from-dedicated-cloud.mdx
+++ b/platform/hosting/export-data-from-dedicated-cloud.mdx
@@ -3,7 +3,7 @@ description: "Export runs, metrics, artifacts, and reports from a W&B Dedicated 
 title: Export data from Dedicated Cloud
 ---
 
-If you would like to export all the data managed in your Dedicated Cloud instance, you can use the W&B SDK API to extract the runs, metrics, artifacts, and more with the [Import and Export API](/models/ref/python/public-api/). The following table has covers some of the key exporting use cases.
+To export the data managed in your Dedicated Cloud instance, you can use the W&B SDK API to extract runs, metrics, artifacts, and more with the [Import and Export API](/models/ref/python/public-api/). The following table covers some of the key exporting use cases.
 
 | Purpose | Documentation |
 |---------|---------------|
@@ -12,8 +12,8 @@ If you would like to export all the data managed in your Dedicated Cloud instanc
 | Export reports | [Report and Workspace API](/models/reports/clone-and-export-reports/) |
 | Export artifacts | [Explore artifact graphs](/models/artifacts/explore-and-traverse-an-artifact-graph/), [Download and use artifacts](/models/artifacts/download-and-use-an-artifact/#download-and-use-an-artifact-stored-on-wb) |
 
-If you manage artifacts stored in the Dedicated Cloud with [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector), you may not need to export the artifacts using the W&B SDK API.
+If you manage artifacts stored in the Dedicated Cloud with [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector), you might not need to export the artifacts using the SDK API.
 
 <Note>
-Using W&B SDK API to export all of your data can be slow if you have a large number of runs, artifacts etc. W&B recommends running the export process in appropriately sized batches so as not to overwhelm your Dedicated Cloud instance.
+If you have many runs, artifacts, and other resources, using the SDK API to export all your data can be slow. W&B recommends that you run the export process in appropriately sized batches to avoid overwhelming your Dedicated Cloud instance.
 </Note>

--- a/platform/hosting/hosting-options.mdx
+++ b/platform/hosting/hosting-options.mdx
@@ -2,21 +2,21 @@
 title: Deployment options
 description: "Choose between W&B deployment types: Multi-tenant Cloud, Dedicated Cloud, and Self-Managed for your organization."
 ---
-This section describes the different ways can you can deploy W&B.
+The following sections describe the different ways you can deploy W&B, so you can choose the deployment model that best fits your organization's security, compliance, and operational needs. The options range from W&B-managed shared infrastructure to fully self-managed deployments in your own environment.
 
-## W&B multi-tenant cloud
-[W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) is fully managed by W&B, including upgrades, maintenance, platform security, and capacity planning. Multi-tenant Cloud is deployed in W&B's Google Cloud account in [Google Cloud's North America regions](https://cloud.google.com/compute/docs/regions-zones). [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store W&B Artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
+## W&B Multi-tenant Cloud
+[W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) is fully managed by W&B, including upgrades, maintenance, platform security, and capacity planning. Multi-tenant Cloud is deployed in W&B's Google Cloud account in [Google Cloud's North America regions](https://cloud.google.com/compute/docs/regions-zones). [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally lets you store W&B Artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 
 See [W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) or [get started for free](https://app.wandb.ai/login?signup=true).
 
 ## W&B Dedicated Cloud
-[W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) is a fully managed platform with dedicated, isolated infrastructure, designed with enterprise organizations in mind. W&B Dedicated Cloud is deployed in W&B's AWS, Google Cloud or Azure account. Dedicated Cloud provides more flexibility than Multi-tenant Cloud, but less complexity than W&B Self-Managed. Upgrades, maintenance, platform security, and capacity planning are managed by W&B. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances.
+[W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) is a fully managed platform with dedicated, isolated infrastructure, designed with enterprise organizations in mind. W&B Dedicated Cloud is deployed in W&B's AWS, Google Cloud, or Azure account. Dedicated Cloud provides more flexibility than Multi-tenant Cloud, but less complexity than W&B Self-Managed. W&B manages upgrades, maintenance, platform security, and capacity planning. Each Dedicated Cloud instance has its own isolated network, compute, and storage, separate from other W&B Dedicated Cloud instances.
 
-Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally allows you to store artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
+Your W&B-specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally lets you store artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 
-W&B Dedicated Cloud includes an [enterprise license](/platform/hosting/hosting-options/self-managed/) with support for important security and other enterprise-friendly capabilities.
+W&B Dedicated Cloud includes an [enterprise license](/platform/hosting/hosting-options/self-managed/) with support for security and other enterprise-friendly capabilities.
 
-For organizations with advanced security or compliance requirements, features such as HIPAA compliance, Single Sign On, or Customer Managed Encryption Keys (CMEK) are available with **Enterprise** support. [Request more information](https://wandb.ai/site/contact).
+For organizations with advanced security or compliance requirements, features such as HIPAA compliance, single sign-on, or customer-managed encryption keys (CMEK) are available with Enterprise support. [Request more information](https://wandb.ai/site/contact).
 
 See [W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) or [get started for free](https://app.wandb.ai/login?signup=true).
 
@@ -27,6 +27,6 @@ See [W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) or [get started
 - Managing upgrades and applying patches.
 - Continuously maintaining your Self-Managed W&B Server instance.
 
-You can optionally obtain an enterprise license for W&B Self-Managed. An enterprise license includes support for important security and other enterprise-friendly capabilities.
+You can optionally obtain an enterprise license for W&B Self-Managed. An enterprise license includes support for security and other enterprise-friendly capabilities.
 
 See [W&B Self-Managed](/platform/hosting/hosting-options/self-managed/) or review the [reference architecture](/platform/hosting/self-managed/ref-arch/) guidelines.

--- a/platform/hosting/hosting-options/dedicated-cloud.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud.mdx
@@ -3,86 +3,92 @@ description: "Learn about W&B Dedicated Cloud deployment features including comp
 title: Dedicated Cloud
 ---
 
-W&B Dedicated Cloud is a fully managed platform with dedicated, isolated infrastructure, deployed in W&B's AWS, Google Cloud, or Azure cloud accounts. Each Dedicated Cloud instance has its own isolated network, compute and storage from other W&B Dedicated Cloud instances. Your W&B specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services.
+W&B Dedicated Cloud is a fully managed platform with dedicated, isolated infrastructure, deployed in W&B's AWS, Google Cloud, or Azure cloud accounts. Each Dedicated Cloud instance has its own isolated network, compute, and storage from other W&B Dedicated Cloud instances. W&B stores your W&B-specific metadata and data in isolated cloud storage and processes it using isolated cloud compute services.
 
-W&B Dedicated Cloud is available in [multiple global regions for each cloud provider](./dedicated-cloud/regions)
+Use Dedicated Cloud when you need the benefits of a managed W&B platform along with isolation that helps you meet security, compliance, and data residency requirements. This page describes the compliance, data security, IAM, monitoring, and maintenance features available with Dedicated Cloud, and links to deeper documentation for each topic.
+
+W&B Dedicated Cloud is available in [multiple global regions for each cloud provider](./dedicated-cloud/regions).
 
 ## Rate limits
 
 W&B applies default rate limits on Dedicated Cloud to maintain instance stability. See [Rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for default values, how limits are enforced, and how to request higher limits when you scale up training.
 
 ## Compliance
+
+W&B Dedicated Cloud supports the following compliance frameworks:
+
 - **SOC 2**: W&B Dedicated Cloud's hosting platform meets the requirements of the [Service and Organization Controls (SOC) 2 Type 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2), published by the [Auditing Standards Board of the American Institute of Certified Public Accountants (AICPA)](https://www.aicpa-cima.com/home). A SOC 2 report evaluates a service organization's controls for security, availability, processing integrity, confidentiality, and privacy. W&B Dedicated Cloud is subject to periodic internal and external audits to verify continued compliance. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request the SOC 2 report and other security and compliance documents.
 - **HIPAA**: When configured appropriately, W&B Dedicated Cloud meets the requirements of the [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://www.hhs.gov/hipaa/for-professionals/index.html). Compliance with HIPAA is a shared responsibility that involves W&B, the customer, and any third-party services involved in the deployment. Organizations subject to HIPAA must have a **Business Associate Agreement** on file with W&B. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request more information.
 
 ## Data security
 
+Dedicated Cloud provides several mechanisms for controlling where your data is stored and how it can be accessed. The following options let you bring your own storage, restrict network access, and connect privately to your instance.
+
 You can bring your own bucket (BYOB) using the [secure storage connector](/platform/hosting/data-security/secure-storage-connector) at the [instance and team levels](/platform/hosting/data-security/secure-storage-connector#configuration-options) to store your files such as models, datasets, and more.
 
-Similar to W&B Multi-tenant Cloud, you can configure a single bucket for multiple teams or you can use separate buckets for different teams. If you do not configure secure storage connector for a team, that data is stored in the instance level bucket.
+Similar to W&B Multi-tenant Cloud, you can configure a single bucket for multiple teams or you can use separate buckets for different teams. If you don't configure secure storage connector for a team, W&B stores that data in the instance-level bucket.
 
 <Frame>
-    <img src="/images/hosting/dedicated_cloud_arch.png" alt="Dedicated Cloud architecture diagram"  />
+    <img src="/images/hosting/dedicated_cloud_arch.png" alt="Dedicated Cloud architecture diagram" />
 </Frame>
 
 In addition to BYOB with secure storage connector, you can use [IP allowlisting](/platform/hosting/data-security/ip-allowlisting) to restrict access to your Dedicated Cloud instance from only trusted network locations.
 
 You can connect privately to your Dedicated Cloud instance using [cloud provider's secure connectivity solution](/platform/hosting/data-security/private-connectivity).
 
-You are responsible for ensuring that your deployment complies with your organization's policies and [Security Technical Implementation Guidelines (STIG)](https://en.wikipedia.org/wiki/Security_Technical_Implementation_Guide), if applicable.
+You're responsible for ensuring that your deployment complies with your organization's policies and [Security Technical Implementation Guidelines (STIG)](https://en.wikipedia.org/wiki/Security_Technical_Implementation_Guide), if applicable.
 
 ## Identity and access management (IAM)
 
 Use the identity and access management capabilities for secure authentication and effective authorization in your W&B Organization. The following features are available for IAM in Dedicated Cloud instances:
 
-* Authenticate with [SSO using OpenID Connect (OIDC)](/platform/hosting/iam/sso) or with [LDAP](/platform/hosting/iam/ldap).
-* [Configure appropriate user roles](/platform/hosting/iam/access-management/manage-organization#assign-or-update-a-users-role) at the scope of the organization and within a team.
-* Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it with [restricted projects](/platform/hosting/iam/access-management/restricted-projects).
-* Leverage JSON Web Tokens with [identity federation](/platform/hosting/iam/identity_federation) to access W&B APIs.
+- Authenticate with [SSO using OpenID Connect (OIDC)](/platform/hosting/iam/sso) or with [LDAP](/platform/hosting/iam/ldap).
+- [Configure appropriate user roles](/platform/hosting/iam/access-management/manage-organization#assign-or-update-a-users-role) at the scope of the organization and within a team.
+- Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it with [restricted projects](/platform/hosting/iam/access-management/restricted-projects).
+- Use JSON Web Tokens with [identity federation](/platform/hosting/iam/identity_federation) to access W&B APIs.
 
 ## Monitor
 
-Use [Audit logs](/platform/hosting/monitoring-usage/audit-logging) to track user activity within your teams and to conform to your enterprise governance requirements. Also, you can view organization usage in our Dedicated Cloud instance with [W&B Organization Dashboard](/platform/hosting/monitoring-usage/org_dashboard).
+Use [Audit logs](/platform/hosting/monitoring-usage/audit-logging) to track user activity within your teams and to conform to your enterprise governance requirements. Also, you can view organization usage in your Dedicated Cloud instance with [W&B Organization Dashboard](/platform/hosting/monitoring-usage/org_dashboard).
 
 ## Maintenance
 
-Similar to W&B Multi-tenant Cloud, you do not incur the overhead and costs of provisioning and maintaining the W&B platform with Dedicated Cloud.
+Similar to W&B Multi-tenant Cloud, you don't incur the overhead and costs of provisioning and maintaining the W&B platform with Dedicated Cloud.
 
 To understand how W&B manages updates on Dedicated Cloud, refer to the [server release process](/platform/hosting/server-upgrade-process).
 
-## Compliance
-
-Security controls for W&B Dedicated Cloud are periodically audited internally and externally. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request the security and compliance documents for your product assessment exercise.
-
 ## Data retention policy
+
 By default, a Dedicated Cloud instance retains the following items for 7 days after deletion:
+
 - Runs and history
 - Non-artifact run files, such as media, configuration files, and log files
 - Artifacts and artifact references
 
-Until this period elapses, these items can be restored. Contact [support](mailto:support@wandb.ai) or your AISE for assistance.
+Until this period elapses, you can restore these items. Contact [support](mailto:support@wandb.ai) or your AISE for assistance.
 
 To meet your data retention requirements, you can change the data retention period for your Dedicated Cloud instance. Depending on your use case, select the **Environment variable** or **Helm** tab for details.
 
 <Tabs>
 <Tab title="Environment variable">
-To change the data retention policy, set the environment variable `GORILLA_DATA_RETENTION_PERIOD` to a number of hours. For example, to retain deleted data for 14 days (336 hours):
+To change the data retention policy, set the environment variable `GORILLA_DATA_RETENTION_PERIOD` to a value in hours. For example, to retain deleted data for 14 days (336 hours):
 ```bash
 export GORILLA_DATA_RETENTION_PERIOD="336h"
 ```
 </Tab>
 <Tab title="Helm">
-To change the data retention policy, set the Helm value `env.dataRetentionPeriod` to a number of hours. For example, to retain deleted data for 14 days (336 hours):
-```helm
-env: dataRetentionPeriod: "336h"
+To change the data retention policy, set the Helm value `env.dataRetentionPeriod` to a value in hours. For example, to retain deleted data for 14 days (336 hours):
+```yaml
+env:
+  dataRetentionPeriod: "336h"
 ```
 </Tab>
 </Tabs>
 
 ## Migration options
 
-Migration to Dedicated Cloud from a [Self-Managed instance](/platform/hosting/hosting-options/self-managed) or [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) is supported, subject to specific limits and migration-related constraints
+W&B supports migration to Dedicated Cloud from a [Self-Managed instance](/platform/hosting/hosting-options/self-managed) or [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), subject to specific limits and migration-related constraints.
 
 ## Next steps
 
-Submit [this form](https://wandb.ai/site/for-enterprise/dedicated-saas-trial) if you are interested in using Dedicated Cloud.
+If you're interested in using Dedicated Cloud, submit the [Dedicated SaaS trial request form](https://wandb.ai/site/for-enterprise/dedicated-saas-trial) to start the process with W&B.

--- a/platform/hosting/hosting-options/dedicated-cloud/export-data.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/export-data.mdx
@@ -3,7 +3,7 @@ description: "Export runs, metrics, artifacts, and reports from a W&B Dedicated 
 title: Export data from Dedicated Cloud
 ---
 
-If you would like to export all the data managed in your Dedicated Cloud instance, you can use the W&B SDK API to extract the runs, metrics, artifacts, and more with the [Import and Export API](/models/ref/python/public-api/). The following table covers some of the key exporting use cases.
+Export the data managed in your W&B Dedicated Cloud instance, such as runs, metrics, artifacts, and reports, when you need a portable copy for backup, migration, or external analysis. To extract this data, use the W&B SDK API with the [Import and Export API](/models/ref/python/public-api/). The following table covers some key export use cases.
 
 | Purpose | Documentation |
 |---------|---------------|
@@ -12,8 +12,8 @@ If you would like to export all the data managed in your Dedicated Cloud instanc
 | Export reports | [Report and Workspace API](/models/reports/clone-and-export-reports/) |
 | Export artifacts | [Explore artifact graphs](/models/artifacts/explore-and-traverse-an-artifact-graph/), [Download and use artifacts](/models/artifacts/download-and-use-an-artifact/#download-and-use-an-artifact-stored-on-wb) |
 
-If you manage artifacts stored in the Dedicated Cloud with [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector), you may not need to export the artifacts using the W&B SDK API.
+If you manage artifacts stored in the Dedicated Cloud with [Secure Storage Connector](/platform/app/settings-page/teams/#secure-storage-connector), you might not need to export the artifacts using the W&B SDK API.
 
 <Note>
-Using W&B SDK API to export all of your data can be slow if you have a large number of runs, artifacts etc. W&B recommends running the export process in appropriately sized batches so as not to overwhelm your Dedicated Cloud instance.
+Using the W&B SDK API to export all of your data can be slow if you have many runs, artifacts, and similar resources. W&B recommends running the export process in appropriately sized batches to avoid overwhelming your Dedicated Cloud instance.
 </Note>

--- a/platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx
@@ -4,10 +4,12 @@ description: Default rate limits on Dedicated Cloud and how to request changes
 ---
 import RateLimitsDefaultsAndNotification from "/snippets/_includes/rate-limits-defaults-and-notification.mdx";
 
-W&B Dedicated Cloud applies rate limits to maintain instance stability. W&B can adjust limits when you scale up training or need higher throughput.
+W&B Dedicated Cloud applies rate limits to maintain instance stability. W&B can adjust limits when you scale up training or need higher throughput. Use this page to understand the default limits that apply to your Dedicated Cloud instance and how to request an increase if your workloads need more capacity.
 
 ## Default limits and notification
 
+The following section lists the default rate limits and describes how the W&B SDK behaves when you exceed a limit.
+
 <RateLimitsDefaultsAndNotification />
 
-These defaults are recommended for typical production workloads. If your workloads consistently exceed these limits, contact [W&B support](mailto:support@wandb.com) or your Account Solutions Engineer (AISE) to request higher limits. Provide details of your experimental setup and usage patterns.
+W&B recommends these defaults for typical production workloads. If your workloads consistently exceed these limits, contact [W&B support](mailto:support@wandb.com) or your Account Solutions Engineer (AISE) to request higher limits. Provide details of your experimental setup and usage patterns so that W&B can scope an appropriate adjustment.

--- a/platform/hosting/hosting-options/dedicated-cloud/regions.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/regions.mdx
@@ -3,73 +3,75 @@ title: Supported Dedicated Cloud regions
 description: "View all supported AWS, Google Cloud, and Azure regions available for W&B Dedicated Cloud instances."
 ---
 
-AWS, Google Cloud, and Azure support cloud computing services in multiple locations worldwide. Global regions help ensure that you satisfy requirements related to data residency & compliance, latency, cost efficiency and more. W&B supports many of the available global regions for Dedicated Cloud.
+AWS, Google Cloud, and Azure support cloud computing services in multiple locations worldwide. Global regions help ensure that you satisfy requirements such as data residency, compliance, latency, and cost efficiency. W&B supports many of the available global regions for Dedicated Cloud. The following sections list the supported regions for each cloud provider.
 
 <Note>
-Reach out to W&B Support if your preferred AWS, Google Cloud, or Azure Region is not listed. W&B can validate if the relevant region has all the services that Dedicated Cloud needs and prioritize support depending on the outcome of the evaluation.
+Reach out to W&B Support if your preferred AWS, Google Cloud, or Azure region isn't listed. W&B can validate whether the relevant region has all the services that Dedicated Cloud needs and prioritize support depending on the outcome of the evaluation.
 </Note>
 
-## Supported AWS Regions
+## Supported AWS regions
 
-The following table lists [AWS Regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) that W&B currently supports for Dedicated Cloud instances.
+The following table lists [AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
 |-------------|--------|
-|US East (Ohio)| us-east-2|
-|US East (N. Virginia)|us-east-1|
-|US West (N. California)|us-west-1|
-|US West (Oregon)|us-west-2|
-|Canada (Central)|ca-central-1|
-|Europe (Frankfurt)|eu-central-1|
-|Europe (Ireland)|eu-west-1|
-|Europe (London)|eu-west-2|
-|Europe (Milan)|eu-south-1|
-|Europe (Stockholm)|eu-north-1|
-|Asia Pacific (Mumbai)|ap-south-1|
-|Asia Pacific (Singapore)| ap-southeast-1|
-|Asia Pacific (Sydney)|ap-southeast-2|
-|Asia Pacific (Tokyo)|ap-northeast-1|
-|Asia Pacific (Seoul)|ap-northeast-2|
+| US East (Ohio) | `us-east-2` |
+| US East (N. Virginia) | `us-east-1` |
+| US West (N. California) | `us-west-1` |
+| US West (Oregon) | `us-west-2` |
+| Canada (Central) | `ca-central-1` |
+| Europe (Frankfurt) | `eu-central-1` |
+| Europe (Ireland) | `eu-west-1` |
+| Europe (London) | `eu-west-2` |
+| Europe (Milan) | `eu-south-1` |
+| Europe (Stockholm) | `eu-north-1` |
+| Asia Pacific (Mumbai) | `ap-south-1` |
+| Asia Pacific (Singapore) | `ap-southeast-1` |
+| Asia Pacific (Sydney) | `ap-southeast-2` |
+| Asia Pacific (Tokyo) | `ap-northeast-1` |
+| Asia Pacific (Seoul) | `ap-northeast-2` |
 
-For more information about AWS Regions, see the [Regions, Availability Zones, and Local Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) in the AWS Documentation.
+For more information about AWS regions, see [Regions, Availability Zones, and Local Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) in the AWS Documentation.
 
-See [What to Consider when Selecting a Region for your Workloads](https://aws.amazon.com/blogs/architecture/what-to-consider-when-selecting-a-region-for-your-workloads/) for an overview of factors that you should consider when choosing an AWS Region.
+See [What to Consider when Selecting a Region for your Workloads](https://aws.amazon.com/blogs/architecture/what-to-consider-when-selecting-a-region-for-your-workloads/) for an overview of factors to consider when choosing an AWS region.
 
 ## Supported Google Cloud regions
-The following table lists [Google Cloud Regions](https://cloud.google.com/compute/docs/regions-zones) that W&B currently supports for Dedicated Cloud instances.
+
+The following table lists [Google Cloud regions](https://cloud.google.com/compute/docs/regions-zones) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
 |-------------|--------|
-|South Carolina|us-east1|
-|N. Virginia|us-east4|
-|Iowa|us-central1|
-|Oregon|us-west1|
-|Los Angeles|us-west2|
-|Las Vegas|us-west4|
-|Toronto|northamerica-northeast2|
-|Belgium|europe-west1|
-|London|europe-west2|
-|Frankfurt|europe-west3|
-|Netherlands|europe-west4|
-|Sydney|australia-southeast1|
-|Tokyo|asia-northeast1|
-|Seoul|asia-northeast3|
+| South Carolina | `us-east1` |
+| N. Virginia | `us-east4` |
+| Iowa | `us-central1` |
+| Oregon | `us-west1` |
+| Los Angeles | `us-west2` |
+| Las Vegas | `us-west4` |
+| Toronto | `northamerica-northeast2` |
+| Belgium | `europe-west1` |
+| London | `europe-west2` |
+| Frankfurt | `europe-west3` |
+| Netherlands | `europe-west4` |
+| Sydney | `australia-southeast1` |
+| Tokyo | `asia-northeast1` |
+| Seoul | `asia-northeast3` |
 
-For more information about Google Cloud Regions, see [Regions and zones](https://cloud.google.com/compute/docs/regions-zones) in the Google Cloud Documentation.
+For more information about Google Cloud regions, see [Regions and zones](https://cloud.google.com/compute/docs/regions-zones) in the Google Cloud Documentation.
 
-## Supported Azure Region
-The following table lists [Azure regions](https://azure.microsoft.com/explore/global-infrastructure/geographies/#geographies) that W&B currently supports for Dedicated Cloud instances.
+## Supported Azure regions
+
+The following table lists [Azure regions](https://azure.microsoft.com/explore/global-infrastructure/geographies/#geographies) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
 |-------------|--------|
-|Virginia|eastus|
-|Iowa|centralus|
-|Washington|westus2|
-|California|westus|
-|Canada Central|canadacentral|
-|France Central|francecentral|
-|Netherlands|westeurope|
-|Tokyo, Saitama|japaneast|
-|Seoul|koreacentral|
+| Virginia | `eastus` |
+| Iowa | `centralus` |
+| Washington | `westus2` |
+| California | `westus` |
+| Canada Central | `canadacentral` |
+| France Central | `francecentral` |
+| Netherlands | `westeurope` |
+| Tokyo, Saitama | `japaneast` |
+| Seoul | `koreacentral` |
 
 For more information about Azure regions, see [Azure geographies](https://azure.microsoft.com/explore/global-infrastructure/geographies/#overview) in the Azure Documentation.

--- a/platform/hosting/hosting-options/dedicated_regions.mdx
+++ b/platform/hosting/hosting-options/dedicated_regions.mdx
@@ -3,73 +3,75 @@ title: Supported Dedicated Cloud regions
 description: "View all supported AWS, Google Cloud, and Azure regions available for W&B Dedicated Cloud deployments."
 ---
 
-AWS, Google Cloud, and Azure support cloud computing services in multiple locations worldwide. Global regions help ensure that you satisfy requirements related to data residency & compliance, latency, cost efficiency and more. W&B supports many of the available global regions for Dedicated Cloud.
+This page lists the AWS, Google Cloud, and Azure regions that W&B supports for Dedicated Cloud deployments. Consult these tables when you're choosing a region for a new Dedicated Cloud instance, so you can satisfy requirements such as data residency and compliance, latency, and cost efficiency.
 
 <Note>
-Reach out to W&B Support if your preferred AWS, Google Cloud, or Azure Region is not listed. W&B can validate if the relevant region has all the services that Dedicated Cloud needs and prioritize support depending on the outcome of the evaluation.
+Contact W&B Support if your preferred AWS, Google Cloud, or Azure region isn't listed. W&B can validate whether the region has all the services that Dedicated Cloud requires. W&B prioritizes support based on the outcome of that evaluation.
 </Note>
 
-## Supported AWS Regions
+## Supported AWS regions
 
-The following table lists [AWS Regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) that W&B currently supports for Dedicated Cloud instances.
+The following table lists [AWS Regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
-|-------------|--------|
-|US East (Ohio)| us-east-2|
-|US East (N. Virginia)|us-east-1|
-|US West (N. California)|us-west-1|
-|US West (Oregon)|us-west-2|
-|Canada (Central)|ca-central-1|
-|Europe (Frankfurt)|eu-central-1|
-|Europe (Ireland)|eu-west-1|
-|Europe (London)|eu-west-2|
-|Europe (Milan)|eu-south-1|
-|Europe (Stockholm)|eu-north-1|
-|Asia Pacific (Mumbai)|ap-south-1|
-|Asia Pacific (Singapore)| ap-southeast-1|
-|Asia Pacific (Sydney)|ap-southeast-2|
-|Asia Pacific (Tokyo)|ap-northeast-1|
-|Asia Pacific (Seoul)|ap-northeast-2|
+|-----------------|-------------|
+| US East (Ohio) | `us-east-2` |
+| US East (N. Virginia) | `us-east-1` |
+| US West (N. California) | `us-west-1` |
+| US West (Oregon) | `us-west-2` |
+| Canada (Central) | `ca-central-1` |
+| Europe (Frankfurt) | `eu-central-1` |
+| Europe (Ireland) | `eu-west-1` |
+| Europe (London) | `eu-west-2` |
+| Europe (Milan) | `eu-south-1` |
+| Europe (Stockholm) | `eu-north-1` |
+| Asia Pacific (Mumbai) | `ap-south-1` |
+| Asia Pacific (Singapore) | `ap-southeast-1` |
+| Asia Pacific (Sydney) | `ap-southeast-2` |
+| Asia Pacific (Tokyo) | `ap-northeast-1` |
+| Asia Pacific (Seoul) | `ap-northeast-2` |
 
-For more information about AWS Regions, see the [Regions, Availability Zones, and Local Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) in the AWS Documentation.
+For more information about AWS Regions, see [Regions, Availability Zones, and Local Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) in the AWS documentation.
 
-See [What to Consider when Selecting a Region for your Workloads](https://aws.amazon.com/blogs/architecture/what-to-consider-when-selecting-a-region-for-your-workloads/) for an overview of factors that you should consider when choosing an AWS Region. 
+See [What to Consider when Selecting a Region for your Workloads](https://aws.amazon.com/blogs/architecture/what-to-consider-when-selecting-a-region-for-your-workloads/) for an overview of factors to consider when choosing an AWS Region.
 
 ## Supported Google Cloud regions
-The following table lists [Google Cloud Regions](https://cloud.google.com/compute/docs/regions-zones) that W&B currently supports for Dedicated Cloud instances.
+
+The following table lists [Google Cloud regions](https://cloud.google.com/compute/docs/regions-zones) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
-|-------------|--------|
-|South Carolina|us-east1|
-|N. Virginia|us-east4|
-|Iowa|us-central1|
-|Oregon|us-west1|
-|Los Angeles|us-west2|
-|Las Vegas|us-west4|
-|Toronto|northamerica-northeast2|
-|Belgium|europe-west1|
-|London|europe-west2|
-|Frankfurt|europe-west3|
-|Netherlands|europe-west4|
-|Sydney|australia-southeast1|
-|Tokyo|asia-northeast1|
-|Seoul|asia-northeast3|
+|-----------------|-------------|
+| South Carolina | `us-east1` |
+| N. Virginia | `us-east4` |
+| Iowa | `us-central1` |
+| Oregon | `us-west1` |
+| Los Angeles | `us-west2` |
+| Las Vegas | `us-west4` |
+| Toronto | `northamerica-northeast2` |
+| Belgium | `europe-west1` |
+| London | `europe-west2` |
+| Frankfurt | `europe-west3` |
+| Netherlands | `europe-west4` |
+| Sydney | `australia-southeast1` |
+| Tokyo | `asia-northeast1` |
+| Seoul | `asia-northeast3` |
 
-For more information about Google Cloud Regions, see [Regions and zones](https://cloud.google.com/compute/docs/regions-zones) in the Google Cloud Documentation.
+For more information about Google Cloud regions, see [Regions and zones](https://cloud.google.com/compute/docs/regions-zones) in the Google Cloud documentation.
 
-## Supported Azure Region
-The following table lists [Azure regions](https://azure.microsoft.com/explore/global-infrastructure/geographies/#geographies) that W&B currently supports for Dedicated Cloud instances.
+## Supported Azure regions
+
+The following table lists [Azure regions](https://azure.microsoft.com/explore/global-infrastructure/geographies/#geographies) that W&B supports for Dedicated Cloud instances.
 
 | Region location | Region name |
-|-------------|--------|
-|Virginia|eastus|
-|Iowa|centralus|
-|Washington|westus2|
-|California|westus|
-|Canada Central|canadacentral|
-|France Central|francecentral|
-|Netherlands|westeurope|
-|Tokyo, Saitama|japaneast|
-|Seoul|koreacentral|
+|-----------------|-------------|
+| Virginia | `eastus` |
+| Iowa | `centralus` |
+| Washington | `westus2` |
+| California | `westus` |
+| Canada Central | `canadacentral` |
+| France Central | `francecentral` |
+| Netherlands | `westeurope` |
+| Tokyo, Saitama | `japaneast` |
+| Seoul | `koreacentral` |
 
-For more information about Azure regions, see [Azure geographies](https://azure.microsoft.com/explore/global-infrastructure/geographies/#overview) in the Azure Documentation.
+For more information about Azure regions, see [Azure geographies](https://azure.microsoft.com/explore/global-infrastructure/geographies/#overview) in the Azure documentation.

--- a/platform/hosting/hosting-options/multi_tenant_cloud.mdx
+++ b/platform/hosting/hosting-options/multi_tenant_cloud.mdx
@@ -3,47 +3,56 @@ title: Multi-tenant Cloud
 description: "Learn about W&B Multi-tenant Cloud, a fully managed deployment on Google Cloud with built-in compliance and data security."
 ---
 
-W&B Multi-tenant Cloud is a fully managed platform deployed in W&B's Google Cloud account in [Google Cloud's North America regions](https://cloud.google.com/compute/docs/regions-zones). W&B Multi-tenant Cloud utilizes autoscaling in Google Cloud to ensure that the platform scales appropriately based on increases or decreases in traffic.
+This page describes W&B Multi-tenant Cloud, including its architecture, compliance posture, data security options, and identity and access management capabilities, so you can decide whether it fits your organization's hosting requirements.
+
+W&B Multi-tenant Cloud is a fully managed platform deployed in W&B's Google Cloud account in [Google Cloud's North America regions](https://cloud.google.com/compute/docs/regions-zones). W&B Multi-tenant Cloud uses autoscaling in Google Cloud to scale the platform based on changes in traffic.
 
 <Frame>
     <img src="/images/hosting/multi_tenant_cloud_arch.png" alt="Multi-tenant Cloud architecture diagram"  />
 </Frame>
 
-W&B Multi-tenant Cloud scales to meet your organization's needs, and supports logging up to 250,000 metrics per project with up to 1 million data points per metric. For larger deployments, contact [support](mailto:support@wandb.com).
+W&B Multi-tenant Cloud scales to meet your organization's needs and supports logging up to 250,000 metrics per project with up to 1 million data points per metric. For larger deployments, contact [support](mailto:support@wandb.com).
 
 ## Compliance
-W&B Multi-tenant Cloud's hosting platform meets the requirements of the [Service and Organization Controls (SOC) 2 Type 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2), published by the [Auditing Standards Board of the American Institute of Certified Public Accountants (AICPA)](https://www.aicpa-cima.com/home). A SOC 2 report evaluates a service organization’s controls for security, availability, processing integrity, confidentiality, and privacy. W&B Multi-tenant Cloud is subject to periodic internal and external audits to verify continued compliance. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request the SOC 2 report and other security and compliance documents.
 
-<Tip>W&B Multi-tenant Cloud does not meet the requirements of the [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://www.hhs.gov/hipaa/for-professionals/index.html). If your organization is subject to HIPAA, consider [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instead.</Tip>
+W&B Multi-tenant Cloud's hosting platform meets the requirements of the [Service and Organization Controls (SOC) 2 Type 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2), published by the [Auditing Standards Board of the American Institute of Certified Public Accountants (AICPA)](https://www.aicpa-cima.com/home). A SOC 2 report evaluates a service organization's controls for security, availability, processing integrity, confidentiality, and privacy. W&B Multi-tenant Cloud is subject to periodic internal and external audits to verify continued compliance. Refer to the [W&B Security Portal](https://security.wandb.ai/) to request the SOC 2 report and other security and compliance documents.
+
+<Tip>W&B Multi-tenant Cloud doesn't meet the requirements of the [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://www.hhs.gov/hipaa/for-professionals/index.html). If your organization is subject to HIPAA, consider [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instead.</Tip>
 
 ## Data security
 
-For users on Free or Pro plans, all data is only stored in the shared cloud storage and is processed with shared cloud compute services. Depending on your pricing plan, you may be subject to storage limits.
+For users on Free or Pro plans, W&B stores all data only in the shared cloud storage and processes it with shared cloud compute services. Depending on your pricing plan, you may be subject to storage limits.
 
-Users on an Enterprise plan can [bring their own bucket (BYOB) using the secure storage connector](/platform/hosting/data-security/secure-storage-connector) at the [team level](/platform/hosting/data-security/secure-storage-connector#configuration-options) to store their files such as models, datasets, and more. You can configure a single bucket for multiple teams or you can use separate buckets for different W&B Teams. If you do not configure BYOB for a team, the team's data is stored in the shared cloud storage.
+Users on an Enterprise plan can [bring their own bucket (BYOB) using the secure storage connector](/platform/hosting/data-security/secure-storage-connector) at the [team level](/platform/hosting/data-security/secure-storage-connector#configuration-options) to store their files such as models, datasets, and more. You can configure a single bucket for multiple teams or you can use separate buckets for different W&B Teams. If you don't configure BYOB for a team, W&B stores the team's data in the shared cloud storage.
 
 You are responsible for ensuring that your deployment complies with your organization's policies and [Security Technical Implementation Guidelines (STIG)](https://en.wikipedia.org/wiki/Security_Technical_Implementation_Guide), if applicable.
 
 ## Data retention policy
-Multi-tenant Cloud retains the following items for 7 days after deletion:
-- Runs and history
-- Non-artifact run files, such as media, configuration files, and log files
-- Artifacts and artifact references
 
-Until this period elapses, these items can be restored. Contact [support](mailto:support@wandb.ai) or your AISE for assistance.
+Multi-tenant Cloud retains the following items for 7 days after deletion:
+
+- Runs and history.
+- Non-artifact run files, such as media, configuration files, and log files.
+- Artifacts and artifact references.
+
+Until this period elapses, W&B can restore these items. Contact [support](mailto:support@wandb.ai) or your AISE for assistance.
 
 ## Identity and access management (IAM)
-If you are on an Enterprise plan, enhanced identity and access managements capabilities allow for secure authentication and effective authorization for your W&B deployment:
 
-* SSO authentication with OIDC or SAML. Reach out to your W&B team or support if you would like to configure SSO for your organization.
-* [Configure appropriate user roles](/platform/hosting/iam/access-management/manage-organization#assign-or-update-a-users-role) at the scope of the organization and within a team.
-* Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it with [restricted projects](/platform/hosting/iam/access-management/restricted-projects).
+If you're on an Enterprise plan, identity and access management features support secure authentication and authorization for your W&B deployment:
 
-## Monitor
-Organization admins can manage usage and billing for their account from the `Billing` tab in their account view. If using the shared cloud storage on Multi-tenant Cloud, an admin can optimize storage usage across different teams in their organization.
+- Authenticate users with SSO using OIDC or SAML. Contact your W&B team or support if you'd like to configure SSO for your organization.
+- [Configure user roles](/platform/hosting/iam/access-management/manage-organization#assign-or-update-a-users-role) at the scope of the organization and within a team.
+- Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it with [restricted projects](/platform/hosting/iam/access-management/restricted-projects).
+
+## Billing and usage
+
+Organization admins can manage usage and billing for their account from the **Billing** tab in their account view. If using the shared cloud storage on Multi-tenant Cloud, an admin can optimize storage usage across different teams in their organization.
 
 ## Maintenance
-W&B Multi-tenant Cloud is a multi-tenant, fully managed platform. Since W&B Multi-tenant Cloud is managed by W&B, you do not incur the overhead and costs of provisioning and maintaining the W&B platform.
+
+W&B Multi-tenant Cloud is a multi-tenant, fully managed platform. Because W&B manages Multi-tenant Cloud, you don't incur the overhead and costs of provisioning and maintaining the W&B platform.
 
 ## Next steps
-Access [Multi-tenant Cloud directly](https://wandb.ai) to get started with most features for free. To try out enhanced data security and IAM features, [request an Enterprise trial](https://wandb.ai/site/for-enterprise/multi-tenant-saas-trial).
+
+Access [Multi-tenant Cloud directly](https://wandb.ai) to get started with most features for free. To try data security and IAM features, [request an Enterprise trial](https://wandb.ai/site/for-enterprise/multi-tenant-saas-trial).

--- a/platform/hosting/hosting-options/self-managed.mdx
+++ b/platform/hosting/hosting-options/self-managed.mdx
@@ -6,17 +6,19 @@ sidebarTitle: Deployment overview
 
 
 <Tip>
-W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
+W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud). W&B fully managed services are secure to use, with minimal configuration required.
 </Tip>
 
-Deploy W&B Server on your [AWS, Google Cloud, or Azure cloud account](#deploy-wb-server-within-Self-Managed-cloud-accounts) or within your [on-premises infrastructure](#deploy-wb-server-in-on-prem-infrastructure). 
+W&B Self-Managed lets you run W&B Server in infrastructure you control, so you can meet internal policies for data residency, network isolation, and compliance. This overview is for IT, DevOps, and MLOps teams who plan, deploy, and operate W&B Server on their own cloud account or on-premises infrastructure.
 
-Your IT/DevOps/MLOps team is responsible for:
-- Provisioning your deployment.
-- Securing your infrastructure in accordance with your organization's policies, [Security Technical Implementation Guidelines (STIG)](https://en.wikipedia.org/wiki/Security_Technical_Implementation_Guide), if applicable.
-- Maintaining compliance with your organization's regulatory requirements, such as [Service and Organization Controls (SOC) 2 Type 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) and [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://www.hhs.gov/hipaa/for-professionals/index.html).
-- Managing upgrades and applying patches.
-- Continuously maintaining your W&B Self-Managed W&B deployment.
+Deploy W&B Server on your [AWS, Google Cloud, or Azure cloud account](#deploy-wb-server-within-Self-Managed-cloud-accounts) or within your [on-premises infrastructure](#deploy-wb-server-in-on-prem-infrastructure).
+
+Your IT, DevOps, or MLOps team has the following responsibilities:
+- Provision your deployment.
+- Secure your infrastructure in accordance with your organization's policies, [Security Technical Implementation Guidelines (STIG)](https://en.wikipedia.org/wiki/Security_Technical_Implementation_Guide), if applicable.
+- Maintain compliance with your organization's regulatory requirements, such as [Service and Organization Controls (SOC) 2 Type 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) and [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://www.hhs.gov/hipaa/for-professionals/index.html).
+- Manage upgrades and apply patches.
+- Maintain your W&B Self-Managed deployment on an ongoing basis.
 
 <Info>
 If your organization is subject to regulatory requirements, consider deploying on [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), which is maintained by W&B.
@@ -28,28 +30,31 @@ Refer to the [W&B Security Portal](https://security.wandb.ai/) to request more i
 
 ## About the W&B Kubernetes Operator
 
-Use the **W&B Kubernetes Operator** to deploy W&B Self-Managed. The operator simplifies deploying, administering, troubleshooting, and scaling W&B.
+W&B Self-Managed installations are delivered and managed through a Kubernetes operator, which handles the day-to-day complexity of running W&B Server.
 
-The operator connects to a central [deploy.wandb.ai](https://deploy.wandb.ai) server to request the latest specification changes for a given release channel and apply them. Updates are received as long as the license is valid. [Helm](https://helm.sh/) is used both to install the operator and for the operator to manage the W&B Kubernetes stack. The deployment consists of multiple pods, one per service; each pod name is prefixed with `wandb-`.
+Use the W&B Kubernetes Operator to deploy W&B Self-Managed. The operator simplifies deploying, administering, troubleshooting, and scaling W&B.
 
-Configuration follows a hierarchy: **Release Channel Values** (defaults from W&B), **User Input Values** (overrides via the System Console), and **Custom Resource Values** (your spec overrides both). For details, see [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator).
+The operator connects to a central [deploy.wandb.ai](https://deploy.wandb.ai) server to request the latest specification changes for a given release channel and apply them. The operator receives updates as long as the license is valid. The operator uses [Helm](https://helm.sh/) both to install itself and to manage the W&B Kubernetes stack. The deployment consists of multiple pods, one per service, and each pod name is prefixed with `wandb-`.
 
+Configuration follows a hierarchy: **Release Channel Values** (defaults from W&B), **User Input Values** (overrides via the System Console), and **Custom Resource Values** (your spec overrides both).
+
+Use the following resources based on your deployment target:
 - To deploy W&B Self-Managed in public cloud or on-premises infrastructure, see [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator).
-- To deploy W&B Self-Managed to a custom cloud platform that is not AWS, the requirements are similar to the requirements for deploying in [on-prem infrastructure](#deploy-wb-server-in-on-prem-infrastructure).
+- To deploy W&B Self-Managed to a custom cloud platform that isn't AWS, the requirements are similar to the requirements to deploy in [on-premises infrastructure](#deploy-wb-server-in-on-prem-infrastructure).
 - To deploy W&B Self-Managed in air-gapped environments, see [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped).
 
-You can optionally [configure rate limits](/platform/hosting/self-managed/rate-limits) on your instance to maintain stability. See [Rate limits](/platform/hosting/self-managed/rate-limits) for default values and notification behavior.
+You can optionally configure rate limits on your instance to maintain stability. For more information, see [Rate limits](/platform/hosting/self-managed/rate-limits).
 
 ## Required infrastructure
 
-All deployment options depend on the following infrastructure:
+Before you deploy, make sure the following infrastructure is available. All W&B Self-Managed deployment options depend on these components:
 - Kubernetes
 - MySQL 8 database
 - Amazon S3-compatible object storage
 - Redis cache
 
-See [Requirements](/platform/hosting/self-managed/requirements) for details. W&B can provide recommendations for the different components and provide guidance through the installation process.
+W&B can provide recommendations for the different components and provide guidance through the installation process. For more information, see [Requirements](/platform/hosting/self-managed/requirements).
 
 ## Obtain your W&B Server license
 
-You need a W&B Server license before deploying. For step-by-step instructions, see [License](/platform/hosting/self-managed/requirements#license) on the Requirements page.
+A W&B Server license authorizes your deployment. You must obtain a license before installation. For step-by-step instructions, see [License](/platform/hosting/self-managed/requirements#license) on the Requirements page.

--- a/platform/hosting/iam/access-management-intro.mdx
+++ b/platform/hosting/iam/access-management-intro.mdx
@@ -3,29 +3,37 @@ title: Access management
 description: "Manage users, teams, roles, and project visibility as an organization or team admin in W&B."
 ---
 
+This page introduces how access management works in W&B, including how to administer users and teams, maintain admin access to your organization, and control who can view individual projects. It's intended for organization admins, team admins, and project owners.
+
 ## Manage users and teams within an organization
-The first user to sign up to W&B with a unique organization domain is assigned as that organization's *instance administrator role*. The organization administrator assigns specific users team administrator roles.
+
+This section explains how admin roles are assigned and what each role can do to manage users and teams.
+
+W&B assigns the *instance admin role* to the first user who signs up to W&B with a unique organization domain. The organization admin assigns specific users team admin roles.
 
 <Note>
-W&B recommends to have more than one instance admin in an organization. It is a best practice to ensure that admin operations can continue when the primary admin is not available.
+W&B recommends that you have more than one instance admin in an organization. This best practice ensures that admin operations can continue when the primary admin isn't available.
 </Note>
 
-A *team administrator* is a user in organization that has administrative permissions within a team. 
+A *team admin* is a user in an organization who has administrative permissions within a team.
 
-Organization administrators can access and use an organization's account settings at `https://wandb.ai/account-settings/` to invite users, assign or update a user's role, create teams, remove users from your organization, assign the billing administrator, and more. See [Add and manage users](/platform/hosting/iam/access-management/manage-organization/#add-and-manage-users) for more information. 
+Organization admins can access and use an organization's account settings at `https://wandb.ai/account-settings/` to invite users, assign or update a user's role, create teams, remove users from your organization, and assign the billing admin. See [Add and manage users](/platform/hosting/iam/access-management/manage-organization/#add-and-manage-users) for more information.
 
-Once an organization administrator creates a team, the instance administrator or a team administrator can:
+After an organization admin creates a team, the instance admin or a team admin can:
 
-- By default, only an admin can invite users to that team or remove users from the team. To change this behavior, refer to [Team settings](/platform/app/settings-page/teams/#privacy).
+- Invite users to the team or remove users from the team. By default, only an admin can perform this action. To change this behavior, see [Team settings](/platform/app/settings-page/teams/#privacy).
 - Assign or update a team member's role.
 - Automatically add new users to a team when they join your organization.
 
-Both the organization administrator and the team administrator use team dashboards at `https://wandb.ai/<your-team-name>` to manage teams. For more information, and to configure a team's default privacy settings, see [Add and manage teams](/platform/hosting/iam/access-management/manage-organization/#add-and-manage-teams).
+Both the organization admin and the team admin use team dashboards at `https://wandb.ai/[YOUR-TEAM-NAME]` to manage teams. For more information, and to configure a team's default privacy settings, see [Add and manage teams](/platform/hosting/iam/access-management/manage-organization/#add-and-manage-teams).
 
 ## Maintain admin access
-You must ensure that at least one admin user exists in your instance or organization at all times. Otherwise, no user will be able to configure or maintain your organization's W&B account.
 
-If users are managed interactively, admin access is required to delete a user, including another admin user. This helps to reduce the risk of the sole admin user being removed.
+This section describes why you must always preserve admin access and how automated user deprovisioning can put that access at risk.
+
+You must ensure that at least one admin user always exists in your instance or organization. Otherwise, no user can configure or maintain your organization's W&B account.
+
+If you manage users interactively, deleting a user requires admin access, including when deleting another admin user. This helps reduce the risk of removing the sole admin user.
 
 However, if an organization uses automated processes to deprovision users from W&B, a deprovisioning operation could inadvertently remove the last remaining admin from the instance or organization.
 
@@ -35,6 +43,6 @@ For assistance with developing operational procedures, or to restore admin acces
 
 Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it. Limiting who can view a project is particularly useful if a team works with sensitive or confidential data.
 
-An organization admin, team admin, or the owner of a project can both set and edit a project's visibility. 
+An organization admin, team admin, or the owner of a project can set and edit a project's visibility.
 
 For more information, see [Project visibility](/platform/hosting/iam/access-management/restricted-projects/).

--- a/platform/hosting/iam/access-management/manage-organization.mdx
+++ b/platform/hosting/iam/access-management/manage-organization.mdx
@@ -2,19 +2,22 @@
 title: Manage your organization
 description: "Manage users, teams, roles, seats, and billing within a W&B organization as an organization admin."
 ---
-As an admin of an organization you can [manage individual users](#add-and-manage-users) within your organization and [manage teams](#add-and-manage-teams). 
+This page describes how to administer a W&B organization, including how to invite users, manage teams, assign roles and seats, and configure billing. Use these procedures to keep your organization's membership, access, and team structure aligned with how your company uses W&B.
 
-As a team admin you can [manage teams](#add-and-manage-teams).
+As an admin of an organization, you can [manage individual users](#add-and-manage-users) within your organization and [manage teams](#add-and-manage-teams). 
+
+As a team admin, you can [manage teams](#add-and-manage-teams).
 
 <Note>
-The following workflow applies to users with instance admin roles. Reach out to an admin in your organization if you believe you should have instance admin permissions.
+The following workflow applies to users with instance admin roles. Contact an admin in your organization if you believe you should have instance admin permissions.
 </Note>
 
-If you are looking to simplify user management in your organization, refer to [Automate user and team management](../automate_iam).
+To simplify user management in your organization, see [Automate user and team management](../automate_iam).
 
 {/* W&B assigns an Admin role to new users within an organization by default. */}
 
 ## Change the name of your organization
+
 <Note>
 The following workflow only applies to W&B Multi-tenant Cloud.
 </Note>
@@ -28,81 +31,86 @@ The following workflow only applies to W&B Multi-tenant Cloud.
 ## Add and manage users
 
 As an admin, use your organization's dashboard to:
+
 - Invite or remove users.
 - Assign or update a user's organization role, and create custom roles.
 - Assign the billing admin.
 
-There are several ways an organization admin can add users to an organization:
+An organization admin can add users to an organization in several ways:
 
-1. Member-by-invite
-2. Auto provisioning with SSO
-3. Domain capture
+- Member-by-invite
+- Auto provisioning with SSO
+- Domain capture
+
+The following sections describe each method.
 
 ### Seats and pricing
 
 The following table summarizes how seats work for Models and Weave:
 
-| Product |Seats | Cost based on |
+| Product | Seats | Cost based on |
 | ----- | ----- | ----- |
-| Models | Pay per set | How many Models paid seats you have, and how much usage you’ve accrued determines your overall subscription cost. Each user can be assigned one of the three available seat types: Full, Viewer, and No-Access |
-| Weave | Free  | Usage based |
+| Models | Pay per set | How many Models paid seats you have and how much usage you've accrued determines your overall subscription cost. You can assign each user one of three available seat types: Full, Viewer, or No-Access. |
+| Weave | Free | Usage based |
 
 ### Invite a user
 
-admins can invite users to their organization, as well as specific teams within the organization.
+Admins can invite users to their organization, as well as to specific teams within the organization.
 
 <Tabs>
 <Tab title="Multi-tenant Cloud">
 1. Navigate to https://wandb.ai/home.
-1. In the upper right corner of the page, select the **User menu** dropdown. Within the **Account** section of the dropdown, select **Users**.
+2. In the upper right corner of the page, select the **User menu** dropdown. Within the **Account** section of the dropdown, select **Users**.
 3. Select **Invite new user**.
 4. In the modal that appears, provide the email or username of the user in the **Email or username** field.
-5. (Recommended) Add the user to a team from the **Choose teams** dropdown menu.
-6. From the **Select role** dropdown, select the role to assign to the user. You can change the user's role at a later time. See the table listed in [Assign a role](#assign-or-update-a-team-members-role) for more information about possible roles.
+5. Optional: Add the user to a team from the **Choose teams** dropdown menu.
+6. From the **Select role** dropdown, select the role to assign to the user. You can change the user's role later. See the table listed in [Assign a role](#assign-or-update-a-team-members-role) for more information about possible roles.
 7. Click the **Send invite** button.
 
-W&B sends an invite link using a third-party email server to the user's email after you select the **Send invite** button. A user can access your organization once they accept the invite.
+After you select the **Send invite** button, W&B sends an invite link to the user's email using a third-party email server. A user can access your organization once they accept the invite.
 </Tab>
 <Tab title="Dedicated Cloud or Self-Managed">
 1. Navigate to `https://<org-name>.io/console/settings/`. Replace `<org-name>` with your organization name.
-2. Select the **Add user** button
+2. Select the **Add user** button.
 3. Within the modal that appears, provide the email of the new user in the **Email** field.
-4. Select a role to assign to the user from the **Role** dropdown. You can change the user's role at a later time. See the table listed in [Assign a role](#assign-or-update-a-team-members-role) for more information about possible roles.
-5. Check the **Send invite email to user** box if you want W&B to send an invite link using a third-party email server to the user's email.
+4. Select a role to assign to the user from the **Role** dropdown. You can change the user's role later. See the table listed in [Assign a role](#assign-or-update-a-team-members-role) for more information about possible roles.
+5. To have W&B send an invite link to the user's email using a third-party email server, check the **Send invite email to user** box.
 6. Select the **Add new user** button.
 </Tab>
 </Tabs>
 
 ### Auto provision users
 
-A W&B user with matching email domain can log in to your W&B Organization with Single Sign-On (SSO) if you configure SSO and your SSO provider permits it. SSO is available for all Enterprise licenses.
+Auto-provisioning streamlines onboarding by letting users join your organization automatically through SSO, so admins don't need to send individual invitations.
+
+If you configure SSO and your SSO provider permits it, a W&B user with a matching email domain can log in to your W&B organization with Single Sign-On (SSO). SSO is available for all Enterprise licenses.
 
 <Note>
 **Enable SSO for authentication**
 
-W&B strongly recommends and encourages that users authenticate using Single Sign-On (SSO). Reach out to your W&B team to enable SSO for your organization. 
+W&B recommends that users authenticate using Single Sign-On (SSO). Contact your W&B team to enable SSO for your organization. 
 
-To learn more about how to set up SSO with Dedicated Cloud or Self-Managed instances, refer to [SSO with OIDC](/platform/hosting/iam/sso/) or [SSO with LDAP](/platform/hosting/iam/ldap/).
+For more information about how to set up SSO with Dedicated Cloud or Self-Managed instances, see [SSO with OIDC](/platform/hosting/iam/sso/) or [SSO with LDAP](/platform/hosting/iam/ldap/).
 </Note>
 
 
-W&B assigned auto-provisioning users "Member" roles by default. You can change the role of auto-provisioned users at any time.
+W&B assigns auto-provisioning users "Member" roles by default. You can change the role of auto-provisioned users at any time.
 
-Auto-provisioning users with SSO is on by default for Dedicated Cloud instances and Self-Managed deployments. You can turn off auto provisioning. Turning auto provisioning off enables you to selectively add specific users to your W&B organization.
+Auto-provisioning users with SSO is on by default for Dedicated Cloud instances and Self-Managed deployments. You can turn off auto provisioning. Turning auto provisioning off lets you selectively add specific users to your W&B organization.
 
 The following tabs describe how to turn off SSO based on deployment type:
 
 <Tabs>
 <Tab title="Multi-tenant Cloud">
-Auto provisioning with SSO is not configurable for Multi-tenant Cloud. Contact your W&B team for assistance.
+Auto provisioning with SSO isn't configurable for Multi-tenant Cloud. Contact your W&B team for assistance.
 </Tab>
 <Tab title="Dedicated Cloud or Self-Managed">
-For Dedicated Cloud instances, reach out to your W&B team if you want to turn off auto provisioning with SSO.
+For Dedicated Cloud instances, contact your W&B team if you want to turn off auto provisioning with SSO.
 
 For Self-Managed deployments, use the W&B Console to turn off auto provisioning with SSO:
 
 1. Navigate to `https://<org-name>.io/console/settings/`. Replace `<org-name>` with your organization name.
-2. Select **Security** 
+2. Select **Security**.
 3. Select the **Disable SSO Provisioning** to turn off auto provisioning with SSO.
 
 {/* For Self-Managed deployments, you can configure the setting `DISABLE_SSO_PROVISIONING=true` to turn off auto provisioning with SSO. */}
@@ -110,29 +118,30 @@ For Self-Managed deployments, use the W&B Console to turn off auto provisioning 
 </Tabs>
 
 <Note>
-Auto provisioning with SSO is useful for adding users to an organization at scale because organization admins do not need to generate individual user invitations.
+Auto provisioning with SSO is useful for adding users to an organization at scale because organization admins don't need to generate individual user invitations.
 </Note>
 
 ### Domain capture
-Domain capture helps your employees join your company's organization to ensure new users do not create assets outside of your company's jurisdiction. 
+
+Domain capture helps your employees join your company's organization to ensure new users don't create assets outside your company's jurisdiction. 
 
 <Note>
 **Domains must be unique**
 
-Domains are unique identifiers. This means that you can not use a domain that is already in use by another organization.
+Domains are unique identifiers. This means that you can't use a domain that's already in use by another organization.
 </Note>
 
 <Tabs>
 <Tab title="Multi-tenant Cloud">
-Domain capture lets you automatically add people with a company email address, such as  `@example.com`, to your W&B Multi-tenant Cloud organization. This helps all your employees join the right organization and ensures that new users do not create assets outside of your company jurisdiction. 
+Domain capture lets you automatically add people with a company email address, such as `@example.com`, to your W&B Multi-tenant Cloud organization. This helps all your employees join the right organization and ensures that new users don't create assets outside your company jurisdiction. 
 
 This table summarizes the behavior of new and existing users with and without domain capture enabled:
 
 | | With domain capture | Without domain capture |
 | ----- | ----- | ----- |
-| New users | Users who sign up for W&B from verified domains are automatically added as members to your organization’s default team. They can choose additional teams to join at sign up, if you enable team joining. They can still join other organizations and teams with an invitation. | Users can create W&B accounts without knowing there is a centralized organization available. | 
-| Invited users | Invited users automatically join your organization when accepting your invite. Invited users are not automatically added as members to your organization’s default team. They can still join other organizations and teams with an invitation. | Invited users automatically join your organization when accepting your invite. They can still join other organizations and teams with an invitation.| 
-| Existing users | Existing users with verified email addresses from your domains can join your organization’s teams within the W&B App. All data that existing users create before joining your organization remains. W&B does not migrate the existing user's data. | Existing W&B users may be spread across multiple organizations and teams.|
+| New users | Users who sign up for W&B from verified domains are automatically added as members to your organization's default team. They can choose additional teams to join at sign up, if you enable team joining. They can still join other organizations and teams with an invitation. | Users can create W&B accounts without knowing a centralized organization is available. | 
+| Invited users | Invited users automatically join your organization when accepting your invite. Invited users aren't automatically added as members to your organization's default team. They can still join other organizations and teams with an invitation. | Invited users automatically join your organization when accepting your invite. They can still join other organizations and teams with an invitation.| 
+| Existing users | Existing users with verified email addresses from your domains can join your organization's teams within the W&B App. All data that existing users create before joining your organization remains. W&B doesn't migrate the existing user's data. | Existing W&B users may be spread across multiple organizations and teams.|
 
 To automatically assign non-invited new users to a default team when they join your organization:
 
@@ -140,21 +149,21 @@ To automatically assign non-invited new users to a default team when they join y
 2. In the upper right corner of the page, select the **User menu** dropdown. From the dropdown, choose **Settings**.
 3. Within the **Settings** tab, select **General**.
 4. Click the **Claim domain** button within **Domain capture**.
-5. Select the team that you want new users to automatically join from the **Default team** dropdown. If no teams are available, you'll need to update team settings. See the instructions in [Add and manage teams](#add-and-manage-teams).
+5. Select the team that you want new users to automatically join from the **Default team** dropdown. If no teams are available, update team settings. See the instructions in [Add and manage teams](#add-and-manage-teams).
 6. Click the **Claim email domain** button.
 
 You must enable domain matching within a team's settings before you can automatically assign non-invited new users to that team.
 
-1. Navigate to the team's dashboard at `https://wandb.ai/<team-name>`. Where `<team-name>` is the name of the team you want to enable domain matching.
+1. Navigate to the team's dashboard at `https://wandb.ai/<team-name>`, where `<team-name>` is the name of the team for which you want to enable domain matching.
 2. Select **Team settings** in the global navigation on the left side of the team's dashboard.
-3. Within the **Privacy** section, toggle the "Recommend new users with matching email domains join this team upon signing up" option.
+3. Within the **Privacy** section, toggle the **Recommend new users with matching email domains join this team upon signing up** option.
 </Tab>
 <Tab title="Dedicated Cloud or Self-Managed">
-Reach out to your W&B Account Team if you use Dedicated Cloud or Self-Managed deployment type to configure domain capture. Once configured, your W&B Multi-tenant Cloud instance automatically prompts users who create a W&B account with your company email address to contact your admin to request access to your Dedicated Cloud or Self-Managed instance.
+If you use Dedicated Cloud or Self-Managed deployment type, contact your W&B Account Team to configure domain capture. Once configured, your W&B Multi-tenant Cloud instance automatically prompts users who create a W&B account with your company email address to contact your admin to request access to your Dedicated Cloud or Self-Managed instance.
 
 | | With domain capture | Without domain capture |
 | ----- | ----- | -----|
-| New users | Users who sign up for W&B on Multi-tenant Cloud from verified domains are automatically prompted to contact an admin with an email address you customize. They can still create an organizations on Multi-tenant Cloud to trial the product. | Users can create W&B Multi-tenant Cloud accounts without learning their company has a centralized dedicated instance. | 
+| New users | Users who sign up for W&B on Multi-tenant Cloud from verified domains are automatically prompted to contact an admin with an email address you customize. They can still create an organization on Multi-tenant Cloud to trial the product. | Users can create W&B Multi-tenant Cloud accounts without learning that their company has a centralized dedicated instance. | 
 | Existing users | Existing W&B users may be spread across multiple organizations and teams.| Existing W&B users may be spread across multiple organizations and teams.|
 </Tab>
 </Tabs>
@@ -162,63 +171,72 @@ Reach out to your W&B Account Team if you use Dedicated Cloud or Self-Managed de
 
 ### Assign or update a user's role
 
-Every member in an Organization has an organization role and seat for both W&B Models and Weave. The type of seat they have determines both their billing status and the actions they can take in each product line.
+A user's organization role controls what they can do across the organization, such as inviting other users, managing teams, or viewing content. Assign or update roles to give each user the appropriate level of administrative authority.
 
-You initially assign an organization role to a user when you invite them to your organization. You can change any user's role at a later time.
+Every member in an organization has an organization role and seat for both W&B Models and Weave. The type of seat they have determines both their billing status and the actions they can take in each product line.
+
+You initially assign an organization role to a user when you invite them to your organization. You can change any user's role later.
 
 A user within an organization can have one of the following roles:
 
 | Role | Descriptions |
 | ----- | ----- |
-| admin| A instance admin who can add or remove other users to the organization, change user roles, manage custom roles, add teams and more. W&B recommends ensuring there is more than one admin in the event that your admin is unavailable. |
-| Member | A regular user of the organization, invited by an instance admin. A organization member cannot invite other users or manage existing users in the organization. |
+| Admin | An instance admin who can add or remove other users to the organization, change user roles, manage custom roles, add teams, and more. W&B recommends having more than one admin in case your admin is unavailable. |
+| Member | A regular user of the organization, invited by an instance admin. An organization member can't invite other users or manage existing users in the organization. |
 | Viewer (Enterprise-only feature) | A view-only user of your organization, invited by an instance admin. A viewer only has read access to the organization and the underlying teams that they are a member of. |
-|Custom Roles (Enterprise-only feature) | Custom roles allow organization admins to compose new roles by inheriting from the preceding View-Only or Member roles, and adding additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. See also [Add and manage custom roles](#add-and-manage-custom-roles)|
+| Custom Roles (Enterprise-only feature) | Custom roles let organization admins compose new roles by inheriting from the preceding View-Only or Member roles and adding additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. For more information, see [Add and manage custom roles](#add-and-manage-custom-roles). |
 
 To change a user's role:
 
 1. Navigate to https://wandb.ai/home.
 2. In the upper right corner of the page, select the **User menu** dropdown. From the dropdown, choose **Users**.
-4. Provide the name or email of the user in the search bar.
+3. Provide the name or email of the user in the search bar.
 4. Select a role from the **TEAM ROLE** dropdown next to the name of the user.
 
 ### Assign or update a user's access
 
-A user within an organization has one of the following model seat or weave access types: full, viewer, or no access.  
+While the organization role controls administrative actions, the seat type controls what a user can do within Models and Weave. Use this procedure when you need to change a user's product-level permissions independent of their organization role.
+
+A user within an organization has one of the following Model seat or Weave access types: full, viewer, or no access.
 
 | Seat type | Description |
 | ----- | ----- |
 | Full | Users with this role type have full permissions to write, read, and export data for Models or Weave. |
-| Viewer | A view-only user of your organization. A viewer only has read access to the organization and the underlying teams that they are a part of, and view only access to Models or Weave. |
+| Viewer | A view-only user of your organization. A viewer only has read access to the organization and the underlying teams that they are a part of, and view-only access to Models or Weave. |
 | No access | Users with this role have no access to the Models or Weave products. |
 
-Model seat type and weave access type are defined at the organization level, and inherited by the team. If you want to change a user's seat type, navigate to the organization settings and follow the following steps:
+Model seat type and Weave access type are defined at the organization level and inherited by the team. To change a user's seat type, navigate to the organization settings and follow these steps:
 
-1. For Multi-tenant Cloud users, navigate to your organization's settings at `https://wandb.ai/account-settings/<organization>/settings`. Ensure to replace the values enclosed in angle brackets (`<>`) with your organization name. For Dedicated Cloud and Self-Managed deployments, navigate to `https://<your-instance>.wandb.io/org/dashboard`.
+1. For Multi-tenant Cloud users, navigate to your organization's settings at `https://wandb.ai/account-settings/<organization>/settings`. Replace the values enclosed in angle brackets (`<>`) with your organization name. For Dedicated Cloud and Self-Managed deployments, navigate to `https://<your-instance>.wandb.io/org/dashboard`.
 2. Select the **Users** tab.
 3. From the **Role** dropdown, select the seat type you want to assign to the user.
 
 <Note>
-The organization role and subscription type determines which seat types are available within your organization.
+The organization role and subscription type determine which seat types are available within your organization.
 </Note>
 
 ### Remove a user
 
 1. Navigate to https://wandb.ai/home.
 2. In the upper right corner of the page, select the **User menu** dropdown. From the dropdown, choose **Users**.
-4. Provide the name or email of the user in the search bar.
-5. Select the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu when it appears.
-6. From the dropdown, choose **Remove member**.
+3. Provide the name or email of the user in the search bar.
+4. Select the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu when it appears.
+5. From the dropdown, choose **Remove member**.
 
 ### Assign the billing admin
+
 1. Navigate to https://wandb.ai/home.
 2. In the upper right corner of the page, select the **User menu** dropdown. From the dropdown, choose **Users**.
-4. Provide the name or email of the user in the search bar.
-5. Under the **Billing admin** column, choose the user you want to assign as the billing admin.
+3. Provide the name or email of the user in the search bar.
+4. Under the **Billing admin** column, choose the user you want to assign as the billing admin.
 
 
 ## Add and manage teams
-Use your organization's dashboard to create  and manage teams within your organization. An organization admin or a team admin can:
+
+Teams group related users together so they can collaborate on projects and share resources within the organization. The following sections describe how to create teams, invite users to them, and manage team membership and roles.
+
+Use your organization's dashboard to create and manage teams within your organization. An organization admin or a team admin can:
+
 - Invite users to a team or remove users from a team.
 - Manage a team member's roles.
 - Automate the addition of users to a team when they join your organization.
@@ -237,7 +255,7 @@ Use your organization's dashboard to create a team:
 4. Choose a storage type. 
 5. Select the **Create team** button.
 
-After you select **Create team** button, W&B redirects you to a new team page at `https://wandb.ai/<team-name>`. Where `<team-name>` consists of the name you provide when you create a team.
+After you select the **Create team** button, W&B redirects you to a new team page at `https://wandb.ai/<team-name>`, where `<team-name>` consists of the name you provide when you create a team.
 
 Once you have a team, you can add users to that team.
 
@@ -252,37 +270,38 @@ Invite users to a team in your organization. Use the team's dashboard to invite 
 </Frame>
 3. Select the **Users** tab.
 4. Click **Invite a new user**.
-5. Within the modal that appears, provide the email of the user in the **Email or username** field and select the role to assign to that user from the **Select a team** role dropdown. For more information about roles a user can have in a team, see [Team roles](#assign-or-update-a-team-members-role).
+5. Within the modal that appears, provide the email of the user in the **Email or username** field and select the role to assign to that user from the **Select a team** role dropdown. For more information about roles a user can have in a team, see [Assign or update a team member's role](#assign-or-update-a-team-members-role).
 6. Click the **Send invite** button.
 
-By default, only a team or instance admin can invite members to a team. To change this behavior, refer to [Team settings](/platform/app/settings-page/teams#privacy).
+By default, only a team or instance admin can invite members to a team. To change this behavior, see [Team settings](/platform/app/settings-page/teams#privacy).
 
-In addition to inviting users manually with email invites, you can automatically add new users to a team if the new user's [email matches the domain of your organization](#domain-capture).
+Besides inviting users manually with email invites, you can automatically add new users to a team if the new user's [email matches the domain of your organization](#domain-capture).
 
 ### Match members to a team organization during sign up
 
-Allow new users within your organization discover Teams within your organization when they sign-up. New users must have a verified email domain that matches your organization's verified email domain. Verified new users can view a list of verified teams that belong to an organization when they sign up for a W&B account.
+Allow new users within your organization to discover teams within your organization when they sign up. New users must have a verified email domain that matches your organization's verified email domain. Verified new users can view a list of verified teams that belong to an organization when they sign up for a W&B account.
 
 An organization admin must enable domain claiming. To enable domain capture, see the steps described in [Domain capture](#domain-capture).
 
 
 ### Assign or update a team member's role
 
+A team member's role determines what they can do within the team, such as managing other members, contributing content, or viewing data only. Update a team member's role when their responsibilities within the team change.
 
 1. Select the account type icon next to the name of the team member. 
-2. From the drop-down, choose the account type you want that team member to possess.
+2. From the dropdown, choose the account type you want that team member to possess.
 
 This table lists the roles you can assign to a member of a team:
 
 | Role   |   Definition   |
 |-----------|---------------------------|
 | Admin    | A user who can add and remove other users in the team, change user roles, and configure team settings.   |
-| Member    | A regular user of a team, invited by email or their organization-level username by the team admin. A member user cannot invite other users to the team.  |
+| Member    | A regular user of a team, invited by email or their organization-level username by the team admin. A member user can't invite other users to the team.  |
 | View-Only (Enterprise-only feature) | A view-only user of a team, invited by email or their organization-level username by the team admin. A view-only user only has read access to the team and its contents.  |
-| Custom Roles (Enterprise-only feature)   | Custom roles allow organization admins to compose new roles by inheriting from the preceding View-Only or Member roles, and adding additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. Refer to the [custom roles announcement](https://wandb.ai/wandb_fc/announcements/reports/Introducing-Custom-Roles-for-W-B-Teams--Vmlldzo2MTMxMjQ3) for details. |
+| Custom Roles (Enterprise-only feature)   | Custom roles let organization admins compose new roles by inheriting from the preceding View-Only or Member roles and adding additional permissions to achieve fine-grained access control. Team admins can then assign any of those custom roles to users in their respective teams. For more information, see the [custom roles announcement](https://wandb.ai/wandb_fc/announcements/reports/Introducing-Custom-Roles-for-W-B-Teams--Vmlldzo2MTMxMjQ3). |
 
 <Info>
-Service accounts are not users, but rather non-human identities used for automation. **Service accounts** provide API keys for automated workflows and do not consume user licenses. Refer to [Use service accounts to automate workflows](/platform/hosting/iam/service-accounts/) for comprehensive information about creating and managing service accounts.
+Service accounts aren't users, but rather non-human identities used for automation. **Service accounts** provide API keys for automated workflows and don't consume user licenses. For more information about creating and managing service accounts, see [Use service accounts to automate workflows](/platform/hosting/iam/service-accounts/).
 </Info>
 
 <Note>
@@ -290,7 +309,8 @@ Only enterprise licenses on Dedicated Cloud or Self-Managed deployment can assig
 </Note>
 
 ### Remove users from a team
-Remove a user from a team using the team's dashboard. W&B preserves runs created in a team even if the member who created the runs is no longer on that team.
+
+Remove a user from a team using the team's dashboard. W&B preserves runs created in a team, even if the member who created the runs is no longer on that team.
 
 1. Navigate to `https://wandb.ai/<team-name>`.
 2. Select **Team settings** in the left navigation bar.
@@ -299,11 +319,14 @@ Remove a user from a team using the team's dashboard. W&B preserves runs created
 5. From the dropdown, select **Remove user**. 
 
 ## Add and manage custom roles
+
+Custom roles let you tailor permissions beyond the built-in roles when the standard View-Only, Member, and Admin roles don't match your organization's access requirements. Use custom roles to grant specific permissions while still building on a familiar base role.
+
 <Note>
 An Enterprise license is required to create or assign custom roles on Dedicated Cloud or Self-Managed deployments.
 </Note>
 
-Organization admins can compose a new role based on either the View-Only or Member role and add additional permissions to achieve fine-grained access control. Team admins can assign a custom role to a team member. Custom roles are created at the organization level but are assigned at the team level.
+Organization admins can compose a new role based on either the View-Only or Member role and add additional permissions to achieve fine-grained access control. Team admins can assign a custom role to a team member. You create custom roles at the organization level but assign them at the team level.
 
 To create a custom role:
 

--- a/platform/hosting/iam/access-management/restricted-projects.mdx
+++ b/platform/hosting/iam/access-management/restricted-projects.mdx
@@ -3,9 +3,9 @@ description: Manage project access using visibility scopes and project-level rol
 title: Manage access control for projects
 ---
 
-Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it. 
+Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it. This page is for team and organization admins, and project owners, who need to control access to sensitive workflows or limit collaboration to a specific group of users.
 
-You can use a combination of a couple of controls to configure the access level for any project within a W&B team. **Visibility scope** is the higher-level mechanism. Use that to control which groups of users can view or submit runs in a project. For a project with _Team_ or _Restricted_ visibility scope, you can then use **Project level roles** to control the level of access that each user has within the project.
+You can combine two controls to configure the access level for any project within a W&B team. **Visibility scope** is the higher-level mechanism. Use it to control which groups of users can view or submit runs in a project. For a project with _Team_ or _Restricted_ visibility scope, you can then use **Project level roles** to control the level of access that each user has within the project.
 
 <Note>
 The owner of a project, a team admin, or an organization admin can set or edit a project's visibility.
@@ -13,44 +13,46 @@ The owner of a project, a team admin, or an organization admin can set or edit a
 
 ## Visibility scopes
 
-There are four project visibility scopes you can choose from. In order of most public to most private, they are: 
+Visibility scope determines which users in your organization can see and contribute to a project. You can choose from four project visibility scopes. From most public to most private, they are:
 
 
 | Scope | Description | 
 | ----- | ----- |
 | Open |Anyone who knows about the project can view it and submit runs or reports.|
 | Public |Anyone who knows about the project can view it. Only your team can submit runs or reports.|
-| Team | Only members of the parent team can view the project and submit runs or reports. Anyone outside the team can not access the project. |
+| Team | Only members of the parent team can view the project and submit runs or reports. Anyone outside the team can't access the project. |
 | Restricted| Only invited members from the parent team can view the project and submit runs or reports.|
 
 
 <Note>
-Set a project's scope to **Restricted** if you would like to collaborate on workflows related to sensitive or confidential data. When you create a restricted project within a team, you can invite or add specific members from the team to collaborate on relevant experiments, artifacts, reports, and so forth. 
+Set a project's scope to **Restricted** if you want to collaborate on workflows related to sensitive or confidential data. When you create a restricted project within a team, you can invite or add specific members from the team to collaborate on relevant experiments, artifacts, and reports.
 
-Unlike other project scopes, all members of a team do not get implicit access to a restricted project. At the same time, team admins can join restricted projects if needed.
+Unlike other project scopes, all members of a team don't get implicit access to a restricted project. At the same time, team admins can join restricted projects if needed.
 </Note>
 
 ### Set visibility scope on a new or existing project
 
-Set a project's visibility scope when you create a project or when editing it later.
+Set a project's visibility scope when you create a project or when you edit it later. The following sections describe both workflows.
 
 <Note>
 * Only the owner of the project or a team admin can set or edit its visibility scope.
 * When a team admin enables **Make all future team projects private (public sharing not allowed)** within a team's privacy setting, that turns off **Open** and **Public** project visibility scopes for that team. In this case, your team can only use **Team** and **Restricted** scopes.
 </Note>
 
-#### Set visibility scope when you create a new project
+#### Set visibility scope when you create a project
+
+To set the visibility scope for a new project:
 
 1. Navigate to your W&B organization on a W&B Multi-tenant Cloud, Dedicated Cloud, or Self-Managed instance.
-2. Click the **Create a new project** button in the left hand sidebar's **My projects** section. Alternatively, navigate to the **Projects** tab of your team and click the **Create new project** button in the upper right hand corner.
-3. After selecting the parent team and entering the name of the project, select the desired scope from the **Project Visibility** dropdown.
+2. Click the **Create a new project** button in the left-hand sidebar's **My projects** section. Alternatively, navigate to the **Projects** tab of your team and click the **Create new project** button in the upper right-hand corner.
+3. After you select the parent team and enter the name of the project, select the desired scope from the **Project Visibility** dropdown.
    <Frame>
        <img src="/images/hosting/restricted_project_add_new.gif" alt="Creating restricted project"  />
    </Frame>
 
-   Complete the following step if you select **Restricted** visibility. 
+   Complete the following step if you select **Restricted** visibility.
 
-4. Provide names of one or more W&B team members in the **Invite team members** field. Add only those members who are essential to collaborate on the project.
+4. Provide names of one or more W&B team members in the **Invite team members** field. Add only those members who are essential to collaborate on the project, since other team members don't get implicit access to a restricted project.
    <Frame>
        <img src="/images/hosting/restricted_project_2.png" alt="Restricted project configuration"  />
    </Frame>
@@ -59,19 +61,25 @@ Set a project's visibility scope when you create a project or when editing it la
    You can add or remove members in a restricted project later, from its **Users** tab.
    </Note>
 
+W&B creates the project with the selected visibility scope, and only the invited members (for a restricted project) or in-scope users can access it.
+
 #### Edit visibility scope of an existing project
 
-1. Navigate to your W&B Project.
+To change the visibility scope of an existing project:
+
+1. Navigate to your W&B project.
 2. Select the **Overview** tab on the left column.
-3. Click the **Edit Project Details** button on the upper right corner.  
+3. Click the **Edit Project Details** button on the upper right corner.
 4. From the **Project Visibility** dropdown, select the desired scope.
    <Frame>
        <img src="/images/hosting/restricted_project_edit.gif" alt="Editing restricted project settings"  />
    </Frame>
 
-   Complete the following step if you select **Restricted** visibility. 
+   Complete the following step if you select **Restricted** visibility.
 
-5. Navigate to the **Users** tab in the project, and click **Add user** button to invite specific users to the restricted project.
+5. Navigate to the **Users** tab in the project, and click the **Add user** button to invite specific users to the restricted project.
+
+W&B updates the project's visibility scope, and access reflects the new scope along with any invited members.
 
 <Warning>
 * All members of a team lose access to a project if you change its visibility scope from **Team** to **Restricted**, unless you invite the required team members to the project.
@@ -81,26 +89,30 @@ Set a project's visibility scope when you create a project or when editing it la
 
 ### Other key things to note for restricted scope
 
-* If you want to use a team-level service account in a restricted project, you should invite or add that specifically to the project. Otherwise a team-level service account can not access a restricted project by default.
-* You can not move runs from a restricted project, but you can move runs from a non-restricted project to a restricted one.
+Keep the following behaviors in mind when working with restricted projects:
+
+* If you want to use a team-level service account in a restricted project, you must invite or add it specifically to the project. Otherwise a team-level service account can't access a restricted project by default.
+* You can't move runs from a restricted project, but you can move runs from a non-restricted project to a restricted one.
 * You can convert the visibility of a restricted project to only **Team** scope, irrespective of the team privacy setting **Make all future team projects private (public sharing not allowed)**.
-* If the owner of a restricted project is not part of the parent team anymore, the team admin should change the owner to ensure seamless operations in the project.
+* If the owner of a restricted project isn't part of the parent team anymore, the team admin must change the owner to maintain access to the project.
 
 ## Project level roles
 
-For the _Team_ or _Restricted_ scoped projects in your team, you can assign a specific role to a user, which could be different from that user's team level role. For example, if a user has _Member_ role at the team level, you can assign the _View-Only_, or _Admin_, or any available custom role to that user within a _Team_ or _Restricted_ scope project in that team.
+After you set a project's visibility scope, you can further refine each user's permissions inside the project by assigning a project level role. For _Team_ or _Restricted_ scoped projects in your team, you can assign a specific role to a user, which can differ from that user's team level role. For example, if a user has _Member_ role at the team level, you can assign the _View-Only_, _Admin_, or any available custom role to that user within a _Team_ or _Restricted_ scope project in that team.
 
 <Note>
 Project level roles are in preview on W&B Multi-tenant Cloud, Dedicated Cloud, and Self-Managed instances.
 </Note>
 
-### Assign project level role to a user
+### Assign a project level role to a user
 
-1. Navigate to your W&B Project.
+To assign a project level role:
+
+1. Navigate to your W&B project.
 2. Select the **Overview** tab on the left column.
 3. Navigate to the **Users** tab in the project.
-4. Click the currently assigned role for the pertinent user in the **Project Role** field, which should open up a dropdown listing the other available roles.
-5. Select another role from the dropdown. It should save instantly.
+4. Click the currently assigned role for the relevant user in the **Project Role** field, which opens a dropdown listing the other available roles.
+5. Select another role from the dropdown. The change saves instantly.
 
 <Note>
 When you change the project level role for a user to be different from their team level role, the project level role includes a **\*** to indicate the difference.
@@ -108,8 +120,10 @@ When you change the project level role for a user to be different from their tea
 
 ### Other key things to note for project level roles
 
-* By default, project level roles for all users in a _team_ or _restricted_ scoped project **inherit** their respective team level roles.
-* You **can not** change the project level role of a user who has _View-only_ role at the team level.
-* If the project level role for a user within a particular project **is same as** the team level role, and at some point if a team admin changes the team level role, the relevant project role is automatically changed to track the team level role.
-* If you change the project level role for a user within a particular project such that **it is different from** the team level role, and at some point if a team admin changes the team level role, the relevant project level role remains as is.
-* If you remove a user from a _restricted_ project when their project level role was different from the team level role, and if you then add the user back to the project after some time, they would inherit the team level role due to the default behavior. If needed, you would need to change the project level role again to be different from the team level role.
+Keep the following behaviors in mind when assigning or changing project level roles:
+
+* By default, project level roles for all users in a _Team_ or _Restricted_ scoped project **inherit** their respective team level roles.
+* You **can't** change the project level role of a user who has _View-Only_ role at the team level.
+* If the project level role for a user within a particular project **is the same as** the team level role, and a team admin later changes the team level role, W&B automatically changes the relevant project role to track the team level role.
+* If you change the project level role for a user within a particular project such that **it differs from** the team level role, and a team admin later changes the team level role, the relevant project level role remains as is.
+* If you remove a user from a _Restricted_ project when their project level role differed from the team level role, and you then add the user back to the project later, they inherit the team level role due to the default behavior. If needed, change the project level role again to differ from the team level role.

--- a/platform/hosting/iam/advanced_env_vars.mdx
+++ b/platform/hosting/iam/advanced_env_vars.mdx
@@ -3,23 +3,23 @@ title: Advanced IAM configuration
 description: "Configure advanced IAM options for W&B with environment variables for SSO, session length, OIDC, and LDAP settings."
 ---
 
-In addition to basic [environment variables](../env-vars), you can use environment variables to configure IAM options for your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instance.
+In addition to basic [environment variables](../env-vars), you can use environment variables to configure advanced IAM options for your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instance. Use these variables to customize SSO behavior, session expiration, OIDC and LDAP integration, and other identity-related settings to match your organization's security and access requirements.
 
 Choose any of the following environment variables for your instance depending on your IAM needs.
 
 | Environment variable | Description |
 |----------------------|-------------|
 | `DISABLE_SSO_PROVISIONING` | Set this to `true` to turn off user auto-provisioning in your W&B instance. |
-| `SESSION_LENGTH` | If you would like to change the default user session expiry time, set this variable to the desired number of hours. For example, set SESSION_LENGTH to `24` to configure session expiry time to 24 hours. The default value is 720 hours. |
-| `GORILLA_ENABLE_SSO_GROUPS_CLAIMS` | When you use OIDC-based SSO, set this variable to `true` to automate W&B team membership in your instance based on your OIDC groups. You must also add a `groups` claim to user OIDC token, formatted as a string array of all team names the user is part of. |
-| `GORILLA_LDAP_GROUP_SYNC` | If you are using LDAP based SSO, set it to `true` to automate W&B team membership in your instance based on your LDAP groups. |
-| `GORILLA_OIDC_CUSTOM_SCOPES` | If you are using OIDC based SSO, you can specify additional [scopes](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes) that W&B instance should request from your identity provider. W&B does not change the SSO functionality due to these custom scopes in any way. |
-| `GORILLA_OIDC_SECRET` | If you are using OIDC based SSO and your IdP requires a OIDC Client Secret, set this variable to the secret. |
-| `GORILLA_USE_IDENTIFIER_CLAIMS` | If you are using OIDC based SSO, set this variable to `true` to enforce username and full name of your users using specific OIDC claims from your identity provider. If set, ensure that you configure the enforced username and full name in the `preferred_username` and `name` OIDC claims respectively. Usernames can only contain alphanumeric characters along with underscores and hyphens as special characters. |
-| `GORILLA_DISABLE_PERSONAL_ENTITY` | When set to true, turns off [personal entities](/support/models/articles/what-is-the-difference-between-team-and-). Prevents creation of new personal projects in their personal entities and prevents writing to existing personal projects.
-| `GORILLA_DISABLE_ADMIN_TEAM_ACCESS` | Set this to `true` to restrict Organization or Instance Admins from self-joining or adding themselves to a W&B team, thus ensuring that only Data & AI personas have access to the projects within the teams. |
+| `SESSION_LENGTH` | To change the default user session expiry time, set this variable to the desired number of hours. For example, set `SESSION_LENGTH` to `24` to configure session expiry time to 24 hours. The default value is 720 hours. |
+| `GORILLA_ENABLE_SSO_GROUPS_CLAIMS` | When you use OIDC-based SSO, set this variable to `true` to automate W&B team membership in your instance based on your OIDC groups. You must also add a `groups` claim to the user OIDC token, formatted as a string array of all team names the user is part of. |
+| `GORILLA_LDAP_GROUP_SYNC` | If you use LDAP-based SSO, set it to `true` to automate W&B team membership in your instance based on your LDAP groups. |
+| `GORILLA_OIDC_CUSTOM_SCOPES` | If you use OIDC-based SSO, you can specify additional [scopes](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes) that the W&B instance requests from your identity provider. These custom scopes don't change the SSO functionality. |
+| `GORILLA_OIDC_SECRET` | If you use OIDC-based SSO and your IdP requires an OIDC Client Secret, set this variable to the secret. |
+| `GORILLA_USE_IDENTIFIER_CLAIMS` | If you use OIDC-based SSO, set this variable to `true` to enforce the username and full name of your users using specific OIDC claims from your identity provider. If set, ensure that you configure the enforced username and full name in the `preferred_username` and `name` OIDC claims respectively. Usernames can only contain alphanumeric characters along with underscores and hyphens as special characters. |
+| `GORILLA_DISABLE_PERSONAL_ENTITY` | When set to `true`, turns off [personal entities](/support/models/articles/what-is-the-difference-between-team-and-). Prevents creation of new personal projects in their personal entities and prevents writing to existing personal projects. |
+| `GORILLA_DISABLE_ADMIN_TEAM_ACCESS` | Set this to `true` to restrict Organization or Instance Admins from self-joining or adding themselves to a W&B team, ensuring that only Data and AI personas have access to the projects within the teams. |
 | `WANDB_IDENTITY_TOKEN_FILE`        | For [identity federation](/platform/hosting/iam/identity_federation/), the absolute path to the local directory where Java Web Tokens (JWTs) are stored. |
 
 <Warning>
-W&B advises to exercise caution and understand all implications before enabling some of these settings, like `GORILLA_DISABLE_ADMIN_TEAM_ACCESS`. Reach out to your W&B team for any questions.
+W&B advises caution and understanding all implications before you enable some of these settings, such as `GORILLA_DISABLE_ADMIN_TEAM_ACCESS`. Contact your W&B team with any questions.
 </Warning>

--- a/platform/hosting/iam/automate_iam.mdx
+++ b/platform/hosting/iam/automate_iam.mdx
@@ -3,53 +3,53 @@ title: Automate user and team management
 description: "Automate user and team management at scale in W&B using the SCIM API and the Python SDK API."
 ---
 
-This page describes how you can automate user and team management using the [SCIM API](/platform/hosting/iam/scim) and the [Python SDK API](/models/ref/python/public-api).
+This page describes how to automate user and team management at scale using the [SCIM API](/platform/hosting/iam/scim) and the [Python SDK API](/models/ref/python/public-api).
 
 ## SCIM API
 
-Use the W&B SCIM API to manage your W&B organization's users and teams at scale using an identity provider (IdP) like Okta or Microsoft Entra.
+Use the W&B SCIM API to manage your W&B organization's users and teams at scale through an identity provider (IdP) like Okta or Microsoft Entra.
 
-For more details and examples, see [Authentication](./scim#authentication) on the SCIM reference page.
+For more information, see [Authentication](./scim#authentication) on the SCIM reference page.
 
 <Tip>
-W&B's implementation includes endpoints for assigning roles, as well as creating and managing custom roles, as well as assigning built-in and custom roles. Role endpoints are not part of the official SCIM schema. W&B adds role endpoints to support automated management of custom roles.
+W&B's implementation includes endpoints for creating and managing custom roles and for assigning built-in and custom roles. Role endpoints aren't part of the official SCIM schema. W&B adds role endpoints to support automated management of custom roles.
 </Tip>
 
 The following sections describe each category of the SCIM API.
 
 ### User SCIM API
 
-The [User SCIM API](./scim#user-resource) allows you to create, deactivate, fetch, and list users in a W&B organization, and to assign predefined or custom roles. For complete request/response examples, use the detailed [SCIM reference](./scim#user-management).
+The [User SCIM API](./scim#user-resource) lets you create, deactivate, fetch, and list users in a W&B organization, and assign predefined or custom roles. For complete request and response examples, see the [SCIM reference](./scim#user-management).
 
 <Note>
-Deactivate a user with `PATCH /scim/Users/{id}` and set `{"active": false}`. Hosting option determines the outcome: Dedicated Cloud and Self-Managed deployments retain the user record, while Multi-tenant Cloud removes the user from the organization. Reactivation is unavailable in Multi-tenant Cloud; re-add the user instead. See [Deactivate user](./scim#deactivate-user) and [Reactivate user](./scim#reactivate-user).
+To deactivate a user, send `PATCH /scim/Users/{id}` with `{"active": false}`. The hosting option determines the outcome: Dedicated Cloud and Self-Managed deployments retain the user record, while Multi-tenant Cloud removes the user from the organization. Reactivation isn't available in Multi-tenant Cloud. Re-add the user instead. See [Deactivate user](./scim#deactivate-user) and [Reactivate user](./scim#reactivate-user).
 </Note>
 
 ### Group SCIM API
 
-The [Group SCIM API](./scim#group-resource) allows for managing W&B teams, including creating or removing teams in an organization. Use the `PATCH Group` to add or remove users in an existing team.
+The [Group SCIM API](./scim#group-resource) lets you manage W&B teams, including creating or removing teams in an organization. To add or remove users in an existing team, use `PATCH Group`.
 
 <Note>
-There is no notion of a `group of users having the same role` within W&B. A W&B team closely resembles a group, and allows diverse personas with different roles to work collaboratively on a set of related projects. Teams can consist of different groups of users. Assign each user in a team a role: team admin, member, viewer, or a custom role.
+W&B has no notion of a "group of users having the same role." A W&B team closely resembles a group and lets users with different roles work collaboratively on a set of related projects. Teams can consist of different groups of users. Assign each user in a team a role: team admin, member, viewer, or a custom role.
 
 W&B maps Group SCIM API endpoints to W&B teams because of the similarity between groups and W&B teams.
 </Note>
 
-### Custom role API
+### Custom role SCIM API
 
-The [Custom Role SCIM API](./scim#role-resource) allows for managing custom roles, including creating, listing, or updating custom roles in an organization.
+The [Custom Role SCIM API](./scim#role-resource) lets you manage custom roles, including creating, listing, or updating custom roles in an organization.
 
 <Warning>
 Delete a custom role with caution.
 
-Delete a custom role within a W&B organization with the `DELETE Role` endpoint. The predefined role that the custom role inherits is assigned to all users that are assigned the custom role before the operation.
+To delete a custom role within a W&B organization, use the `DELETE Role` endpoint. W&B assigns the inherited predefined role to all users who had the custom role before deletion.
 
-Update the inherited role for a custom role with the `PUT Role` endpoint. This operation doesn't affect any of the existing, that is, non-inherited custom permissions in the custom role.
+To update the inherited role for a custom role, use the `PUT Role` endpoint. This operation doesn't affect any existing non-inherited custom permissions in the custom role.
 </Warning>
 
 ## W&B Python SDK API
 
-Use the [W&B Python SDK API](/models/ref/python/public-api/api) to manage organization users, teams, and team membership.
+Use the [W&B Python SDK API](/models/ref/python/public-api/api) to manage organization users, teams, and team membership through the following classes:
 
 - [`User`](/models/ref/python/public-api/user)
 - [`Team`](/models/ref/python/public-api/team)

--- a/platform/hosting/iam/identity_federation.mdx
+++ b/platform/hosting/iam/identity_federation.mdx
@@ -3,7 +3,9 @@ title: Use federated identities with SDK
 description: "Use identity federation with JSON Web Tokens (JWTs) to authenticate with the W&B SDK and CLI without API keys."
 ---
 
-Use identity federation to sign in using your organizational credentials through W&B SDK. If your W&B organization admin has configured SSO for your organization, then you already use your organizational credentials to sign-in to the W&B app UI. In that sense, identity federation is like SSO for W&B SDK, but by using JSON Web Tokens (JWTs) directly. You can use identity federation as an alternative to API keys.
+Use identity federation to sign in to the W&B SDK and CLI with your organizational credentials, instead of using a long-lived API key. If your W&B organization admin has configured SSO for your organization, you already use those credentials to sign in to the W&B app UI. Identity federation is like SSO for the W&B SDK, but uses JSON Web Tokens (JWTs) directly. Use identity federation as an alternative to API keys.
+
+This page is for organization admins who configure the JWT issuer for a W&B organization. It's also for users or service accounts that authenticate to W&B using JWTs.
 
 [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) forms the underlying basis for identity federation with SDK.
 
@@ -12,62 +14,64 @@ Identity federation is available in preview for Multi-tenant Cloud, Dedicated Cl
 </Note>
 
 <Note>
-For the purpose of this document, the terms `identity provider` and `JWT issuer` are used interchangeably. Both refer to one and the same thing in the context of this capability.
+This document uses the terms "identity provider" and "JWT issuer" interchangeably. Both refer to the same thing in the context of this capability.
 </Note>
 
-## JWT issuer setup
+## Set up the JWT issuer
 
-As a first step, an organization admin must set up a federation between your W&B organization and a publicly accessible JWT issuer.
+Before users can authenticate with JWTs, an organization admin must set up a federation between your W&B organization and a publicly accessible JWT issuer.
 
-* Navigate to the **Settings** tab in your organization dashboard
-* In the **Authentication** option, click **Set up JWT Issuer**
-* Add the JWT issuer URL in the text box and click **Create**
+1. Navigate to the **Settings** tab in your organization dashboard.
+2. In the **Authentication** option, click **Set up JWT Issuer**.
+3. Add the JWT issuer URL in the text box and click **Create**.
 
-W&B will automatically look for a OIDC discovery document at the path `${ISSUER_URL}/.well-known/openid-configuration`, and try to find the JSON Web Key Set (JWKS) at a relevant URL in the discovery document. The JWKS is used for real-time validation of the JWTs to ensure that those have been issued by the relevant identity provider.
+W&B automatically looks for an OIDC discovery document at the path `${ISSUER_URL}/.well-known/openid-configuration`. From the discovery document, W&B locates the JSON Web Key Set (JWKS) at the relevant URL. W&B uses the JWKS for real-time validation of the JWTs to ensure that the relevant identity provider issued them.
 
-## Using the JWT to access W&B
+After this step, your W&B organization is federated with the JWT issuer. Users in your organization can then authenticate to W&B using JWTs issued by that provider.
 
-Once a JWT issuer has been setup for your W&B organization, users can start accessing the relevant W&B projects using JWTs issued by that identity provider. The mechanism for using JWTs is as follows:
+## Use the JWT to access W&B
 
-* You must sign-in to the identity provider using one of the mechanisms available in your organization. Some providers can be accessed in an automated manner using an API or SDK, while some can only be accessed using a relevant UI. Reach out to your W&B organization admin or the owner of the JWT issuer for details.
-* Once you've retrieved the JWT after signing in to your identity provider, store it in a file at a secure location and configure the absolute file path in an environment variable `WANDB_IDENTITY_TOKEN_FILE`.
-* Access your W&B project using the W&B SDK or CLI. The SDK or CLI should automatically detect the JWT and exchange it for a W&B access token after the JWT has been successfully validated. The W&B access token is used to access the relevant APIs for enabling your AI workflows, that is, to log runs, metrics, artifacts and so forth. The access token is by default stored at the path `~/.config/wandb/credentials.json`. You can change that path by specifying the environment variable `WANDB_CREDENTIALS_FILE`.
+After an organization admin sets up a JWT issuer, users can start accessing W&B projects using JWTs issued by that identity provider. The mechanism for using JWTs is as follows:
+
+1. You must sign in to the identity provider using one of the mechanisms available in your organization. You can access some providers in an automated manner using an API or SDK, while others are only accessible through a relevant UI. Contact your W&B organization admin or the owner of the JWT issuer for details.
+2. After you've retrieved the JWT by signing in to your identity provider, store it in a file at a secure location. Configure the absolute file path in an environment variable `WANDB_IDENTITY_TOKEN_FILE`.
+3. Access your W&B project using the W&B SDK or CLI. The SDK or CLI automatically detects the JWT and exchanges it for a W&B access token after validating the JWT. The W&B access token grants access to the relevant APIs for enabling your AI workflows, such as logging runs, metrics, and artifacts. By default, the access token is stored at the path `~/.config/wandb/credentials.json`. You can change that path by specifying the environment variable `WANDB_CREDENTIALS_FILE`.
 
 <Note>
-JWTs are meant to be short-lived credentials to address the shortcomings of long-lived credentials like API keys, passwords and so forth. Depending on the JWT expiry time configured in your identity provider, you must continuously refresh the JWT and ensure that it's stored in the file referenced by the environment variable `WANDB_IDENTITY_TOKEN_FILE`.
+JWTs are short-lived credentials that address the shortcomings of long-lived credentials such as API keys and passwords. The JWT expiry time depends on your identity provider's configuration. Refresh the JWT before it expires, and ensure that it's stored in the file referenced by the environment variable `WANDB_IDENTITY_TOKEN_FILE`.
 
-W&B access token also has a default expiry duration, after which the SDK or the CLI automatically try to refresh that using your JWT. If the user JWT has also expired by that time and is not refreshed, that could result in an authentication failure. If possible, the JWT retrieval and post-expiry refresh mechanism should be implemented as part of the AI workload that uses the W&B SDK or CLI.
+The W&B access token also has a default expiry duration, after which the SDK or CLI tries to refresh it using your JWT. If the user JWT has also expired by that time and isn't refreshed, authentication fails. If possible, implement the JWT retrieval and post-expiry refresh mechanism as part of the AI workload that uses the W&B SDK or CLI.
 </Note>
 
 ### JWT validation
 
-As part of the workflow to exchange the JWT for a W&B access token and then access a project, the JWT undergoes following validations:
+To ensure that only valid tokens grant access, the JWT undergoes the following validations. These validations run when the SDK or CLI exchanges the JWT for a W&B access token and then accesses a project:
 
-* The JWT signature is verified using the JWKS at the W&B organization level. This is the first line of defense, and if this fails, that means there's a problem with your JWKS or how your JWT is signed.
-* The `iss` claim in the JWT should be equal to the issuer URL configured at the organization level.
-* The `sub` claim in the JWT should be equal to the user's email address as configured in the W&B organization.
-* Typically, the `aud` claim in the JWT should be equal to the name of the W&B organization which houses the project that you are accessing as part of your AI workflow.
+* W&B verifies the JWT signature using the JWKS at the W&B organization level. This is the first line of defense, and if this fails, that means there's a problem with your JWKS or how your JWT is signed.
+* The `iss` claim in the JWT must equal the issuer URL configured at the organization level.
+* The `sub` claim in the JWT must equal the user's email address as configured in the W&B organization.
+* The `aud` claim in the JWT must equal the name of the W&B organization that houses the project you're accessing as part of your AI workflow.
 
     On [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instances:
-    - To skip audience validation, you can set  the environment variable `FEDERATED_AUTH_AUDIENCES` to `wandb`.
+    - To skip audience validation, you can set the environment variable `FEDERATED_AUTH_AUDIENCES` to `wandb`.
     - Some organizations have specific requirements for the audience. To customize the `aud` value, set the environment variable `FEDERATED_AUTH_AUDIENCES` to a string with a comma-separated list of audience values.
   
-* The `exp` claim in the JWT is checked to see if the token is valid or has expired and needs to be refreshed.
+* W&B checks the `exp` claim in the JWT to determine whether the token is valid or has expired and needs to be refreshed.
 
 ## External service accounts
 
-W&B has supported built-in service accounts with long-lived API keys for long. With the identity federation capability for SDK and CLI, you can also bring external service accounts that could use JWTs for authentication, though as long as those are issued by the same issuer which is configured at the organization level. A team admin can configure external service accounts within the scope of a team, like the built-in service accounts.
+W&B has long supported built-in service accounts with long-lived API keys. With identity federation for the SDK and CLI, you can also bring external service accounts that use JWTs for authentication. The organization's configured issuer must issue those JWTs. A team admin can configure external service accounts within the scope of a team, like the built-in service accounts.
 
-To configure an external service account:
+To configure an external service account, a team admin must:
 
-* Navigate to the **Service Accounts** tab for your team
-* Click **New service account**
-* Provide a name for the service account, select `Federated Identity` as the `Authentication Method`, provide a `Subject`, and click **Create**
+1. Navigate to the **Service Accounts** tab for your team.
+2. Click **New service account**.
+3. Provide a name for the service account, select **Federated Identity** as the **Authentication Method**, provide a **Subject**, and click **Create**.
 
-The `sub` claim in the external service account's JWT should be same as what the team admin configures as its subject in the team-level **Service Accounts** tab. That claim is verified as part of [JWT validation](#jwt-validation). The `aud` claim requirement is similar to that for human user JWTs.
+After this step, the external service account is registered with the team and can use JWTs issued by the configured identity provider to access W&B. The `sub` claim in the external service account's JWT must equal the subject configured by the team admin in the team-level **Service Accounts** tab. W&B verifies that claim as part of [JWT validation](#jwt-validation). The `aud` claim requirement is similar to that for human user JWTs.
 
-When [using an external service account's JWT to access W&B](#using-the-jwt-to-access-wb), it's typically easier to automate the workflow to generate the initial JWT and continuously refresh it. If you would like to attribute the runs logged using an external service account to a human user, you can configure the environment variables `WANDB_USERNAME` or `WANDB_USER_EMAIL` for your AI workflow, similar to how it's done for the built-in service accounts.
+When [using an external service account's JWT to access W&B](#use-the-jwt-to-access-wb), it's often easier to automate the workflow. Automation generates the initial JWT and refreshes it as needed. To attribute runs logged using an external service account to a human user, configure the environment variables `WANDB_USERNAME` or `WANDB_USER_EMAIL` for your AI workflow, similar to built-in service accounts.
 
 <Note>
-W&B recommends to use a mix of built-in and external service accounts across your AI workloads with different levels of data sensitivity, in order to strike a balance between flexibility and simplicity.
+W&B recommends using a mix of built-in and external service accounts across your AI workloads with different levels of data sensitivity. This mix strikes a balance between flexibility and simplicity.
 </Note>

--- a/platform/hosting/iam/ldap.mdx
+++ b/platform/hosting/iam/ldap.mdx
@@ -3,10 +3,10 @@ title: Configure SSO with LDAP
 description: "Configure LDAP-based SSO authentication for W&B Server including connection parameters and environment variables."
 ---
 
-Authenticate your credentials with the W&B Server LDAP server. The following guide explains how to configure the settings for W&B Server. It covers mandatory and optional configurations, as well as instructions for configuring the LDAP connection from systems settings UI. it also provides information on the different inputs of the LDAP configuration, such as the address, base distinguished name, and attributes. You can specify these attributes from the W&B App UI or using environment variables. You can set up either an anonymous bind, or bind with an administrator DN and Password.
+This guide is for W&B Admins who enable LDAP-based single sign-on (SSO) for W&B Server, so that users can authenticate against an existing LDAP directory instead of managing separate W&B credentials. It explains how to configure the LDAP connection from the W&B App system settings UI or with environment variables. It also describes the required and optional configuration parameters, including the address, base distinguished name, and attributes. You can set up either an anonymous bind, or bind with an administrator DN and password.
 
 {/* <Note>
-As a W&B Team Admin you can set up either an anonymous bind, or bind with an administrator DN and Password.
+As a W&B Team Admin, you can set up either an anonymous bind, or bind with an administrator DN and password.
 </Note> */}
 
 <Note>
@@ -15,17 +15,23 @@ Only W&B Admin roles can enable and configure LDAP authentication.
 
 ## Configure LDAP connection
 
+Choose one of the following methods to configure the LDAP connection. Use the W&B App tab to configure LDAP through the system settings UI, or use the Environment variable tab to configure LDAP at deployment time.
+
 <Tabs>
 <Tab title="W&B App">
-1. Navigate to the W&B App. 
-2. Select your profile icon from the upper right. From the dropdown, select **System Settings**. 
+To configure LDAP through the W&B App:
+
+1. Go to the W&B App.
+2. Select your profile icon, then select **System Settings**.
 3. Toggle **Configure LDAP Client**.
-4. Add the details in the form. Refer to **Configuring Parameters** section for details on each input.
-5. Click on **Update Settings** to test your settings. This will establish a test client/connection with the W&B server.
-6. If your connection is verified, toggle the **Enable LDAP Authentication** and select the **Update Settings** button.
+4. Add the details in the form. For more information about each input, see [Configuration parameters](#configuration-parameters).
+5. Click **Update Settings** to test your settings. This step establishes a test client or connection with W&B Server.
+6. If your connection is verified, toggle **Enable LDAP Authentication** and select **Update Settings**.
+
+After you complete these steps, W&B Server authenticates users against your LDAP directory.
 </Tab>
 <Tab title="Environment variable">
-Set LDAP an connection with the following environment variables:
+Set an LDAP connection with the following environment variables:
 
 | Environment variable          | Required | Example                         |
 | ----------------------------- | -------- | ------------------------------- |
@@ -38,7 +44,7 @@ Set LDAP an connection with the following environment variables:
 | `LOCAL_LDAP_GROUP_ALLOW_LIST` | No       |                                 |
 | `LOCAL_LDAP_LOGIN`            | No       |                                 |
 
-See the [Configuration parameters](#configuration-parameters) section for definitions of each environment variable. Note that the environment variable prefix `LOCAL_LDAP` was omitted from the definition names for clarity.
+The following Configuration parameters section defines each environment variable. For clarity, the definition names omit the environment variable prefix `LOCAL_LDAP`.
 </Tab>
 </Tabs>
 
@@ -49,11 +55,11 @@ The following table lists and describes required and optional LDAP configuration
 
 | Environment variable | Definition              | Required |
 | -------------------- | ----------------------- | -------- |
-| `ADDRESS`            | This is the address of your LDAP server within the VPC that hosts W&B Server.      | Yes      |
-| `BASE_DN`            | The root path searches start from and required for doing any queries into this directory.             | Yes      |
-| `BIND_DN`            | Path of the administrative user registered in the LDAP server. This is required if the LDAP server does not support unauthenticated binding. If specified, W&B Server connects to the LDAP server as this user. Otherwise, W&B Server connects using anonymous binding. | No       |
-| `BIND_PW`            | The password for administrative user, this is used to authenticate the binding. If left blank, W&B Server connects using anonymous binding.   | No       |
-| `ATTRIBUTES`         | Provide an email and group ID attribute names as comma separated string values.    | Yes      |
+| `ADDRESS`            | The address of your LDAP server within the VPC that hosts W&B Server.      | Yes      |
+| `BASE_DN`            | The root path that searches start from, required for any queries into this directory.             | Yes      |
+| `BIND_DN`            | Path of the administrative user registered in the LDAP server. Required if the LDAP server doesn't support unauthenticated binding. If specified, W&B Server connects to the LDAP server as this user. Otherwise, W&B Server connects with anonymous binding. | No       |
+| `BIND_PW`            | The password for the administrative user, used to authenticate the binding. If left blank, W&B Server connects with anonymous binding.   | No       |
+| `ATTRIBUTES`         | Provide email and group ID attribute names as comma-separated string values.    | Yes      |
 | `TLS_ENABLE`         | Enable TLS.                | No       |
 | `GROUP_ALLOW_LIST`   | Group allowlist.           | No       |
-| `LOGIN`              | This tells W&B Server to use LDAP to authenticate. Set to either `True` or `False`. Optionally set this to false to test the LDAP configuration. Set this to true to start LDAP authentication. | No       |
+| `LOGIN`              | Instructs W&B Server to use LDAP to authenticate. Set to either `True` or `False`. Optionally set this to `False` to test the LDAP configuration. Set this to `True` to start LDAP authentication. | No       |

--- a/platform/hosting/iam/org_team_struct.mdx
+++ b/platform/hosting/iam/org_team_struct.mdx
@@ -3,29 +3,30 @@ title: Identity and access management (IAM)
 description: "Understand the three IAM scopes in W&B (organizations, teams, and projects) and how they map to your company."
 ---
 
-W&B Platform has three IAM scopes within W&B: [Organizations](#organization), [Teams](#team), and [Projects](#project).
+W&B Platform has three IAM scopes within W&B: [Organizations](#organization), [Teams](#team), and [Projects](#project). Understanding how these scopes nest helps you plan how to structure access, group users, and organize AI work across your company.
+
+The following sections describe each scope and how it maps to your company's structure, and link to detailed management guides.
 
 ## Organization
 
-An *Organization* is the root scope in your W&B account or instance. All actions in your account or instance take place within the context of that root scope, including managing users, managing teams, managing projects within teams, tracking usage and more.
+An *Organization* is the root scope in your W&B account or instance. All actions in your account or instance take place within the context of that root scope, including managing users, managing teams, managing projects within teams, and tracking usage.
 
-If you are using [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), you may have more than one organization where each may correspond to a business unit, a personal user, a joint partnership with another business and more.
+If you use [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), you may have more than one organization where each may correspond to a business unit, a personal user, or a joint partnership with another business.
 
-If you are using [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or a [Self-Managed instance](/platform/hosting/hosting-options/self-managed), it corresponds to one organization. Your company may have more than one of Dedicated Cloud or Self-Managed instances to map to different business units or departments, though that is strictly an optional way to manage AI practioners across your businesses or departments.
+If you use [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or a [Self-Managed instance](/platform/hosting/hosting-options/self-managed), it corresponds to one organization. Your company may have more than one Dedicated Cloud or Self-Managed instance to map to different business units or departments, though that's strictly an optional way to manage AI practitioners across your businesses or departments.
 
 For more information, see [Manage organizations](./access-management/manage-organization).
 
 ## Team
 
-A *Team* is a subscope within a organization, that may map to a business unit / function, department, or a project team in your company. You may have more than one team in your organization depending on your deployment type and pricing plan.
+A *Team* is a subscope within an organization that may map to a business unit, function, department, or project team in your company. You may have more than one team in your organization depending on your deployment type and pricing plan.
 
-AI projects are organized within the context of a team. The access control within a team is governed by team admins, who may or may not be admins at the parent organization level.
+AI projects are organized within the context of a team. Team admins govern access control within a team, and they may or may not be admins at the parent organization level.
 
 For more information, see [Add and manage teams](./access-management/manage-organization#add-and-manage-teams).
 
 ## Project
 
-A *Project* is a subscope within a team, that maps to an actual AI project with specific intended outcomes. You may have more than one project within a team. Each project has a visibility mode which determines who can access it.
+A *Project* is a subscope within a team that maps to an AI project with specific intended outcomes. You may have more than one project within a team. Each project has a visibility mode that determines who can access it.
 
-
-Every project is comprised of [Workspaces](/models/track/workspaces/) and [Reports](/models/reports/), and is linked to relevant [Artifacts](/models/artifacts/), [Sweeps](/models/sweeps/), and [Automations](/models/automations/).
+Within each project, your team's work is organized into the following building blocks. Every project comprises [Workspaces](/models/track/workspaces/) and [Reports](/models/reports/), and links to relevant [Artifacts](/models/artifacts/), [Sweeps](/models/sweeps/), and [Automations](/models/automations/).

--- a/platform/hosting/iam/scim.mdx
+++ b/platform/hosting/iam/scim.mdx
@@ -9,71 +9,77 @@ Watch a [video demonstrating SCIM in action](https://www.youtube.com/watch?v=Nw3
 
 ## Overview
 
-The System for Cross-domain Identity Management (SCIM) API allows instance or organization admins to manage users, groups, and custom roles in their W&B organization. SCIM groups map to W&B Teams.
+This page describes how instance and organization admins use the System for Cross-domain Identity Management (SCIM) API to automate identity management in W&B. With the SCIM API, you can provision and deprovision users, manage team membership, and define custom roles programmatically through an identity provider or CI/CD pipeline instead of clicking through the W&B App. SCIM groups map to W&B Teams.
 
-W&B's SCIM API is compatible with major identity providers including Okta, enabling automated user provisioning and deprovisioning. For SSO configuration with Okta and other identity providers, see the [SSO documentation](/platform/hosting/iam/sso/).
+W&B's SCIM API is compatible with identity providers such as Okta. For SSO configuration with Okta and other identity providers, see the [SSO documentation](/platform/hosting/iam/sso/).
 
-For practical Python examples demonstrating how to interact with the SCIM API, visit our [`wandb-scim`](https://github.com/wandb/examples/tree/master/wandb-scim) repository.
+For practical Python examples that demonstrate how to interact with the SCIM API, visit the [`wandb-scim`](https://github.com/wandb/examples/tree/master/wandb-scim) repository.
 
 ### Supported features
-- **Filtering**: The API supports filtering for `/Users` and `/Groups` endpoints
-- **PATCH Operations**: Supports PATCH for partial resource updates
-- **ETag Support**: Conditional updates using ETags for conflict detection  
-- **Service Account Authentication**: Organization service accounts can access the API
+
+The SCIM API supports the following features:
+
+- **Filtering**: The API supports filtering for `/Users` and `/Groups` endpoints.
+- **PATCH operations**: Supports `PATCH` for partial resource updates.
+- **ETag support**: Conditional updates using ETags for conflict detection.
+- **Service account authentication**: Organization service accounts can access the API.
 - **Service account lifecycle**: Provision and deprovision [team-scoped and organization-scoped service accounts](/platform/hosting/iam/service-accounts). Supported on **Multi-tenant Cloud** and on **Dedicated Cloud** and **Self-Managed** v0.81.0+.
 
 <Note>
-If you are an admin of multiple Enterprise [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) organizations, you must configure the organization where SCIM API requests are sent to ensure SCIM API requests sent using your API Key affect the correct organization. Click your profile image, then click **User Settings**, then check the setting **Default API organization**.
+If you're an admin of multiple Enterprise [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) organizations, configure the organization that receives SCIM API requests so that requests made with your API key affect the correct organization. Click your profile image, click **User Settings**, then check the **Default API organization** setting.
 
-The chosen hosting option determines the value for the `<host-url>` placeholder used in the examples in this page.
+The chosen hosting option determines the value for the `[HOST-URL]` placeholder used in the examples on this page.
 
-In addition, examples use user IDs such as `abc` and `def`. Real requests and responses have hashed values for user IDs.
+Examples use user IDs such as `abc` and `def`. Real requests and responses use hashed values for user IDs.
 </Note>
 
 ## Authentication
 
-Organization admins can authenticate with a **Bearer token** or **HTTP Basic** credentials. Either style uses the _same API key string_ where a key applies. Choose a user identity or an organization-scoped service account after reviewing the key differences.
+Every SCIM request must be authenticated as an admin principal. Organization admins can authenticate with a **Bearer token** or **HTTP Basic** credentials. Either style uses the _same API key string_ where a key applies. Choose a user identity or an organization-scoped service account after reviewing the key differences in the following section.
 
 ### Key differences
-- Who should use it: Users are best for interactive, one-off admin actions; service accounts are best for automation and integrations (CI/CD, provisioning tools).
-- Credentials: Users send username and API key for Basic auth; service accounts send only an API key (no username) for Basic auth. For Bearer auth, send only the API key in the header (no username).
-- Bearer versus Basic: Bearer uses `Authorization: Bearer <API-KEY>` with the key verbatim. Basic uses `Authorization: Basic <base64(...)>` (users encode `username:API-KEY`; service accounts encode `:API-KEY` with a leading colon and empty username).
-- Scope and permissions: Use an API key from an instance or organization admin user, or from an [organization-scoped service account](/platform/hosting/iam/service-accounts/#organization-scoped-service-accounts). Keys from [team-scoped service accounts](/platform/hosting/iam/service-accounts/#team-scoped-service-accounts) cannot authenticate to the SCIM API. Service accounts that use SCIM are organization-scoped and headless, which supports clearer audit trails for automation.
-- Where to get credentials: Users copy their API key from User Settings; organization-scoped service account keys are in the organization dashboard under the **Service account** tab.
-- Multi-tenant Cloud: If you have access to more than one Multi-tenant Cloud organizations, you must set the Default API organization to ensure that SCIM API calls are routed to the intended organization.
+
+The following list compares user credentials and service account credentials for SCIM authentication:
+
+- Who should use it: Users are best for interactive, one-off admin actions. Service accounts are best for automation and integrations (CI/CD, provisioning tools).
+- Credentials: Users send username and API key for Basic auth. Service accounts send only an API key (no username) for Basic auth. For Bearer auth, send only the API key in the header (no username).
+- Bearer versus Basic: Bearer uses `Authorization: Bearer [API-KEY]` with the key verbatim. Basic uses `Authorization: Basic <base64(...)>` (users encode `username:API-KEY`, and service accounts encode `:API-KEY` with a leading colon and empty username).
+- Scope and permissions: Use an API key from an instance or organization admin user, or from an [organization-scoped service account](/platform/hosting/iam/service-accounts/#organization-scoped-service-accounts). Keys from [team-scoped service accounts](/platform/hosting/iam/service-accounts/#team-scoped-service-accounts) can't authenticate to the SCIM API. Service accounts that use SCIM are organization-scoped and headless, which supports clearer audit trails for automation.
+- Where to get credentials: Users copy their API key from User Settings. Organization-scoped service account keys are in the organization dashboard under the **Service account** tab.
+- Multi-tenant Cloud: If you have access to more than one Multi-tenant Cloud organization, you must set the Default API organization to ensure that SCIM API calls are routed to the intended organization.
 
 ### Bearer token
 
 Send the API key as a Bearer token:
 
 ```bash
-Authorization: Bearer <API-KEY>
+Authorization: Bearer [API-KEY]
 ```
 
-The `<API-KEY>` value is the same string you would use as the password in HTTP Basic authentication for that principal. You do not Base64-encode the key for Bearer requests.
+The `[API-KEY]` value is the same string you'd use as the password in HTTP Basic authentication for that principal. Don't Base64-encode the key for Bearer requests.
 
 <Note>
-Bearer authentication for the SCIM API is available in W&B Multi-tenant Cloud, and in Dedicated Cloud and Self-Managed v0.79.0 and above. 
+Bearer authentication for the SCIM API is available in W&B Multi-tenant Cloud, and in Dedicated Cloud and Self-Managed v0.79.0 and later.
 </Note>
 
-The following examples use `<YOUR_API_KEY>` as a placeholder. Replace it with a real key from an admin user or an organization-scoped service account.
+The following examples use `[API-KEY]` as a placeholder. Replace it with a real key from an admin user or an organization-scoped service account.
 
 **List users**
 
 ```bash
 curl -s -S \
-  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Authorization: Bearer [API-KEY]" \
   -H "Content-Type: application/scim+json" \
-  "<host-url>/scim/Users"
+  "[HOST-URL]/scim/Users"
 ```
 
 **Create a user**
 
 ```bash
 curl -s -S -X POST \
-  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Authorization: Bearer [API-KEY]" \
   -H "Content-Type: application/scim+json" \
-  "<host-url>/scim/Users" \
+  "[HOST-URL]/scim/Users" \
   -d '{
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
     "userName": "dev-user2",
@@ -81,11 +87,11 @@ curl -s -S -X POST \
   }'
 ```
 
-For more details, see [Create user](#create-user).
+For more information, see [Create user](#create-user).
 
 ### Users
 
-Use your personal admin credentials when performing interactive admin tasks. Construct the HTTP `Authorization` header as `Basic <base64(username:API-KEY)>`.
+Use your personal admin credentials when you perform interactive admin tasks. Construct the HTTP `Authorization` header as `Basic <base64(username:API-KEY)>`.
 
 For example, authorize as `demo:p@55w0rd`:
 ```bash
@@ -103,7 +109,7 @@ Authorization: Basic OnNhLXBANTV3MHJk
 
 ## User management
 
-The SCIM user resource maps to W&B users and service accounts. Use these endpoints to manage users and service accounts in your organization.
+The SCIM user resource maps to W&B users and service accounts. Use the endpoints in this section to provision, update, and remove users and service accounts in your organization, for example, when you onboard new employees, rotate service credentials, or remove access for departing users.
 
 For service account concepts and UI workflows, see [Use service accounts to automate workflows](/platform/hosting/iam/service-accounts).
 
@@ -122,11 +128,11 @@ Request bodies for creating or updating users already used the array form and ar
 
 Retrieves information for a specific user or service account in your organization by user ID, or for a user by email address.
 
-Service account responses include `accountType` (`SERVICE` for team-scoped service accounts, `ORG_SERVICE` for organization-scoped service accounts). Service accounts do not include `emails`.
+Service account responses include `accountType` (`SERVICE` for team-scoped service accounts, `ORG_SERVICE` for organization-scoped service accounts). Service accounts don't include `emails`.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `GET`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -142,7 +148,7 @@ GET /scim/Users/abc
 ```
 </Tab>
 <Tab title="Get User Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -173,10 +179,12 @@ GET /scim/Users/abc
 ```
 
 The response includes details about the user's activity in the organization:
+
 - **`daysActive`**: Total number of days the user has been active in the organization.
-- **`lastActiveAt`**: ISO 8601 timestamp of the user's most recent activity. Returns `null` if the user has never been active.
+- **`lastActiveAt`**: ISO 8601 timestamp of the user's most recent activity. Returns `null` if the user hasn't been active.
 
 The definition of "active" differs by deployment type:
+
 - **Dedicated Cloud / Self-Managed**: A user is active if they sign in, open any page in the W&B App, log runs, use the SDK, or interact with the W&B server in any way.
 - **Multi-tenant Cloud**: A user is active if they perform any auditable action scoped to the organization after May 8, 2025. See [Audit logging actions](/platform/hosting/monitoring-usage/audit-logging#actions) for the full list.
 
@@ -192,18 +200,19 @@ Retrieves a list of all users and service accounts in your organization. Each re
 
 The `/Users` endpoint supports filtering users by username or email:
 
-- `userName eq "value"` - Filter by username
-- `emails.value eq "value"` - Filter by email address
+- `userName eq "value"`: Filter by username.
+- `emails.value eq "value"`: Filter by email address.
 
 ##### Example
+
 ```bash
 GET /scim/Users?filter=userName eq "john.doe"
 GET /scim/Users?filter=emails.value eq "john@example.com"
 ```
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Users`
+- **Method**: `GET`
 
 #### Example
 
@@ -214,7 +223,7 @@ GET /scim/Users
 ```
 </Tab>
 <Tab title="List Users Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -255,10 +264,12 @@ GET /scim/Users
 ```
 
 The response includes details about each user's activity in the organization:
+
 - **`daysActive`**: Total number of days the user has been active in the organization.
-- **`lastActiveAt`**: ISO 8601 timestamp of the user's most recent activity. Returns `null` if the user has never been active.
+- **`lastActiveAt`**: ISO 8601 timestamp of the user's most recent activity. Returns `null` if the user hasn't been active.
 
 The definition of "active" differs by deployment type:
+
 - **Dedicated Cloud / Self-Managed**: A user is active if they sign in, open any page in the W&B App, log runs, use the SDK, or interact with the W&B server in any way.
 - **Multi-tenant Cloud**: A user is active if they perform any auditable action scoped to the organization after May 8, 2025. See [Audit logging actions](/platform/hosting/monitoring-usage/audit-logging#actions) for the full list.
 
@@ -270,8 +281,8 @@ The definition of "active" differs by deployment type:
 Creates a new user in your organization.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users`
-- **Method**: POST
+- **URL**: `[HOST-URL]/scim/Users`
+- **Method**: `POST`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -338,7 +349,7 @@ POST /scim/Users
 
 <Tabs>
 <Tab title="Create User Response (Dedicated/Self-Managed)">
-```bash
+```text
 (Status 201)
 ```
 
@@ -368,7 +379,7 @@ POST /scim/Users
 ```
 </Tab>
 <Tab title="Create User Response (Multi-tenant)">
-```bash
+```text
 (Status 201)
 ```
 
@@ -414,20 +425,20 @@ POST /scim/Users
 
 ### Provision service account
 
-Creates a team-scoped or organization-scoped service account in your organization. Omit `accountType` to create a regular user instead. See [Create user](#create-user).
+Creates a team-scoped or organization-scoped service account in your organization. Use this endpoint to create headless identities for automation, CI/CD, or integrations that shouldn't be tied to a human user. Omit `accountType` to create a regular user instead. See [Create user](#create-user).
 
 <Note>
 Available in **Dedicated Cloud** and **Self-Managed** v0.81.0+ and in **Multi-tenant Cloud**.
 
-- Set `userName` to the service account name. The API uses `userName` for the account's display name; `displayName` in the request body is ignored.
-- `emails` are not required for service accounts.
-- `modelsSeat` and `weaveRole` are not supported on create and return `400 Bad Request` if present.
-- Service accounts cannot be updated with `PATCH` or `PUT`, cannot be deactivated, and cannot be assigned organization, team, or registry roles through SCIM. Create API keys in the W&B App after provisioning.
+- Set `userName` to the service account name. The API uses `userName` for the account's display name. The `displayName` field in the request body is ignored.
+- `emails` aren't required for service accounts.
+- `modelsSeat` and `weaveRole` aren't supported on create and return `400 Bad Request` if present.
+- Service accounts can't be updated with `PATCH` or `PUT`, can't be deactivated, and can't be assigned organization, team, or registry roles through SCIM. Create API keys in the W&B App after provisioning.
 </Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users`
-- **Method**: POST
+- **URL**: `[HOST-URL]/scim/Users`
+- **Method**: `POST`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -485,7 +496,7 @@ POST /scim/Users
 
 <Tabs>
 <Tab title="Provision Team Service Account Response">
-```bash
+```text
 (Status 201)
 ```
 
@@ -519,7 +530,7 @@ POST /scim/Users
 ```
 </Tab>
 <Tab title="Provision Org Service Account Response">
-```bash
+```text
 (Status 201)
 ```
 
@@ -559,23 +570,23 @@ For an organization-scoped service account, `accountType` is `ORG_SERVICE`.
 
 In **Self-Managed** deployments, `organizationRole` is `service` or `org_service` instead of `member`, matching the account type.
 
-If the response returns one of these errors, check the request for these common problems:
+If the response returns one of the following errors, check the request for these common problems:
 
 - `409 Conflict`: The request includes duplicate `userName` keys for the same service account.
-- `400 Bad Request`: The request is missing  `defaultTeam` or sets it to an invalid value.
+- `400 Bad Request`: The request is missing `defaultTeam` or sets it to an invalid value.
 
 
 ### Deprovision service account
 
-Permanently deletes a service account and its organization membership. This is a hard delete; the account cannot be reactivated through SCIM.
+Permanently deletes a service account and its organization membership. Use this endpoint when a service account is no longer needed (for example, after you retire an automation pipeline). This is a hard delete, and the account can't be reactivated through SCIM.
 
 <Note>
-Available in **Dedicated Cloud** and **Self-Managed** v0.81.0+ and in **Multi-tenant Cloud**. Use the service account's SCIM user `id` from the provision response or from [Get user](#get-user). Deprovisioning does not delete API keys that were already issued; revoke keys separately in the W&B App if needed.
+Available in **Dedicated Cloud** and **Self-Managed** v0.81.0+ and in **Multi-tenant Cloud**. Use the service account's SCIM user `id` from the provision response or from [Get user](#get-user). Deprovisioning doesn't delete API keys that were already issued. Revoke keys separately in the W&B App if needed.
 </Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: DELETE
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `DELETE`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -591,7 +602,7 @@ DELETE /scim/Users/xyz
 ```
 </Tab>
 <Tab title="Deprovision Service Account Response">
-```bash
+```text
 (Status 204)
 ```
 </Tab>
@@ -602,7 +613,7 @@ DELETE /scim/Users/xyz
 <Warning>
 **Maintain admin access**
 
-You must ensure that at least one admin user exists in your instance or organization at all times. Otherwise, no user will be able to configure or maintain your organization's W&B account. If an organization uses SCIM or another automated process to deprovision users from W&B, a deprovisioning operation could inadvertently remove the last remaining admin from the instance or organization.
+Ensure that at least one admin user always exists in your instance or organization. Otherwise, no user can configure or maintain your organization's W&B account. If an organization uses SCIM or another automated process to deprovision users from W&B, a deprovisioning operation could inadvertently remove the last remaining admin from the instance or organization.
 
 For assistance with developing operational procedures, or to restore admin access, contact [support](mailto:support@wandb.com).
 </Warning>
@@ -610,8 +621,8 @@ For assistance with developing operational procedures, or to restore admin acces
 Fully deletes a user from your organization. To delete a service account, see [Deprovision service account](#deprovision-service-account).
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: DELETE
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `DELETE`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -627,23 +638,25 @@ DELETE /scim/Users/abc
 ```
 </Tab>
 <Tab title="Delete User Response">
-```bash
+```text
 (Status 204)
 ```
 </Tab>
 </Tabs>
 
 <Note>
-To temporarily deactivate the user, refer to [Deactivate user](#deactivate-user) API which uses the `PATCH` endpoint.
+To temporarily deactivate the user, refer to the [Deactivate user](#deactivate-user) API, which uses the `PATCH` endpoint.
 </Note>
 
 ### Update user email
+
 Updates a user's primary email address.
-**Not supported for Multi-tenant Cloud**, where a user's account is not managed by the organization.
+
+**Not supported for Multi-tenant Cloud**, where a user's account isn't managed by the organization.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -680,7 +693,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Update Email Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -713,11 +726,12 @@ PATCH /scim/Users/abc
 ### Update user display name
 
 Updates a user's display name.
-**Not supported for Multi-tenant Cloud**, where a user's account is not managed by the organization.
+
+**Not supported for Multi-tenant Cloud**, where a user's account isn't managed by the organization.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -749,7 +763,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Update Display Name Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -781,16 +795,16 @@ PATCH /scim/Users/abc
 
 ### Deactivate user
 
-Deactivates a user in your organization. The actual result differs by deployment type:
+Deactivates a user in your organization. The result differs by deployment type:
 
-- **Dedicated Cloud** / **Self-Managed**: Sets the user's `active` field to `false`. To restore a deactivated user's access your organization, see [Reactivate user](#reactivate-user).
-- **Multi-tenant Cloud**: Removes the user from the organization. To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account is not managed by the organization.
+- **Dedicated Cloud** / **Self-Managed**: Sets the user's `active` field to `false`. To restore a deactivated user's access to your organization, see [Reactivate user](#reactivate-user).
+- **Multi-tenant Cloud**: Removes the user from the organization. To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account isn't managed by the organization.
 
-<Note>This operation works for users only, not service accounts. Deactivating a service account is not supported. Manage team service accounts in the settings for the W&B Team.</Note>
+<Note>This operation works for users only, not service accounts. Deactivating a service account isn't supported. Manage team service accounts in the settings for the W&B Team.</Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -843,7 +857,7 @@ PATCH /scim/Users
 
 <Tabs>
 <Tab title="Deactivate User Response (Dedicated/Self-Managed)">
-```bash
+```text
 (Status 200)
 ```
 
@@ -872,7 +886,7 @@ PATCH /scim/Users
 ```
 </Tab>
 <Tab title="Deactivate User Response (Multi-tenant)">
-```bash
+```text
 (Status 200)
 ```
 ```json
@@ -894,9 +908,9 @@ PATCH /scim/Users
 Reactivates a previously deactivated user in your organization.
 
 <Note>
-- User reactivation works for users only, not service accounts. Reactivation is not supported for service accounts. Manage service accounts in the settings for the W&B Team.
+- User reactivation works for users only, not service accounts. Reactivation isn't supported for service accounts. Manage service accounts in the settings for the W&B Team.
 
-- User reactivation is not supported in [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud). To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account is not managed by the organization. An attempt to reactivate a user results in an HTTP `400` error. The `detail` field in the response body is returned verbatim from the API and may still use legacy product wording:
+- User reactivation isn't supported in [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud). To restore the user's access, re-add them to your organization. See [Create user](#create-user-request-multi-tenant). In Multi-tenant Cloud, a user's account isn't managed by the organization. An attempt to reactivate a user results in an HTTP `400` error. The `detail` field in the response body is returned verbatim from the API and may still use legacy product wording:
     ```json
     {
         "schemas": [
@@ -909,8 +923,8 @@ Reactivates a previously deactivated user in your organization.
 </Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -939,7 +953,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Reactivate User Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -973,11 +987,11 @@ PATCH /scim/Users/abc
 
 Assigns an organization-level role to a user.
 
-<Note>This operation works for users only, not service accounts. Custom roles are not supported for service accounts.</Note>
+<Note>This operation works for users only, not service accounts. Custom roles aren't supported for service accounts.</Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -989,13 +1003,13 @@ Assigns an organization-level role to a user.
 
 <Note>
 The organization-scoped `viewer` role is deprecated and can no longer be assigned in the UI. If you use SCIM to assign the `viewer` role to a user:
-- They are assigned the `member` role in the organization.
+- They're assigned the `member` role in the organization.
 - Their `modelsSeat` is set to `viewer` instead of `full`. This allows view-only access to Models and full access to Registry. If no Models seats are available, a `Seat limit reached` error is returned. This can be updated later if a seat is available.
 - Their `weaveRole` is set to `viewer` instead of `full`. This allows view-only access to Weave.
 - All of their existing team and project roles are set to `viewer`.
-- They are assigned the Registry `viewer` role in registries that are visible at the organization level.
+- They're assigned the Registry `viewer` role in registries that are visible at the organization level.
 
-Assigning the `member` or `admin` organization role does not change the user's `modelsSeat` or `weaveRole`.
+Assigning the `member` or `admin` organization role doesn't change the user's `modelsSeat` or `weaveRole`.
 </Note>
 
 #### Example
@@ -1020,7 +1034,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Assign Org Role Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1062,8 +1076,8 @@ PATCH /scim/Users/abc
 Updates a user's Models seat.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -1095,7 +1109,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Update Models Seat Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1133,8 +1147,8 @@ PATCH /scim/Users/abc
 Updates a user's Weave role.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -1166,7 +1180,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Update Weave Role Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1203,11 +1217,11 @@ PATCH /scim/Users/abc
 
 Assigns a team-level role to a user.
 
-<Note>This operation works for users only, not service accounts. Custom roles are not supported for service accounts.</Note>
+<Note>This operation works for users only, not service accounts. Custom roles aren't supported for service accounts.</Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -1244,7 +1258,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Assign Team Role Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1286,11 +1300,11 @@ PATCH /scim/Users/abc
 
 Adds a user to a registry with an assigned registry-level role.
 
-<Note>This operation works for users only, not service accounts. Custom roles are not supported for service accounts.</Note>
+<Note>This operation works for users only, not service accounts. Custom roles aren't supported for service accounts.</Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -1328,7 +1342,7 @@ PATCH /scim/Users/abc
 </Tab>
 <Tab title="Add to Registry Response">
 
-```bash
+```text
 (Status 200)
 ```
 
@@ -1376,8 +1390,8 @@ Removes a user from a registry.
 </Note>
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Users/{id}`
-- **Method**: PATCH
+- **URL**: `[HOST-URL]/scim/Users/{id}`
+- **Method**: `PATCH`
 
 #### Parameters
 | Parameter | Type | Required | Description |
@@ -1407,7 +1421,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Remove from Registry Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1463,7 +1477,7 @@ PATCH /scim/Users/abc
 ```
 </Tab>
 <Tab title="Remove from ALL Registries Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1496,20 +1510,24 @@ PATCH /scim/Users/abc
 
 ## Group resource
 
-When you create a SCIM group in your IAM, it creates and maps to a W&B Team, and other SCIM group operations operate on the team. To configure custom storage during team creation, include `storageBucket` in the request.
+The SCIM group resource maps to a W&B Team. Use the endpoints in this section to create teams, manage team membership, and (optionally) configure team-level storage from your identity provider or automation. When you create a SCIM group in your IAM, it creates and maps to a W&B Team, and other SCIM group operations act on the team. To configure custom storage during team creation, include `storageBucket` in the request.
 
-### Service Accounts
+### Service accounts
 
-When a W&B Team is created using SCIM, all organization-level service accounts are automatically added to the team, to maintain the service account's access to team resources.
+When you create a W&B Team using SCIM, all organization-level service accounts are automatically added to the team, to maintain the service account's access to team resources.
 
-### Filtering groups
+### Filter groups
 
-The `/Groups` endpoint supports filtering to search for specific teams:
+The `/Groups` endpoint supports filtering to search for specific teams.
 
-#### Supported Filters
-- `displayName eq "value"` - Filter by team display name
+#### Supported filters
+
+The `/Groups` endpoint supports the following filter:
+
+- `displayName eq "value"`: Filter by team display name.
 
 #### Example
+
 ```bash
 GET /scim/Groups?filter=displayName eq "engineering-team"
 ```
@@ -1519,8 +1537,8 @@ GET /scim/Groups?filter=displayName eq "engineering-team"
 Retrieve team information by providing the team's unique ID.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Groups/{id}`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Groups/{id}`
+- **Method**: `GET`
 
 #### Example
 
@@ -1531,7 +1549,7 @@ GET /scim/Groups/ghi
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1566,8 +1584,8 @@ GET /scim/Groups/ghi
 Retrieve a list of teams.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Groups`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Groups`
+- **Method**: `GET`
 
 #### Example
 
@@ -1578,7 +1596,7 @@ GET /scim/Groups
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1620,10 +1638,13 @@ GET /scim/Groups
 
 ### Create team
 
-- **Endpoint**: **`<host-url>/scim/Groups`**
-- **Method**: POST
-- **Description**: Create a new team resource.
-- **Supported Fields**:
+Creates a new team resource.
+
+#### Endpoint
+- **URL**: `[HOST-URL]/scim/Groups`
+- **Method**: `POST`
+
+#### Supported fields
 
 | Field | Type | Required |
 | --- | --- | --- |
@@ -1633,16 +1654,16 @@ GET /scim/Groups
 
 You can configure team-level [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) during team creation by including a `storageBucket` object. If omitted, the team uses default or instance-level storage. Provision the bucket (policy, CORS, credentials) and determine the storage address format per provider using the BYOB guide. The `storageBucket` object has the following sub-fields:
 
-- **Required**: `name` (bucket name), `provider` (one of `COREWEAVE`, `AWS`, `AZURE`, `GCP`, or `MINIO`). The value is case-sensitive; use uppercase as shown.
+- **Required**: `name` (bucket name), `provider` (one of `COREWEAVE`, `AWS`, `AZURE`, `GCP`, or `MINIO`). The value is case-sensitive. Use uppercase as shown.
 - **Optional**: `path` (path prefix within the bucket), `kmsKeyId` (KMS key for encryption, for example for AWS), `awsExternalId` (AWS cross-account access), `azureTenantId` (Azure tenant ID), `azureClientId` (Azure managed identity client ID).
 
-W&B validates that the bucket exists and is reachable before creating the team. If validation fails, the SCIM request fails and the team is not created.
+W&B validates that the bucket exists and is reachable before creating the team. If validation fails, the SCIM request fails and the team isn't created.
 
 An invalid `provider` value returns `400 Bad Request` with a SCIM error that lists the allowed values.
 
 #### Examples
 
-These examples show how to create a team without custom storage and with BYOB storage on a specific provider. Select a tab for the desired storage configuration for an example request, and select the **Response** tab for an example response.
+These examples show how to create a team without custom storage and with BYOB storage on a specific provider. Select a tab for the desired storage configuration to see an example request, and select the **Response** tab for an example response.
 
 <Tabs>
 <Tab title="Request (no BYOB)">
@@ -1768,7 +1789,7 @@ Content-Type: application/scim+json
 
 
 <Tab title="Response">
-```bash
+```text
 (Status 201)
 ```
 
@@ -1800,17 +1821,20 @@ Content-Type: application/scim+json
 
 ### Update team
 
-- **Endpoint**: **`<host-url>/scim/Groups/{id}`**
-- **Method**: PATCH
-- **Description**: Update an existing team's membership list.
-- **Supported Operations**: `add` member, `remove` member, `replace` members
+Updates an existing team's membership list.
+
+#### Endpoint
+- **URL**: `[HOST-URL]/scim/Groups/{id}`
+- **Method**: `PATCH`
+- **Supported operations**: `add` member, `remove` member, `replace` members.
 
 <Note>
 - The remove operations follow RFC 7644 SCIM protocol specifications. Use the filter syntax `members[value eq "{user_id}"]` to remove a specific user, or `members` to remove all users from the team.
 
-    **User Identification**: The `{user_id}` in member operations can be either:
-    - A W&B user ID
-    - An email address (e.g., "user@example.com")
+    **User identification**: The `{user_id}` in member operations can be either of the following:
+
+    - A W&B user ID.
+    - An email address (for example, "user@example.com").
 - These operations work for users only, not service accounts. Update a team's service accounts in the settings for the W&B Team.
 </Note>
 
@@ -1825,9 +1849,9 @@ Replaces all members of a team with a new list.
 
 <Note>This operation works for users only, not service accounts. Manage service accounts in the settings for the W&B Team.</Note>
 
-- **Endpoint**: **`<host-url>/scim/Groups/{id}`**
-- **Method**: PUT
-- **Description**: Replace the entire team membership list.
+#### Endpoint
+- **URL**: `[HOST-URL]/scim/Groups/{id}`
+- **Method**: `PUT`
 
 <Tabs>
 <Tab title="Request">
@@ -1851,7 +1875,7 @@ PUT /scim/Groups/{team_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1887,9 +1911,9 @@ PUT /scim/Groups/{team_id}
 </Tab>
 </Tabs>
 
-**Adding a user to a team**
+### Add a user to a team
 
-Adding `dev-user2` to `acme-devs`:
+Adds `dev-user2` to `acme-devs`:
 
 <Note>This operation works for users only, not service accounts. Manage service accounts in the settings for the W&B Team.</Note>
 
@@ -1917,7 +1941,7 @@ PATCH /scim/Groups/{team_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -1953,9 +1977,9 @@ PATCH /scim/Groups/{team_id}
 </Tab>
 </Tabs>
 
-**Removing a specific user from a team**
+### Remove a specific user from a team
 
-Removing `dev-user2` from `acme-devs`:
+Removes `dev-user2` from `acme-devs`:
 
 <Note>This operation works for users only, not service accounts. Manage service accounts in the settings for the W&B Team.</Note>
 
@@ -1978,7 +2002,7 @@ PATCH /scim/Groups/{team_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2006,9 +2030,9 @@ PATCH /scim/Groups/{team_id}
 </Tab>
 </Tabs>
 
-**Removing all users from a team**
+### Remove all users from a team
 
-Removing all users from `acme-devs`:
+Removes all users from `acme-devs`:
 
 <Note>This operation works for users only, not service accounts. Manage service accounts in the settings for the W&B Team.</Note>
 
@@ -2031,7 +2055,7 @@ PATCH /scim/Groups/{team_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2056,19 +2080,19 @@ PATCH /scim/Groups/{team_id}
 
 ### Delete team
 
-- Deleting teams is currently unsupported by the SCIM API since there is additional data linked to teams. Delete teams from the app to confirm you want everything deleted.
+The SCIM API doesn't support deleting teams because additional data is linked to teams. Delete teams from the W&B App to confirm you want everything deleted.
 
 ## Role resource
 
-The SCIM role resource maps to W&B custom roles. As mentioned earlier, the `/Roles` endpoints are not part of the official SCIM schema, W&B adds `/Roles` endpoints to support automated management of custom roles in W&B organizations.
+The SCIM role resource maps to W&B custom roles. Use the endpoints in this section to create and maintain custom roles programmatically (for example, to keep role definitions in sync with your access policies). The `/Roles` endpoints aren't part of the official SCIM schema. W&B adds `/Roles` endpoints to support automated management of custom roles in W&B organizations.
 
 ### Get custom role
 
 Retrieve information for a custom role by providing the role's unique ID.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Roles/{id}`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Roles/{id}`
+- **Method**: `GET`
 
 #### Example
 
@@ -2079,7 +2103,7 @@ GET /scim/Roles/abc
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2121,8 +2145,8 @@ GET /scim/Roles/abc
 Retrieve information for all custom roles in the W&B organization.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Roles`
-- **Method**: GET
+- **URL**: `[HOST-URL]/scim/Roles`
+- **Method**: `GET`
 
 #### Example
 
@@ -2133,7 +2157,7 @@ GET /scim/Roles
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2209,17 +2233,21 @@ GET /scim/Roles
 
 ### Create custom role
 
-- **Endpoint**: **`<host-url>/scim/Roles`**
-- **Method**: POST
-- **Description**: Create a new custom role in the W&B organization.
-- **Supported Fields**:
+Creates a new custom role in the W&B organization.
+
+#### Endpoint
+- **URL**: `[HOST-URL]/scim/Roles`
+- **Method**: `POST`
+
+#### Supported fields
 
 | Field | Type | Required |
 | --- | --- | --- |
 | `name` | String | Name of the custom role |
 | `description` | String | Description of the custom role |
 | `permissions` | Object array | Array of permission objects where each object includes a `name` string field that has value of the form `w&bobject:operation`. For example, a permission object for delete operation on W&B runs would have `name` as `run:delete`. |
-| `inheritedFrom` | String | The predefined role which the custom role would inherit from. It can either be `member` or `viewer`. |
+| `inheritedFrom` | String | The predefined role that the custom role inherits from. It can be either `member` or `viewer`. |
+
 #### Example
 
 <Tabs>
@@ -2243,7 +2271,7 @@ POST /scim/Roles
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 201)
 ```
 
@@ -2282,11 +2310,15 @@ POST /scim/Roles
 
 ### Update custom role
 
+The following sections describe how to add or remove permissions on an existing custom role.
+
 #### Add permissions to role
 
-- **Endpoint**: **`<host-url>/scim/Roles/{id}`**
-- **Method**: PATCH
-- **Description**: Add permissions to an existing custom role.
+Adds permissions to an existing custom role.
+
+##### Endpoint
+- **URL**: `[HOST-URL]/scim/Roles/{id}`
+- **Method**: `PATCH`
 
 <Tabs>
 <Tab title="Request">
@@ -2315,7 +2347,7 @@ PATCH /scim/Roles/{role_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2325,9 +2357,11 @@ Returns the updated role with new permissions added.
 
 #### Remove a permission from a role
 
-- **Endpoint**: **`<host-url>/scim/Roles/{id}`**
-- **Method**: PATCH
-- **Description**: Remove permissions from an existing custom role.
+Removes permissions from an existing custom role.
+
+##### Endpoint
+- **URL**: `[HOST-URL]/scim/Roles/{id}`
+- **Method**: `PATCH`
 
 <Tabs>
 <Tab title="Request">
@@ -2353,7 +2387,7 @@ PATCH /scim/Roles/{role_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
@@ -2363,9 +2397,11 @@ Returns the updated role with specified permissions removed.
 
 ### Replace custom role
 
-- **Endpoint**: **`<host-url>/scim/Roles/{id}`**
-- **Method**: PUT
-- **Description**: Replace an entire custom role definition.
+Replaces an entire custom role definition.
+
+#### Endpoint
+- **URL**: `[HOST-URL]/scim/Roles/{id}`
+- **Method**: `PUT`
 
 <Tabs>
 <Tab title="Request">
@@ -2394,21 +2430,21 @@ PUT /scim/Roles/{role_id}
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 200)
 ```
 
-Returns the completely replaced role definition.
+Returns the replaced role definition.
 </Tab>
 </Tabs>
 
 ### Delete custom role
 
-Delete a custom role in the W&B organization. **Use it with caution**. The predefined role from which the custom role inherited is now assigned to all users that were assigned the custom role before the operation.
+Delete a custom role in the W&B organization. **Use this operation with caution**. The predefined role that the custom role inherited from is reassigned to all users who held the custom role before the deletion.
 
 #### Endpoint
-- **URL**: `<host-url>/scim/Roles/{id}`
-- **Method**: DELETE
+- **URL**: `[HOST-URL]/scim/Roles/{id}`
+- **Method**: `DELETE`
 
 #### Example
 
@@ -2419,7 +2455,7 @@ DELETE /scim/Roles/abc
 ```
 </Tab>
 <Tab title="Response">
-```bash
+```text
 (Status 204 No Content)
 ```
 </Tab>
@@ -2427,20 +2463,22 @@ DELETE /scim/Roles/abc
 
 ## Advanced features
 
-### ETag Support
+The following sections describe optional capabilities (ETag-based concurrency control and standard error responses) that help SCIM integrations behave safely in production.
 
-The SCIM API supports ETags for conditional updates to prevent concurrent modification conflicts. ETags are returned in the `ETag` response header and the `meta.version` field.
+### ETag support
+
+The SCIM API supports ETags for conditional updates to prevent concurrent modification conflicts. This matters when multiple admins or automated systems update the same resource, because it ensures that one update doesn't silently overwrite another. ETags are returned in the `ETag` response header and the `meta.version` field.
 
 #### ETags
 
-To use Etags:
+To use ETags, follow these steps:
 
-1. **Get current ETag**: When you GET a resource, note the ETag header in the response
-2. **Conditional update**: Include the ETag in the `If-Match` header when updating
+1. **Get current ETag**: When you GET a resource, note the ETag header in the response.
+2. **Conditional update**: Include the ETag in the `If-Match` header when updating.
 
 #### Example
 
-```
+```text
 # Get user and note ETag
 GET /scim/Users/abc
 # Response includes: ETag: W/"xyz123"
@@ -2461,7 +2499,7 @@ If-Match: W/"xyz123"
 }
 ```
 
-A `412 Precondition Failed` error response indicates that the resources has been modified since you retrieved it.
+A `412 Precondition Failed` error response indicates that the resource has been modified since you retrieved it.
 
 ### Error handling
 
@@ -2472,17 +2510,17 @@ The SCIM API returns standard SCIM error responses:
 | `200` | Success |
 | `201` | Created |
 | `204` | No Content (successful deletion) |
-| `400` | Bad Request - Invalid parameters or request body |
-| `401` | Unauthorized - Authentication failed |
-| `403` | Forbidden - Insufficient permissions |
-| `404` | Not Found - Resource does not exist |
-| `409` | Conflict - Resource already exists |
-| `412` | Precondition Failed - ETag mismatch |
+| `400` | Bad Request: invalid parameters or request body |
+| `401` | Unauthorized: authentication failed |
+| `403` | Forbidden: insufficient permissions |
+| `404` | Not Found: resource doesn't exist |
+| `409` | Conflict: resource already exists |
+| `412` | Precondition Failed: ETag mismatch |
 | `500` | Internal Server Error |
 
 ### Implementation differences per deployment type
 
-W&B maintains two separate SCIM API implementations, and the features differ between them:
+W&B maintains two separate SCIM API implementations, and the features differ between them. Review the following table before you integrate with SCIM to confirm that the operations you rely on are available on your deployment type.
 
 | Feature                         | Multi-tenant Cloud | Dedicated Cloud and Self-Managed |
 |---------------------------------|-----------------|--------------|
@@ -2497,8 +2535,10 @@ W&B maintains two separate SCIM API implementations, and the features differ bet
 
 ## Limitations
 
-- **Maximum results**: 9999 items per request.
+Keep the following constraints in mind when you design SCIM integrations:
+
+- **Maximum results**: 9,999 items per request.
 - **Dedicated Cloud and Self-Managed**: Only support one email per user.
-- **Team deletion**: Not supported via SCIM (use the W&B web interface).
+- **Team deletion**: Not supported through SCIM (use the W&B web interface).
 - **User reactivation**: Not supported in Multi-tenant Cloud environments.
 - **Seat limits**: Operations may fail if organization seat limits are reached.

--- a/platform/hosting/iam/service-accounts.mdx
+++ b/platform/hosting/iam/service-accounts.mdx
@@ -13,26 +13,28 @@ import ServiceAccountApiKeyDelete from "/snippets/_includes/service-account-api-
 
 A service account represents a non-human or machine user that can automatically perform common tasks across projects within a team or across teams. Service accounts are ideal for CI/CD pipelines, automated training jobs, and other machine-to-machine workflows.
 
+This page explains the scopes available for service accounts, walks through how to create and manage them, and outlines best practices for using them safely in production automation. It's intended for organization and team admins who provision credentials for automated systems.
+
 ## Key benefits
 
 <ServiceAccountBenefits/>
 
 ## Overview
 
-Service accounts provide a secure way to automate W&B workflows without using personal user credentials or hard-coded credentials. They can be created at two scopes:
+Service accounts provide a secure way to automate W&B workflows without using personal user credentials or hardcoded credentials. You can create them at two scopes:
 
 - **Organization-scoped**: Created by org admins, with access across all teams.
-- **Team-scoped**: Created by team admins, with access limited to a specific team
+- **Team-scoped**: Created by team admins, with access limited to a specific team.
 	
-A service account's API key allows the caller to read from or write to projects within the service account's scope. This enables centralized management of automated workflows for experiment tracking in W&B Models or logging traces in W&B Weave.
+A service account's API key lets the caller read from or write to projects within the service account's scope. This enables centralized management of automated workflows for experiment tracking in W&B Models or logging traces in W&B Weave.
 
-Service accounts are particularly useful for:
-- **CI/CD pipelines**: Automatically log model training runs from GitHub Actions, GitLab CI, or Jenkins
-- **Scheduled jobs**: Nightly model retraining, periodic evaluation runs, or data validation workflows
-- **Production monitoring**: Log inference metrics and model performance from production systems
-- **Jupyter notebooks**: Shared notebooks in JupyterHub or Google Colab environments
-- **Kubernetes jobs**: Automated workflows running in K8s clusters
-- **Airflow/Prefect/Dagster**: ML pipeline orchestration tools
+Service accounts are useful for:
+- **CI/CD pipelines**: Automatically log model training runs from GitHub Actions, GitLab CI, or Jenkins.
+- **Scheduled jobs**: Nightly model retraining, periodic evaluation runs, or data validation workflows.
+- **Production monitoring**: Log inference metrics and model performance from production systems.
+- **Jupyter notebooks**: Shared notebooks in JupyterHub or Google Colab environments.
+- **Kubernetes jobs**: Automated workflows running in Kubernetes clusters.
+- **Airflow/Prefect/Dagster**: ML pipeline orchestration tools.
 
 <Note>
 Service accounts are available on [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), [Self-Managed instances](/platform/hosting/hosting-options/self-managed) with an enterprise license, and enterprise accounts in [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud).
@@ -40,7 +42,7 @@ Service accounts are available on [Dedicated Cloud](/platform/hosting/hosting-op
 
 ## Organization-scoped service accounts
 
-Service accounts scoped to an organization have permissions to read and write in all projects in the organization, regardless of the team, with the exception of [restricted projects](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes). Before an organization-scoped service account can access a restricted project, an admin of that project must explicitly add the service account to the project.
+Use an organization-scoped service account when your automation needs to read or write across projects in multiple teams. Service accounts scoped to an organization have permissions to read and write in all projects in the organization, regardless of the team, with the exception of [restricted projects](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes). Before an organization-scoped service account can access a restricted project, an admin of that project must explicitly add the service account to the project.
 
 ### Create an organization-scoped service account
 
@@ -49,12 +51,12 @@ Service accounts scoped to an organization have permissions to read and write in
 <ApiKeyViewOnceWarning/>
 
 <Note>
-An organization-scoped service account requires a default team, even though it has access to non-restricted projects owned by all teams within the organization. This helps to prevent a workload from failing if the `WANDB_ENTITY` variable is not set in the environment for your model training or generative AI app. To use an organization-scoped service account for a project in a different team, you must set the `WANDB_ENTITY` environment variable to that team.
+An organization-scoped service account requires a default team, even though it has access to non-restricted projects owned by all teams within the organization. This helps to prevent a workload from failing if the `WANDB_ENTITY` variable isn't set in the environment for your model training or generative AI app. To use an organization-scoped service account for a project in a different team, you must set the `WANDB_ENTITY` environment variable to that team.
 </Note>
 
 ## Team-scoped service accounts
 
-A team-scoped service account can read and write in all projects within its team, except to [restricted projects](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes) in that team. Before a team-scoped service account can access a restricted project, an admin of that project must explicitly add the service account to the project.
+Use a team-scoped service account when you want to limit automation to a single team's projects, following the principle of least privilege. A team-scoped service account can read and write in all projects within its team, except to [restricted projects](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes) in that team. Before a team-scoped service account can access a restricted project, an admin of that project must explicitly add the service account to the project.
 
 ### Create a team-scoped service account
 
@@ -72,32 +74,32 @@ A team-scoped service account can read and write in all projects within its team
 
 <ServiceAccountApiKeyDelete/>
 
-If you do not configure a team in your model training or generative AI app environment that uses a team-scoped service account, the model runs or weave traces log to the named project within the service account's parent team. In such a scenario, user attribution using the `WANDB_USERNAME` or `WANDB_USER_EMAIL` variables _do not work_ unless the referenced user is part of the service account's parent team.
+If you don't configure a team in your model training or generative AI app environment that uses a team-scoped service account, the model runs or weave traces log to the named project within the service account's parent team. In such a scenario, user attribution using the `WANDB_USERNAME` or `WANDB_USER_EMAIL` variables _doesn't work_ unless the referenced user is part of the service account's parent team.
 
 <Warning>
-A team-scoped service account cannot log runs to a [team or restricted-scoped project](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes) in a team different from its parent team, but it can log runs to an open visibility project within another team.
+A team-scoped service account can't log runs to a [team or restricted-scoped project](/platform/hosting/iam/access-management/restricted-projects/#visibility-scopes) in a team different from its parent team, but it can log runs to an open visibility project within another team.
 </Warning>
 
 ### External service accounts
 
-In addition to built-in service accounts, W&B also supports team-scoped external service accounts with the W&B SDK and CLI using [Identity federation](./identity_federation#external-service-accounts) with identity providers (IdPs) that can issue JSON Web Tokens (JWTs).
+If you'd prefer to issue credentials through your own identity provider instead of managing W&B-native API keys, use external service accounts. In addition to built-in service accounts, W&B also supports team-scoped external service accounts with the W&B SDK and CLI using [Identity federation](./identity_federation#external-service-accounts) with identity providers (IdPs) that issue JSON Web Tokens (JWTs).
 
 ## Best practices
 
-Follow these recommendations to ensure secure and efficient use of service accounts in your organization:
+After you create the service accounts you need, follow these recommendations to ensure secure and efficient use of service accounts in your organization:
 
-- **Use a secrets manager**: Store service account API keys in a secure secrets management system (e.g., AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) rather than in plain text configuration files.
+- **Use a secrets manager**: Store service account API keys in a secure secrets management system (for example, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) rather than in plain text configuration files.
 
 - **Principle of least privilege**: Create team-scoped service accounts when possible, rather than organization-scoped accounts, to limit access to only necessary projects.
 
-- **Unique service accounts per use case**: Create separate service accounts for different automation workflows (e.g., one for CI/CD, another for scheduled retraining) to improve auditability and enable granular access control.
+- **Unique service accounts per use case**: Create separate service accounts for different automation workflows (for example, one for CI/CD, another for scheduled retraining) to improve auditability and enable granular access control.
 
 - **Regular audits**: Periodically review active service accounts and remove those no longer in use. Check the audit logs to monitor service account activity.
 
-- **Secure API key handling**: 
-  - Never commit API keys to version control
-  - Use environment variables to pass keys to applications
-  - Rotate keys if they are accidentally exposed
+- **Secure API key handling**:
+  - Never commit API keys to version control.
+  - Use environment variables to pass keys to applications.
+  - Rotate keys if they're accidentally exposed.
 
 - **Naming conventions**: Use descriptive names that indicate the service account's purpose:
   - Good: `ci-model-training`, `nightly-eval-pipeline`, `prod-inference-monitor`
@@ -105,7 +107,7 @@ Follow these recommendations to ensure secure and efficient use of service accou
 
 - **User attribution**: When multiple team members use the same automation workflow, set `WANDB_USERNAME` or `WANDB_USER_EMAIL` to track who triggered each run:
   ```bash
-  export WANDB_API_KEY="<service_account_key>"
+  export WANDB_API_KEY="[SERVICE_ACCOUNT_KEY]"
   export WANDB_USERNAME="john.doe@company.com"
   ```
 
@@ -115,18 +117,18 @@ Follow these recommendations to ensure secure and efficient use of service accou
   export WANDB_PROJECT="production-models"
   ```
 
-- **Error handling**: Implement proper error handling and alerts for failed authentication to quickly identify issues with service account credentials.
+- **Error handling**: Implement proper error handling and alerts for failed authentication to identify issues with service account credentials quickly.
 
 - **Documentation**: Maintain documentation of:
-  - Which service accounts exist and their purposes
-  - Which systems/workflows use each service account
-  - Contact information for the team responsible for each account
+  - Which service accounts exist and their purposes.
+  - Which systems or workflows use each service account.
+  - Contact information for the team responsible for each account.
 
 ## Troubleshooting
 
-Common issues and solutions:
+If a service account isn't behaving as expected, check the following common issues and solutions:
 
-- **"Unauthorized" errors**: Verify the API key is correctly set and the service account has access to the target project
-- **Runs not appearing**: Check that `WANDB_ENTITY` is set to the correct team name
-- **User attribution not working**: Ensure the user specified in `WANDB_USERNAME` is a member of the team
-- **Access denied to restricted projects**: Explicitly add the service account to the restricted project's access list
+- **"Unauthorized" errors**: Verify the API key is correctly set and the service account has access to the target project.
+- **Runs not appearing**: Check that `WANDB_ENTITY` is set to the correct team name.
+- **User attribution not working**: Ensure the user specified in `WANDB_USERNAME` is a member of the team.
+- **Access denied to restricted projects**: Explicitly add the service account to the restricted project's access list.

--- a/platform/hosting/iam/sso.mdx
+++ b/platform/hosting/iam/sso.mdx
@@ -3,59 +3,60 @@ title: Configure SSO with OIDC
 description: "Configure SSO using OpenID Connect with identity providers like Okta, Azure AD, and AWS Cognito for W&B instances."
 ---
 
-W&B's support for OpenID Connect (OIDC) compatible identity providers allows for management of user identities and group memberships through external identity providers like Okta, Keycloak, Auth0, Google, and Entra.
+This guide is for administrators of W&B Dedicated Cloud or Self-Managed instances who want to enable single sign-on (SSO) using an OpenID Connect (OIDC) compatible identity provider. By the end, you've configured your identity provider, connected it to W&B so that users can sign in through your organization's existing identity system, and you can manage user identities and group memberships through providers like Okta, Keycloak, Auth0, Google, and Entra.
 
-## OpenID Connect (OIDC)
+## OpenID Connect
 
-W&B supports the following OIDC authentication flows for integrating with external Identity Providers (IdPs).
-1. Implicit Flow with Form Post 
-2. Authorization Code Flow with Proof Key for Code Exchange (PKCE)
+W&B supports the following OIDC authentication flows for integrating with external Identity Providers (IdPs):
 
-These flows authenticate users and provide W&B with the necessary identity information (in the form of ID tokens) to manage access control.
+- Implicit flow with form post.
+- Authorization code flow with Proof Key for Code Exchange (PKCE).
+
+These flows authenticate users and provide W&B with the identity information (in the form of ID tokens) needed to manage access control.
 
 The ID token is a JWT that contains the user's identity information, such as their name, username, email, and group memberships. W&B uses this token to authenticate the user and map them to appropriate roles or groups in the system.
 
-In the context of W&B, access tokens authorize requests to APIs on behalf of the user, but since W&B’s primary concern is user authentication and identity, it only requires the ID token.
+In the context of W&B, access tokens authorize requests to APIs on behalf of the user, but because W&B's primary concern is user authentication and identity, it only requires the ID token.
 
 You can use environment variables to [configure IAM options](/platform/hosting/iam/advanced_env_vars) for your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instance.
 
-To assist with configuring Identity Providers for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) deployments, follow these guidelines. If you’re using W&B Multi-tenant Cloud, reach out to [support@wandb.com](mailto:support@wandb.com) for assistance.
+To assist with configuring Identity Providers for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) deployments, follow these guidelines. If you're using W&B Multi-tenant Cloud, reach out to [support@wandb.com](mailto:support@wandb.com) for assistance.
 
 ## Configure your IdP
-This section shows how to configure your identity provider (IdP) for OIDC. Select the tab for your IdP for details.
+
+The following sections describe how to configure your identity provider (IdP) for OIDC. Complete the configuration steps for your IdP first. You use the resulting **Client ID**, **Issuer URL**, and (optionally) **Client Secret** when you set up SSO in W&B in the next section. Select the tab for your IdP for details.
 <Tabs>
 <Tab title="Cognito">
-Follow the procedure below to set up AWS Cognito for authorization: 
+Follow this procedure to set up AWS Cognito as your IdP. At the end, you have a **Client ID** and **OIDC issuer URL** to use when you configure W&B.
 
-1. First, sign in to your AWS account and navigate to the [AWS Cognito](https://aws.amazon.com/cognito/) App.
+1. Sign in to your AWS account and navigate to the [AWS Cognito](https://aws.amazon.com/cognito/) App.
 
     <Frame>
     <img src="/images/hosting/setup_aws_cognito.png" alt="AWS Cognito setup"  />
     </Frame>
 
-2. Provide an allowed callback URL to configure the application in your IdP:
-     * Add `http(s)://YOUR-W&B-HOST/oidc/callback` as the callback URL. Replace `YOUR-W&B-HOST` with your W&B host path.
+2. Provide an allowed callback URL to configure the application in your IdP. Add `http(s)://[YOUR-W-AND-B-HOST]/oidc/callback` as the callback URL. Replace `[YOUR-W-AND-B-HOST]` with your W&B host path.
 
-3. If your IdP supports universal logout, set the Logout URL to `http(s)://YOUR-W&B-HOST`. Replace `YOUR-W&B-HOST` with your W&B host path.
+3. If your IdP supports universal logout, set the Logout URL to `http(s)://[YOUR-W-AND-B-HOST]`. Replace `[YOUR-W-AND-B-HOST]` with your W&B host path.
 
-    For example, if your application was running at `https://wandb.mycompany.com`, you would replace `YOUR-W&B-HOST` with `wandb.mycompany.com`.
+    For example, if your application runs at `https://wandb.mycompany.com`, replace `[YOUR-W-AND-B-HOST]` with `wandb.mycompany.com`.
 
-    The image below demonstrates how to provide allowed callback and sign-out URLs in AWS Cognito.
+    The following image demonstrates how to provide allowed callback and sign-out URLs in AWS Cognito.
 
     <Frame>
     <img src="/images/hosting/setup_aws_cognito_ui_settings.png" alt="Host configuration"  />
     </Frame>
 
 
-    _wandb/local_ uses the [`implicit` grant with the `form_post` response type](https://auth0.com/docs/get-started/authentication-and-authorization-flow/implicit-flow-with-form-post) by default. 
+    `wandb/local` uses the [`implicit` grant with the `form_post` response type](https://auth0.com/docs/get-started/authentication-and-authorization-flow/implicit-flow-with-form-post) by default.
 
-    You can also configure _wandb/local_ to perform an `authorization_code` grant that uses the [PKCE Code Exchange](https://www.oauth.com/oauth2-servers/pkce/) flow. 
+    You can also configure `wandb/local` to perform an `authorization_code` grant that uses the [PKCE Code Exchange](https://www.oauth.com/oauth2-servers/pkce/) flow.
 
 4. Select one or more OAuth grant types to configure how AWS Cognito delivers tokens to your app.
 5. W&B requires specific OpenID Connect (OIDC) scopes. Select the following from AWS Cognito App:
-    * "openid" 
-    * "profile"
-    * "email"
+    * `openid`
+    * `profile`
+    * `email`
 
     For example, your AWS Cognito App UI should look similar to the following image:
 
@@ -63,88 +64,88 @@ Follow the procedure below to set up AWS Cognito for authorization:
     <img src="/images/hosting/setup_aws_required_fields.png" alt="Required fields"  />
     </Frame>
 
-    Select the **Auth Method** in the settings page or set the OIDC_AUTH_METHOD environment variable to tell _wandb/local_ which grant to.
+    Select the **Auth Method** in the settings page or set the `OIDC_AUTH_METHOD` environment variable to specify which grant `wandb/local` uses.
 
-    You must set the Auth Method to `pkce`.
+    You must set the **Auth Method** to `pkce`.
 
-6. You need a Client ID and the URL of your OIDC issuer. The OpenID discovery document must be available at `$OIDC_ISSUER/.well-known/openid-configuration` 
+6. You need a **Client ID** and the URL of your OIDC issuer. The OpenID discovery document must be available at `$OIDC_ISSUER/.well-known/openid-configuration`.
 
-    For example, , you can generate your issuer URL by appending your User Pool ID to the Cognito IdP URL from the **App Integration** tab within the **User Pools** section:
+    For example, you can generate your issuer URL by appending your User Pool ID to the Cognito IdP URL from the **App Integration** tab within the **User Pools** section:
 
     <Frame>
     <img src="/images/hosting/setup_aws_cognito_issuer_url.png" alt="AWS Cognito issuer URL"  />
     </Frame>
 
-    Do not use the "Cognito domain" for the IDP URL. Cognito provides it's discovery document at `https://cognito-idp.$REGION.amazonaws.com/$USER_POOL_ID`
+    Don't use the Cognito domain for the IdP URL. Cognito provides its discovery document at `https://cognito-idp.$REGION.amazonaws.com/$USER_POOL_ID`.
 
 Next, [Set up SSO in W&B](#set-up-sso-in-w%26b).
 </Tab>
 <Tab title="Okta">
-Follow the procedure below to set up Okta for authorization: 
+Follow this procedure to set up Okta as your IdP. At the end, you have a **Client ID** and **OIDC issuer URL** to use when you configure W&B.
 
-1. Log in to the [Okta Portal](https://login.okta.com/). 
+1. Sign in to the [Okta Portal](https://login.okta.com/).
 
 2. On the left side, select **Applications** and then **Applications** again.
     <Frame>
     <img src="/images/hosting/okta_select_applications.png" alt="Okta Applications menu"  />
     </Frame>
 
-3. Click on "Create App integration."
+3. Click **Create App integration**.
     <Frame>
     <img src="/images/hosting/okta_create_new_app_integration.png" alt="Create App integration button"  />
     </Frame>
 
-4. On the screen named "Create a new app integration," select **OIDC - OpenID Connect** and **Single-Page Application**. Then click "Next."
+4. On the screen named **Create a new app integration**, select **OIDC - OpenID Connect** and **Single-Page Application**. Then click **Next**.
     <Frame>
     <img src="/images/hosting/okta_create_a_new_app_integration.png" alt="OIDC Single-Page Application selection"  />
     </Frame>
 
-5. On the screen named "New Single-Page App Integration," fill out the values as follows and click **Save**:
-    - App integration name, for example "W&B"
-    - Grant type: Select both **Authorization Code** and **Implicit (hybrid)**
-    - Sign-in redirect URIs: https://YOUR_W_AND_B_URL/oidc/callback
-    - Sign-out redirect URIs: https://YOUR_W_AND_B_URL/logout
-    - Assignments: Select **Skip group assignment for now**
+5. On the screen named **New Single-Page App Integration**, complete the values as follows and click **Save**:
+    - **App integration name**, for example `W&B`.
+    - **Grant type**: Select both **Authorization Code** and **Implicit (hybrid)**.
+    - **Sign-in redirect URIs**: `https://[YOUR-W-AND-B-URL]/oidc/callback`.
+    - **Sign-out redirect URIs**: `https://[YOUR-W-AND-B-URL]/logout`.
+    - **Assignments**: Select **Skip group assignment for now**.
     <Frame>
     <img src="/images/hosting/okta_new_single_page_app_integration.png" alt="Single-Page App configuration"  />
     </Frame>
 
-6. On the overview screen of the Okta application that you just created, make note of the **Client ID** under **Client Credentials** under the **General** tab:
+6. On the overview screen of the Okta application you created, make note of the **Client ID** under **Client Credentials** under the **General** tab:
     <Frame>
     <img src="/images/hosting/okta_make_note_of_client_id.png" alt="Okta Client ID location"  />
     </Frame>
 
-7. To identify the Okta OIDC Issuer URL, select **Settings** and then **Account** on the left side.
+7. To identify the Okta **OIDC Issuer URL**, select **Settings** and then **Account** on the left side.
     The Okta UI shows the company name under **Organization Contact**.
     <Frame>
     <img src="/images/hosting/okta_identify_oidc_issuer_url.png" alt="Okta organization settings"  />
     </Frame>
 
-The OIDC issuer URL has the following format: `https://COMPANY.okta.com`. Replace COMPANY with the corresponding value. Make note of it.
+The OIDC issuer URL has the following format: `https://[COMPANY].okta.com`. Replace `[COMPANY]` with the corresponding value. Make note of it.
 
 Next, [Set up SSO in W&B](#set-up-sso-in-w%26b).
 </Tab>
 <Tab title="Entra">
 Azure AD (Entra ID) supports two OIDC configuration modes for W&B. Choose the configuration that matches your security requirements:
 
-- [Public Client](#public-client): Uses PKCE without a client secret. Simpler to configure, suitable for most deployments.
-- [Confidential Client](#confidential-client): Uses PKCE with a client secret for enhanced security. Required if you need to set the `GORILLA_OIDC_SECRET` environment variable.
+- [Public client](#public-client): Uses PKCE without a client secret. Simpler to configure, suitable for most deployments.
+- [Confidential client](#confidential-client): Uses PKCE with a client secret. Required if you need to set the `GORILLA_OIDC_SECRET` environment variable.
 
 <Warning>
-Do not mix configurations. If you select "Single-page application" in Azure AD, do not provide a client secret. If you need a client secret, you must select "Web" as the platform type.
+Don't mix configurations. If you select **Single-page application** in Azure AD, don't provide a client secret. If you need a client secret, you must select **Web** as the platform type.
 </Warning>
 
 <AccordionGroup>
 <Accordion title="Public client" defaultOpen="true">
-Use this configuration if you do not need to specify a client secret. This configuration is suitable for deployments without advanced security requirements.
+Use this configuration if you don't need to specify a client secret. It's suitable for deployments without advanced security requirements.
 
-1. Log in to the [Azure Portal](https://portal.azure.com/).
+1. Sign in to the [Azure Portal](https://portal.azure.com/).
 2. Navigate to **Microsoft Entra ID** service and select **App registrations** from the left sidebar.
 3. Click **New registration** at the top of the page.
-4. On the "Register an application" screen, configure the following:
+4. On the **Register an application** screen, configure the following:
    - **Name**: Enter a descriptive name.
-   - **Supported account types**: Keep the default "Single tenant" or modify as needed.
-   - **Redirect URI**: Select platform type **Single-page application** and enter `https://YOUR_W_AND_B_URL/oidc/callback`.
+   - **Supported account types**: Keep the default **Single tenant** or modify as needed.
+   - **Redirect URI**: Select platform type **Single-page application** and enter `https://[YOUR-W-AND-B-URL]/oidc/callback`.
    - Click **Register**.
 5. After registration, note the following values from the Overview page:
    - **Application (client) ID**: Your OIDC Client ID.
@@ -154,29 +155,29 @@ Use this configuration if you do not need to specify a client secret. This confi
    </Frame>
 6. Configure authentication settings:
    - Select **Authentication** from the left sidebar.
-   - Under **Front-channel logout URL**, enter `https://YOUR_W_AND_B_URL/logout`.
+   - Under **Front-channel logout URL**, enter `https://[YOUR-W-AND-B-URL]/logout`.
    - Click **Save**.
 
 Make a note of the following details:
-- **OIDC Client ID**: The Application (client) ID from step 5
-- **OIDC Issuer URL**: `https://login.microsoftonline.com/{TenantID}/v2.0` (replace {TenantID} with your Directory ID from step 5)
+- **OIDC Client ID**: The Application (client) ID from step 5.
+- **OIDC Issuer URL**: `https://login.microsoftonline.com/[TENANT-ID]/v2.0` (replace `[TENANT-ID]` with your Directory ID from step 5).
 
 When configuring W&B, use:
-- **Auth Method**: `pkce`
-- **OIDC Client Secret**: Leave empty (do not set `GORILLA_OIDC_SECRET`)
+- **Auth Method**: `pkce`.
+- **OIDC Client Secret**: Leave empty (don't set `GORILLA_OIDC_SECRET`).
 
 Next, [Set up SSO in W&B](#set-up-sso-in-w%26b).
 </Accordion>
 <Accordion title="Confidential client">
 Use this configuration if you need to authenticate using a client secret.
 
-1. Log in to the [Azure Portal](https://portal.azure.com/).
+1. Sign in to the [Azure Portal](https://portal.azure.com/).
 2. Navigate to **Microsoft Entra ID** service and select **App registrations** from the left sidebar.
 3. Click **New registration** at the top of the page.
-4. On the "Register an application" screen, configure the following:
+4. On the **Register an application** screen, configure the following:
    - **Name**: Enter a descriptive name.
-   - **Supported account types**: Keep the default "Single tenant" or modify as needed.
-   - **Redirect URI**: Select platform type **Web** and enter `https://YOUR_W_AND_B_URL/oidc/callback`.
+   - **Supported account types**: Keep the default **Single tenant** or modify as needed.
+   - **Redirect URI**: Select platform type **Web** and enter `https://[YOUR-W-AND-B-URL]/oidc/callback`.
    - Click **Register**.
 5. After registration, note the following values from the Overview page:
    - **Application (client) ID**: Your OIDC Client ID.
@@ -186,14 +187,14 @@ Use this configuration if you need to authenticate using a client secret.
    </Frame>
 6. Configure authentication settings:
    - Select **Authentication** from the left sidebar.
-   - Under **Front-channel logout URL**, enter `https://<YOUR_W_AND_B_URL>/logout`.
-   - Click **Save**
+   - Under **Front-channel logout URL**, enter `https://[YOUR-W-AND-B-URL]/logout`.
+   - Click **Save**.
 7. Create a client secret:
    - Select **Certificates & secrets** from the left sidebar.
    - Click **New client secret**.
    - Add a description for the secret.
    - Choose an expiration period.
-   - Click **Add**. <Warning>Copy and save the secret **Value** immediately (not the Secret ID)</Warning>.
+   - Click **Add**. <Warning>Copy and save the secret **Value** immediately (not the Secret ID).</Warning>
    <Frame>
    <img src="/images/hosting/entra_make_note_of_secret_value.png" alt="Client secret value"  />
    </Frame>
@@ -201,14 +202,14 @@ Use this configuration if you need to authenticate using a client secret.
 Make a note of the following details:
 - **OIDC Client ID**: The Application (client) ID from step 5.
 - **OIDC Client Secret**: The secret value from step 7.
-- **OIDC Issuer URL**: `https://login.microsoftonline.com/{TenantID}/v2.0` (replace {TenantID} with your Directory ID from step 5).
+- **OIDC Issuer URL**: `https://login.microsoftonline.com/[TENANT-ID]/v2.0` (replace `[TENANT-ID]` with your Directory ID from step 5).
 
 When configuring W&B, use:
-- **Auth Method**: `pkce`
-- **OIDC Client Secret**: Set the `GORILLA_OIDC_SECRET` environment variable to the secret value from step 7
+- **Auth Method**: `pkce`.
+- **OIDC Client Secret**: Set the `GORILLA_OIDC_SECRET` environment variable to the secret value from step 7.
 
 <Note>
-The v2.0 endpoint supports both personal Microsoft accounts and work/school accounts. If your organization requires the v1.0 endpoint, use `https://login.microsoftonline.com/{TenantID}` instead.
+The v2.0 endpoint supports both personal Microsoft accounts and work/school accounts. If your organization requires the v1.0 endpoint, use `https://login.microsoftonline.com/[TENANT-ID]` instead.
 </Note>
 
 Next, [Set up SSO in W&B](#set-up-sso-in-w%26b).
@@ -219,29 +220,32 @@ Next, [Set up SSO in W&B](#set-up-sso-in-w%26b).
 
 ## Set up SSO in W&B
 
-To set up SSO, you need administrator privileges and the following information:
-- OIDC Client ID
-- OIDC Auth method (`implicit` or `pkce`)
-- OIDC Issuer URL
-- OIDC Client Secret (optional; depends on how you have setup your IdP) 
+After you finish configuring your IdP, complete the following steps in W&B to connect the IdP and enable SSO for your instance.
 
-If your IdP requires a OIDC Client Secret, specify it by passing the [environment variables](/platform/hosting/env-vars) `GORILLA_OIDC_SECRET`.
-- In the W&B App, go to **System Console** > **Settings** > **Advanced** > **User Spec** and add `GORILLA_OIDC_SECRET` to the `extraENV` section as shown below.
-- In Helm, configure `values.global.extraEnv` as shown below.
+To set up SSO, you must have administrator privileges and the following information:
+- **OIDC Client ID**.
+- **OIDC Auth method** (`implicit` or `pkce`).
+- **OIDC Issuer URL**.
+- **OIDC Client Secret** (optional, depends on how you've set up your IdP).
+
+If your IdP requires an OIDC Client Secret, specify it by passing the [environment variables](/platform/hosting/env-vars) `GORILLA_OIDC_SECRET`:
+
+- In the W&B App, go to **System Console** > **Settings** > **Advanced** > **User Spec** and add `GORILLA_OIDC_SECRET` to the `extraENV` section as shown in the following example.
+- In Helm, configure `values.global.extraEnv` as shown in the following example.
     ```yaml
     values:
     global:
         extraEnv:
-        GORILLA_OIDC_SECRET="<your_secret>"
+        GORILLA_OIDC_SECRET="[YOUR-SECRET]"
     ```
 
 <Note>
-If you're unable to log in to your instance after configuring SSO, you can restart the instance with the `LOCAL_RESTORE=true` environment variable set. This outputs a temporary password to the containers logs and disables SSO. Once you've resolved any issues with SSO, you must remove that environment variable to enable SSO again.
+If you can't sign in to your instance after configuring SSO, you can restart the instance with the `LOCAL_RESTORE=true` environment variable set. This outputs a temporary password to the containers logs and disables SSO. After you resolve any issues with SSO, you must remove that environment variable to enable SSO again.
 </Note>
 
 <Tabs>
 <Tab title="System Console">
-The System Console is the successor to the System Settings page. It is available with the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator) based deployment.
+Use this tab if you deploy W&B with the W&B Kubernetes Operator. The System Console is the successor to the System Settings page. It's available with the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator) based deployment.
 
 1. Refer to [Access the W&B Management Console](/platform/hosting/self-managed/operator#access-the-wb-management-console).
 
@@ -252,19 +256,19 @@ The System Console is the successor to the System Settings page. It is available
 
 3. Enter the values.
 
-4. Click on **Save**.
+4. Click **Save**.
 
-5. Log out and then log back in, this time using the IdP login screen.
+5. Sign out and then sign back in, this time using the IdP sign-in screen.
 
 ## Find your customer namespace
 
-Before you can configure team-level BYOB with CoreWeave storage on W&B Dedicated Cloud or Self-Managed, you need to obtain your organization's **Customer Namespace**. You can view and copy it from the bottom of the **Authentication** tab.
+Before you can configure team-level BYOB with CoreWeave storage on W&B Dedicated Cloud or Self-Managed, you must obtain your organization's **Customer Namespace**. You can view and copy it from the bottom of the **Authentication** tab.
 
-For detailed instructions on configuring CoreWeave storage with your Customer Namespace, see [CoreWeave requirements for Dedicated Cloud / Self-Managed](/platform/hosting/data-security/secure-storage-connector#coreweave-customer-namespace).
+For detailed instructions on configuring CoreWeave storage with your Customer Namespace, see [CoreWeave requirements for Dedicated Cloud or Self-Managed](/platform/hosting/data-security/secure-storage-connector#coreweave-customer-namespace).
 </Tab>
 <Tab title="System settings">
-1. Log in to your Weights & Biases instance. 
-2. Navigate to the W&B App. 
+1. Sign in to your W&B instance.
+2. Navigate to the W&B App.
 
     <Frame>
     <img src="/images/hosting/system_settings.png" alt="W&B App navigation"  />
@@ -276,7 +280,7 @@ For detailed instructions on configuring CoreWeave storage with your Customer Na
     <img src="/images/hosting/system_settings_select_settings.png" alt="System Settings dropdown"  />
     </Frame>
 
-4. Enter your Issuer, Client ID, and Authentication Method. 
+4. Enter your **Issuer**, **Client ID**, and **Authentication Method**.
 5. Select **Update settings**.
 
 <Frame>
@@ -286,8 +290,8 @@ For detailed instructions on configuring CoreWeave storage with your Customer Na
 </Tabs>
 
 <Note>
-If you're unable to log in to your instance after configuring SSO, you can restart the instance with the `LOCAL_RESTORE=true` environment variable set. This outputs a temporary password to the containers logs and turn off SSO. Once you've resolved any issues with SSO, you must remove that environment variable to enable SSO again.
+If you can't sign in to your instance after configuring SSO, you can restart the instance with the `LOCAL_RESTORE=true` environment variable set. This outputs a temporary password to the containers logs and disables SSO. After you resolve any issues with SSO, you must remove that environment variable to enable SSO again.
 </Note>
 
 ## Security Assertion Markup Language (SAML)
-W&B does not support SAML.
+W&B doesn't support SAML.

--- a/platform/hosting/managing-bucket-storage.mdx
+++ b/platform/hosting/managing-bucket-storage.mdx
@@ -1,9 +1,11 @@
 ---
 title: Manage bucket storage and costs
-description: Understand how W&B uses object storage, how deletion maps to bucket bytes, and how to reduce usage on self-managed, Dedicated Cloud, and bring-your-own-bucket deployments.
+description: Understand how W&B uses object storage, how deletion maps to bucket bytes, and how to reduce usage on Self-Managed, Dedicated Cloud, and Bring Your Own Bucket deployments.
 ---
 
-When you use [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector), [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), or [W&B Self-Managed](/platform/hosting/hosting-options/self-managed), your team often pays cloud storage providers directly. This page explains what occupies your bucket, how W&B removes objects after deletion in the app or API, and what you should expect in practice.
+When you use [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector), [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), or [W&B Self-Managed](/platform/hosting/hosting-options/self-managed), your team often pays cloud storage providers directly. This page explains what occupies your bucket, how W&B removes objects after deletion in the app or API, and what you should expect. Use it to understand bucket usage, plan cleanup, and set realistic expectations for when storage is reclaimed.
+
+This page is intended for W&B administrators and operators who manage object storage for Self-Managed, Dedicated Cloud, or BYOB deployments.
 
 ## What uses bucket space
 
@@ -11,7 +13,7 @@ W&B stores several categories of data in your configured object storage. The [BY
 
 ## How W&B removes data from storage
 
-Deletion in the W&B App or [Public API](/models/ref/python/public-api/api) updates W&B metadata first. **Removing a run, artifact, or file from the product does not guarantee an immediate drop in reported bucket usage.** Object storage cleanup runs as background work that can lag, especially on busy instances.
+Deletion in the W&B App or [Public API](/models/ref/python/public-api/api) updates W&B metadata first. Removing a run, artifact, or file from the product doesn't guarantee an immediate drop in reported bucket usage. Object storage cleanup runs as background work that can lag, especially on busy instances.
 
 ### Artifacts
 
@@ -19,36 +21,44 @@ Deleted artifacts are soft-deleted, then processed by artifact garbage collectio
 
 ### Run data and run files
 
-After runs or run-associated files are deleted, permanent removal of the underlying stored objects is controlled separately from artifacts. On Dedicated Cloud and Self-Managed deployments, `GORILLA_DATA_RETENTION_PERIOD` sets how long **deleted run data** is retained before it can be removed from storage. **This setting does not delete artifacts.** See [Configure environment variables](/platform/hosting/env-vars), [Data retention policy](/platform/hosting/hosting-options/dedicated-cloud#data-retention-policy) for Dedicated Cloud, and [Delete runs](/models/runs/delete-runs#when-deleted-run-data-is-removed-from-storage) for how run and file deletion relates to storage.
+After runs or run-associated files are deleted, permanent removal of the underlying stored objects is controlled separately from artifacts. On Dedicated Cloud and Self-Managed deployments, `GORILLA_DATA_RETENTION_PERIOD` sets how long deleted run data is retained before it can be removed from storage. This setting does not delete artifacts. See [Configure environment variables](/platform/hosting/env-vars), [Data retention policy](/platform/hosting/hosting-options/dedicated-cloud#data-retention-policy) for Dedicated Cloud, and [Delete runs](/models/runs/delete-runs#when-deleted-run-data-is-removed-from-storage) for how run and file deletion relates to storage.
 
 ## What to expect from background cleanup
 
-Garbage collection and related jobs that free object storage are **best-effort**. W&B does **not** guarantee that a given object disappears from your bucket within a specific time after you delete content in the UI or API. For projects with a large number of files per run, such as when logging many media files per run, expect **longer delays** before storage usage is released.
+Garbage collection and related jobs that free object storage run without timing guarantees. W&B does not guarantee that a given object disappears from your bucket within a specific time after you delete content in the UI or API. For projects with a large number of files per run, such as when logging many media files per run, expect longer delays before storage usage is released.
 
-Monitor your bucket in your cloud provider and contact [W&B Support](mailto:support@wandb.ai) or your account team if cleanup appears stuck relative to your expectations.
+Monitor your bucket in your cloud provider and contact [W&B Support](mailto:support@wandb.ai) or your account team if cleanup appears stuck.
 
 ## Reduce bucket usage
+
+This section describes the recommended order of operations for freeing space in your bucket, starting with safe product flows and ending with direct bucket operations that require more care.
 
 Use supported product flows first:
 
 - [Delete runs in the W&B App](/models/runs/delete-runs#ui) or [with Python](/models/runs/delete-runs#python) when you no longer need them.
 - [Delete artifacts](/models/artifacts/delete-artifacts) you no longer need, and use [Artifact TTL](/models/artifacts/ttl) where it fits your workflow.
 
-If you must **reclaim space immediately**, operators with access to the bucket may delete specific object keys directly in cloud storage. Be aware of the following:
+If you must reclaim space immediately, operators with access to the bucket may delete specific object keys directly in cloud storage.
 
-- Objects you remove will **no longer be available to download** through W&B.
+:::caution
+Deleting object keys directly in your bucket bypasses W&B and can cause data loss or break access for the app. Review the following before you proceed:
+
+- Objects you remove are **no longer available to download** through W&B.
 - You should delete **only** keys you intend to remove. Incorrect deletes can break access to data the app still references.
 - If your bucket uses **object versioning** or **provider soft delete** (for example on Google Cloud Storage), storage charges can persist until non-current versions or soft-deleted objects expire under your cloud lifecycle rules.
+:::
 
 For high-level usage in W&B Multi-tenant Cloud, organization admins can review storage-related usage from organization settings. See [Billing settings](/platform/app/settings-page/billing-settings).
 
 ## Troubleshooting
 
-If deletions do not appear correctly in the W&B App after you use the Public API, **upgrade the W&B Python SDK** to a current release and retry. Very large per-run file counts can increase how long background cleanup takes across the instance.
+If deletions don't appear correctly in the W&B App after you use the Public API, upgrade the W&B Python SDK to a current release and retry. Large per-run file counts can increase how long background cleanup takes across the instance.
 
 For scripted cleanup patterns that match your deployment, contact [W&B Support](mailto:support@wandb.ai) or your account team.
 
 ## Related documentation
+
+For more information, see the following resources:
 
 - [Delete runs](/models/runs/delete-runs#delete-runs)
 - [Delete an artifact](/models/artifacts/delete-artifacts)

--- a/platform/hosting/monitoring-usage/audit-logging.mdx
+++ b/platform/hosting/monitoring-usage/audit-logging.mdx
@@ -3,26 +3,30 @@ title: Track user activity with audit logs
 description: "Access, fetch, and analyze W&B audit logs across deployment types, including the log schema and tracked actions."
 ---
 
-Use W&B audit logs to track user activity within your organization and to conform to your enterprise governance requirements. Audit logs are available in JSON format. Refer to [Audit log schema](#audit-log-schema).
+Use W&B audit logs to track user activity within your organization and to conform to your enterprise governance requirements. This page is for organization-level admins who need to access, fetch, and analyze audit log data across W&B deployment types. Audit logs are available in JSON format. Refer to [Audit log schema](#audit-log-schema).
 
-How to access audit logs depends on your W&B platform deployment type:
+How you access audit logs depends on your W&B platform deployment type:
 
-| W&B Platform Deployment type | Audit logs access mechanism |
+| W&B Platform deployment type | Audit logs access mechanism |
 |----------------------------|--------------------------------|
-| [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) | <ul><li>[Instance-level BYOB](/platform/hosting/data-security/secure-storage-connector): Synced to instance-level bucket (BYOB) every 10 minutes. Also available using [the API](#fetch-audit-logs-using-api).</li><li>Default instance-level storage: Available only by using [the API](#fetch-audit-logs-using-api).</li></ul> |
-| [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) | Available for Enterprise plans only. Available only by using [the API](#fetch-audit-logs-using-api). |
-| [Self-Managed](/platform/hosting/hosting-options/self-managed) | Synced to instance-level bucket every 10 minutes. Also available using [the API](#fetch-audit-logs-using-api). |
+| [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) | <ul><li>[Instance-level BYOB](/platform/hosting/data-security/secure-storage-connector): Synced to instance-level bucket (BYOB) every 10 minutes. Also available with [the API](#fetch-audit-logs-using-api).</li><li>Default instance-level storage: Available only with [the API](#fetch-audit-logs-using-api).</li></ul> |
+| [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) | Available for Enterprise plans only. Available only with [the API](#fetch-audit-logs-using-api). |
+| [Self-Managed](/platform/hosting/hosting-options/self-managed) | Synced to instance-level bucket every 10 minutes. Also available with [the API](#fetch-audit-logs-using-api). |
 
-After fetching audit logs, you can analyze them using tools like [Pandas](https://pandas.pydata.org/docs/index.html), [Amazon Redshift](https://aws.amazon.com/redshift/), [Google BigQuery](https://cloud.google.com/bigquery), or [Microsoft Fabric](https://www.microsoft.com/microsoft-fabric). Some audit log analysis tools do not support JSON; refer to the documentation for your analysis tool for guidelines and requirements for transforming the JSON-formatted audit logs before analysis.
+After you fetch audit logs, you can analyze them with tools like [Pandas](https://pandas.pydata.org/docs/index.html), [Amazon Redshift](https://aws.amazon.com/redshift/), [Google BigQuery](https://cloud.google.com/bigquery), or [Microsoft Fabric](https://www.microsoft.com/microsoft-fabric). Some audit log analysis tools don't support JSON. Refer to the documentation for your analysis tool for guidelines and requirements to transform the JSON-formatted audit logs before analysis.
 
 For more details about the format of the logs, see [Audit log schema](#audit-log-schema) and [Actions](#actions).
 
 ## Audit log retention
-- If you require audit logs to be retained for a specific period of time, W&B recommends periodically transferring logs to long-term storage, either using storage buckets or the Audit Logging API.
-- If you are subject to the [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://hhs.gov/hipaa/for-professionals/index.html), audit logs must be retained for a minimum of 6 years in an environment where they cannot be deleted or modified by any internal or external actor before the end of the mandatory retention period. For HIPAA-compliant [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instances with [BYOB](/platform/hosting/data-security/secure-storage-connector), you must configure guardrails for your managed storage, including any long-term retention storage.
+
+The following recommendations help you retain audit logs to meet your organization's governance and compliance obligations:
+
+- If you must retain audit logs for a specific period of time, W&B recommends periodically transferring logs to long-term storage, either with storage buckets or the Audit Logging API.
+- If you are subject to the [Health Insurance Portability and Accountability Act of 1996 (HIPAA)](https://hhs.gov/hipaa/for-professionals/index.html), you must retain audit logs for a minimum of 6 years in an environment where no internal or external actor can delete or modify them before the end of the mandatory retention period. For HIPAA-compliant [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) instances with [BYOB](/platform/hosting/data-security/secure-storage-connector), you must configure guardrails for your managed storage, including any long-term retention storage.
 
 ## Audit log schema
-This table shows all keys which may appear in an audit log entry, ordered alphabetically. Depending on the action and the circumstances, a specific log entry may include only a subset of the possible fields.
+
+Use this schema to interpret the fields returned in each audit log entry. The following table shows all keys that can appear in an audit log entry, ordered alphabetically. Depending on the action and the circumstances, a specific log entry may include only a subset of the possible fields.
 
 | Key | Definition |
 |---------| -------|
@@ -48,14 +52,17 @@ This table shows all keys which may appear in an audit log entry, ordered alphab
 
 ### Personally identifiable information (PII)
 
-Personally identifiable information (PII), such as email addresses and the names of projects, teams, and reports, is available only using the API endpoint option.
-- For [Self-Managed](/platform/hosting/hosting-options/self-managed) and 
-  [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), an organization admin can [exclude PII](#exclude-pii) when fetching audit logs.
-- For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), the API endpoint always returns relevant fields for audit logs, including PII. This is not configurable.
+Personally identifiable information (PII), such as email addresses and the names of projects, teams, and reports, is available only with the API endpoint option:
+
+- For [Self-Managed](/platform/hosting/hosting-options/self-managed) and [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), an organization admin can [exclude PII](#exclude-pii) when fetching audit logs.
+- For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), the API endpoint always returns relevant fields for audit logs, including PII. This isn't configurable.
 
 ## Before you begin
-1. Organization level admins can fetch audit logs. If you receive a `403` error, ensure that you or your service account has adequate permission.
-1. **Multi-tenant Cloud**: If you are a member of multiple Multi-tenant Cloud organizations, you _must_ configure the **Default API organization**, which determines where audit logging API calls are routed. Otherwise, you will receive the following error:
+
+Before you fetch audit logs, confirm that you meet the following prerequisites for your deployment type:
+
+- Organization-level admins can fetch audit logs. If you receive a `403` error, ensure that you or your service account has adequate permission.
+- **Multi-tenant Cloud**: If you're a member of multiple Multi-tenant Cloud organizations, you must configure the **Default API organization**, which determines where audit logging API calls are routed. Otherwise, you receive the following error:
      ```text
      user is associated with multiple organizations but no valid org ID found in user info
      ```
@@ -63,51 +70,54 @@ Personally identifiable information (PII), such as email addresses and the names
      1. Click your profile image, then click **User Settings**.
      1. For **Default API organization**, select an organization.
 
-     This is not applicable to a service account, which can be a member of only one Multi-tenant Cloud organization.
+     This doesn't apply to a service account, which can be a member of only one Multi-tenant Cloud organization.
 
 ## Fetch audit logs
-To fetch audit logs:
+
+To retrieve audit logs from the W&B Audit Logging API, follow these steps. After you complete this procedure, you have a set of newline-separated JSON objects you can analyze using your preferred tooling.
 
 1. Determine the correct API endpoint for your instance:
 
-    - [Self-Managed](/platform/hosting/hosting-options/self-managed): `<wandb-platform-url>/admin/audit_logs`
-    - [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud): `<instance-name>.wandb.io/admin/audit_logs`
+    - [Self-Managed](/platform/hosting/hosting-options/self-managed): `[WANDB-PLATFORM-URL]/admin/audit_logs`
+    - [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud): `[INSTANCE-NAME].wandb.io/admin/audit_logs`
     - [Multi-tenant Cloud (Enterprise required)](/platform/hosting/hosting-options/multi_tenant_cloud): `https://api.wandb.ai/audit_logs`
 
-    In the following steps, replace `<API-endpoint>` with your API endpoint.
-1. (Optional) Construct query parameters to append to the endpoint. In the following steps, replace `<parameters>` with the resulting string.
-    - `anonymize`: if the URL includes the parameter `anonymize=true`, remove any PII. Otherwise, PII is included. Refer to [Exclude PII when fetching audit logs](#exclude-pii-when-fetching-audit-logs). Not supported for Multi-tenant Cloud, where all fields are included, including PII.
-    - Configure the date window of logs to fetch using a combination of `numdays` and `startDate`. Each parameter is optional, and they interact.
+    In the following steps, replace `[API-ENDPOINT]` with your API endpoint.
+1. Optional: Construct query parameters to append to the endpoint. In the following steps, replace `[PARAMETERS]` with the resulting string.
+    - `anonymize`: If the URL includes the parameter `anonymize=true`, W&B removes any PII. Otherwise, PII is included. Refer to [Exclude PII when fetching audit logs](#exclude-pii-when-fetching-audit-logs). Not supported for Multi-tenant Cloud, where all fields are included, including PII.
+    - Configure the date window of logs to fetch with a combination of `numDays` and `startDate`. Each parameter is optional, and they interact.
       - If neither parameter is included, only today's logs are fetched.
-      - `numDays`: An integer indicating the number of days backward from `startDate` to fetch logs. If it is omitted or set to `0`, logs are fetched for `startDate` only. On **Multi-tenant Cloud**, you can fetch a maximum of 7 days of audit logs, even if you set `numDays` to a larger value.
+      - `numDays`: An integer that indicates the number of days backward from `startDate` to fetch logs. If you omit it or set it to `0`, logs are fetched for `startDate` only. On **Multi-tenant Cloud**, you can fetch a maximum of 7 days of audit logs, even if you set `numDays` to a larger value.
       - `startDate`: Optional. Use `startDate=YYYY-MM-DD` to set the newest calendar day in the range. If you omit it or set it to today, the range ends today and `numDays` counts backward from that day.
           - Supported in **Multi-tenant Cloud** only with an Enterprise license.
           - Supported in **Dedicated Cloud** and **Self-Managed** v0.80.0 and above.
-1. Construct the fully qualified endpoint URL in the format `<API-endpoint>?<parameters>`.
-1. Execute an HTTP `GET` request on the fully qualified API endpoint using a web browser or a tool like [Postman](https://www.postman.com/downloads/), [HTTPie](https://httpie.io/), or cURL.
+1. Construct the fully qualified endpoint URL in the format `[API-ENDPOINT]?[PARAMETERS]`.
+1. Execute an HTTP `GET` request on the fully qualified API endpoint with a web browser or a tool like [Postman](https://www.postman.com/downloads/), [HTTPie](https://httpie.io/), or cURL.
 
-The API response contains new-line separated JSON objects. Objects will include the fields described in the [schema](#audit-log-schema), just like when audit logs are synced to an instance-level bucket. In those cases, the audit logs are located in the `/wandb-audit-logs` directory in your bucket.
+The API response contains newline-separated JSON objects. Objects include the fields described in the [schema](#audit-log-schema), just like when audit logs are synced to an instance-level bucket. In those cases, the audit logs are located in the `/wandb-audit-logs` directory in your bucket.
 
 ### Use basic authentication
-To use basic authentication with your API key to access the audit logs API, set the HTTP request's `Authorization` header to the string `Basic` followed by a space, then the base-64 encoded string in the format `username:API-KEY`. In other words, replace the username and API key with your values separated with a `:` character, then base-64-encode the result. For example, to authorize as `demo:p@55w0rd`, the header should be `Authorization: Basic ZGVtbzpwQDU1dzByZA==`.
+
+You must authenticate each request to the audit logs API. To use basic authentication with your API key to access the audit logs API, set the HTTP request's `Authorization` header to the string `Basic` followed by a space, then the base64-encoded string in the format `[USERNAME]:[API-KEY]`. In other words, replace the username and API key with your values separated with a `:` character, then base64-encode the result. For example, to authorize as `demo:p@55w0rd`, set the header to `Authorization: Basic ZGVtbzpwQDU1dzByZA==`.
 
 ### Exclude PII when fetching audit logs <a id="exclude-pii"></a>
-For [Self-Managed](/platform/hosting/hosting-options/self-managed) and [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), a W&B organization or instance admin can exclude PII when fetching audit logs. For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), the API endpoint always returns relevant fields for audit logs, including PII. This is not configurable.
 
+For [Self-Managed](/platform/hosting/hosting-options/self-managed) and [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), a W&B organization or instance admin can exclude PII when fetching audit logs. For [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), the API endpoint always returns relevant fields for audit logs, including PII. This isn't configurable.
 
-To exclude PII, pass the `anonymize=true` URL parameter. For example, if your W&B instance URL is `https://mycompany.wandb.io` and you would like to get audit logs for user activity within the last week and exclude PII, use an API endpoint like:
+To exclude PII, pass the `anonymize=true` URL parameter. For example, to get audit logs for user activity within the last week and exclude PII, if your W&B instance URL is `https://mycompany.wandb.io`, use an API endpoint like:
 
 ```text
-https://mycompany.wandb.io/admin/audit_logs?anonymize=true&<additional-parameters>.
+https://mycompany.wandb.io/admin/audit_logs?anonymize=true&[ADDITIONAL-PARAMETERS].
 ```
 
 ## Actions
-This table describes possible actions that can be recorded by W&B, sorted alphabetically.
+
+Each audit log entry records one of the following actions. Use this reference to interpret the `action` field in a log entry. The following table describes possible actions that W&B can record, sorted alphabetically.
 
 |Action | Definition |
 |-----|-----|
 | `artifact:create`             | Artifact is created.
-| `artifact:delete   `          | Artifact is deleted.
+| `artifact:delete`             | Artifact is deleted.
 | `artifact:read`               | Artifact is read.
 | `project:delete`              | Project is deleted.
 | `project:read`                | Project is read.
@@ -139,4 +149,4 @@ This table describes possible actions that can be recorded by W&B, sorted alphab
 <a id="1">1</a>: On [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud), audit logs are not collected for:
 - Open or Public projects.
 - The `report:read` action.
-- `User` actions which are not tied to a specific organization.
+- `User` actions that aren't tied to a specific organization.

--- a/platform/hosting/monitoring-usage/mobile-app.mdx
+++ b/platform/hosting/monitoring-usage/mobile-app.mdx
@@ -18,13 +18,15 @@ description: From your iPhone or iPad, track training runs, review console logs,
   </Frame>
 </Columns>
 
-The W&B Mobile App for iOS keeps you connected to your W&B Models projects wherever you go. From your iPhone or iPad, track training runs and read run logs in real time, view line plots and system metrics, explore project histories, and follow your team's progress.
+The W&B Mobile App for iOS keeps you connected to your W&B Models projects wherever you go. Use it on your iPhone or iPad to track training runs and read run logs in real time, view line plots and system metrics, explore project histories, and follow your team's progress so you can monitor experiments without opening your laptop. This page describes the app's features and shows you how to set up notifications.
 
 <Info>
-The mobile app is only available for [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) accounts. It is not available for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) deployments.
+The mobile app is only available for [Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) accounts. It isn't available for [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-managed](/platform/hosting/hosting-options/self-managed) deployments.
 </Info>
 
 ## Download the app
+
+Install the app from the App Store to get started.
 
 <Card
   title="Download on the App Store"
@@ -35,36 +37,42 @@ The mobile app is only available for [Multi-tenant Cloud](/platform/hosting/host
 
 ## Features
 
+The following features are available in the mobile app.
+
 - **Explore projects**: Browse and search across your W&B projects.
     - **Full project history**: Metric charts on project panels include data from _all runs_ in the project, not only the latest run.
     - **Star projects**: See your most important projects at a glance. Click the star icon next to a project to star it. To filter the list to only starred projects, click the **Starred** tab at the top of the list.
 - **Track experiments**: View run status, metrics, and line plots for your experiments in real time.
     - **Run overview tab**: On each run, open the **Overview** tab for a dedicated summary of run details alongside metrics and logs. Long run config values wrap to multiple lines instead of truncating.
     - **View system metrics**: On each run, open the **Metrics** tab to view [system metrics](/models/ref/python/experiments/system-metrics) that W&B logs automatically during training, such as GPU utilization, CPU usage, memory, disk I/O, and network traffic. System metrics appear in a collapsible **System** section alongside your logged metrics. Each metric displays as a line chart with the same tooltip and search behavior as other metrics on the tab.
-    - **Mobile-optimized panel grouping**: Panels are automatically grouped by name into collapsible sections. Sections are a single level (not nested), and grouping follows the same rules as [workspace panels](/models/app/features/panels) in the W&B web app, so the layout stays consistent when you move between desktop and your phone.
+    - **Mobile-optimized panel grouping**: The app automatically groups panels by name into collapsible sections. Sections are a single level (not nested), and grouping follows the same rules as [workspace panels](/models/app/features/panels) in the W&B web app, so the layout stays consistent when you move between desktop and your phone.
     - **Star panels**: See your most important panels at a glance. When viewing a run or a project, click the star icon at the top of a panel to star it. To filter the list to only starred panels, click the **Starred** tab at the top of the list.
     - **Search panels**: When viewing a run or a project, use the **panel search** field at the bottom of the screen to filter which runs appear in each chart. You can search with [JavaScript regular expressions](https://www.w3schools.com/js/js_regexp.asp) to match patterns in run names.
     - **Chart tooltips**: On line charts, tooltips show metric values with up to four decimal places so you can read small changes accurately.
     - **Stop runs**: When viewing an in-progress run, click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Stop run**.
-    - **View console logs**: View [console logs](/models/runs/view-logged-runs#logs) for active or completed runs, or download logs for completed runs. The app polls active runs for new log lines every 5 seconds. The most recent 10,000 lines display by default, and you can scroll backward to view older logs. Log search stays responsive even for very large outputs.
-- **Switch teams**: Use the **team picker** to change teams. The picker uses an updated layout for quicker navigation.
+    - **View console logs**: View [console logs](/models/runs/view-logged-runs#logs) for active or completed runs, or download logs for completed runs. The app polls active runs for new log lines every 5 seconds. The most recent 10,000 lines display by default, and you can scroll backward to view older logs. Log search stays responsive even for large outputs.
+- **Switch teams**: Use the **team picker** to change teams.
 - **Stay informed**: Get updates on your experiments without opening your laptop using notifications. **Remove alerts** you no longer need from the **Notifications** tab by swiping them away.
 
 ## Set up notifications
 
-You can configure notifications in two ways:
+Configure notifications to receive updates about your experiments on your mobile device. The following sections describe the two kinds of notifications you can configure.
 
-**Metric threshold alerts**
+### Metric threshold alerts
+
+Use metric threshold alerts to get notified when a metric crosses a value you specify.
 
 1. Navigate to a run.
 2. Tap the graph to enter fullscreen view.
-3. Tap the bell icon on the top-right.
+3. Tap the bell icon in the top right.
 4. Set notifications that trigger when future runs cross the specified metric threshold.
 
-**Run failure alerts**
+### Run failure alerts
+
+Use run failure alerts to get notified when runs in a project fail.
 
 1. Navigate to a project.
-2. Tap the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu on the top-right.
+2. Tap the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu in the top right.
 3. Select **Run failed alert** to receive notifications for future run failures in that project.
 
 The **Manage notifications** screen lists both kinds of settings in one place, with short descriptions that explain what each section controls.

--- a/platform/hosting/monitoring-usage/org_dashboard.mdx
+++ b/platform/hosting/monitoring-usage/org_dashboard.mdx
@@ -3,54 +3,58 @@ title: View organization activity
 description: "View user status, activity, and usage trends in the W&B organization dashboard across deployment types."
 ---
 
-This page describes how to view activity in your W&B organization. Select your deployment type to continue.
+This page describes how to view activity in your W&B organization, including user status, activity trends over time, and how to export user details as a CSV. Organization admins use this information to audit access, monitor adoption, and report on usage. Select your deployment type in each section to continue.
 
 ## View user status and activity
+
+The following procedure shows how to open the dashboard that lists every user in your organization and interpret each user's status.
 
 <Tabs>
 <Tab title="Dedicated Cloud / Self-Managed">
 1. Navigate to the **Organization Dashboard**:
-   - **Dedicated Cloud**: `https://<org-name>.io/org/dashboard/`. Replace `<org-name>` with your organization name.
-   - **Self-Managed**: `https://<YOUR-W&B-SERVER-IP>/org/dashboard`. Replace `<YOUR-W&B-SERVER-IP>` with your deployment's IP address.
+   - **Dedicated Cloud**: `https://[ORG-NAME].io/org/dashboard/`. Replace `[ORG-NAME]` with your organization name.
+   - **Self-Managed**: `https://[YOUR-W&B-SERVER-IP]/org/dashboard`. Replace `[YOUR-W&B-SERVER-IP]` with your deployment's IP address.
 
    The **Users** tab opens by default and lists every user in the organization.
 2. To sort the list by user status, click the **Last Active** column header. Each user's status is one of the following:
    * **Invite pending**: An invitation was sent but not yet accepted.
    * **A timestamp**: The user accepted the invitation and has signed in at least once. The timestamp indicates the most recent activity.
    * **Deactivated**: An admin revoked the user's access.
-   * **No status**: Indicated by a hyphen. The user was previously active but has not been active in the last six months.
-3. Hover over a user's **Last Active** field to see the date the user was added and their total active days.
+   * **No status (hyphen)**: The user was previously active but hasn't been active in the last six months.
+3. Hover over a user's **Last Active** field to see the date you added the user and their total active days.
 
-A user is _active_ if they:
-- log in to W&B.
-- open any page in the W&B App.
-- log runs.
-- use the SDK to track an experiment.
-- interact with the W&B server in any way.
+A user is _active_ if they do any of the following:
+- Log in to W&B.
+- Open any page in the W&B App.
+- Log runs.
+- Use the SDK to track an experiment.
+- Interact with the W&B server in any way.
 </Tab>
 <Tab title="Multi-tenant Cloud">
 1. Open the [**Members** page](https://wandb.ai/account-settings/wandb/members/). The table lists every user in your organization.
 2. Click the **Last Active** column header to sort by user status. Each user's status is one of the following:
    * **A timestamp**: The user has signed in at least once. The timestamp indicates the most recent activity.
-   * **No status**: Indicated by a hyphen. The user has not yet been active within the organization.
+   * **No status (hyphen)**: The user hasn't yet been active within the organization.
 
-A user is _active_ if they perform any auditable action scoped to the organization after May 8 2025. For a full list, see [Actions](/platform/hosting/monitoring-usage/audit-logging#actions) in **Audit logging**.
+A user is _active_ if they perform any auditable action scoped to the organization after May 8, 2025. For a full list, see [Actions](/platform/hosting/monitoring-usage/audit-logging#actions) in **Audit logging**.
 </Tab>
 </Tabs>
 
 ## View activity over time
 
+After you understand individual user status, use the activity views to track how usage in your organization changes over time.
+
 <Tabs>
 <Tab title="Dedicated Cloud / Self-Managed">
 Use the **Activity** tab to see how many users have been active during a given period.
 
-1. Open the **Organization Dashboard**. See [View user activity](#view-user-activity).
+1. Open the **Organization Dashboard**. See [View user status and activity](#view-user-status-and-activity).
 2. Click **Activity**.
 3. Review the following plots:
-   * **Total active users**: unique active users during the selected period (defaults to 3 months).
-   * **Users active over time**: fluctuation of active users over the period (defaults to 6 months). Hover over a point to see the exact count on that date.
+   * **Total active users**: Unique active users during the selected period (defaults to 3 months).
+   * **Users active over time**: Fluctuation of active users over the period (defaults to 6 months). Hover over a point to see the exact count on that date.
 
-To change the reporting period, use the drop-down above a plot. Options are Last 30 days, Last 3 months, Last 6 months, Last 12 months, and All time.
+To change the reporting period, use the drop-down above a plot. Options are **Last 30 days**, **Last 3 months**, **Last 6 months**, **Last 12 months**, and **All time**.
 </Tab>
 <Tab title="Multi-tenant Cloud">
 Use the **Activity Dashboard** to view aggregate activity.
@@ -58,16 +62,16 @@ Use the **Activity Dashboard** to view aggregate activity.
 1. Click your user icon in the upper-right corner of the W&B App.
 2. Under **Account**, click **Users**.
 3. Above the table of users, review the Activity Panel:
-   * **Active user count**: unique active users during the selected period (defaults to 3 months).
-   * **Weekly active users**: users active per week.
-   * **Most active user**: top-10 users ranked by active days and last-active date.
-4. To change the date range, click the date picker in the upper-right corner and choose a new value: 7 days, 30 days (the default), 90 days, 6 months, or 12 months. All plots update automatically.
+   * **Active user count**: Unique active users during the selected period (defaults to 3 months).
+   * **Weekly active users**: Users active per week.
+   * **Most active user**: Top-10 users ranked by active days and last-active date.
+4. To change the date range, click the date picker in the upper-right corner and choose a new value: **7 days**, **30 days** (the default), **90 days**, **6 months**, or **12 months**. All plots update automatically.
 </Tab>
 </Tabs>
 
 ## Export user details
 
-From the **Users** tab you can download a CSV that lists each user's details (user name, email address, last-active time, roles, and more).
+When you need to share user details outside the dashboard or analyze them in another tool, export the user list as a CSV. From the **Users** tab you can download a CSV that lists each user's details (username, email address, last-active time, roles, and more).
 
 <Tabs>
 <Tab title="Dedicated Cloud / Self-Managed">
@@ -75,6 +79,7 @@ From the **Users** tab you can download a CSV that lists each user's details (us
 2. Click **Export as CSV**.
 
 ### Export CSV schema
+
 The CSV export uses the comma (`,`) as the separator, encloses strings in double quotes, and includes a header row that defines these columns:
 - `"Name"`
 - `"Username"`
@@ -90,6 +95,7 @@ The CSV export uses the comma (`,`) as the separator, encloses strings in double
 2. Select **Export as CSV** to download the file.
 
 ### Export CSV schema
+
 The CSV export uses the comma (`,`) as the separator, encloses strings in double quotes, and includes a header row that defines these columns:
 - `"Name"`
 - `"Username"`

--- a/platform/hosting/monitoring-usage/slack-alerts.mdx
+++ b/platform/hosting/monitoring-usage/slack-alerts.mdx
@@ -3,23 +3,23 @@ title: Configure Slack alerts
 description: "Create and configure a Slack application to receive W&B Server alerts, notifications, and monitoring updates."
 ---
 
-Integrate W&B Server with [Slack](https://slack.com/).
+Integrate W&B Server with [Slack](https://slack.com/) so that your W&B instance can dispatch alerts and notifications to a Slack workspace your team already uses. This page walks W&B Server administrators through creating a Slack application, configuring its OAuth scopes and redirect URL, and registering the application with W&B.
 <Note>
 Watch a [video demonstrating setting up Slack alerts on W&B Dedicated Cloud deployment](https://www.youtube.com/watch?v=JmvKb-7u-oU) (6 min).
 </Note>
 
 ## Create the Slack application
 
-Follow the procedure below to create a Slack application.
+W&B Server uses a custom Slack application as the bridge for delivering alerts. Follow this procedure to create that application in the Slack workspace where you want to receive notifications.
 
-1. Visit https://api.slack.com/apps and select **Create an App**.
+1. Visit [https://api.slack.com/apps](https://api.slack.com/apps) and select **Create an App**.
 
     <Frame>
         <img src="/images/hosting/create_an_app.png" alt="Create an App button"  />
     </Frame>
 
 2. Provide a name for your app in the **App Name** field.
-3. Select a Slack workspace where you want to develop your app in. Ensure that the Slack workspace you use is the same workspace you intend to use for alerts.
+3. Select a Slack workspace where you want to develop your app. Ensure that the Slack workspace you use is the same workspace you intend to use for alerts.
 
     <Frame>
         <img src="/images/hosting/name_app_workspace.png" alt="App name and workspace selection"  />
@@ -27,47 +27,53 @@ Follow the procedure below to create a Slack application.
 
 ## Configure the Slack application
 
-1. On the left sidebar, select **OAth & Permissions**.
+After you create the Slack application, grant it the permissions to post messages and accept the redirect from W&B during the OAuth handshake.
+
+1. On the left sidebar, select **OAuth & Permissions**.
 
     <Frame>
         <img src="/images/hosting/add_an_oath.png" alt="OAuth & Permissions menu"  />
     </Frame>
 
-2. Within the Scopes section, provide the bot with the **incoming_webhook** scope. Scopes give your app permission to perform actions in your development workspace.
+2. In the **Scopes** section, grant the bot the `incoming_webhook` scope. Scopes give your app permission to perform actions in your development workspace.
 
-    For more information about OAuth scopes for Bots, see the Understanding OAuth scopes for Bots tutorial in the Slack API documentation.
+    For more information about OAuth scopes for bots, see [Understanding OAuth scopes for bots](https://api.slack.com/legacy/oauth-scopes) in the Slack API documentation.
 
     <Frame>
     <img src="/images/hosting/save_urls.png" alt="Bot token scopes"  />
     </Frame>
 
-3. Configure the Redirect URL to point to your W&B installation. Use the same URL that your host URL is set to in your local system settings. You can specify multiple URLs if you have different DNS mappings to your instance.
+3. Configure the **Redirect URL** to point to your W&B installation. Use the same URL that you set as your host URL in your local system settings. You can specify multiple URLs if you have different DNS mappings to your instance.
 
     <Frame>
     <img src="/images/hosting/redirect_urls.png" alt="Redirect URLs configuration"  />
     </Frame>
 
 4. Select **Save URLs**.
-5. You can optionally specify an IP range under **Restrict API Token Usage**, allow-list the IP or IP range of your W&B instances. Limiting the allowed IP address helps further secure your Slack application.
+5. Optional: Under **Restrict API Token Usage**, specify an IP or IP range to allowlist for your W&B instances. Limiting the allowed IP address helps secure your Slack application.
 
 ## Register your Slack application with W&B
 
-1. Navigate to the **System Settings** or **System Console** page of your W&B instance, depending on your deployment
+Register the Slack application you configured with your W&B instance so that W&B can use it to dispatch alerts.
 
-2. Depending on the System page you are on follow one of the below options:
+1. Navigate to the **System Settings** or **System Console** page of your W&B instance, depending on your deployment.
 
-    - If you are in the **System Console**: go to **Settings** then to **Notifications**
+2. Depending on the System page you're on, follow one of the following options:
+
+    - If you're in the **System Console**: go to **Settings** then to **Notifications**.
 
         <Frame>
         <img src="/images/hosting/register_slack_app_console.png" alt="System Console notifications"  />
         </Frame>
 
-    - If you are in the **System Settings**: toggle the **Enable a custom Slack application to dispatch alerts** to enable a custom Slack application
+    - If you're in the **System Settings**: toggle the **Enable a custom Slack application to dispatch alerts** to enable a custom Slack application.
 
         <Frame>
         <img src="/images/hosting/register_slack_app.png" alt="Enable Slack application toggle"  />
         </Frame>
 
-3. Supply your **Slack client ID** and **Slack secret** then click **Save**. Navigate to Basic Information in Settings to find your application’s client ID and secret.
+3. Supply your **Slack client ID** and **Slack secret**, then select **Save**. To find your application's client ID and secret, navigate to **Basic Information** in **Settings**.
 
-4. Verify that everything is working by setting up a Slack integration in the W&B app.
+4. To verify that everything works, set up a Slack integration in the W&B app.
+
+Your W&B Server is now registered with the Slack application and can dispatch alerts to the configured Slack workspace.

--- a/platform/hosting/privacy-settings.mdx
+++ b/platform/hosting/privacy-settings.mdx
@@ -3,44 +3,50 @@ title: Configure privacy settings
 description: "Configure and enforce privacy settings for team visibility, project access, and code saving defaults in W&B."
 ---
 
-Organization and Team admins can configure a set of privacy settings at the organization and team scopes respectively. When configured at the organization scope, organization admins enforce those settings for all teams in that organization.
+This page describes how organization and team admins can configure privacy settings in W&B to control team visibility, project access, invitations, report sharing, and default code saving. Use these settings to standardize privacy across an organization or to tune controls for a single team.
+
+Organization admins can configure privacy settings at the organization scope, and team admins can configure them at the team scope. When configured at the organization scope, the settings are enforced for all teams in that organization.
 
 <Note>
-To avoid unexpected changes in team workflows, W&B recommends organization admins to enforce a privacy setting only after communicating in advance to all team admins and users in the organization.
+To avoid unexpected changes in team workflows, W&B recommends that organization admins enforce a privacy setting only after communicating in advance to all team admins and users in the organization.
 </Note>
 
 ## Enforce privacy settings for all teams
 
-Organization admins can enforce privacy settings for all teams in their organization from within the **Privacy** section of the **Settings** tab in the account or organization dashboard. If organization admins enforce a setting, team admins are not allowed to configure that within their respective teams.
+Organization admins can enforce privacy settings for all teams in their organization from within the **Privacy** section of the **Settings** tab in the account or organization dashboard. If organization admins enforce a setting, team admins can't configure it within their respective teams.
 
-* **Enforce team visibility restrictions** - Hides all teams from non-members across the organization
-* **Enforce privacy for future projects** - Requires all new projects in all teams to be private or [restricted](./iam/access-management/restricted-projects)
-* **Enforce invitation control** - Prevents non-admins from inviting members to any team
-* **Enforce report sharing control** - Turns off public sharing of reports in private projects and deactivates existing magic links
-* **Enforce team self-joining restrictions** - Restricts users with matching organization email domain from automatically joining any team
+* **Enforce team visibility restrictions**: Hides all teams from non-members across the organization.
+* **Enforce privacy for future projects**: Requires all new projects in all teams to be private or [restricted](./iam/access-management/restricted-projects).
+* **Enforce invitation control**: Prevents non-admins from inviting members to any team.
+* **Enforce report sharing control**: Turns off public sharing of reports in private projects and deactivates existing magic links.
+* **Enforce team self-joining restrictions**: Restricts users with matching organization email domain from automatically joining any team.
   <Note>This setting is only available in [Multi-tenant Cloud](./hosting-options/multi_tenant_cloud) deployments.</Note>
-* **Enforce default code saving restrictions** - Turns off code saving by default for all teams
+* **Enforce default code saving restrictions**: Turns off code saving by default for all teams.
 
 To open organization privacy settings:
 
 1. Sign in as an organization admin.
-2. On Multi-tenant Cloud, navigate to `https://wandb.ai/account-settings/<organization>/settings`. Replace `<organization>` with your organization name. On Dedicated Cloud or Self-Managed deployments, open your instance organization dashboard. For environment-specific URLs, see [Add and manage users](/platform/hosting/iam/access-management/manage-organization#add-and-manage-users).
+2. On Multi-tenant Cloud, navigate to `https://wandb.ai/account-settings/[ORGANIZATION]/settings`. Replace `[ORGANIZATION]` with your organization name. On Dedicated Cloud or Self-Managed deployments, open your instance organization dashboard. For environment-specific URLs, see [Add and manage users](/platform/hosting/iam/access-management/manage-organization#add-and-manage-users).
 3. Open the **Privacy** section and configure **Enforce default code saving restrictions** and any other organization-wide controls you need.
+
+After you save changes, the enforced settings apply to all teams in the organization, and team admins can no longer override them at the team scope.
 
 ## Configure privacy settings for a team
 
-Team admins can configure privacy settings for their respective teams from within the **Privacy** section of the team **Settings** tab. Each setting is configurable as long as it's not enforced at the organization scope:
+If a setting isn't enforced at the organization scope, team admins can manage it for their own team from the **Privacy** section of the team **Settings** tab. Each setting is configurable as long as it isn't enforced at the organization scope:
 
-* **Hide this team from all non-members** - Prevents the team from being visible to users who are not members
-* **Make all future team projects private** - Ensures all new projects created in the team are private (public sharing not allowed)
-* **Allow any team member to invite other members** - Enables all team members to invite new members, not just admins
-* **Turn off public sharing for reports in private projects** - Disables public sharing of reports and deactivates existing magic links
-* **Allow users with matching organization email domain to join this team** - Permits automatic team joining for users with the same email domain
+* **Hide this team from all non-members**: Hides the team from users who aren't members.
+* **Make all future team projects private**: Ensures all new projects created in the team are private (public sharing isn't allowed).
+* **Allow any team member to invite other members**: Lets all team members invite new members, not only admins.
+* **Turn off public sharing for reports in private projects**: Disables public sharing of reports and deactivates existing magic links.
+* **Allow users with matching organization email domain to join this team**: Lets users with the same email domain join the team automatically.
   <Note>This setting is only available in [Multi-tenant Cloud](./hosting-options/multi_tenant_cloud) deployments.</Note>
-* **Enable code saving by default** - Automatically saves code for all runs in the team
+* **Enable code saving by default**: Automatically saves code for all runs in the team.
 
 To open team privacy settings:
 
-1. Navigate to `https://wandb.ai/<team>`. Replace `<team>` with your team name.
+1. Navigate to `https://wandb.ai/[TEAM]`. Replace `[TEAM]` with your team name.
 2. Select **Team settings** in the left navigation.
 3. Open the **Privacy** section and configure **Enable code saving by default**.
+
+After you save changes, the selected settings apply to your team.

--- a/platform/hosting/self-managed/disable-automatic-app-version-updates.mdx
+++ b/platform/hosting/self-managed/disable-automatic-app-version-updates.mdx
@@ -3,10 +3,10 @@ title: Disable automatic updates for W&B Server
 description: Learn how to disable automatic updates for W&B Server.
 ---
 
-This page shows how to disable automatic version upgrades for W&B Server and pin its version. These instructions work for deployments managed by the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator) only.
+This page shows administrators of Self-Managed W&B deployments how to disable automatic version upgrades for W&B Server and pin its version to a specific release. Pinning a version gives you control over when upgrades happen. This control is useful when you need to coordinate upgrades with internal change management processes or validate a release in a staging environment before you roll it out. These instructions work only for deployments managed by the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator).
 
 <Note>
-W&B supports a major W&B Server release for 12 months from its initial release date. Customers with **Self-Managed** instances are responsible for upgrading in time to maintain support. Avoid staying on an unsupported version. W&B strongly recommends customers with **Self-Managed** instances to update their deployments with the latest release at minimum once per quarter to maintain support and receive the latest features, performance improvements, and fixes.
+W&B supports a major W&B Server release for 12 months from its initial release date. Customers with **Self-Managed** instances are responsible for upgrading in time to maintain support. Avoid staying on an unsupported version. W&B recommends that customers with **Self-Managed** instances update their deployments with the latest release at least once per quarter to maintain support and to receive the latest features, performance improvements, and fixes.
 </Note>
 
 ## Requirements
@@ -17,21 +17,24 @@ W&B supports a major W&B Server release for 12 months from its initial release d
 To verify that you meet these requirements, refer to the W&B Custom Resource or Helm chart for your instance. Check the `version` values for the `operator-wandb` and `system-console` components.
 
 ## Disable automatic updates
+
+To disable automatic updates, use the System Console to pin W&B Server to a specific version, then check the Operator reconciliation logs to confirm that version pinning is active.
+
 1. Log in to the W&B App as a user with the `admin` role.
 2. Click the user icon at the top, then click **System Console**.
-3. Navigate to **Settings** > **Advanced**, then select the **Other** tab.
+3. Go to **Settings** > **Advanced**, then select the **Other** tab.
 4. In the **Disable Auto Upgrades** section, turn on **Pin specific version**.
-5. Click the **Select a version** drop-down, select a W&B Server version.
+5. Click the **Select a version** drop-down list, then select a W&B Server version.
 6. Click **Save**.
 
     <Frame>
-    <img src="/images/hosting/disable_automatic_updates_saved_and_enabled.png" alt="Disable Automatic Updates Saved"  />
+    <img src="/images/hosting/disable_automatic_updates_saved_and_enabled.png" alt="System Console showing Pin specific version turned on with a selected W&B Server version" />
     </Frame>
 
     Automatic upgrades are turned off and W&B Server is pinned at the version you selected.
-1. Verify that automatic upgrades are turned off. Navigate to the **Operator** tab and search the reconciliation logs for the string `Version pinning is enabled`.
+7. Verify that automatic upgrades are turned off. Go to the **Operator** tab and search the reconciliation logs for the string `Version pinning is enabled`.
 
-```
+```text
 │info 2025-04-17T17:24:16Z wandb default No changes found
 │info 2025-04-17T17:24:16Z wandb default Active spec found
 │info 2025-04-17T17:24:16Z wandb default Desired spec

--- a/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
+++ b/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
@@ -14,17 +14,17 @@ import SelfManagedVerifyInstallation from "/snippets/_includes/self-managed-veri
 
 ## Introduction
 
-This guide provides step-by-step instructions to deploy the W&B Platform in air-gapped, fully disconnected, or restricted network customer-managed environments. Air-gapped deployments are common in:
+This guide provides step-by-step instructions to deploy the W&B Platform in air-gapped, disconnected, or restricted network customer-managed environments. By following this guide, you set up an internal container registry and Helm repository to host W&B images and charts, install the W&B Kubernetes Operator, and deploy the W&B Platform without requiring outbound internet connectivity. This guide targets platform administrators and DevOps engineers who manage Kubernetes infrastructure in regulated or isolated networks.
 
-- Secure government facilities
-- Financial institutions with strict network isolation
-- Healthcare organizations with compliance requirements
-- Industrial control systems (ICS) environments
-- Research facilities with classified networks
+Air-gapped deployments are common in the following environments:
 
-Use an internal container registry and Helm repository to host the required W&B images and charts. Run these commands in a shell console with proper access to the Kubernetes cluster.
+- Secure government facilities.
+- Financial institutions with strict network isolation.
+- Healthcare organizations with compliance requirements.
+- Industrial control systems (ICS) environments.
+- Research facilities with classified networks.
 
-You can adapt these commands to work with any CI/CD tooling you use to deploy Kubernetes applications.
+Run these commands in a shell console with proper access to the Kubernetes cluster. You can adapt these commands to work with any CI/CD tooling you use to deploy Kubernetes applications.
 
 For standard on-premises Kubernetes deployments with internet connectivity, see [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator).
 
@@ -62,20 +62,22 @@ For detailed object storage provisioning guidance, see the [Bring Your Own Bucke
 
 ### Air-gapped specific requirements
 
-In addition to the standard requirements above, air-gapped deployments require:
+In addition to the preceding standard requirements, air-gapped deployments require the following:
 
-- **Internal container registry**: Access to a private container registry (Harbor, JFrog Artifactory, Nexus, etc.) with all required W&B images
-- **Internal Helm repository**: Access to a private Helm chart repository with W&B Helm charts
-- **Image transfer capability**: A method to transfer container images from an internet-connected system to your air-gapped registry
+- **Internal container registry**: Access to a private container registry such as Harbor, JFrog Artifactory, or Nexus, with all required W&B images.
+- **Internal Helm repository**: Access to a private Helm chart repository with W&B Helm charts.
+- **Image transfer capability**: A method to transfer container images from an internet-connected system to your air-gapped registry.
 - **License file**: A valid W&B Enterprise license. To obtain a license (for example, from an internet-connected machine), see the [License](/platform/hosting/self-managed/requirements#license) section on the Requirements page, or contact your W&B account team.
 
 For complete infrastructure requirements, including networking and load balancer configuration, see the [reference architecture](/platform/hosting/self-managed/ref-arch#infrastructure-requirements).
 
 ## Prepare your air-gapped environment
 
+The following steps prepare your air-gapped environment to host the W&B container images and Helm charts. Complete these steps before installing the operator or deploying the platform.
+
 ### Step 1: Set up internal container registry
 
-For a successful air-gapped deployment, all required container images must be available in your air-gapped container registry.
+Because the Kubernetes cluster cannot pull images from public registries, all required container images must be available in your internal air-gapped container registry before deployment.
 
 <Note>
 You are responsible for tracking the W&B Operator's requirements and maintaining your container registry with updated images regularly. For the most current list of required container images and versions, refer to the Helm chart, or contact [W&B Support](mailto:support@wandb.com) or your assigned W&B support engineer.
@@ -85,19 +87,19 @@ You are responsible for tracking the W&B Operator's requirements and maintaining
 
 The following core images are required:
 
-- [`docker.io/wandb/controller`](https://hub.docker.com/r/wandb/controller) - W&B Kubernetes Operator
-- [`docker.io/wandb/local`](https://hub.docker.com/r/wandb/local) - W&B application server
-- [`docker.io/wandb/console`](https://hub.docker.com/r/wandb/console) - W&B management console
-- [`docker.io/wandb/megabinary`](https://hub.docker.com/r/wandb/megabinary) - W&B microservices (API, executor, glue, parquet)
+- [`docker.io/wandb/controller`](https://hub.docker.com/r/wandb/controller): W&B Kubernetes Operator.
+- [`docker.io/wandb/local`](https://hub.docker.com/r/wandb/local): W&B application server.
+- [`docker.io/wandb/console`](https://hub.docker.com/r/wandb/console): W&B management console.
+- [`docker.io/wandb/megabinary`](https://hub.docker.com/r/wandb/megabinary): W&B microservices (API, executor, glue, parquet).
 
 #### Dependency containers
 
 The following third-party dependency images are required:
 
-- [`docker.io/bitnamilegacy/redis`](https://hub.docker.com/r/bitnamilegacy/redis) - Required for local Redis deployment during testing and development. For production Redis requirements, see the [Redis section](#redis) in Prerequisites.
-- [`docker.io/otel/opentelemetry-collector-contrib`](https://hub.docker.com/r/otel/opentelemetry-collector-contrib) - OpenTelemetry agent for collecting metrics and logs
-- [`quay.io/prometheus/prometheus`](https://quay.io/repository/prometheus/prometheus) - Prometheus for metrics collection
-- [`quay.io/prometheus-operator/prometheus-config-reloader`](https://quay.io/repository/prometheus-operator/prometheus-config-reloader) - Prometheus dependency
+- [`docker.io/bitnamilegacy/redis`](https://hub.docker.com/r/bitnamilegacy/redis): Required for local Redis deployment during testing and development. For production Redis requirements, see the [Redis section](#redis) in Prerequisites.
+- [`docker.io/otel/opentelemetry-collector-contrib`](https://hub.docker.com/r/otel/opentelemetry-collector-contrib): OpenTelemetry agent for collecting metrics and logs.
+- [`quay.io/prometheus/prometheus`](https://quay.io/repository/prometheus/prometheus): Prometheus for metrics collection.
+- [`quay.io/prometheus-operator/prometheus-config-reloader`](https://quay.io/repository/prometheus-operator/prometheus-config-reloader): Prometheus dependency.
 
 #### Get the complete image list
 
@@ -121,7 +123,7 @@ To extract the complete list of required images and versions from the Helm chart
    helm show values charts/operator-wandb | grep -E "repository:|tag:" | grep -v "^#"
    ```
 
-   Alternatively, use this command to extract just the repository names (without version tags):
+   Alternatively, use this command to extract only the repository names (without version tags):
 
    ```bash
    helm show values charts/operator-wandb \
@@ -130,7 +132,7 @@ To extract the complete list of required images and versions from the Helm chart
      | sort -u
    ```
 
-   The list of repositories will look similar to the following:
+   The list of repositories looks similar to the following:
 
    ```text
    wandb/controller
@@ -145,14 +147,14 @@ To extract the complete list of required images and versions from the Helm chart
    bitnamilegacy/redis
    ```
 
-   To get the specific version tags for each image, use the first command above (`grep -E "repository:|tag:"`), which will show both repository names and their corresponding version tags.
+   To get the specific version tags for each image, use the preceding first command (`grep -E "repository:|tag:"`), which shows both repository names and their corresponding version tags.
 
 #### Transfer images to air-gapped registry
 
 1. On an internet-connected system, pull and save all required images. 
 
     <Note>
-    Replace version numbers in the examples below with the actual versions from your Helm chart inspection in step 2 above. The versions shown here are examples and will become outdated.
+    Replace version numbers in the following examples with the actual versions from your Helm chart inspection in the preceding step. The versions shown here are examples and become outdated over time.
     </Note>
 
     Use shell variables to manage versions consistently:
@@ -178,7 +180,7 @@ To extract the complete list of required images and versions from the Helm chart
     # ... save all other images
     ```
 
-2. Transfer the `.tar` files to your air-gapped environment using your approved method (USB drive, secure file transfer, etc.).
+2. Transfer the `.tar` files to your air-gapped environment using your approved method, such as a USB drive or secure file transfer.
 
 3. In your air-gapped environment, load and push images to your internal registry:
 
@@ -213,7 +215,7 @@ To extract the complete list of required images and versions from the Helm chart
 
 ### Step 2: Set up internal Helm chart repository
 
-Along with the container images, ensure the following Helm charts are available in your internal Helm repository:
+With the container images in place, the Kubernetes Operator also needs access to the W&B Helm charts. Ensure the following Helm charts are available in your internal Helm repository:
 
 - [W&B Operator chart](https://github.com/wandb/helm-charts/tree/main/charts/operator)
 - [W&B Platform chart](https://github.com/wandb/helm-charts/tree/main/charts/operator-wandb)
@@ -236,6 +238,8 @@ Along with the container images, ensure the following Helm charts are available 
 
 ### Step 3: Configure Helm repository access
 
+Configure your local Helm client in the air-gapped environment to point to your internal repository so that subsequent install commands can locate the charts.
+
 1. In your air-gapped environment, configure Helm to use your internal repository:
 
    ```bash
@@ -252,9 +256,11 @@ Along with the container images, ensure the following Helm charts are available 
 
 ## Deploy W&B in air-gapped environment
 
+With your internal registry and Helm repository in place, you can now install the Kubernetes Operator, configure external services, and deploy the W&B Platform.
+
 ### Step 4: Install the Kubernetes Operator
 
-The W&B Kubernetes Operator (controller manager) manages the W&B platform components. To install it in an air-gapped environment, configure it to use your internal container registry.
+The W&B Kubernetes Operator (controller manager) manages the W&B Platform components. To install it in an air-gapped environment, configure it to use your internal container registry.
 
 1. Create a `values.yaml` file with the following content:
 
@@ -267,7 +273,7 @@ The W&B Kubernetes Operator (controller manager) manages the W&B platform compon
    ```
 
    <Note>
-   Replace the repository and tag with the actual versions you transferred to your internal registry in Step 1. The version shown here (`1.13.3`) is an example and will become outdated.
+   Replace the repository and tag with the actual versions you transferred to your internal registry in Step 1. The version shown here (`1.13.3`) is an example and becomes outdated over time.
    </Note>
 
 2. Install the operator and Custom Resource Definition (CRD):
@@ -287,11 +293,13 @@ The W&B Kubernetes Operator (controller manager) manages the W&B platform compon
 
    You should see the operator pod in a `Running` state.
 
+The W&B Kubernetes Operator is now installed and ready to deploy the W&B Platform from your internal chart repository.
+
 For full details about supported values, refer to the [Kubernetes operator GitHub repository values file](https://github.com/wandb/helm-charts/blob/main/charts/operator/values.yaml).
 
 ### Step 5: Set up MySQL database
 
-Before configuring the W&B Custom Resource, set up an external MySQL database. For production deployments, W&B strongly recommends using managed database services where available. However, if you are running your own MySQL instance, create the database and user:
+Before configuring the W&B Custom Resource, set up an external MySQL database. For production deployments, W&B strongly recommends using managed database services where available. However, if you're running your own MySQL instance, create the database and user:
 
 <SelfManagedMysqlDatabaseCreation/>
 
@@ -299,12 +307,10 @@ For MySQL configuration parameters, see the [reference architecture MySQL config
 
 ### Step 6: Configure W&B Custom Resource
 
-After installing the W&B Kubernetes Operator, configure the Custom Resource (CR) to point to your internal Helm repository and container registry.
-
-This configuration ensures the Kubernetes operator uses your internal registry and repository when deploying the required components of the W&B platform.
+After installing the W&B Kubernetes Operator, configure the Custom Resource (CR) to point to your internal Helm repository and container registry. This configuration ensures the Kubernetes operator uses your internal registry and repository when deploying the required components of the W&B Platform, instead of attempting to reach public sources.
 
 <Note>
-The example configuration below includes image version tags that will become outdated. Replace all `tag:` values with the actual versions you transferred to your internal registry in Step 1.
+The following example configuration includes image version tags that become outdated over time. Replace all `tag:` values with the actual versions you transferred to your internal registry in Step 1.
 </Note>
 
 Create a file named `wandb.yaml` with the following content:
@@ -341,14 +347,14 @@ spec:
       mysql:
         database: wandb
         host: mysql.yourdomain.com
-        password: <your-mysql-password>
+        password: [YOUR-MYSQL-PASSWORD]
         port: 3306
         user: wandb
       
       redis:
         host: redis.yourdomain.com
         port: 6379
-        password: <your-redis-password>
+        password: [YOUR-REDIS-PASSWORD]
       
       api:
         enabled: true
@@ -421,10 +427,11 @@ spec:
 ```
 
 <Note>
-Replace all placeholder values (hostnames, passwords, tags, etc.) with your actual configuration values. The example above shows the most commonly used components.
+Replace all placeholder values, such as hostnames, passwords, and tags, with your actual configuration values. The preceding example shows the most commonly used components.
 </Note>
 
-Depending on your deployment needs, you may also need to configure image repositories for additional components such as:
+Depending on your deployment needs, you may also need to configure image repositories for additional components such as the following:
+
 - `settingsMigrationJob`
 - `weave-trace`
 - `filestream`
@@ -432,7 +439,9 @@ Depending on your deployment needs, you may also need to configure image reposit
 
 Refer to the [W&B Helm repository values file](https://github.com/wandb/helm-charts/blob/main/charts/operator-wandb/values.yaml) for the complete list of configurable components.
 
-### Step 7: Deploy the W&B platform
+### Step 7: Deploy the W&B Platform
+
+Applying the Custom Resource triggers the operator to install the W&B Platform components defined in the `operator-wandb` chart, using the configuration and image references from `wandb.yaml`.
 
 1. Apply the W&B Custom Resource to deploy the platform:
 
@@ -457,7 +466,7 @@ Refer to the [W&B Helm repository values file](https://github.com/wandb/helm-cha
 
 ## OpenShift configuration
 
-W&B fully supports deployment on air-gapped OpenShift Kubernetes clusters. OpenShift deployments require additional security context configurations due to OpenShift's stricter security policies.
+W&B supports deployment on air-gapped OpenShift Kubernetes clusters. OpenShift deployments require additional security context configurations because of OpenShift's stricter security policies. If you're deploying on OpenShift, apply the configurations in this section in addition to the preceding steps.
 
 ### OpenShift security context constraints
 
@@ -586,8 +595,8 @@ If your OpenShift cluster uses an internal image registry with authentication:
    ```bash
    kubectl create secret docker-registry wandb-registry-secret \
      --docker-server=registry.yourdomain.com \
-     --docker-username=<username> \
-     --docker-password=<password> \
+     --docker-username=[USERNAME] \
+     --docker-password=[PASSWORD] \
      --namespace=wandb
    ```
 
@@ -602,10 +611,10 @@ If your OpenShift cluster uses an internal image registry with authentication:
 
 ### OpenShift complete example
 
-Here's a complete example CR for OpenShift air-gapped deployment:
+The following example shows a complete CR for OpenShift air-gapped deployment:
 
 <Note>
-Replace all `tag:` values in this example with the actual versions you transferred to your internal registry in Step 1. The versions shown are examples and will become outdated.
+Replace all `tag:` values in this example with the actual versions you transferred to your internal registry in Step 1. The versions shown are examples and become outdated over time.
 </Note>
 
 ```yaml
@@ -624,11 +633,11 @@ spec:
   values:
     global:
       host: https://wandb.apps.openshift.yourdomain.com
-      license: <your-license>
+      license: [YOUR-LICENSE]
       
       bucket:
-        accessKey: <your-access-key>
-        secretKey: <your-secret-key>
+        accessKey: [YOUR-ACCESS-KEY]
+        secretKey: [YOUR-SECRET-KEY]
         name: s3.yourdomain.com:9000
         path: wandb
         provider: s3
@@ -637,14 +646,14 @@ spec:
       mysql:
         database: wandb
         host: mysql.yourdomain.com
-        password: <your-mysql-password>
+        password: [YOUR-MYSQL-PASSWORD]
         port: 3306
         user: wandb
       
       redis:
         host: redis.yourdomain.com
         port: 6379
-        password: <your-redis-password>
+        password: [YOUR-REDIS-PASSWORD]
 
     # OpenShift-specific: Use Routes instead of Ingress
     ingress:
@@ -706,7 +715,9 @@ Contact [W&B Support](mailto:support@wandb.com) or your assigned W&B support eng
 
 ## Verify your installation
 
-After deploying W&B, verify the installation is working correctly:
+After deploying W&B, verify the installation is working correctly so that you can confirm the platform is reachable, pods are healthy, and the deployment is using only your internal resources.
+
+Follow the general verification steps, then complete the additional air-gapped checks in the following section.
 
 <SelfManagedVerifyInstallation/>
 
@@ -734,19 +745,20 @@ For air-gapped deployments, also verify:
 
 ### Image pull errors
 
-If pods fail to pull images:
+If pods fail to pull images, check the following:
 
-1. Verify images exist in your internal registry
-2. Check image pull secret is correctly configured
-3. Verify network connectivity from Kubernetes nodes to registry
-4. Check registry authentication credentials
+- Verify images exist in your internal registry.
+- Check that the image pull secret is correctly configured.
+- Verify network connectivity from Kubernetes nodes to the registry.
+- Check registry authentication credentials.
 
-   ```bash
-   # Test image pull manually
-   kubectl run test-pull --image=registry.yourdomain.com/wandb/local:0.59.2 --namespace=wandb
-   kubectl logs test-pull -n wandb
-   kubectl delete pod test-pull -n wandb
-   ```
+To test an image pull manually:
+
+```bash
+kubectl run test-pull --image=registry.yourdomain.com/wandb/local:0.59.2 --namespace=wandb
+kubectl logs test-pull -n wandb
+kubectl delete pod test-pull -n wandb
+```
 
 ### OpenShift SCC errors
 
@@ -754,7 +766,7 @@ If pods fail with permission errors on OpenShift:
 
 ```bash
 # Check which SCC is being used
-oc get pod <pod-name> -n wandb -o yaml | grep scc
+oc get pod [POD-NAME] -n wandb -o yaml | grep scc
 
 # Check service account permissions
 oc describe scc wandb-scc
@@ -763,11 +775,11 @@ oc get rolebinding -n wandb
 
 ### Helm chart not found
 
-If the operator cannot find the platform chart:
+If the operator can't find the platform chart, check the following:
 
-1. Verify the chart repository URL in the Custom Resource
-2. Check that the operator pod can reach your internal Helm repository
-3. Verify the chart exists in your repository:
+- Verify the chart repository URL in the Custom Resource.
+- Check that the operator pod can reach your internal Helm repository.
+- Verify the chart exists in your repository:
 
    ```bash
    helm search repo local-repo/operator-wandb
@@ -806,11 +818,11 @@ spec:
 
 ### How do I prevent automatic updates?
 
-Configure the operator to not automatically update W&B:
+To configure the operator to not automatically update W&B, do the following:
 
-1. Set `airgapped: true` in the operator installation (this disables automatic update checks)
-2. Control version updates by manually updating the `spec.chart.version` in your Custom Resource
-3. Optionally, disable automatic updates from the W&B System Console
+- Set `airgapped: true` in the operator installation (this disables automatic update checks).
+- Control version updates by manually updating the `spec.chart.version` in your Custom Resource.
+- Optionally, disable automatic updates from the W&B System Console.
 
 See [Disable automatic app version updates](/platform/hosting/self-managed/disable-automatic-app-version-updates) for more details.
 
@@ -820,35 +832,35 @@ W&B strongly recommends customers with Self-Managed instances update their deplo
 
 ### Does the deployment work with no connection to public repositories?
 
-Yes. When `airgapped: true` is set in the operator configuration, the Kubernetes operator uses only your internal resources and does not attempt to connect to public repositories.
+Yes. When `airgapped: true` is set in the operator configuration, the Kubernetes operator uses only your internal resources and doesn't attempt to connect to public repositories.
 
 ### How do I update W&B in an air-gapped environment?
 
 To update W&B:
 
-1. Pull new container images on an internet-connected system
-2. Transfer images to your air-gapped registry
-3. Upload new Helm charts to your internal repository
-4. Update the `spec.chart.version` and image tags in your Custom Resource
-5. Apply the updated Custom Resource
+1. Pull new container images on an internet-connected system.
+2. Transfer images to your air-gapped registry.
+3. Upload new Helm charts to your internal repository.
+4. Update the `spec.chart.version` and image tags in your Custom Resource.
+5. Apply the updated Custom Resource.
 
-   The operator will perform a rolling update of the W&B components.
+   The operator performs a rolling update of the W&B components.
 
 ## Next steps
 
-After successful deployment:
+After successful deployment, complete the following tasks:
 
-1. **Configure user authentication**: Set up [SSO](/platform/hosting/iam/sso) or other authentication methods
-2. **Set up monitoring**: Configure monitoring for your W&B instance and infrastructure
-3. **Plan for updates**: Review the [Server upgrade process](/platform/hosting/server-upgrade-process) and establish an update cadence
-4. **Configure backups**: Establish backup procedures for your MySQL database
-5. **Document your process**: Create runbooks for your specific air-gapped update procedures
+- **Configure user authentication**: Set up [SSO](/platform/hosting/iam/sso) or other authentication methods.
+- **Set up monitoring**: Configure monitoring for your W&B instance and infrastructure.
+- **Plan for updates**: Review the [Server upgrade process](/platform/hosting/server-upgrade-process) and establish an update cadence.
+- **Configure backups**: Establish backup procedures for your MySQL database.
+- **Document your process**: Create runbooks for your specific air-gapped update procedures.
 
-## Getting help
+## Get help
 
 If you encounter issues during deployment:
 
-- Review the [Reference Architecture](/platform/hosting/self-managed/ref-arch) for infrastructure guidance
-- Check the [Operator guide](/platform/hosting/self-managed/operator) for configuration details
-- Contact [W&B Support](mailto:support@wandb.com) or your assigned W&B support engineer
-- For OpenShift-specific issues, reference Red Hat OpenShift documentation
+- Review the [Reference Architecture](/platform/hosting/self-managed/ref-arch) for infrastructure guidance.
+- Check the [Operator guide](/platform/hosting/self-managed/operator) for configuration details.
+- Contact [W&B Support](mailto:support@wandb.com) or your assigned W&B support engineer.
+- For OpenShift-specific issues, reference Red Hat OpenShift documentation.

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -11,13 +11,15 @@ import SelfManagedVerifyInstallation from "/snippets/_includes/self-managed-veri
 
 ## Overview
 
+This page shows platform administrators how to deploy and manage W&B Server on Kubernetes (cloud or on-premises) using the W&B Kubernetes Operator. By the end, you have a running W&B Server installation that the operator manages and upgrades automatically. Use this guide if you self-manage a W&B deployment and need an installation method that works across cloud, on-premises, and air-gapped environments.
+
 The W&B Kubernetes Operator is the recommended way to deploy W&B Server on Kubernetes (cloud or on-premises). For an overview of the operator, why W&B uses it, and how configuration hierarchy works, see [Self-Managed](/platform/hosting/hosting-options/self-managed#about-the-wb-kubernetes-operator).
 
 ## Before you begin
 
 Before deploying W&B with the Kubernetes Operator, ensure your infrastructure meets all requirements:
 
-1. **Review infrastructure requirements**: See the [Self-Managed infrastructure requirements](/platform/hosting/self-managed/requirements/) page for comprehensive details on:
+1. **Review infrastructure requirements**: See the [Self-Managed infrastructure requirements](/platform/hosting/self-managed/requirements/) page for details on:
   - Software version requirements (Kubernetes, MySQL, Redis, Helm)
   - Hardware requirements (CPU architecture, sizing recommendations)
   - Kubernetes cluster configuration
@@ -27,7 +29,7 @@ Before deploying W&B with the Kubernetes Operator, ensure your infrastructure me
 
 For additional context, see the [reference architecture](/platform/hosting/self-managed/ref-arch/) page.
 
-### MySQL Database
+### MySQL database
 <SelfManagedMysqlRequirements/>
 
 For complete MySQL setup instructions including configuration parameters and database creation, see the [MySQL section in the requirements page](/platform/hosting/self-managed/requirements/#mysql-database).
@@ -54,7 +56,7 @@ W&B recommends you install with the official W&B Helm chart.
 
 #### Run the container as an un-privileged user
 
-By default, containers use a `$UID` of 999. Specify `$UID` >= 100000 and a `$GID` of 0 if your orchestrator requires the container run with a non-root user.
+OpenShift and similar orchestrators often reject containers that run as root, so W&B containers must be configured to run as a non-root user that still belongs to the root group. By default, containers use a `$UID` of 999. Specify `$UID` >= 100000 and a `$GID` of 0 if your orchestrator requires the container run with a non-root user.
 
 <Note>
 W&B must start as the root group (`$GID=0`) for file system permissions to function properly.
@@ -92,7 +94,7 @@ If needed, configure a custom security context for other components like `app` o
 ## Deploy W&B Server application
 
 <Note>
-**The W&B Kubernetes Operator with Helm is the recommended installation method** for all W&B Self-Managed deployments, including cloud, on-premises, and air-gapped environments.
+**The W&B Kubernetes Operator with Helm is the recommended installation method** for all W&B self-managed deployments, including cloud, on-premises, and air-gapped environments.
 </Note>
 
 Choose your deployment method:
@@ -100,7 +102,7 @@ Choose your deployment method:
 <Tabs>
 <Tab title="Helm CLI">
 
-W&B provides a Helm Chart to deploy the W&B Kubernetes operator to a Kubernetes cluster. This approach allows you to deploy W&B Server with Helm CLI or a continuous delivery tool like ArgoCD.
+W&B provides a Helm chart to deploy the W&B Kubernetes Operator to a Kubernetes cluster. This approach lets you deploy W&B Server with Helm CLI or a continuous delivery tool like ArgoCD.
 
 For deployment-specific considerations, see [Environment-specific considerations](#environment-specific-considerations) and [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud). For disconnected environments, see [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/).
 
@@ -152,19 +154,22 @@ Follow these steps to install the W&B Kubernetes Operator with Helm CLI:
 
 5. To verify the installation using the web UI, create the first admin user account, then follow the verification steps outlined in [Verify the installation](#verify-the-installation).
 
+After these steps complete, you have a W&B Kubernetes Operator running in the `wandb-cr` namespace and a W&B Server application that the operator manages from your `operator.yaml` custom resource.
+
 </Tab>
 
 <Tab title="Terraform">
 
 Deploy W&B using Terraform for infrastructure-as-code deployments. Choose between:
-- **Helm Terraform Module**: Deploys the operator to existing Kubernetes infrastructure
-- **Cloud Terraform Modules**: Complete infrastructure + application deployment for AWS, Google Cloud, and Azure
+
+- **Helm Terraform Module**: Deploys the operator to existing Kubernetes infrastructure.
+- **Cloud Terraform Modules**: Complete infrastructure plus application deployment for AWS, Google Cloud, and Azure.
 
 For deployment-specific considerations, see [Environment-specific considerations](#environment-specific-considerations) and [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud). For disconnected environments, see [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped/).
 
 #### Helm Terraform Module
 
-This method allows for customized deployments tailored to specific requirements, leveraging Terraform's infrastructure-as-code approach for consistency and repeatability. The official W&B Helm-based Terraform Module is located [here](https://registry.terraform.io/modules/wandb/wandb/helm/latest). 
+This method supports customized deployments tailored to specific requirements, using Terraform's infrastructure-as-code approach for consistency and repeatability. The official W&B [Helm-based Terraform Module](https://registry.terraform.io/modules/wandb/wandb/helm/latest) is available on the Terraform Registry. 
 
 Use the following code as a starting point. It includes all necessary configuration options for a production grade deployment: 
 
@@ -198,7 +203,7 @@ module "wandb" {
 }
 ```
 
-Note that the configuration options are the same as described in [Configuration Reference](#configuration-reference-for-wb-server), but that the syntax has to follow the HashiCorp Configuration Language (HCL). The Terraform module creates the W&B custom resource definition (CRD).
+The configuration options are the same as described in [Configuration Reference](#configuration-reference-for-wb-server), but the syntax must follow the HashiCorp Configuration Language (HCL). The Terraform module creates the W&B custom resource definition (CRD).
 
 To see how W&B themselves use the Helm Terraform module to deploy Dedicated Cloud installations for customers, follow these links:
 - [AWS](https://github.com/wandb/terraform-aws-wandb/blob/45e1d746f53e78e73e68f911a1f8cad5408e74b6/main.tf#L225)
@@ -207,7 +212,7 @@ To see how W&B themselves use the Helm Terraform module to deploy Dedicated Clou
 
 #### Cloud Terraform Modules
 
-W&B provides a set of Terraform Modules for AWS, Google Cloud and Azure. These modules deploy entire infrastructures including Kubernetes clusters, load balancers, MySQL databases and so on as well as the W&B Server application. The W&B Kubernetes Operator is already pre-baked with these official W&B cloud-specific Terraform Modules with the following versions:
+W&B provides a set of Terraform Modules for AWS, Google Cloud, and Azure. These modules deploy the complete infrastructure, including Kubernetes clusters, load balancers, and MySQL databases, along with the W&B Server application. The W&B Kubernetes Operator is included in these official W&B cloud-specific Terraform Modules with the following versions:
 
 | Terraform Registry                                                  | Source Code                                      | Version |
 | ------------------------------------------------------------------- | ------------------------------------------------ | ------- |
@@ -215,9 +220,9 @@ W&B provides a set of Terraform Modules for AWS, Google Cloud and Azure. These m
 | [Azure](https://github.com/wandb/terraform-azurerm-wandb)           | https://github.com/wandb/terraform-azurerm-wandb | v2.0.0+ |
 | [Google Cloud](https://github.com/wandb/terraform-google-wandb)     | https://github.com/wandb/terraform-google-wandb  | v2.0.0+ |
 
-This integration ensures that W&B Kubernetes Operator is ready to use for your instance with minimal setup, providing a streamlined path to deploying and managing W&B Server in your cloud environment.
+These modules install the W&B Kubernetes Operator as part of the deployment, so you can use it to manage W&B Server in your cloud environment without additional setup.
 
-For detailed instructions on using these cloud-specific modules, see [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud) below.
+For detailed instructions on using these cloud-specific modules, see [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud).
 
 </Tab>
 </Tabs>
@@ -236,14 +241,14 @@ For end-user client configuration and the tool catalog, see [Use the W&B MCP ser
 
 Make sure your deployment meets the following requirements before you enable the MCP server:
 
-- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`, but the Datadog and privacy fields used in the example below were added later.
+- **Chart version**: `operator-wandb` `0.42.3` or later. The `mcp-server` subchart was introduced in `0.42.1`, but the Datadog and privacy fields used in the following example were added later.
 - **Weave Traces enabled**: the MCP server depends on Weave Traces for trace tools and for the `WF_TRACE_SERVER_URL` default. Set `weave-trace.install: true`. If Weave Traces isn't enabled, the Helm render fails with `mcp-server requires weave-trace.install=true`.
 - **Reachable ingress**: `global.host` must already resolve and route to the W&B ingress. The MCP pod reads `WANDB_BASE_URL` from `global.host` and is available at `<global.host>/mcp`.
 - **Node capacity**: the MCP pod requests `500m` CPU and `1Gi` memory by default (limits `2` CPU and `4Gi` memory). Confirm your node pool has enough headroom before you enable the subchart.
 
 ### Enable the subchart
 
-Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource (CR), alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
+Enable the `mcp-server` subchart so that the operator deploys an in-cluster MCP server and extends your existing W&B ingress with a `/mcp` route. Add the following to the `spec.values` block of your existing `WeightsAndBiases` custom resource (CR), alongside your existing `global`, `ingress`, and other overrides. The Datadog block is optional, but recommended when a Datadog Agent DaemonSet already collects pod logs and traces in your cluster.
 
 ```yaml
 spec:
@@ -316,7 +321,7 @@ After the MCP server is healthy, configure your MCP client to use `https://<HOST
 
 ## Environment-specific considerations
 
-Kubernetes is the same whether it runs on-premises or in the cloud. The main differences are in naming and managed services (for example, MySQL vs RDS, or S3 vs on-premises object storage). This section covers considerations that vary by environment.
+Kubernetes is the same whether it runs on-premises or in the cloud. The main differences are in naming and managed services (for example, MySQL compared to RDS, or S3 compared to on-premises object storage). This section covers considerations that vary by environment.
 
 ### On-premises and bare metal
 
@@ -326,30 +331,30 @@ When deploying on on-premises or bare-metal Kubernetes, pay attention to the fol
 
 On-premises Kubernetes clusters typically require manual load balancer configuration. Options include:
 
-- **External load balancer**: Configure an existing hardware or software load balancer (F5, HAProxy, etc.)
-- **Nginx Ingress Controller**: Deploy nginx-ingress-controller with NodePort or host networking
-- **MetalLB**: For bare-metal Kubernetes clusters, MetalLB provides load balancer services
+- **External load balancer**: Configure an existing hardware or software load balancer, such as F5 or HAProxy.
+- **Nginx Ingress Controller**: Deploy nginx-ingress-controller with NodePort or host networking.
+- **MetalLB**: For bare-metal Kubernetes clusters, MetalLB provides load balancer services.
 
 For detailed load balancer configuration examples, see the [Reference Architecture networking section](/platform/hosting/self-managed/ref-arch#networking).
 
 #### Persistent storage
 
-Ensure your Kubernetes cluster has a StorageClass configured for persistent volumes. W&B components may require persistent storage for caching and temporary data.
+Ensure your Kubernetes cluster has a StorageClass configured for persistent volumes. W&B components might require persistent storage for caching and temporary data.
 
-Common on-premises storage options:
+Common on-premises storage options include:
 
 - NFS-based storage classes
 - Ceph/Rook storage
 - Local persistent volumes
-- Enterprise storage solutions (NetApp, Pure Storage, etc.)
+- Enterprise storage solutions such as NetApp or Pure Storage
 
 #### DNS and certificate management
 
-For on-premises deployments:
+For on-premises deployments, complete the following tasks:
 
-- Configure internal DNS records to point to your W&B hostname
-- Provision SSL/TLS certificates from your internal Certificate Authority (CA)
-- If using self-signed certificates, configure the operator to trust your CA certificate
+- Configure internal DNS records to point to your W&B hostname.
+- Provision SSL/TLS certificates from your internal Certificate Authority (CA).
+- If using self-signed certificates, configure the operator to trust your CA certificate.
 
 See the [SSL/TLS requirements](/platform/hosting/self-managed/requirements#ssl-tls) for certificate configuration details.
 
@@ -357,7 +362,7 @@ See the [SSL/TLS requirements](/platform/hosting/self-managed/requirements#ssl-t
 
 W&B fully supports deployment on OpenShift Kubernetes clusters. OpenShift deployments require additional security context configurations due to OpenShift's stricter security policies.
 
-For OpenShift-specific configuration details, see [OpenShift Kubernetes clusters](#openshift-kubernetes-clusters) above. For comprehensive OpenShift examples in air-gapped environments, see [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped#openshift-configuration).
+For OpenShift-specific configuration details, see [OpenShift Kubernetes clusters](#openshift-kubernetes-clusters). For OpenShift examples in air-gapped environments, see [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped#openshift-configuration).
 
 #### Object storage for on-premises and S3-compatible
 
@@ -365,7 +370,7 @@ After provisioning your object storage bucket (see [Object storage provisioning]
 
 **AWS S3 (on-premises)**
 
-For on-premises AWS S3 (via Outposts or compatible storage):
+For on-premises AWS S3 (through Outposts or compatible storage):
 
 ```yaml
 bucket:
@@ -376,7 +381,7 @@ bucket:
   region: <region>       # Example: us-east-1
 ```
 
-**S3-compatible storage (MinIO, Ceph, NetApp, etc.)**
+**S3-compatible storage such as MinIO, Ceph, or NetApp**
 
 For S3-compatible storage systems:
 
@@ -404,7 +409,7 @@ The certificate must be trusted. Self-signed certificates require additional con
 
 When running your own object storage, consider:
 
-1. **Storage capacity and performance**: Monitor disk capacity carefully. Average W&B usage results in tens to hundreds of gigabytes. Heavy usage could result in petabytes of storage consumption.
+1. **Storage capacity and performance**: Monitor disk capacity carefully. Average W&B usage results in tens to hundreds of gigabytes. Heavy usage can result in petabytes of storage consumption.
 2. **Fault tolerance**: At minimum, use RAID arrays for physical disks. For S3-compatible storage, use distributed or highly available configurations.
 3. **Availability**: Configure monitoring to ensure the storage remains available.
 
@@ -430,15 +435,15 @@ mc mb --region=us-east-1 local/wandb-files
 
 ### Public cloud with Terraform
 
-For full infrastructure-plus-application deployment on AWS, Google Cloud, or Azure, see [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud) below.
+For full infrastructure-plus-application deployment on AWS, Google Cloud, or Azure, see [Deploy with Terraform on public cloud](#deploy-with-terraform-on-public-cloud).
 
 ## Deploy with Terraform on public cloud
 
 <Note>
-W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
+W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) deployment types. Fully managed services require little or no configuration.
 </Note>
 
-W&B provides Terraform modules for deploying the platform on public cloud providers. These modules automate the provisioning of infrastructure and installation of W&B Server.
+W&B provides Terraform modules for deploying the platform on public cloud providers. These modules automate the provisioning of infrastructure and installation of W&B Server, so you can stand up a complete environment without manually creating each cloud resource.
 
 Before you start, W&B recommends that you choose one of the [remote backends](https://developer.hashicorp.com/terraform/language/backend) available for Terraform to store the [State File](https://developer.hashicorp.com/terraform/language/state). The State File is the necessary resource to roll out upgrades or make changes in your deployment without recreating all components.
 
@@ -467,9 +472,9 @@ Optional components include:
 - Elastic Cache for Redis
 - SQS
 
-### Pre-requisite permissions
+### Prerequisite permissions
 
-The account that runs Terraform needs to be able to create all components described above and permission to create **IAM Policies** and **IAM Roles** and assign roles to resources.
+The account that runs Terraform must be able to create all components listed in the preceding section and have permission to create **IAM Policies** and **IAM Roles** and assign roles to resources.
 
 ### General steps
 
@@ -477,10 +482,10 @@ The steps in this section are common for any deployment option.
 
 1. Prepare the development environment.
    - Install [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-   - W&B recommend creating a Git repository for version control.
+   - W&B recommends creating a Git repository for version control.
 2. Create the `terraform.tfvars` file.
 
-   The `tvfars` file content can be customized according to the installation type, but the minimum recommended will look like the example below.
+   Customize the `tvfars` file content according to the installation type. The minimum recommended content looks like the following example.
 
    ```bash
    namespace                  = "wandb"
@@ -493,15 +498,15 @@ The steps in this section are common for any deployment option.
    eks_cluster_version        = "1.29"
    ```
 
-   Ensure to define variables in your `tvfars` file before you deploy because the `namespace` variable is a string that prefixes all resources created by Terraform.
+   Define variables in your `tvfars` file before you deploy because the `namespace` variable is a string that prefixes all resources created by Terraform.
 
-   The combination of `subdomain` and `domain` forms the FQDN for your W&B instance. In the example above, the W&B FQDN will be `wandb-aws.wandb.ml` and the DNS `zone_id` where the FQDN record will be created.
+   The combination of `subdomain` and `domain` forms the FQDN for your W&B instance. In the preceding example, the W&B FQDN is `wandb-aws.wandb.ml` and the DNS `zone_id` is where Terraform creates the FQDN record.
 
    Both `allowed_inbound_cidr` and `allowed_inbound_ipv6_cidr` also require setting. In the module, this is a mandatory input. The following example permits access from any source to the W&B installation.
 
-3. Create the file `versions.tf`
+3. Create the file `versions.tf`.
 
-   This file will contain the Terraform and Terraform provider versions required to deploy W&B in AWS:
+   This file contains the Terraform and Terraform provider versions required to deploy W&B in AWS:
 
    ```bash
    provider "aws" {
@@ -520,13 +525,13 @@ The steps in this section are common for any deployment option.
 
    Refer to the [Terraform Official Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#provider-configuration) to configure the AWS provider.
 
-   Optionally, but highly recommended, add the [remote backend configuration](https://developer.hashicorp.com/terraform/language/backend) mentioned at the beginning of this documentation.
+   W&B recommends that you also add the [remote backend configuration](https://developer.hashicorp.com/terraform/language/backend) mentioned at the beginning of this documentation.
 
 4. Create the file `variables.tf`
 
    For every option configured in the `terraform.tfvars` Terraform requires a correspondent variable declaration.
 
-   ```
+   ```hcl
    variable "namespace" {
      type        = string
      description = "Name prefix used for resources"
@@ -579,7 +584,7 @@ This is the most straightforward deployment option configuration that creates al
 
    In the same directory where you created the files in the General Steps, create a file `main.tf` with the following content:
 
-   ```
+   ```hcl
    module "wandb_infra" {
      source  = "wandb/wandb/aws"
      version = "~>7.0"
@@ -636,7 +641,7 @@ This is the most straightforward deployment option configuration that creates al
 
    To deploy W&B, execute the following commands:
 
-   ```
+   ```bash
    terraform init
    terraform apply -var-file=terraform.tfvars
    ```
@@ -645,7 +650,7 @@ This is the most straightforward deployment option configuration that creates al
 
 To use Redis to cache SQL queries and speed up the application response when loading metrics, add the option `create_elasticache_subnet = true` to the `main.tf` file:
 
-```
+```hcl
 module "wandb_infra" {
   source  = "wandb/wandb/aws"
   version = "~>7.0"
@@ -664,10 +669,10 @@ module "wandb_infra" {
 To enable an external message broker using SQS, add the option `use_internal_queue = false` to the `main.tf` file:
 
 <Note>
-This is optional because W&B includes an embedded broker. This option does not bring a performance improvement.
+This is optional because W&B includes an embedded broker. This option doesn't bring a performance improvement.
 </Note>
 
-```
+```hcl
 module "wandb_infra" {
   source  = "wandb/wandb/aws"
   version = "~>7.0"
@@ -694,7 +699,7 @@ module "wandb_infra" {
 
 W&B recommends using the [W&B Server Google Cloud Terraform Module](https://registry.terraform.io/modules/wandb/wandb/google/latest) to deploy the platform on Google Cloud.
 
-The module documentation is extensive and contains all available options that can be used.
+The module documentation lists all available options.
 
 Before you start, W&B recommends that you choose one of the [remote backends](https://developer.hashicorp.com/terraform/language/backend/remote) available for Terraform to store the [State File](https://developer.hashicorp.com/terraform/language/state). The State File is the necessary resource to roll out upgrades or make changes in your deployment without recreating all components.
 
@@ -714,7 +719,7 @@ Optional components include:
 
 ### Prerequisite permissions
 
-The account that will run Terraform needs to have the role `roles/owner` in the Google Cloud project used.
+The account that runs Terraform must have the role `roles/owner` in the Google Cloud project used.
 
 ### General steps
 
@@ -722,12 +727,12 @@ The steps in this section are common for any deployment option.
 
 1. Prepare the development environment.
    - Install [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli).
-   - W&B recommends creating a Git repository with the code that will be used, but you can keep your files locally.
+   - W&B recommends creating a Git repository for your code, but you can keep your files locally.
    - Create a project in [Google Cloud Console](https://console.cloud.google.com/).
-   - Authenticate with Google Cloud (make sure to [install gcloud](https://cloud.google.com/sdk/docs/install) before) using `gcloud auth application-default login`.
+   - Authenticate with Google Cloud (make sure to [install gcloud](https://cloud.google.com/sdk/docs/install) first) using `gcloud auth application-default login`.
 2. Create the `terraform.tfvars` file.
 
-   The `tvfars` file content can be customized according to the installation type, but the minimum recommended will look like the example below.
+   Customize the `tvfars` file content according to the installation type. The minimum recommended content looks like the following example.
 
    ```bash
    project_id  = "wandb-project"
@@ -739,15 +744,15 @@ The steps in this section are common for any deployment option.
    domain_name = "wandb.ml"
    ```
 
-   The variables defined here need to be decided before the deployment. The `namespace` variable will be a string that will prefix all resources created by Terraform.
+   You must decide the values for these variables before deployment. The `namespace` variable is a string that prefixes all resources created by Terraform.
 
-   The combination of `subdomain` and `domain` will form the FQDN that W&B will be configured. In the example above, the W&B FQDN will be `wandb-gcp.wandb.ml`.
+   The combination of `subdomain` and `domain` forms the FQDN that configures W&B. In the preceding example, the W&B FQDN is `wandb-gcp.wandb.ml`.
 
 3. Create the file `variables.tf`.
 
    For every option configured in the `terraform.tfvars` Terraform requires a correspondent variable declaration.
 
-   ```
+   ```hcl
    variable "project_id" {
      type        = string
      description = "Project ID"
@@ -792,7 +797,7 @@ This is the most straightforward deployment option configuration that creates al
 
    In the same directory where you created the files in the General Steps, create a file `main.tf` with the following content:
 
-   ```
+   ```hcl
    provider "google" {
     project = var.project_id
     region  = var.region
@@ -850,7 +855,7 @@ This is the most straightforward deployment option configuration that creates al
 
    To deploy W&B, execute the following commands:
 
-   ```
+   ```bash
    terraform init
    terraform apply -var-file=terraform.tfvars
    ```
@@ -859,7 +864,7 @@ This is the most straightforward deployment option configuration that creates al
 
 To use Redis to cache SQL queries and speed up the application response when loading metrics, add the option `create_redis = true` to the `main.tf` file:
 
-```
+```hcl
 [...]
 
 module "wandb" {
@@ -880,10 +885,10 @@ module "wandb" {
 To enable an external message broker using Pub/Sub, add the option `use_internal_queue = false` to the `main.tf` file:
 
 <Note>
-This is optional because W&B includes an embedded broker. This option does not bring a performance improvement.
+This is optional because W&B includes an embedded broker. This option doesn't bring a performance improvement.
 </Note>
 
-```
+```hcl
 [...]
 
 module "wandb" {
@@ -911,14 +916,14 @@ module "wandb" {
 
 W&B recommends using the [W&B Server Azure Terraform Module](https://registry.terraform.io/modules/wandb/wandb/azurerm/latest) to deploy the platform on Azure.
 
-The module documentation is extensive and contains all available options that can be used.
+The module documentation lists all available options.
 
 The Terraform Module deploys the following mandatory components:
 
 - Azure Resource Group
 - Azure Virtual Network (VPC)
 - Azure MySQL Flexible Server
-- Azure Storage Account & Blob Storage
+- Azure Storage Account and Blob Storage
 - Azure Kubernetes Service
 - Azure Application Gateway
 
@@ -927,11 +932,11 @@ Optional components include:
 - Azure Cache for Redis
 - Azure Event Grid
 
-### Pre-requisite permissions
+### Prerequisite permissions
 
-The simplest way to get the AzureRM provider configured is via [Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli) but in case of automation using [Azure Service Principal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret) can also be useful.
+The simplest way to configure the AzureRM provider is through the [Azure CLI](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli). For automation, you can also use an [Azure Service Principal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret).
 
-Regardless of the authentication method used, the account that will run Terraform needs to be able to create all components described above.
+Regardless of the authentication method used, the account that runs Terraform must be able to create all components listed in the preceding section.
 
 ### General steps
 
@@ -939,11 +944,11 @@ The steps in this section are common for any deployment option.
 
 1. Prepare the development environment.
    - Install [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-   - W&B recommends creating a Git repository with the code that will be used, but you can keep your files locally.
+   - W&B recommends creating a Git repository for your code, but you can keep your files locally.
 
 2. Create the `terraform.tfvars` file.
 
-   The `tvfars` file content can be customized according to the installation type, but the minimum recommended will look like the example below.
+   Customize the `tvfars` file content according to the installation type. The minimum recommended content looks like the following example.
 
    ```bash
     namespace     = "wandb"
@@ -953,13 +958,13 @@ The steps in this section are common for any deployment option.
     location      = "westeurope"
    ```
 
-   The variables defined here need to be decided before the deployment. The `namespace` variable will be a string that will prefix all resources created by Terraform.
+   You must decide the values for these variables before deployment. The `namespace` variable is a string that prefixes all resources created by Terraform.
 
-   The combination of `subdomain` and `domain` will form the FQDN that W&B will be configured. In the example above, the W&B FQDN will be `wandb-azure.wandb.ml`.
+   The combination of `subdomain` and `domain` forms the FQDN that configures W&B. In the preceding example, the W&B FQDN is `wandb-azure.wandb.ml`.
 
-3. Create the file `versions.tf`
+3. Create the file `versions.tf`.
 
-   This file will contain the Terraform and Terraform provider versions required to deploy W&B in Azure:
+   This file contains the Terraform and Terraform provider versions required to deploy W&B in Azure:
 
    ```bash
      terraform {
@@ -976,7 +981,7 @@ The steps in this section are common for any deployment option.
 
    Refer to the [Terraform Official Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs) to configure the Azure provider.
 
-   Optionally, but highly recommended, add the [remote backend configuration](https://developer.hashicorp.com/terraform/language/backend) mentioned at the beginning of this documentation.
+   W&B recommends that you also add the [remote backend configuration](https://developer.hashicorp.com/terraform/language/backend) mentioned at the beginning of this documentation.
 
 4. Create the file `variables.tf`
 
@@ -1070,7 +1075,7 @@ This is the most straightforward deployment option configuration that creates al
 
    To deploy W&B, execute the following commands:
 
-   ```
+   ```bash
    terraform init
    terraform apply -var-file=terraform.tfvars
    ```
@@ -1101,7 +1106,7 @@ module "wandb" {
 To enable an external message broker using Azure Event Grid, add the option `use_internal_queue = false` to the `main.tf` file:
 
 <Note>
-This is optional because W&B includes an embedded broker. This option does not bring a performance improvement.
+This is optional because W&B includes an embedded broker. This option doesn't bring a performance improvement.
 </Note>
 
 ```bash
@@ -1139,15 +1144,16 @@ Refer to the module documentation for your cloud provider for the full list of a
 - [Google Cloud Module documentation](https://registry.terraform.io/modules/wandb/wandb/google/latest)
 - [Azure Module documentation](https://registry.terraform.io/modules/wandb/wandb/azurerm/latest)
 
-## Access the W&B Management Console
-The W&B Kubernetes operator comes with a management console. It is located at `${HOST_URI}/console`, for example `https://wandb.company-name.com/console`.
+## Access the W&B management console
 
-There are two ways to log in to the management console:
+The W&B Kubernetes Operator comes with a management console where you can review deployment status, view component metrics, and adjust operator-level settings. It's available at `${HOST_URI}/console`, for example `https://wandb.company-name.com/console`.
+
+You can log in to the management console in two ways:
 
 <Tabs>
 <Tab title="Option 1 (Recommended)">
 1. Open the W&B application in the browser and log in. Log in to the W&B application with `${HOST_URI}/`, for example `https://wandb.company-name.com/`
-2. Access the console. Click on the icon in the top right corner and then click **System console**. Only users with admin privileges can see the **System console** entry.
+2. Access the console. Click the icon in the top right corner and then click **System console**. Only users with admin privileges can see the **System console** entry.
 
     <Frame>
     <img src="/images/hosting/access_system_console_via_main_app.png" alt="System console access"  />
@@ -1155,10 +1161,10 @@ There are two ways to log in to the management console:
 </Tab>
 <Tab title="Option 2">
 <Note>
-W&B recommends you access the console using the following steps only if Option 1 does not work.
+W&B recommends you access the console using the following steps only if Option 1 doesn't work.
 </Note>
 
-1. Open console application in browser. Open the above described URL, which redirects you to the login screen:
+1. Open the console application in your browser. Open the URL described in the preceding section, which redirects you to the login screen:
     <Frame>
     <img src="/images/hosting/access_system_console_directly.png" alt="Direct system console access"  />
     </Frame>
@@ -1171,34 +1177,37 @@ W&B recommends you access the console using the following steps only if Option 1
 </Tab>
 </Tabs>
 
-## Update the W&B Kubernetes operator
-This section describes how to update the W&B Kubernetes operator. 
+## Update the W&B Kubernetes Operator
+
+This section describes how to update the W&B Kubernetes Operator itself. Update the operator periodically so that you get bug fixes and new reconciliation features.
 
 <Note>
-* Updating the W&B Kubernetes operator does not update the W&B server application.
-* See the instructions [here](#migrate-Self-Managed-instances-to-wb-operator) if you use a Helm chart that does not use the W&B Kubernetes operator before you follow the following instructions to update the W&B operator.
+* Updating the W&B Kubernetes Operator doesn't update the W&B Server application.
+* If you use a Helm chart that doesn't use the W&B Kubernetes Operator, see the [migration instructions](#migrate-self-managed-instances-to-wb-operator) before following the steps in this section to update the W&B Operator.
 </Note>
 
-Copy and paste the code snippets below into your terminal. 
+Copy and paste the following code snippets into your terminal. 
 
-1. First, update the repo with [`helm repo update`](https://helm.sh/docs/helm/helm_repo_update/):
+1. Update the repo with [`helm repo update`](https://helm.sh/docs/helm/helm_repo_update/):
     ```shell
     helm repo update
     ```
 
-2. Next, update the Helm chart with [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/):
+2. Update the Helm chart with [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/):
     ```shell
     helm upgrade operator wandb/operator -n wandb-cr --reuse-values
     ```
 
 ## Update the W&B Server application
-You no longer need to update W&B Server application if you use the W&B Kubernetes operator.
+
+You no longer need to update W&B Server application if you use the W&B Kubernetes Operator.
 
 The operator automatically updates your W&B Server application when a new version of the software of W&B is released.
 
 
-## Migrate Self-Managed instances to W&B Operator
-The following section describes how to migrate from self-managing your own W&B Server installation to using the W&B Operator to do this for you. The migration process depends on how you installed W&B Server:
+## Migrate self-managed instances to W&B Operator
+
+The following section describes how to migrate from self-managing your own W&B Server installation to using the W&B Operator to do this for you. Migrating lets the operator handle reconciliation and W&B Server upgrades automatically, so you no longer have to coordinate manifest changes or Helm upgrades for the application. The migration process depends on how you installed W&B Server:
 
 <Note>
 The W&B Operator is the default and recommended installation method for W&B Server. Reach out to [Customer Support](mailto:support@wandb.com) or your W&B team if you have any questions.
@@ -1208,33 +1217,33 @@ The W&B Operator is the default and recommended installation method for W&B Serv
   - [AWS](#migrate-to-operator-based-aws-terraform-modules)
   - [Google Cloud](#migrate-to-operator-based-google-cloud-terraform-modules)
   - [Azure](#migrate-to-operator-based-azure-terraform-modules)
-- If you used the [W&B Non-Operator Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/wandb),  continue [here](#migrate-to-operator-based-helm-chart).
-- If you used the [W&B Non-Operator Helm chart with Terraform](https://registry.terraform.io/modules/wandb/wandb/kubernetes/latest),  continue [here](#migrate-to-operator-based-terraform-helm-chart).
-- If you created the Kubernetes resources with manifests,  continue [here](#migrate-to-operator-based-helm-chart).
+- If you used the [W&B Non-Operator Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/wandb), see [Migrate to operator-based Helm chart](#migrate-to-operator-based-helm-chart).
+- If you used the [W&B Non-Operator Helm chart with Terraform](https://registry.terraform.io/modules/wandb/wandb/kubernetes/latest), see [Migrate to operator-based Terraform Helm chart](#migrate-to-operator-based-terraform-helm-chart).
+- If you created the Kubernetes resources with manifests, see [Migrate to operator-based Helm chart](#migrate-to-operator-based-helm-chart).
 
 
-### Migrate to Operator-based AWS Terraform Modules
+### Migrate to operator-based AWS Terraform modules
 
-For a detailed description of the migration process,  continue [here](https://github.com/wandb/helm-charts/tree/main/charts/operator-wandb).
+For a detailed description of the migration process, see the [operator-wandb chart documentation](https://github.com/wandb/helm-charts/tree/main/charts/operator-wandb).
 
-### Migrate to Operator-based Google Cloud Terraform Modules
-
-Reach out to [Customer Support](mailto:support@wandb.com) or your W&B team if you have any questions or need assistance.
-
-
-### Migrate to Operator-based Azure Terraform Modules
+### Migrate to operator-based Google Cloud Terraform modules
 
 Reach out to [Customer Support](mailto:support@wandb.com) or your W&B team if you have any questions or need assistance.
 
-### Migrate to Operator-based Helm chart
 
-Follow these steps to migrate to the Operator-based Helm chart:
+### Migrate to operator-based Azure Terraform modules
 
-1. Get the current W&B configuration. If W&B was deployed with an non-operator-based version of the Helm chart,  export the values like this:
+Reach out to [Customer Support](mailto:support@wandb.com) or your W&B team if you have any questions or need assistance.
+
+### Migrate to operator-based Helm chart
+
+Follow these steps to migrate to the operator-based Helm chart:
+
+1. Get the current W&B configuration. If you deployed W&B with a non-operator-based version of the Helm chart, export the values like this:
     ```shell
     helm get values wandb
     ```
-    If W&B was deployed with Kubernetes manifests,  export the values like this:
+    If you deployed W&B with Kubernetes manifests, export the values like this:
     ```shell
     kubectl get deployment wandb -o yaml
     ```
@@ -1242,7 +1251,7 @@ Follow these steps to migrate to the Operator-based Helm chart:
 
 2. Create a file called `operator.yaml`. Follow the format described in the [Configuration Reference](#configuration-reference-for-wb-operator). Use the values from step 1.
 
-3. Scale the current deployment to 0 pods. This step is stops the current deployment.
+3. Scale the current deployment to 0 pods. This step stops the current deployment.
     ```shell
     kubectl scale --replicas=0 deployment wandb
     ```
@@ -1254,7 +1263,7 @@ Follow these steps to migrate to the Operator-based Helm chart:
     ```shell
     helm upgrade --install operator wandb/operator -n wandb-cr --create-namespace
     ```
-6. Configure the new helm chart and trigger W&B application deployment. Apply the new configuration.
+6. Configure the new Helm chart and trigger W&B application deployment. Apply the new configuration.
     ```shell
     kubectl apply -f operator.yaml
     ```
@@ -1262,27 +1271,30 @@ Follow these steps to migrate to the Operator-based Helm chart:
 
 7. Verify the installation. Make sure that everything works by following the steps in [Verify the installation](#verify-the-installation).
 
-8. Remove to old installation. Uninstall the old helm chart or delete the resources that were created with manifests.
+8. Remove the old installation. Uninstall the old Helm chart or delete the resources that you created with manifests.
 
-### Migrate to Operator-based Terraform Helm chart
+### Migrate to operator-based Terraform Helm chart
 
-Follow these steps to migrate to the Operator-based Helm chart:
+Follow these steps to migrate to the operator-based Helm chart:
 
 
-1. Prepare Terraform config. Replace the Terraform code from the old deployment in your Terraform config with the one that is described [here](#deploy-wb-with-helm-terraform-module). Set the same variables as before. Do not change .tfvars file if you have one.
-2. Execute Terraform run. Execute terraform init, plan and apply
+1. Prepare Terraform config. Replace the Terraform code from the old deployment in your Terraform config with the code described in [Deploy W&B with Helm Terraform module](#deploy-wb-with-helm-terraform-module). Set the same variables as before. Do not change the `.tfvars` file if you have one.
+2. Execute Terraform run. Execute `terraform init`, `terraform plan`, and `terraform apply`.
 3. Verify the installation. Make sure that everything works by following the steps in [Verify the installation](#verify-the-installation).
-4. Remove to old installation. Uninstall the old helm chart or delete the resources that were created with manifests.
+4. Remove the old installation. Uninstall the old Helm chart or delete the resources that you created with manifests.
 
 
 
-## Configuration Reference for W&B Server
+## Configuration reference for W&B Server
 
-This section describes the configuration options for W&B Server application. The application receives its configuration as custom resource definition named [WeightsAndBiases](#how-it-works). Some configuration options are exposed with the below configuration, some need to be set as environment variables.
+This section is a reference for the configuration options that you set in your `WeightsAndBiases` custom resource. Use it to look up the YAML schema for a specific subsystem (for example, MySQL, Redis, ingress, or OIDC) as you build or update your `operator.yaml` file.
 
-The documentation has two lists of environment variables: [basic](/platform/hosting/env-vars/) and [advanced](/platform/hosting/iam/advanced_env_vars/). Only use environment variables if the configuration option that you need is not exposed using the Helm Chart.
+This section describes the configuration options for W&B Server application. The application receives its configuration as custom resource definition named [WeightsAndBiases](#how-it-works). Some configuration options are exposed with the following configuration. You must set others as environment variables.
+
+The documentation has two lists of environment variables: [basic](/platform/hosting/env-vars/) and [advanced](/platform/hosting/iam/advanced_env_vars/). Only use environment variables if the configuration option that you need is not exposed using the Helm chart.
 
 ### Basic example
+
 This example defines the minimum set of values required for W&B. For a more realistic production example, see [Complete example](#complete-example).
 
 This YAML file defines the desired state of your W&B deployment, including the version, environment variables, external resources like databases, and other necessary settings.
@@ -1312,7 +1324,8 @@ spec:
 
 Find the full set of values in the [W&B Helm repository](https://github.com/wandb/helm-charts/blob/main/charts/operator-wandb/values.yaml). **Change only those values you need to override**.
 
-### Complete example 
+### Complete example
+
 This example configuration deploys W&B to Google Cloud Anthos using Google Cloud Storage:
 
 ```yaml
@@ -1472,7 +1485,7 @@ global:
 
 ### Ingress
 
-To identify the ingress class,  see this FAQ [entry](#how-to-identify-the-kubernetes-ingress-class).
+See [How to identify the Kubernetes ingress class](#how-to-identify-the-kubernetes-ingress-class).
 
 **Without TLS**
 
@@ -1507,15 +1520,15 @@ ingress:
         - <HOST_URI>
 ```
 
-In case of Nginx you might have to add the following annotation:
+For Nginx, you might have to add the following annotation:
 
-```
+```yaml
 ingress:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 0
 ```
 
-### Custom Kubernetes ServiceAccounts
+### Custom Kubernetes service accounts
 
 Specify custom Kubernetes service accounts to run the W&B pods. 
 
@@ -1609,7 +1622,7 @@ To reference the `password` from a secret:
 kubectl create secret generic redis-secret --from-literal=redis-password=supersecret
 ```
 
-Reference it in below configuration:
+Reference it in the following configuration:
 ```yaml
 redis:
   install: false
@@ -1682,7 +1695,7 @@ To create the config map you can use the following command:
 kubectl create configmap ldap-tls-cert --from-file=certificate.crt
 ```
 
-And use the config map in the YAML like the example below
+And use the config map in the YAML like the following example.
 
 ```yaml
 global:
@@ -1848,18 +1861,18 @@ app:
       allowPrivilegeEscalation: false 
 ```
 
-The same concept applies to `console`, `weave`, `weave-trace` and `parquet`.
+The same concept applies to `console`, `weave`, `weave-trace`, and `parquet`.
 
 ## Configuration reference for W&B Operator
 
-This section describes configuration options for W&B Kubernetes operator (`wandb-controller-manager`). The operator receives its configuration in the form of a YAML file. 
+This section describes configuration options for W&B Kubernetes Operator (`wandb-controller-manager`). The operator receives its configuration in the form of a YAML file. 
 
-By default, the W&B Kubernetes operator does not need a configuration file. Create a configuration file if required. For example, you might need a configuration file to specify custom certificate authorities, deploy in an air gap environment and so forth. 
+By default, the W&B Kubernetes Operator doesn't need a configuration file. Create a configuration file if required. For example, you might need a configuration file to specify custom certificate authorities, deploy in an air gap environment, and so forth. 
 
 Find the full list of spec customization [in the Helm repository](https://github.com/wandb/helm-charts/blob/main/charts/operator/values.yaml).
 
 ### Custom CA
-A custom certificate authority (`customCACerts`), is a list and can take many certificates. Those certificate authorities when added only apply to the W&B Kubernetes operator (`wandb-controller-manager`). 
+A custom certificate authority (`customCACerts`) is a list and can take many certificates. Those certificate authorities, when added, only apply to the W&B Kubernetes Operator (`wandb-controller-manager`). 
 
 ```yaml
 customCACerts:
@@ -1909,17 +1922,21 @@ Each key in the ConfigMap must end with `.crt` (for example, `my-cert.crt` or `c
 
 ## FAQ
 
-### What is the purpose/role of each individual pod?
-* **`wandb-app`**: the core of W&B, including the GraphQL API and frontend application. It powers most of our platform's functionality.
-* **`wandb-console`**: the administration console, accessed via `/console`. 
+### Purpose and role of each pod
+
+A W&B Server deployment includes the following pods:
+
+* **`wandb-app`**: the core of W&B, including the GraphQL API and frontend application. It powers most of the W&B platform's functionality.
+* **`wandb-console`**: the administration console, accessed through `/console`. 
 * **`wandb-otel`**: the OpenTelemetry agent, which collects metrics and logs from resources at the Kubernetes layer for display in the administration console.
 * **`wandb-prometheus`**: the Prometheus server, which captures metrics from various components for display in the administration console.
 * **`wandb-parquet`**: a backend microservice separate from the `wandb-app` pod that exports database data to object storage in Parquet format.
 * **`wandb-weave`**: another backend microservice that loads query tables in the UI and supports various core app features.
-* **`wandb-weave-trace`**: a framework for tracking, experimenting with, evaluating, deploying, and improving LLM-based applications. The framework is accessed via the `wandb-app` pod.
+* **`wandb-weave-trace`**: a framework for tracking, experimenting with, evaluating, deploying, and improving LLM-based applications. The framework is accessed through the `wandb-app` pod.
 
-### How to get the  W&B Operator Console password
-See [Accessing the W&B Kubernetes Operator Management Console](#access-the-wb-management-console).
+### How to get the W&B Operator Console password
+
+See [Access the W&B management console](#access-the-wb-management-console).
 
 
 ### How to access the W&B Operator Console if Ingress doesn't work
@@ -1932,7 +1949,7 @@ kubectl port-forward svc/wandb-console 8082
 
 Access the console in the browser with `https://localhost:8082/` console.
 
-See [Accessing the W&B Kubernetes Operator Management Console](#access-the-wb-management-console) on how to get the password (Option 2).
+For how to get the password (Option 2), see [Access the W&B management console](#access-the-wb-management-console).
 
 ### How to view W&B Server logs
 

--- a/platform/hosting/self-managed/rate-limits.mdx
+++ b/platform/hosting/self-managed/rate-limits.mdx
@@ -4,10 +4,10 @@ description: Optional rate limits on Self-Managed instances for stability
 ---
 import RateLimitsDefaultsAndNotification from "/snippets/_includes/rate-limits-defaults-and-notification.mdx";
 
-You can configure rate limits on your W&B Self-Managed instance to maintain stability and prevent one user or workload from negatively impacting others. These limits are optional. If you do not set them, the instance does not enforce the limits described below.
+You can configure rate limits on your W&B Self-Managed instance to maintain stability and prevent one user or workload from affecting others. These limits are optional. If you don't set them, the instance doesn't enforce any limits.
 
 ## Default limits and notification
 
 <RateLimitsDefaultsAndNotification />
 
-These defaults are recommended for typical production workloads. If your workloads consistently exceed these limits, you can configure these limits (or leave them unset) according to your instance size and shared usage. For configuration details, refer to [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator) or contact [W&B support](mailto:support@wandb.com).
+W&B recommends these defaults for typical production workloads. If your workloads consistently exceed these limits, you can adjust them (or leave them unset) according to your instance size and shared usage. For configuration details, see [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator) or contact [W&B support](mailto:support@wandb.com).

--- a/platform/hosting/self-managed/ref-arch.mdx
+++ b/platform/hosting/self-managed/ref-arch.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference Architecture
+title: Reference architecture
 description: "Review the reference architecture for self-managed W&B deployments covering Kubernetes, MySQL, object storage, and networking."
 ---
 
@@ -7,25 +7,29 @@ import SelfManagedVersionRequirements from "/snippets/_includes/self-managed-ver
 import SelfManagedNetworkingRequirements from "/snippets/_includes/self-managed-networking-requirements.mdx";
 import SelfManagedSslTlsRequirements from "/snippets/_includes/self-managed-ssl-tls-requirements.mdx";
 
-This page describes a reference architecture for a W&B deployment and outlines the recommended infrastructure and resources to support a production deployment of the platform.
+This page describes a reference architecture for a W&B deployment and outlines the recommended infrastructure and resources to support a production deployment of the platform. Use it as a planning guide to size, provision, and integrate the components required for a reliable Self-Managed installation.
 
-Depending on your chosen deployment environment for W&B, various services can help to enhance the resiliency of your deployment.
+This page is intended for platform engineers, site reliability engineers, and infrastructure administrators who deploy and operate W&B on their own infrastructure.
 
-For instance, major cloud providers offer robust managed database services which help to reduce the complexity of database configuration, maintenance, high availability, and resilience.
+Depending on your chosen deployment environment for W&B, different services can help to enhance the resiliency of your deployment.
 
-This reference architecture addresses some common deployment scenarios and shows how you can integrate your W&B deployment with cloud vendor services for optimal performance and reliability.
+For instance, major cloud providers offer managed database services that help to reduce the complexity of database configuration, maintenance, high availability, and resilience.
+
+This reference architecture addresses common deployment scenarios and shows how you can integrate your W&B deployment with cloud vendor services for performance and reliability.
 
 ## Before you start
 
-Running any application in production comes with its own set of challenges, and W&B is no exception. While we aim to streamline the process, certain complexities may arise depending on your unique architecture and design decisions. Typically, managing a production deployment involves overseeing various components, including hardware, operating systems, networking, storage, security, the W&B platform itself, and other dependencies. This responsibility extends to both the initial setup of the environment and its ongoing maintenance.
+Running any application in production comes with its own set of challenges, and W&B is no exception. Although W&B aims to streamline the process, complexities may arise depending on your architecture and design decisions. Typically, managing a production deployment involves overseeing components including hardware, operating systems, networking, storage, security, the W&B platform itself, and other dependencies. This responsibility extends to both the initial setup of the environment and its ongoing maintenance.
 
-Consider carefully whether a Self-Managed approach with W&B is suitable for your team and specific requirements.
+Consider carefully whether a Self-Managed approach with W&B is suitable for your team and your requirements.
 
-A strong understanding of how to run and maintain production-grade application is an important prerequisite before you deploy Self-Managed W&B. If your team needs assistance, our Professional Services team and partners offer support for implementation and optimization.
+A strong understanding of how to run and maintain production-grade application is an important prerequisite before you deploy Self-Managed W&B. If your team needs assistance, the W&B Professional Services team and partners offer support for implementation and optimization.
 
 To learn more about managed solutions for running W&B instead of managing it yourself, refer to [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) and [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud).
 
 ## Infrastructure
+
+A W&B deployment consists of an application layer and a storage layer. The following diagram shows how these layers fit together, and the subsections that follow describe each one.
 
 <Frame>
     <img src="/images/hosting/reference_architecture.png" alt="W&B infrastructure diagram"  />
@@ -33,7 +37,7 @@ To learn more about managed solutions for running W&B instead of managing it you
 
 ### Application layer
 
-The application layer consists of a multi-node Kubernetes cluster, with resilience against node failures. The Kubernetes cluster runs and maintains W&B's pods.
+The application layer consists of a multi-node Kubernetes cluster, with resilience against node failures. The Kubernetes cluster runs and maintains the W&B pods.
 
 ### Storage layer
 
@@ -41,32 +45,35 @@ The storage layer consists of a MySQL database and object storage. The MySQL dat
 
 ## Infrastructure requirements
 
-The following sections detail requirements for various aspects of a W&B deployment, including Kubernetes cluster details, MySQL, Redis, object storage, software versions, networking, DNS, load balancer and ingress, SSL/TLS, and supported CPU architectures.
+The following sections detail requirements for a W&B deployment, including Kubernetes cluster details, MySQL, Redis, object storage, software versions, networking, DNS, load balancer and ingress, SSL/TLS, and supported CPU architectures. Confirm that your environment meets each of these requirements before you begin a deployment.
 
 ### Kubernetes
-The W&B Server application is deployed as a [Kubernetes Operator](/platform/hosting/self-managed/operator) that deploys multiple pods. For this reason, W&B requires a Kubernetes cluster with:
-- A fully configured and functioning Ingress controller.
+
+W&B deploys the W&B Server application as a [Kubernetes Operator](/platform/hosting/self-managed/operator) that deploys multiple pods. For this reason, W&B requires a Kubernetes cluster with:
+
+- A fully configured and functioning ingress controller.
 - The capability to provision Persistent Volumes.
 
 W&B supports deployment on [OpenShift Kubernetes clusters](https://www.redhat.com/en/technologies/cloud-computing/openshift) in cloud, on-premises, and air-gapped environments. For specific configuration instructions, see the [OpenShift section](/platform/hosting/self-managed/operator#openshift-kubernetes-clusters) in the Operator guide.
 
 ### MySQL
+
 W&B stores metadata in a MySQL database. The database's performance and storage requirements depend on the shapes of the model parameters and related metadata. For example, the database grows in size as you track more training runs, and load on the database increases based on queries in run tables, user workspaces, and reports.
 
-**W&B strongly recommends using managed database services** (such as AWS RDS Aurora MySQL, Google Cloud SQL for MySQL, or Azure Database for MySQL) for production deployments. Managed services provide automated backups, monitoring, high availability, patching, and significantly reduce operational complexity. See the [Cloud provider instance recommendations](#cloud-provider-instance-recommendations) section below for specific service recommendations.
+**W&B strongly recommends using managed database services** (such as AWS RDS Aurora MySQL, Google Cloud SQL for MySQL, or Azure Database for MySQL) for production deployments. Managed services provide automated backups, monitoring, high availability, and patching, and reduce operational complexity. See the [Cloud provider instance recommendations](#cloud-provider-instance-recommendations) section for specific service recommendations.
 
 If you choose to deploy a self-managed MySQL database, consider the following:
 
-- **Backups**: You should periodically back up the database to a separate facility. W&B recommends daily backups with at least 1 week of retention.
+- **Backups**: Periodically back up the database to a separate facility. W&B recommends daily backups with at least 1 week of retention.
 - **Performance**: The database requires fast storage hardware, such as SSD or accelerated NAS.
 - **Monitoring**: The database requires adequate CPU resources. Monitor the database server's CPU load. If CPU usage is sustained at > 90% of the system for more than 5 minutes, consider adding CPU capacity.
-- **Availability**: To meet your availability and durability requirements, W&B recommends configuring a hot standby deployment on a separate machine that streams all updates in realtime from the primary deployment, and is ready to fail over if the primary server crashes, becomes corrupted, or experiences sustained downtime.
+- **Availability**: To meet your availability and durability requirements, W&B recommends configuring a hot standby deployment on a separate machine. The standby streams all updates in real time from the primary deployment and is ready to fail over if the primary server crashes, becomes corrupted, or experiences sustained downtime.
 
 #### MySQL topology
 
-For production, a managed MySQL service is the simplest path to high availability because the cloud provider handles failover, backups, and patching. Use the provider's high availability option, for example Aurora Multi-AZ on AWS.
+For production, a managed MySQL service is the simplest path to high availability because the cloud provider handles failover, backups, and patching. Use the provider's high availability option, for example, Aurora Multi-AZ on AWS.
 
-If you run self-managed MySQL, use a primary database with a hot standby that receives a realtime replication stream and can take over on failure. W&B does not support a multi-master topology or read-only replicas for the application database.
+If you run self-managed MySQL, use a primary database with a hot standby that receives a real-time replication stream and can take over on failure. W&B doesn't support a multi-primary topology or read-only replicas for the application database.
 
 #### MySQL database creation
 
@@ -74,9 +81,9 @@ For instructions to manually create the MySQL database and user, see the [bare-m
 
 #### MySQL configuration parameters
 
-If you are running your own MySQL instance, configure MySQL with these settings:
+These parameters tune MySQL for the write patterns and schema changes that W&B performs at scale. If you're running your own MySQL instance, configure MySQL with these settings:
 
-```
+```ini
 binlog_format = 'ROW'
 binlog_row_image = 'MINIMAL'
 innodb_flush_log_at_trx_commit = 1
@@ -86,28 +93,31 @@ sort_buffer_size = '67108864'
 sync_binlog = 1
 ```
 
-These settings have been validated by W&B for optimal performance and reliability.
+W&B has validated these settings for performance and reliability.
 
 ### Redis
-W&B depends on a single-node Redis 7.x deployment used by W&B's components for job queuing and data caching. For convenience during testing and development of proofs of concept, W&B Self-Managed includes a local Redis deployment that is not appropriate for production deployments.
+
+W&B depends on a single-node Redis 7.x deployment that W&B components use for job queuing and data caching. For convenience during testing and development of proofs of concept, W&B Self-Managed includes a local Redis deployment that isn't appropriate for production deployments.
 
 W&B can connect to a Redis instance in the following environments:
 
-- [AWS Elasticache](https://aws.amazon.com/elasticache/)
-- [Google Cloud Memory Store](https://cloud.google.com/memorystore?hl=en)
-- [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache)
-- Redis deployment hosted in your cloud or on-premise infrastructure
+- [AWS Elasticache](https://aws.amazon.com/elasticache/).
+- [Google Cloud Memory Store](https://cloud.google.com/memorystore?hl=en).
+- [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache).
+- Redis deployment hosted in your cloud or on-premises infrastructure.
 
 ### Object storage
+
 W&B requires object storage with pre-signed URL and CORS support, deployed in one of:
 
-- [CoreWeave AI Object Storage](https://docs.coreweave.com/products/storage/object-storage) is a high-performance, S3-compatible object storage service optimized for AI workloads.
-- [Amazon S3](https://aws.amazon.com/s3/) is an object storage service offering industry-leading scalability, data availability, security, and performance.
+- [CoreWeave AI Object Storage](https://docs.coreweave.com/products/storage/object-storage) is an S3-compatible object storage service optimized for AI workloads.
+- [Amazon S3](https://aws.amazon.com/s3/) is an object storage service that provides scalability, data availability, security, and performance.
 - [Google Cloud Storage](https://cloud.google.com/storage) is a managed service for storing unstructured data at scale.
-- [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) is a cloud-based object storage solution for storing massive amounts of unstructured data like text, binary data, images, videos, and logs.
+- [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs) is a cloud-based object storage solution for storing unstructured data like text, binary data, images, videos, and logs.
 - S3-compatible storage such as [MinIO Enterprise (AIStor)](https://www.min.io/product/aistor), [NetApp StorageGRID](https://www.netapp.com/data-storage/storagegrid/), or other enterprise-grade solutions hosted in your cloud or on-premises infrastructure.
 
 ### Versions
+
 <SelfManagedVersionRequirements/>
 
 ### Networking
@@ -115,7 +125,8 @@ W&B requires object storage with pre-signed URL and CORS support, deployed in on
 <SelfManagedNetworkingRequirements/>
 
 ### DNS
-The fully qualified domain name (FQDN) of the W&B deployment must resolve to the IP address of the ingress/load balancer using an A record.
+
+The fully qualified domain name (FQDN) of the W&B deployment must resolve to the IP address of the ingress or load balancer using an `A` record.
 
 ### Load balancer and ingress
 
@@ -124,14 +135,15 @@ The W&B Kubernetes Operator can expose services using a Kubernetes ingress contr
 #### Ingress controller requirements
 
 Your Kubernetes cluster must have an `IngressClass` available. Common ingress controller options include:
-- [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
-- [Istio](https://istio.io)
-- [Traefik](https://traefik.io/)
-- Cloud provider ingress controllers (AWS ALB, GCP Ingress, Azure Application Gateway)
+
+- [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/).
+- [Istio](https://istio.io).
+- [Traefik](https://traefik.io/).
+- Cloud provider ingress controllers (AWS ALB, GCP Ingress, and Azure Application Gateway).
 
 #### W&B service routing
 
-The W&B Operator automatically routes requests to multiple backend services based on path:
+The W&B Operator routes requests automatically to multiple backend services based on path:
 
 | Path | Service | Default port | Purpose |
 |------|---------|------|---------|
@@ -202,34 +214,45 @@ spec:
 ```
 
 <Note>
-The W&B Operator creates and manages the ingress configuration automatically. You typically do not need to create ingress resources manually. Ensure your cluster has a functioning ingress controller and the appropriate `IngressClass` configured.
+The W&B Operator creates and manages the ingress configuration automatically. You typically don't need to create ingress resources manually. Make sure your cluster has a functioning ingress controller and the appropriate `IngressClass` configured.
 </Note>
 
 ### SSL/TLS
+
 <SelfManagedSslTlsRequirements/>
 
 ### Supported CPU architectures
-W&B runs on Intel and AMD 64-bit architecture. ARM is not supported.
+
+W&B runs on Intel and AMD 64-bit architecture. ARM isn't supported.
 
 ## Deployment method
 
-### Recommended: W&B Kubernetes Operator with Helm
-The recommended installation method for W&B Self-Managed is using the **W&B Kubernetes Operator**, deployed via Helm. This approach provides:
-- Automated updates and management of W&B components
-- Simplified configuration and deployment
-- Support for all deployment scenarios (cloud, on-premises, air-gapped)
+After your infrastructure meets the preceding requirements, choose how to install W&B and provision the underlying resources. The following sections describe the recommended deployment method and the recommended approach for infrastructure provisioning.
+
+### W&B Kubernetes Operator with Helm
+
+The recommended installation method for W&B Self-Managed uses the **W&B Kubernetes Operator**, deployed through Helm. This approach provides:
+
+- Automated updates and management of W&B components.
+- Simplified configuration and deployment.
+- Support for all deployment scenarios (cloud, on-premises, and air-gapped).
 
 For detailed installation instructions, see:
-- [Deploy W&B Platform On-premises](/platform/hosting/self-managed/operator) - Primary installation guide
-- [Kubernetes operator for air-gapped instances](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped) - For disconnected environments
+
+- [Deploy W&B Platform On-premises](/platform/hosting/self-managed/operator) - Primary installation guide.
+- [Kubernetes operator for air-gapped instances](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped) - For disconnected environments.
 
 ### Infrastructure provisioning
-Terraform is the recommended way to provision infrastructure for W&B production deployments. Using Terraform, you define the required resources, their references to other resources, and their dependencies. W&B provides Terraform modules for the major cloud providers. For details, refer to [Deploy W&B Server within Self-Managed cloud accounts](/platform/hosting/hosting-options/self-managed#deploy-wb-server-within-Self-Managed-cloud-accounts).
+
+Terraform is the recommended way to provision infrastructure for W&B production deployments. With Terraform, you define the required resources, their references to other resources, and their dependencies. W&B provides Terraform modules for the major cloud providers. For details, refer to [Deploy W&B Server within Self-Managed cloud accounts](/platform/hosting/hosting-options/self-managed#deploy-wb-server-within-Self-Managed-cloud-accounts).
 
 ## Sizing
-Use the following general guidelines as a starting point when planning a deployment. W&B recommends that you monitor all components of a new deployment closely and that you make adjustments based on observed usage patterns. Continue to monitor production deployments over time and make adjustments as needed to maintain optimal performance.
 
-When you plan capacity, you size two core components: a Kubernetes cluster for the W&B Operator workload and a MySQL database for metadata. Recommendations vary by **environment** (Test/Dev or Production) and, for Kubernetes only, by **product mix** (Models only, Weave only, or Models and Weave). W&B recommends starting with a minimum of 3 worker nodes for both Test/Dev and Production, with cluster autoscaling enabled in Production.
+Use the following guidelines as a starting point when planning a deployment. W&B recommends that you monitor all components of a deployment closely and that you make adjustments based on observed usage patterns. Continue to monitor production deployments over time and make adjustments as needed to maintain performance.
+
+When you plan capacity, you size two core components: a Kubernetes cluster for the W&B Operator workload and a MySQL database for metadata. Recommendations vary by **environment** (Test/Dev or Production) and, for Kubernetes only, by **product mix** (Models only, Weave only, or Models and Weave). W&B recommends starting with a minimum of 3 worker nodes for both Test/Dev and Production, and enabling cluster autoscaling in Production.
+
+The following sections give per-node sizing recommendations for the Kubernetes cluster and the MySQL database.
 
 ### Kubernetes sizing
 
@@ -268,7 +291,7 @@ Numbers are per Kubernetes worker node.
 
 ### MySQL sizing
 
-These recommendations do not vary by product mix. For topology and availability guidance, see [MySQL topology](#mysql-topology) under [MySQL](#mysql).
+These recommendations don't vary by product mix. For topology and availability guidance, see [MySQL topology](#mysql-topology) under [MySQL](#mysql).
 
 | Environment      | CPU                | Memory             | Disk               |
 | ---------------- | ------------------ | ------------------ | ------------------ |
@@ -279,7 +302,7 @@ Numbers are per MySQL node.
 
 ## Cloud provider instance recommendations
 
-These recommendations apply to each node of a Self-Managed deployment of W&B in cloud infrastructure.
+After you determine the per-node CPU, memory, and disk requirements from the preceding sizing tables, use the following recommendations to pick specific cloud provider instance types and managed services that meet those requirements. These recommendations apply to each node of a Self-Managed deployment of W&B in cloud infrastructure.
 
 <Tabs>
 <Tab title="AWS">

--- a/platform/hosting/self-managed/requirements.mdx
+++ b/platform/hosting/self-managed/requirements.mdx
@@ -14,10 +14,10 @@ import SelfManagedNetworkingRequirements from "/snippets/_includes/self-managed-
 import SelfManagedSslTlsRequirements from "/snippets/_includes/self-managed-ssl-tls-requirements.mdx";
 import SelfManagedObtainLicense from "/snippets/_includes/self-managed-obtain-license.mdx";
 
-This page provides a comprehensive overview of the infrastructure and software requirements for deploying W&B Self-Managed. Review these requirements before beginning your deployment.
+This page describes the infrastructure and software requirements for deploying W&B Self-Managed. It's intended for platform and infrastructure engineers planning a Self-Managed installation. Review these requirements before you begin your deployment to confirm that your environment can support W&B Server.
 
 <Note>
-W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) deployment types. W&B fully managed services are simple and secure to use, with minimum to no configuration required.
+W&B recommends fully managed deployment options such as [W&B Multi-tenant Cloud](/platform/hosting/hosting-options/multi_tenant_cloud) or [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) deployment types. W&B fully managed services are straightforward and secure to use, and require minimal to no configuration.
 </Note>
 
 For complete architectural guidance, see the [reference architecture](/platform/hosting/self-managed/ref-arch/).
@@ -34,12 +34,12 @@ For detailed sizing recommendations based on your use case (Models only, Weave o
 
 ## Kubernetes
 
-W&B Server is deployed as a [Kubernetes Operator](/platform/hosting/self-managed/operator/) that manages multiple pods. Your Kubernetes cluster must meet these requirements:
+W&B Server is deployed as a [Kubernetes Operator](/platform/hosting/self-managed/operator/) that manages multiple pods. Your Kubernetes cluster must meet the following requirements:
 
-- **Version**: See [Software version requirements](#software-version-requirements) above
-- **Ingress controller**: A fully-configured and functioning ingress controller (Nginx, Istio, Traefik, or cloud provider ingress)
-- **Persistent volumes**: Capability to provision persistent volumes
-- **CPU architecture**: Intel or AMD 64-bit (ARM is not supported)
+- **Version**: See the preceding [Software version requirements](#software-version-requirements) section.
+- **Ingress controller**: A fully configured and functioning ingress controller (Nginx, Istio, Traefik, or cloud provider ingress).
+- **Persistent volumes**: Capability to provision persistent volumes.
+- **CPU architecture**: Intel or AMD 64-bit (ARM is not supported).
 
 W&B supports deployment on [OpenShift Kubernetes clusters](https://www.redhat.com/en/technologies/cloud-computing/openshift) in cloud, on-premises, and air-gapped environments. For specific configuration instructions, see the [OpenShift section](/platform/hosting/self-managed/operator/#openshift-kubernetes-clusters) in the Operator guide.
 
@@ -49,13 +49,13 @@ For complete Kubernetes requirements, including load balancer and ingress config
 
 <SelfManagedMysqlRequirements/>
 
-**W&B strongly recommends using managed database services** such as AWS RDS Aurora MySQL, Google Cloud SQL for MySQL, or Azure Database for MySQL for production deployments. Managed services provide automated backups, monitoring, high availability, patching, and significantly reduce operational complexity.
+W&B recommends using managed database services such as AWS RDS Aurora MySQL, Google Cloud SQL for MySQL, or Azure Database for MySQL for production deployments. Managed services provide automated backups, monitoring, high availability, and patching, and they reduce operational complexity.
 
 ### MySQL configuration parameters
 
-If you are running your own MySQL instance, configure MySQL with these settings:
+If you're running your own MySQL instance, configure MySQL with the following settings for compatibility with W&B Server:
 
-```
+```ini
 binlog_format = 'ROW'
 binlog_row_image = 'MINIMAL'
 innodb_flush_log_at_trx_commit = 1
@@ -65,11 +65,11 @@ sort_buffer_size = '67108864'
 sync_binlog = 1
 ```
 
-These settings have been validated by W&B for optimal performance and reliability.
+W&B has validated these settings for performance and reliability.
 
 ### Database creation
 
-For instructions to manually create the MySQL database and user:
+If you aren't using a managed MySQL service that provisions the database automatically, follow these instructions to manually create the MySQL database and user that W&B Server uses:
 
 <SelfManagedMysqlDatabaseCreation/>
 
@@ -77,16 +77,20 @@ For additional considerations, including backups, performance, monitoring, and a
 
 ## Redis
 
+W&B Server uses Redis for caching and background job coordination.
+
 <SelfManagedRedisRequirements/>
 
-W&B can connect to a Redis instance in the following environments:
+W&B can connect to a Redis instance in any of the following environments:
 
-- [AWS Elasticache](https://aws.amazon.com/pm/elasticache/)
-- [Google Cloud Memory Store](https://cloud.google.com/memorystore?hl=en)
-- [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache)
-- Redis deployment hosted in your cloud or on-premises infrastructure
+- [AWS Elasticache](https://aws.amazon.com/pm/elasticache/).
+- [Google Cloud Memory Store](https://cloud.google.com/memorystore?hl=en).
+- [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache).
+- Redis deployment hosted in your cloud or on-premises infrastructure.
 
 ## Object storage
+
+W&B Server requires an object storage bucket to store artifacts, media, and run data.
 
 <SelfManagedObjectStorageRequirements/>
 
@@ -94,19 +98,21 @@ W&B can connect to a Redis instance in the following environments:
 
 ### Configure W&B to use your bucket
 
-After provisioning your bucket, configure W&B to use it through the Operator's Helm values. See the [Operator object storage configuration section](/platform/hosting/self-managed/operator/#object-storage-bucket) for details.
+After you provision your bucket, you must configure W&B to use it through the Operator's Helm values so that W&B Server can read from and write to the bucket. See the [Operator object storage configuration section](/platform/hosting/self-managed/operator/#object-storage-bucket) for details.
 
 ## Networking
+
+Networking configuration exposes W&B Server to users and machine-learning workloads. The following sections describe DNS, load balancer, and ingress requirements.
 
 <SelfManagedNetworkingRequirements/>
 
 ### DNS
 
-The fully-qualified domain name (FQDN) of the W&B deployment must resolve to the IP address of the ingress/load balancer using an A record.
+The fully qualified domain name (FQDN) of the W&B deployment must resolve to the IP address of the ingress or load balancer using an A record.
 
 ### Load balancer and ingress
 
-The W&B Kubernetes Operator exposes services using a Kubernetes ingress controller, which routes to service endpoints based on URL paths. The ingress controller must be accessible by all machines that execute machine learning payloads or access the service through web browsers.
+The W&B Kubernetes Operator exposes services using a Kubernetes ingress controller, which routes to service endpoints based on URL paths. The ingress controller must be accessible by all machines that execute machine-learning payloads or access the service through web browsers.
 
 For detailed load balancer options, ingress controller requirements, and configuration examples, see the [reference architecture load balancer section](/platform/hosting/self-managed/ref-arch/#load-balancer-and-ingress).
 
@@ -116,14 +122,14 @@ For detailed load balancer options, ingress controller requirements, and configu
 
 ## License
 
-A valid W&B Server license is required for all Self-Managed deployments.
+All Self-Managed deployments require a valid W&B Server license. Without a license, W&B Server can't start.
 
 <SelfManagedObtainLicense/>
 
 ## Next steps
 
-After ensuring your infrastructure meets these requirements:
+After you confirm that your infrastructure meets these requirements, proceed to the deployment guide that matches your environment:
 
 - **Cloud and on-premises deployments**: See [Deploy W&B with Kubernetes Operator](/platform/hosting/self-managed/operator) for Helm and Terraform deployment options.
 - **Air-gapped deployments**: See [Deploy on Air-Gapped Kubernetes](/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped) for disconnected environments.
-- **All deployment methods**: See [Deploy with Kubernetes Operator](/platform/hosting/self-managed/operator) for the core operator deployment guide
+- **All deployment methods**: See [Deploy with Kubernetes Operator](/platform/hosting/self-managed/operator) for the core operator deployment guide.

--- a/platform/hosting/server-upgrade-process.mdx
+++ b/platform/hosting/server-upgrade-process.mdx
@@ -3,17 +3,19 @@ description: Guide for updating W&B version and license across different install
 title: Update W&B license and version
 ---
 
-Update your W&B Server Version and License with the same method you installed W&B Server with. The following table lists how to update your license and version based on different deployment methods:
+This guide shows W&B Server administrators how to update the W&B Server version and license key for an existing self-managed deployment. Keeping your server and license current ensures access to the latest features, fixes, and continued entitlement to use W&B Server.
+
+Update your W&B Server version and license with the same method you used to install W&B Server. The following table lists how to update your license and version based on different deployment methods.
 
 
-| Release Type    | Description         |
+| Release type    | Description         |
 | ---------------- | ------------------ |
 | [Terraform](#update-with-terraform) | W&B supports three public Terraform modules for cloud deployment: [AWS](https://registry.terraform.io/modules/wandb/wandb/aws/latest), [Google Cloud](https://registry.terraform.io/modules/wandb/wandb/google/latest), and [Azure](https://registry.terraform.io/modules/wandb/wandb/azurerm/latest). |
-| [Helm](#update-with-helm)              | You can use the [Helm Chart](https://github.com/wandb/helm-charts) to install W&B into an existing Kubernetes cluster.  |
+| [Helm](#update-with-helm)              | Use the [Helm Chart](https://github.com/wandb/helm-charts) to install W&B into an existing Kubernetes cluster.  |
 
 ## Update with Terraform
 
-Update your license and version with Terraform. The following table lists W&B managed Terraform modules based cloud platform.
+If you deployed W&B Server with one of the W&B-maintained Terraform modules, use Terraform to update both your license key and the W&B version in place. The following table lists W&B-managed Terraform modules by cloud platform.
 
 |Cloud provider| Terraform module|
 |-----|-----|
@@ -21,12 +23,12 @@ Update your license and version with Terraform. The following table lists W&B ma
 |Google Cloud|[Google Cloud Terraform module](https://registry.terraform.io/modules/wandb/wandb/google/latest)|
 |Azure|[Azure Terraform module](https://registry.terraform.io/modules/wandb/wandb/azurerm/latest)|
 
-1. First, navigate to the W&B maintained Terraform module for your appropriate cloud provider. See the preceding table to find the appropriate Terraform module based on your cloud provider.
-2. Within your Terraform configuration, update `wandb_version` and `license` in your Terraform `wandb_app` module configuration:
+1. Navigate to the W&B-maintained Terraform module for your cloud provider. See the preceding table to find the Terraform module that matches your cloud provider.
+2. In your Terraform configuration, update `wandb_version` and `license` in your Terraform `wandb_app` module configuration:
 
    ```hcl
    module "wandb_app" {
-       source  = "wandb/wandb/<cloud-specific-module>"
+       source  = "wandb/wandb/[CLOUD-SPECIFIC-MODULE]"
        version = "new_version"
        license       = "new_license_key" # Your new license key
        wandb_version = "new_wandb_version" # Desired W&B version
@@ -39,25 +41,30 @@ Update your license and version with Terraform. The following table lists W&B ma
    terraform apply
    ```
 
-4. (Optional) If you use a `terraform.tfvars` or other `.tfvars` file.
-
-   Update or create a `terraform.tfvars` file with the new W&B version and license key.
+4. Optional: If you use a `terraform.tfvars` or other `.tfvars` file, update or create one with the new W&B version and license key.
    ```bash
    terraform plan -var-file="terraform.tfvars"
    ```
-   Apply the configuration. In your Terraform workspace directory execute:  
+   From your Terraform workspace directory, apply the configuration:
    ```bash
    terraform apply -var-file="terraform.tfvars"
    ```
+
+After Terraform applies the change, your deployment runs the specified W&B version and uses the updated license key.
+
 ## Update with Helm
 
 <Warning>
-The `wandb` Helm chart is deprecated and no longer supported. It deployed a single pod and has been replaced by the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator). If you are still using this chart, follow the [migration guide](/platform/hosting/self-managed/operator#migrate-self-managed-instances-to-wb-operator) to move to the operator.
+The `wandb` Helm chart is deprecated and no longer supported. It deployed a single pod and has been replaced by the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator). If you're still using this chart, follow the [migration guide](/platform/hosting/self-managed/operator#migrate-self-managed-instances-to-wb-operator) to move to the operator.
 </Warning>
+
+Two Helm-based update paths are available: update from your existing Helm values file, or set the new license and image tag directly on the upgrade command. The following sections describe each approach.
 
 ### Update W&B with spec
 
-1. Specify a new version by modifying the `image.tag` and/or `license` values in your Helm chart `*.yaml` configuration file:
+Use this approach when you manage your Helm configuration in a tracked `*.yaml` values file.
+
+1. Specify a new version by modifying the `image.tag` or `license` values, or both, in your Helm chart `*.yaml` configuration file:
 
    ```yaml
    license: 'new_license'
@@ -66,7 +73,7 @@ The `wandb` Helm chart is deprecated and no longer supported. It deployed a sing
      tag: 'new_version'
    ```
 
-2. Execute the Helm upgrade with the following command:
+2. Update the Helm repository and upgrade the W&B release using your values file:
 
    ```bash
    helm repo update
@@ -77,6 +84,8 @@ The `wandb` Helm chart is deprecated and no longer supported. It deployed a sing
 
 ### Update license and version directly
 
+Use this approach to update the license and image tag without editing a values file, and reuse your existing Helm release configuration.
+
 1. Set the new license key and image tag as environment variables:
 
    ```bash
@@ -84,7 +93,7 @@ The `wandb` Helm chart is deprecated and no longer supported. It deployed a sing
    export TAG='new_version'
    ```
 
-2. Upgrade your Helm release with the command below, merging the new values with the existing configuration:
+2. Upgrade your Helm release, merging the new values with the existing configuration:
 
    ```bash
    helm repo update
@@ -93,13 +102,13 @@ The `wandb` Helm chart is deprecated and no longer supported. It deployed a sing
      --reuse-values --set license=$LICENSE --set image.tag=$TAG
    ```
 
-For more details, see the [upgrade guide](https://github.com/wandb/helm-charts/blob/main/upgrade) in the public repository.
+For more information, see the [upgrade guide](https://github.com/wandb/helm-charts/blob/main/upgrade) in the public repository.
 
 ## Update with admin UI
 
-This method only works for updating licenses that are not set with an environment variable in the W&B server container, typically in Self-Managed Docker installations.
+Use the admin UI to rotate your license key from within the W&B App, without changing your deployment configuration. This method only works for updating licenses that aren't set with an environment variable in the W&B server container, typically in self-managed Docker installations. This method updates the license only. It doesn't change the running W&B Server version.
 
-1. Obtain a new license from the [W&B Deployment Page](https://deploy.wandb.ai/), ensuring it matches the correct organization and deployment ID for the deployment you are looking to upgrade.
-2. Access the **License** page in the W&B App. Click **Settings** > **License** or browse to `<host-url>/console/settings/license`.
+1. Obtain a new license from the [W&B Deployment Page](https://deploy.wandb.ai/), ensuring it matches the correct organization and deployment ID for the deployment you want to upgrade.
+2. Access the **License** page in the W&B App. Click **Settings** > **License** or browse to `HOST_URL/console/settings/license`, where `HOST_URL` is your W&B Server host URL.
 3. Navigate to the license management section.
 4. Enter the new license key and save your changes.

--- a/platform/hosting/smtp.mdx
+++ b/platform/hosting/smtp.mdx
@@ -3,12 +3,14 @@ title: Configure SMTP
 description: "Configure an internal SMTP server to send email invitations from a self-managed W&B Server instance."
 ---
 
-In W&B server, adding users to the instance or team will trigger an email invite. To send these email invites, W&B uses a third-party mail server. In some cases, organizations might have strict policies on traffic leaving the corporate network and hence causing these email invites to never be sent to the end user. W&B server offers an option to configure sending these invite emails via an internal SMTP server.
+In W&B Server, adding users to the instance or a team triggers an email invitation. By default, W&B sends these invitations through a third-party mail server. If your organization restricts outbound traffic from the corporate network, these invitations might not reach the end user. To work around this, administrators of a self-managed W&B Server can route invitation emails through an internal SMTP server.
 
-To configure, follow the steps below:
+To configure W&B Server to use your internal SMTP server, complete the following steps:
 
-- Set the `GORILLA_EMAIL_SINK` environment variable in the docker container or the kubernetes deployment to `smtp://<user:password>@smtp.host.com:<port>`
-- `username` and `password` are optional
-- If you’re using an SMTP server that’s designed to be unauthenticated you would just set the value for the environment variable like `GORILLA_EMAIL_SINK=smtp://smtp.host.com:<port>`
-- Commonly used port numbers for SMTP are ports 587, 465 and 25. Note that this might differ based on the type of the mail server you're using.
-- To configure the default sender email address for SMTP, which is initially set to `noreply@wandb.com`, you can update it to an email address of your choice. This can be done by setting the `GORILLA_EMAIL_FROM_ADDRESS` environment variable on the server to your desired sender email address.
+1. Set the `GORILLA_EMAIL_SINK` environment variable in the Docker container or the Kubernetes deployment to `smtp://[USER:PASSWORD]@smtp.host.com:[PORT]`.
+   - `USER` and `PASSWORD` are optional.
+   - If you're using an SMTP server that's designed to be unauthenticated, set the value for the environment variable like `GORILLA_EMAIL_SINK=smtp://smtp.host.com:[PORT]`.
+   - Commonly used port numbers for SMTP are `587`, `465`, and `25`. The port might differ based on the type of mail server you're using.
+2. Optional: To configure the default sender email address for SMTP, which is initially set to `noreply@wandb.com`, set the `GORILLA_EMAIL_FROM_ADDRESS` environment variable on the server to your desired sender email address.
+
+After you set these environment variables, W&B Server routes new user and team invitation emails through your internal SMTP server using the sender address you specified.

--- a/platform/launch/add-job-to-queue.mdx
+++ b/platform/launch/add-job-to-queue.mdx
@@ -2,10 +2,10 @@
 title: Add job to queue
 description: "Add launch jobs to a W&B Launch queue using the App UI or CLI to schedule ML workloads on target resources."
 ---
-The following page describes how to add launch jobs to a launch queue.
+This page describes how to add launch jobs to a launch queue. Adding a job to a queue submits it to run on the queue's target resource. You can schedule ML workloads against the compute environment your team configured.
 
 <Note>
-Ensure that you, or someone on your team, has already configured a launch queue. For more information, see the [Set up Launch](/platform/launch/set-up-launch/) page.
+Ensure that you, or someone on your team, already configured a launch queue. For more information, see [Set up Launch](/platform/launch/set-up-launch/).
 </Note>
 
 ## Add jobs to your queue
@@ -13,38 +13,38 @@ Ensure that you, or someone on your team, has already configured a launch queue.
 Add jobs to your queue interactively with the W&B App or programmatically with the W&B CLI.
 
 <Tabs>
-<Tab title="W&B app">
-Add a job to your queue programmatically with the W&B App.
+<Tab title="W&B App">
+To add a job to your queue interactively with the W&B App:
 
-1. Navigate to your W&B Project Page.
+1. Navigate to your W&B project page.
 2. Select the **Jobs** icon in the project sidebar:
   <Frame>
-    <img src="/images/launch/project_jobs_tab_gs.png" alt="Project Jobs tab"  />
+    <img src="/images/launch/project_jobs_tab_gs.png" alt="Project Jobs tab" />
 </Frame>
-3. The **Jobs** page displays a list of W&B launch jobs that were created from previously executed W&B runs. 
+3. The **Jobs** page displays a list of W&B launch jobs created from previously executed W&B runs.
   <Frame>
-    <img src="/images/launch/view_jobs.png" alt="Jobs listing"  />
+    <img src="/images/launch/view_jobs.png" alt="Jobs listing" />
 </Frame>
-4. Select the **Launch** button next to the name of the Job name. A modal will appear on the right side of the page.
-5. From the **Job version** dropdown, select the version of the launch job you want to use. Launch jobs are versioned like any other [W&B Artifact](/models/artifacts/create-a-new-artifact-version/). Different versions of the same launch job will be created if you make modifications to the software dependencies or source code used to run the job.
-6. Within the **Overrides** section, provide new values for any inputs that are configured for your launch job. Common overrides include a new entrypoint command, arguments, or values in the `wandb.Run.config` of your new W&B run.  
+4. Select the **Launch** button next to the job name. A modal appears.
+5. From the **Job version** dropdown, select the version of the launch job you want to use. Launch jobs are versioned like any other [W&B artifact](/models/artifacts/create-a-new-artifact-version/). W&B creates different versions of the same launch job if you modify the software dependencies or source code used to run the job.
+6. Within the **Overrides** section, provide new values for any inputs configured for your launch job. Common overrides include a new entrypoint command, arguments, or values in the `wandb.Run.config` of your new W&B run.
   <Frame>
-    <img src="/images/launch/create_starter_queue_gs.png" alt="Queue configuration"  />
+    <img src="/images/launch/create_starter_queue_gs.png" alt="Queue configuration" />
 </Frame>
-  You can copy and paste values from other W&B runs that used your launch job by clicking on the **Paste from...** button.
-7. From the **Queue** dropdown, select the name of the launch queue you want to add your launch job to. 
-8. Use the **Job Priority** dropdown to specify the priority of your launch job. A launch job's priority is set to "Medium" if the launch queue does not support prioritization.
-9. **(Optional) Follow this step only if a queue config template was created by your team admin**  
-Within the **Queue Configurations** field, provide values for configuration options that were created by the admin of your team.  
-For example, in the following example, the team admin configured AWS instance types that can be used by the team. In this case, team members can pick either the `ml.m4.xlarge` or `ml.p3.xlarge` compute instance type to train their model.
+  To copy and paste values from other W&B runs that used your launch job, select the **Paste from...** button.
+7. From the **Queue** dropdown, select the name of the launch queue you want to add your launch job to.
+8. Use the **Job Priority** dropdown to specify the priority of your launch job. If the launch queue doesn't support prioritization, W&B sets the priority to `Medium`.
+9. Optional: Follow this step only if your team admin created a queue config template. Within the **Queue Configurations** field, provide values for configuration options that your team admin created. For example, the following image shows a team admin who configured AWS instance types that the team can use. In this case, team members can select either the `ml.m4.xlarge` or `ml.p3.xlarge` compute instance type to train their model.
 <Frame>
-    <img src="/images/launch/team_member_use_config_template.png" alt="Config template selection"  />
+    <img src="/images/launch/team_member_use_config_template.png" alt="Config template selection" />
 </Frame>
-10. Select the **Destination project**, where the resulting run will appear. This project needs to belong to the same entity as the queue.
+10. Select the **Destination project**, where the resulting run appears. This project must belong to the same entity as the queue.
 11. Select the **Launch now** button.
+
+Your job is now queued and runs on the queue's target resource. The resulting run appears in the destination project you selected.
 </Tab>
 <Tab title="W&B CLI">
-Use the `wandb launch` command to add jobs to a queue. Create a JSON configuration with hyperparameter overrides. For example, using the script from the [Quickstart](/platform/launch/walkthrough/) guide, we create a JSON file with the following overrides:
+Use the `wandb launch` command to add jobs to a queue. For example, using the script from the [Quickstart](/platform/launch/walkthrough/) guide, create a JSON file with the following hyperparameter overrides:
 
 ```json title="config.json"
 {
@@ -60,10 +60,10 @@ Use the `wandb launch` command to add jobs to a queue. Create a JSON configurati
 ```
 
 <Note>
-W&B Launch will use the default parameters if you do not provide a JSON configuration file.
+W&B Launch uses the default parameters if you don't provide a JSON configuration file.
 </Note>
 
-If you want to override the queue configuration, or if your launch queue does not have a configuration resource defined, you can specify the `resource_args` key in your config.json file. For example, following continuing the example above, your config.json file might look similar to the following:
+To override the queue configuration, or if your launch queue doesn't have a configuration resource defined, specify the `resource_args` key in your `config.json` file. For example, continuing the preceding example, your `config.json` file might look similar to the following:
 
 ```json title="config.json"
 {
@@ -76,21 +76,24 @@ If you want to override the queue configuration, or if your launch queue does no
       "entry_point": []
   },
   "resource_args": {
-        "<resource-type>" : {
-            "<key>": "<value>"
+        "[RESOURCE-TYPE]" : {
+            "[KEY]": "[VALUE]"
         }
   }
 }
 ```
 
-Replace values within the `<>` with your own values.
+Replace the bracketed placeholders with your own values.
 
-Provide the name of the queue for the `queue`(`-q`) flag, the name of the job for the `job`(`-j`) flag, and the path to the configuration file for the `config`(`-c`) flag.
+Provide the name of the queue for the `queue` (`-q`) flag, the name of the job for the `job` (`-j`) flag, and the path to the configuration file for the `config` (`-c`) flag:
 
 ```bash
-wandb launch -j <job> -q <queue-name> \ 
--e <entity-name> -c path/to/config.json
+wandb launch -j [JOB-NAME] -q [QUEUE-NAME] \
+-e [ENTITY-NAME] -c path/to/config.json
 ```
-If you work within a W&B Team, we suggest you specify the `entity` flag (`-e`) to indicate which entity the queue will use.
+
+If you work within a W&B team, specify the `entity` flag (`-e`) to indicate which entity the queue uses.
+
+After the command succeeds, your job is added to the specified queue and runs on the queue's target resource.
 </Tab>
 </Tabs>

--- a/platform/launch/create-launch-job.mdx
+++ b/platform/launch/create-launch-job.mdx
@@ -4,7 +4,9 @@ description: "Create W&B Launch jobs from Git repositories, code artifacts, or D
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/drive/1wX0OSVxZJDHRsZaOaOEDx-lLUrO1hHgP" icon="python"/>
 
-Launch jobs are blueprints for reproducing W&B runs. Jobs are W&B Artifacts that capture the source code, dependencies, and inputs required to execute a workload. 
+This page shows you how to create W&B Launch jobs so you can reproduce W&B runs on demand. Launch jobs are blueprints for reproducing W&B runs. Jobs are W&B Artifacts that capture the source code, dependencies, and inputs required to execute a workload.
+
+Use this page when you want to package a workload from a Git repository, a local code directory, or a pre-built Docker image so that you can re-run it later with different parameters or on different infrastructure.
 
 Create and run jobs with the `wandb launch` command.
 
@@ -15,9 +17,9 @@ To create a job without submitting it for execution, use the `wandb job create` 
 
 ## Git jobs
 
-You can create a Git-based job where code and other tracked assets are cloned from a certain commit, branch, or tag in a remote git repository with W&B Launch. Use the `--uri` or `-u` flag to specify the URI containing the code, along with optionally a `--build-context` flag to specify a subdirectory.
+Use a Git-based job when your source code lives in a remote repository and you want Launch to clone it at a specific commit, branch, or tag. W&B Launch clones code and other tracked assets from a commit, branch, or tag in a remote Git repository. Use the `--uri` or `-u` flag to specify the URI containing the code, along with an optional `--build-context` flag to specify a subdirectory.
 
-Run a "hello world" job from a git repository with the following command:
+Run a hello world job from a Git repository with the following command:
 
 ```bash
 wandb launch --uri "https://github.com/wandb/launch-jobs.git" --build-context jobs/hello_world --dockerfile Dockerfile.wandb --project "hello-world" --job-name "hello-world" --entry-point "python job.py"
@@ -25,27 +27,29 @@ wandb launch --uri "https://github.com/wandb/launch-jobs.git" --build-context jo
 
 The command does the following:
 1. Clones the [W&B Launch jobs repository](https://github.com/wandb/launch-jobs) to a temporary directory.
-2. Creates a job named **hello-world-git** in the **hello** project. The job is associated with the commit at the head of the default branch of the repository.
+2. Creates a job named `hello-world-git` in the `hello` project. The job is associated with the commit at the head of the default branch of the repository.
 3. Builds a container image from the `jobs/hello_world` directory and the `Dockerfile.wandb`.
 4. Starts the container and runs `python job.py`.
+
+After the command completes, you have a reusable Git-based job in the `hello-world` project that other users or automations can re-run with `wandb launch`.
 
 To build a job from a specific branch or commit hash, append the `-g`, `--git-hash` argument. For a full list of arguments, run `wandb launch --help`.
 
 ### Remote URL format
 
-The git remote associated with a Launch job can be either an HTTPS or an SSH URL. The URL type determines the protocol used to fetch job source code. 
+The Git remote associated with a Launch job can be either an HTTPS or an SSH URL. The URL type determines the protocol used to fetch job source code. 
 
-| Remote URL Type| URL Format | Requirements for access and authentication |
+| Remote URL type| URL format | Requirements for access and authentication |
 | ----------| ------------------- | ------------------------------------------ |
-| https      | `https://github.com/organization/repository.git`  | username and password to authenticate with the git remote |
-| ssh        | `git@github.com:organization/repository.git` | ssh key to authenticate with the git remote |
+| HTTPS      | `https://github.com/organization/repository.git`  | Username and password to authenticate with the Git remote |
+| SSH        | `git@github.com:organization/repository.git` | SSH key to authenticate with the Git remote |
 
-Note that the exact URL format varies by hosting provider. Jobs created with `wandb launch --uri` will use the transfer protocol specified in the provided `--uri`.
+Note that the exact URL format varies by hosting provider. Jobs created with `wandb launch --uri` use the transfer protocol specified in the provided `--uri`.
 
 
 ## Code artifact jobs
 
-Jobs can be created from any source code stored in a W&B Artifact. Use a local directory with the `--uri` or `-u` argument to create a new code artifact and job.
+Use a code artifact job when your source lives in a local directory rather than a remote Git repository. You can create jobs from any source code stored in a W&B Artifact. Use a local directory with the `--uri` or `-u` argument to create a new code artifact and job.
 
 To get started, create an empty directory and add a Python script named `main.py` with the following content:
 
@@ -58,7 +62,7 @@ with wandb.init() as run:
 
 Add a file `requirements.txt` with the following content:
 
-```txt
+```text
 wandb>=0.17.1
 ```
 
@@ -71,15 +75,17 @@ wandb launch --uri . --job-name hello-world-code --project launch-quickstart --e
 The preceding command does the following:
 1. Logs the current directory as a code artifact named `hello-world-code`.
 2. Creates a job named `hello-world-code` in the `launch-quickstart` project.
-3. Builds a container image from the current directory and Launch's default Dockerfile. The default Dockerfile will install the `requirements.txt` file and set the entry point to `python main.py`.
+3. Builds a container image from the current directory and Launch's default Dockerfile. The default Dockerfile installs the `requirements.txt` file and sets the entry point to `python main.py`.
+
+After the command completes, your local code is captured as a W&B code artifact and is associated with a reusable job in the `launch-quickstart` project.
 
 ## Image jobs
 
-Alternatively, you can build jobs off of pre-made Docker images. This is useful when you already have an established build system for your ML code, or when you don't expect to adjust the code or requirements for the job but do want to experiment with hyperparameters or different infrastructure scales.
+Alternatively, you can build jobs from pre-made Docker images. This approach is useful when you already have a build system for your ML code, or when you don't expect to adjust the code or requirements for the job but do want to experiment with hyperparameters or different infrastructure scales.
 
-The image is pulled from a Docker registry and run with the specified entry point, or the default entry point if none is specified. Pass a full image tag to the `--docker-image` option to create and run a job from a Docker image.
+Launch pulls the image from a Docker registry and runs it with the specified entry point, or the default entry point if none is specified. Pass a full image tag to the `--docker-image` option to create and run a job from a Docker image.
 
-To run a simple job from a pre-made image, use the following command:
+Run a job from a pre-made image with the following command:
 
 ```bash
 wandb launch --docker-image "wandb/job_hello_world:main" --project "hello-world"           
@@ -88,26 +94,26 @@ wandb launch --docker-image "wandb/job_hello_world:main" --project "hello-world"
 
 ## Automatic job creation
 
-W&B will automatically create and track a job for any run with tracked source code, even if that run was not created with Launch. Runs are considered to have tracked source code if any of the three following conditions are met:
-- The run has an associated git remote and commit hash.
+In addition to jobs you create explicitly with `wandb launch`, W&B can create jobs for you as a side effect of running tracked code. W&B automatically creates and tracks a job for any run with tracked source code, even if that run wasn't created with Launch. Runs are considered to have tracked source code if any of the three following conditions are met:
+- The run has an associated Git remote and commit hash.
 - The run logged a code artifact. See [`Run.log_code`](/models/ref/python/experiments/run#log_code).
-- The run was executed in a Docker container with the `WANDB_DOCKER` environment variable set to an image tag
+- The run was executed in a Docker container with the `WANDB_DOCKER` environment variable set to an image tag.
 
-The Git remote URL is inferred from the local git repository if your Launch job is created automatically by a W&B run. 
+If W&B automatically creates your Launch job from a W&B run, W&B infers the Git remote URL from the local Git repository. 
 
 ### Launch job names
 
-By default, W&B automatically generates a job name for you. The name is generated depending on how the job is created (GitHub, code artifact, or Docker image). Alternatively, you can define a Launch job's name with environment variables or with the W&B Python SDK.
+By default, W&B automatically generates a job name for you. The name depends on how the job is created (GitHub, code artifact, or Docker image). Alternatively, you can define a Launch job's name with environment variables or with the W&B Python SDK.
 
 The following table describes the job naming convention used by default based on job source:
 
 | Source        | Naming convention                       |
 | ------------- | --------------------------------------- |
-| GitHub        | `job-<git-remote-url>-<path-to-script>` |
-| Code artifact | `job-<code-artifact-name>`              |
-| Docker image  | `job-<image-name>`                      |
+| GitHub        | `job-[GIT-REMOTE-URL]-[PATH-TO-SCRIPT]` |
+| Code artifact | `job-[CODE-ARTIFACT-NAME]`              |
+| Docker image  | `job-[IMAGE-NAME]`                      |
 
-Name your job with a W&B environment variable or with the W&B Python SDK
+Name your job with a W&B environment variable or with the W&B Python SDK.
 
 <Tabs>
 <Tab title="Environment variable">
@@ -128,31 +134,31 @@ wandb.init(settings=settings)
 </Tabs>
 
 <Note>
-For docker image jobs, the version alias is automatically added as an alias to the job.
+For Docker image jobs, W&B automatically adds the version alias as an alias to the job.
 </Note>
 
 ## Containerization
 
-Jobs are executed in a container. Image jobs use a pre-built Docker image, while Git and code artifact jobs require a container build step.
+Jobs run in a container. Image jobs use a pre-built Docker image, while Git and code artifact jobs require a container build step.
 
-Job containerization can be customized with arguments to `wandb launch` and files within the job source code.
+You can customize job containerization with arguments to `wandb launch` and files within the job source code. The following sections describe how to control the build context, supply a custom Dockerfile, and manage Python dependencies.
 
 ### Build context
 
-The term build context refers to the tree of files and directories that are sent to the Docker daemon to build a container image. By default, Launch uses the root of the job source code as the build context. To specify a subdirectory as the build context, use the `--build-context` argument of `wandb launch` when creating and launching a job.
+The term build context refers to the tree of files and directories sent to the Docker daemon to build a container image. By default, Launch uses the root of the job source code as the build context. To specify a subdirectory as the build context, use the `--build-context` argument of `wandb launch` when you create and launch a job.
 
 <Note>
-The `--build-context` argument is particularly useful for working with Git jobs that refer to a monorepo with multiple projects. By specifying a subdirectory as the build context, you can build a container image for a specific project within the monorepo.
+The `--build-context` argument is useful for working with Git jobs that refer to a monorepo with multiple projects. By specifying a subdirectory as the build context, you can build a container image for a specific project within the monorepo.
 
-See the [example above](#git-jobs) for a demonstration of how to use the `--build-context` argument with the official W&B Launch jobs repository.
+See [Git jobs](#git-jobs) for a demonstration of how to use the `--build-context` argument with the official W&B Launch jobs repository.
 </Note>
 
 ### Dockerfile
 
 The Dockerfile is a text file that contains instructions for building a Docker image. By default, Launch uses a default Dockerfile that installs the `requirements.txt` file. To use a custom Dockerfile, specify the path to the file with the `--dockerfile` argument of `wandb launch`.
 
-The Dockerfile path is specified relative to the build context. For example, if the build context is `jobs/hello_world`, and the Dockerfile is located in the `jobs/hello_world` directory, the `--dockerfile` argument should be set to `Dockerfile.wandb`. See the [example above](#git-jobs) for a demonstration of how to use the `--dockerfile` argument with the official W&B Launch jobs repository.
+Specify the Dockerfile path relative to the build context. For example, if the build context is `jobs/hello_world`, and the Dockerfile is located in the `jobs/hello_world` directory, set the `--dockerfile` argument to `Dockerfile.wandb`. See [Git jobs](#git-jobs) for a demonstration of how to use the `--dockerfile` argument with the official W&B Launch jobs repository.
 
 ### Requirements file
 
-If no custom Dockerfile is provided, Launch will look in the build context for Python dependencies to install. If a `requirements.txt` file is found at the root of the build context, Launch will install the dependencies listed in the file. Otherwise, if a `pyproject.toml` file is found, Launch will install dependencies from the `project.dependencies` section.
+If no custom Dockerfile is provided, Launch looks in the build context for Python dependencies to install. If a `requirements.txt` file is found at the root of the build context, Launch installs the dependencies listed in the file. Otherwise, if a `pyproject.toml` file is found, Launch installs dependencies from the `project.dependencies` section.

--- a/platform/launch/job-inputs.mdx
+++ b/platform/launch/job-inputs.mdx
@@ -1,21 +1,19 @@
 ---
 title: Manage job inputs
-description: "Programmatically manage and configure job inputs like hyperparameters and file-based configs for W&B Launch jobs."
+description: "Programmatically manage and configure job inputs such as hyperparameters and file-based configs for W&B Launch jobs."
 ---
-The core experience of Launch is easily experimenting with different job inputs like hyperparameters and datasets, and routing these jobs to appropriate hardware. Once a job is created, users beyond the original author can adjust these inputs via the W&B GUI or CLI. For information on how job inputs can be set when launching from the CLI or UI, see the [Enqueue jobs](./add-job-to-queue) guide.
+The core experience of Launch is experimenting with different job inputs such as hyperparameters and datasets, and routing these jobs to appropriate hardware. After you create a job, users beyond the original author can adjust these inputs through the W&B UI or CLI. For information about how to set job inputs when launching from the CLI or UI, see the [Enqueue jobs](./add-job-to-queue) guide.
 
-This section describes how to programmatically control the inputs that can be tweaked for a job.
-
-By default, W&B jobs capture the entire `Run.config` as the inputs to a job, but the Launch SDK provides a function to control select keys in the run config or to specify JSON or YAML files as inputs.
+This guide describes how to programmatically control which inputs you can adjust for a job, so that you expose only the parameters you want end users to change. By default, W&B jobs capture the entire `Run.config` as the inputs to a job, but the Launch SDK provides a function to control select keys in the run config or to specify JSON or YAML files as inputs.
 
 
 <Note>
-Launch SDK functions require `wandb-core`. See the [`wandb-core` README](https://github.com/wandb/wandb/blob/main/core/README) for more information.
+Launch SDK functions require `wandb-core`. For more information, see the [`wandb-core` README](https://github.com/wandb/wandb/blob/main/core/README).
 </Note>
 
 ## Reconfigure the `Run` object
 
-The `Run` object returned by `wandb.init()` in a job can be reconfigured, by default. The Launch SDK provides a way to customize what parts of the `Run.config` object can be reconfigured when launching the job.
+By default, you can reconfigure the `Run` object returned by `wandb.init()` in a job. Use the Launch SDK to customize which parts of the `Run.config` object you can reconfigure when launching the job, so that you can hide internal settings while exposing the parameters that matter to end users.
 
 
 ```python
@@ -47,21 +45,21 @@ with wandb.init(config=config):
     # Etc.
 ```
 
-The function `launch.manage_wandb_config()` configures the job to accept input values for the `Run.config` object. The optional `include` and `exclude` options take path prefixes within the nested config object. This can be useful if, for example, a job uses a library whose options you don't want to expose to end users. 
+The function `launch.manage_wandb_config()` configures the job to accept input values for the `Run.config` object. The optional `include` and `exclude` options take path prefixes within the nested config object. This is useful if, for example, a job uses a library whose options you don't want to expose to end users.
 
-If `include` prefixes are provided, only paths within the config that match an `include` prefix will accept input values. If `exclude` prefixes are provided, no paths that match the `exclude` list will be filtered out of the input values. If a path matches both an `include` and an `exclude` prefix, the `exclude` prefix will take precedence.
+If you provide `include` prefixes, only paths within the config that match an `include` prefix accept input values. If you provide `exclude` prefixes, paths that match the `exclude` list are filtered out of the input values. If a path matches both an `include` and an `exclude` prefix, the `exclude` prefix takes precedence.
 
-In the preceding example, the path `["trainer.private"]` will filter out the `private` key from the `trainer` object, and the path `["trainer"]` will filter out all keys not under the `trainer` object.
+In the preceding example, the path `["trainer.private"]` filters out the `private` key from the `trainer` object, and the path `["trainer"]` filters out all keys not under the `trainer` object.
 
 <Note>
-Use a `\`-escaped `.` to filter out keys with a `.` in their name. 
+Use a `\`-escaped `.` to filter out keys with a `.` in their name.
 
 For example, `r"trainer\.private"` filters out the `trainer.private` key rather than the `private` key under the `trainer` object.
 
-Note that the `r` prefix above denotes a raw string.
+The `r` prefix in the preceding example denotes a raw string.
 </Note>
 
-If the code above is packaged and run as a job, the input types of the job will be:
+If you package and run the preceding code as a job, the input types of the job are:
 
 ```json
 {
@@ -74,29 +72,29 @@ If the code above is packaged and run as a job, the input types of the job will 
 }
 ```
 
-When launching the job from the W&B CLI or UI, the user will be able to override only the four `trainer` parameters.
+When launching the job from the W&B CLI or UI, you can override only the four `trainer` parameters.
 
 ### Access run config inputs
 
-Jobs launched with run config inputs can access the input values through the `Run.config`. The `Run` returned by `wandb.init()` in the job code will have the input values automatically set. Use 
+Jobs launched with run config inputs can access the input values through the `Run.config`. The `Run` returned by `wandb.init()` in the job code has the input values automatically set. To load the run config input values anywhere in the job code, use `launch.load_wandb_config()`:
+
 ```python
 from wandb.sdk import launch
 
 run_config_overrides = launch.load_wandb_config()
 ```
-to load the run config input values anywhere in the job code.
 
 ## Reconfigure a file
 
-The Launch SDK also provides a way to manage input values stored in config files in the job code. This is a common pattern in many deep learning and large language model use cases, like this [torchtune](https://github.com/meta-pytorch/torchtune/blob/main/recipes/configs/llama3/8B_lora.yaml) example or this [Axolotl config](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/examples/llama-3/qlora-fsdp-70b.yaml). 
+The Launch SDK can also manage input values stored in config files in the job code. This is a common pattern in many deep learning and large language model use cases, such as this [torchtune](https://github.com/meta-pytorch/torchtune/blob/main/recipes/configs/llama3/8B_lora.yaml) example or this [Axolotl config](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/examples/llama-3/qlora-fsdp-70b.yaml).
 
 <Note>
 [Sweeps on Launch](/platform/launch/sweeps-on-launch/) does not support the use of config file inputs as sweep parameters. Sweep parameters must be controlled through the `Run.config` object.
 </Note>
 
-The `launch.manage_config_file()` function can be used to add a config file as an input to the Launch job, giving you access to edit values within the config file when launching the job.
+Use the `launch.manage_config_file()` function to add a config file as an input to the Launch job, giving you access to edit values within the config file when launching the job.
 
-By default, no run config inputs will be captured if `launch.manage_config_file()` is used. Calling `launch.manage_wandb_config()` overrides this behavior.
+By default, no run config inputs are captured if you use `launch.manage_config_file()`. Calling `launch.manage_wandb_config()` overrides this behavior.
 
 Consider the following example:
 
@@ -118,7 +116,7 @@ with wandb.init(config=config):
     pass
 ```
 
-Imagine the code is run with an adjacent file `config.yaml`:
+Imagine you run the code with an adjacent file `config.yaml`:
 
 ```yaml
 learning_rate: 0.01
@@ -127,26 +125,26 @@ model: resnet
 dataset: cifar10
 ```
 
-The call to `launch.manage_config_file()` will add the `config.yaml` file as an input to the job, making it reconfigurable when launching from the W&B CLI or UI. 
+The call to `launch.manage_config_file()` adds the `config.yaml` file as an input to the job, making it reconfigurable when launching from the W&B CLI or UI.
 
-The `include` and `exclude` keyword arguments may be used to filter the acceptable input keys for the config file in the same way as `launch.manage_wandb_config()`.
+Use the `include` and `exclude` keyword arguments to filter the acceptable input keys for the config file in the same way as `launch.manage_wandb_config()`.
 
 
 ### Access config file inputs
 
-When `launch.manage_config_file()` is called in a run created by Launch, `launch` patches the contents of the config file with the input values. The patched config file is available in the job environment.
+When you call `launch.manage_config_file()` in a run created by Launch, `launch` patches the contents of the config file with the input values. The patched config file is available in the job environment.
 
 <Warning>
 Call `launch.manage_config_file()` before reading the config file in the job code to ensure input values are used.
 </Warning>
 
 
-### Customize a job's launch drawer UI
+## Customize a job's launch drawer UI
 
-Defining a schema for a job's inputs allows you to create a custom UI for launching the job. To define a job's schema, include it in the call to `launch.manage_wandb_config()` or `launch.manage_config_file()`. The schema can either be a python dict in the form of a [JSON Schema](https://json-schema.org/understanding-json-schema/reference) or a Pydantic model class.
+Beyond filtering which inputs you expose, you can define a schema for a job's inputs to create a custom UI for launching the job. This presents structured fields, validation hints, and dropdowns in the launch drawer instead of freeform text entry. To define a job's schema, include it in the call to `launch.manage_wandb_config()` or `launch.manage_config_file()`. The schema can be either a Python `dict` in the form of a [JSON Schema](https://json-schema.org/understanding-json-schema/reference) or a Pydantic model class.
 
 <Warning>
-Job input schemas are not used to validate inputs. They are only used to define the UI in the launch drawer.
+Job input schemas don't validate inputs. They only define the UI in the launch drawer.
 </Warning>
 
 
@@ -154,11 +152,11 @@ Job input schemas are not used to validate inputs. They are only used to define 
 <Tab title="JSON schema">
 The following example shows a schema with these properties:
 
-- `seed`, an integer
+- `seed`, an integer.
 - `trainer`, a dictionary with some keys specified:
-  - `trainer.learning_rate`, a float that must be greater than zero
-  - `trainer.batch_size`, an integer that must be either 16, 64, or 256
-  - `trainer.dataset`, a string that must be either `cifar10` or `cifar100`
+  - `trainer.learning_rate`, a float that must be greater than zero.
+  - `trainer.batch_size`, an integer that must be either 16, 64, or 256.
+  - `trainer.dataset`, a string that must be either `cifar10` or `cifar100`.
 
 ```python
 schema = {
@@ -199,7 +197,7 @@ launch.manage_wandb_config(
 
 In general, the following JSON Schema attributes are supported:
 
-| Attribute | Required |  Notes |
+| Attribute | Required | Notes |
 | --- | --- | --- |
 | `type` | Yes | Must be one of `number`, `integer`, `string`, or `object` |
 | `title` | No | Overrides the property's display name |
@@ -209,16 +207,16 @@ In general, the following JSON Schema attributes are supported:
 | `maximum` | No | Allowed only if `type` is `number` or `integer` |
 | `exclusiveMinimum` | No | Allowed only if `type` is `number` or `integer` |
 | `exclusiveMaximum` | No | Allowed only if `type` is `number` or `integer` |
-| `properties` | No | If `type` is `object`, used to define nested configurations |
+| `properties` | No | If `type` is `object`, defines nested configurations |
 </Tab>
 <Tab title="Pydantic model">
 The following example shows a schema with these properties:
 
-- `seed`, an integer
+- `seed`, an integer.
 - `trainer`, a schema with some sub-attributes specified:
-  - `trainer.learning_rate`, a float that must be greater than zero
-  - `trainer.batch_size`, an integer that must be between 1 and 256, inclusive
-  - `trainer.dataset`, a string that must be either `cifar10` or `cifar100`
+  - `trainer.learning_rate`, a float that must be greater than zero.
+  - `trainer.batch_size`, an integer that must be between 1 and 256, inclusive.
+  - `trainer.dataset`, a string that must be either `cifar10` or `cifar100`.
 
 ```python
 class DatasetEnum(str, Enum):
@@ -255,8 +253,8 @@ launch.manage_wandb_config(
 </Tab>
 </Tabs>
 
-Adding a job input schema will create a structured form in the launch drawer, making it easier to launch the job.
+Adding a job input schema creates a structured form in the launch drawer for users launching the job.
 
 <Frame>
-    <img src="/images/launch/schema_overrides.png" alt="Job input schema form"  />
+    <img src="/images/launch/schema_overrides.png" alt="Job input schema form" />
 </Frame>

--- a/platform/launch/launch-faq/best_practices_launch_effectively.mdx
+++ b/platform/launch/launch-faq/best_practices_launch_effectively.mdx
@@ -2,8 +2,8 @@
 title: Are there best practices for using Launch effectively?
 ---
 
-1. Create the queue before starting the agent to enable easy configuration. Failure to do this results in errors that prevent the agent from functioning until a queue is added.
+Follow these practices to avoid common setup errors and keep your Launch workflows maintainable:
 
-2. Create a W&B service account to initiate the agent, ensuring it is not linked to an individual user account.
-
-3. Use `wandb.Run.config` to manage hyperparameters, allowing for overwriting during job re-runs. Refer to the [configuration with argparse guide](/models/track/config/#set-the-configuration-with-argparse) for details on using argparse.
+- Create the queue before you start the agent to streamline configuration. Otherwise, the agent fails with errors until you add a queue.
+- Create a W&B service account to start the agent so that it doesn't link to an individual user account.
+- Use `wandb.Run.config` to manage hyperparameters, which lets you overwrite values during job re-runs. For more information about using `argparse`, see [Set the configuration with argparse](/models/track/config/#set-the-configuration-with-argparse).

--- a/platform/launch/launch-faq/build_container_launch.mdx
+++ b/platform/launch/launch-faq/build_container_launch.mdx
@@ -1,8 +1,8 @@
 ---
-title: I do not want W&B to build a container for me, can I still use Launch?
+title: I don't want W&B to build a container for me, can I still use Launch?
 ---
 
-To launch a pre-built Docker image, execute the following command. Replace the placeholders in the `<>` with your specific information:
+To launch a pre-built Docker image, replace the `<>` placeholders with your values and run:
 
 ```bash
 wandb launch -d <docker-image-uri> -q <queue-name> -E <entrypoint>
@@ -10,7 +10,7 @@ wandb launch -d <docker-image-uri> -q <queue-name> -E <entrypoint>
 
 This command creates a job and starts a run.
 
-To create a job from an image, use the following command:
+To create a job from an image, run:
 
 ```bash
 wandb job create image <image-name> -p <project> -e <entity>

--- a/platform/launch/launch-faq/clicking_launch_without_going_ui.mdx
+++ b/platform/launch/launch-faq/clicking_launch_without_going_ui.mdx
@@ -1,8 +1,8 @@
 ---
-title: I do not like clicking- can I use Launch without going through the UI?
+title: I don't like clicking, can I use Launch without going through the UI?
 ---
 
-Yes. The standard `wandb` CLI includes a `launch` subcommand to launch jobs. For more information, run:
+Yes. The `wandb` CLI includes a `launch` subcommand for launching jobs. To see usage details, run:
 
 ```bash
 wandb launch --help

--- a/platform/launch/launch-faq/control_push_queue.mdx
+++ b/platform/launch/launch-faq/control_push_queue.mdx
@@ -2,4 +2,4 @@
 title: How do I control who can push to a queue?
 ---
 
-Queues are specific to a user team. Define the owning entity during queue creation. To restrict access, modify team membership.
+Queues are specific to a user team. Define the owning entity when you create the queue. To restrict access, modify team membership.

--- a/platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact.mdx
+++ b/platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact.mdx
@@ -3,6 +3,6 @@ title: When multiple jobs in a Docker queue download the same artifact, is any c
   used, or is it re-downloaded every run?
 ---
 
-No caching exists. Each launch job operates independently. Configure the queue or agent to mount a shared cache using Docker arguments in the queue configuration.
+Launch jobs share no cache. Each launch job runs independently. To share a cache, configure the queue or agent to mount one with Docker arguments in the queue configuration.
 
-Additionally, mount the W&B artifacts cache as a persistent volume for specific use cases.
+For specific use cases, you can also mount the W&B artifacts cache as a persistent volume.

--- a/platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me.mdx
+++ b/platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me.mdx
@@ -1,33 +1,33 @@
 ---
 title: Can I specify a Dockerfile and let W&B build a Docker image for me?
 ---
-This feature suits projects with stable requirements but frequently changing codebases.
+Yes. You can provide your own Dockerfile and have W&B Launch build the image for your run. This lets you control the build environment while still using Launch to queue and run jobs. This approach works well for projects with stable requirements but changing codebases.
 
 <Warning>
-Format your Dockerfile to use mounts. For further details, visit the [Mounts documentation on the Docker Docs website](https://docs.docker.com/build/guide/mounts/).
+Format your Dockerfile to use mounts. For details, see the [Docker mounts documentation](https://docs.docker.com/build/guide/mounts/).
 </Warning>
 
-After configuring the Dockerfile, specify it in one of three ways to W&B:
+After you configure the Dockerfile, specify it to W&B in one of the following ways:
 
-* Use Dockerfile.wandb
+* Use `Dockerfile.wandb`
 * Use W&B CLI
 * Use W&B App
 
 <Tabs>
 <Tab title="Dockerfile.wandb">
-Include a `Dockerfile.wandb` file in the same directory as the W&B run's entrypoint. W&B utilizes this file instead of the built-in Dockerfile.
+Include a `Dockerfile.wandb` file in the same directory as the W&B run's entrypoint. W&B uses this file instead of the built-in Dockerfile.
 </Tab>
 <Tab title="W&B CLI">
-Use the `--dockerfile` flag with the `wandb launch` command to queue a job:
+To queue a job, use the `--dockerfile` flag with the `wandb launch` command:
 
 ```bash
 wandb launch --dockerfile path/to/Dockerfile
 ```
 </Tab>
-<Tab title="W&B app">
-When adding a job to a queue in the W&B App, provide the Dockerfile path in the **Overrides** section. Enter it as a key-value pair with `"dockerfile"` as the key and the path to the Dockerfile as the value.
+<Tab title="W&B App">
+When you add a job to a queue in the W&B App, provide the Dockerfile path in the **Overrides** section. Enter it as a key-value pair with `"dockerfile"` as the key and the path as the value.
 
-The following JSON demonstrates how to include a Dockerfile in a local directory:
+The following JSON shows how to include a Dockerfile from a local directory:
 
 ```json title="Launch job W&B App"
 {

--- a/platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment.mdx
+++ b/platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment.mdx
@@ -3,4 +3,9 @@ title: Can Launch automatically provision (and spin down) compute resources for 
   in the target environment?
 ---
 
-This process depends on the environment. Resources provision in Amazon SageMaker and Vertex. In Kubernetes, autoscalers automatically adjust resources based on demand. Solution Architects at W&B assist in configuring Kubernetes infrastructure to enable retries, autoscaling, and the use of spot instance node pools. For support, contact support@wandb.com or use your shared Slack channel.
+Whether Launch automatically provisions and scales compute resources depends on the target environment:
+
+- **Amazon SageMaker and Vertex AI**: These platforms provision resources automatically.
+- **Kubernetes**: Autoscalers adjust resources based on demand. W&B solution architects can help you configure your Kubernetes infrastructure to enable retries, autoscaling, and spot instance node pools.
+
+For support, contact [W&B support](mailto:support@wandb.com) or use your shared Slack channel.

--- a/platform/launch/launch-faq/launch_build_images.mdx
+++ b/platform/launch/launch-faq/launch_build_images.mdx
@@ -1,6 +1,8 @@
 ---
-title: How does W&B Launch build images?
+title: How W&B Launch builds images
 ---
+
+This page explains how W&B Launch builds container images for your jobs, so you can predict which build actions Launch performs and configure your queue or job accordingly.
 
 The steps for building an image depend on the job source and the specified accelerator base image in the resource configuration.
 
@@ -10,7 +12,7 @@ When configuring a queue or submitting a job, include a base accelerator image i
 {
     "builder": {
         "accelerator": {
-            "base_image": "image-name"
+            "base_image": "[IMAGE-NAME]"
         }
     }
 }

--- a/platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker.mdx
+++ b/platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker.mdx
@@ -1,21 +1,21 @@
 ---
-title: Is `wandb launch -d` or `wandb job create image` uploading a whole docker artifact
+title: Is `wandb launch -d` or `wandb job create image` uploading a whole Docker artifact
   and not pulling from a registry?
 ---
 
-No, the `wandb launch -d` command does not upload images to a registry. Upload images to a registry separately. Follow these steps:
+No, the `wandb launch -d` command doesn't upload images to a registry. Upload images to a registry separately. Follow these steps:
 
 1. Build an image.
 2. Push the image to a registry.
 
-The workflow is as follows:
+The workflow is as follows. Replace `[REPO-URL]` with your registry URL and `[TAG]` with the image tag:
 
 ```bash
-docker build -t <repo-url>:<tag> .
-docker push <repo-url>:<tag>
-wandb launch -d <repo-url>:<tag>
+docker build -t [REPO-URL]:[TAG] .
+docker push [REPO-URL]:[TAG]
+wandb launch -d [REPO-URL]:[TAG]
 ```
 
-The launch agent then spins up a job pointing to the specified container. See [Advanced agent setup](/platform/launch/setup-agent-advanced/#agent-configuration) for examples on configuring agent access to pull images from a container registry.
+The launch agent then starts a job pointing to the specified container. For examples of configuring agent access to pull images from a container registry, see [Advanced agent setup](/platform/launch/setup-agent-advanced/#agent-configuration).
 
-For Kubernetes, ensure that the Kubernetes cluster pods have access to the registry where the image is pushed.
+For Kubernetes, ensure that the Pods in the cluster have access to the registry where the image is pushed.

--- a/platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job.mdx
+++ b/platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job.mdx
@@ -1,13 +1,13 @@
 ---
-title: Does Launch support parallelization?  How can I limit the resources consumed
+title: Does Launch support parallelization? How can I limit the resources consumed
   by a job?
 ---
 
-Launch supports scaling jobs across multiple GPUs and nodes. Refer to the [Volcano integration guide](/models/integrations) for details.
+Launch supports scaling jobs across multiple GPUs and nodes. For details, see the [Volcano integration guide](/models/integrations).
 
-Each launch agent is configured with a `max_jobs` parameter, which determines the maximum number of simultaneous jobs it can run. Multiple agents can point to a single queue as long as they connect to an appropriate launching infrastructure.
+Each launch agent has a `max_jobs` parameter that sets the maximum number of simultaneous jobs the agent can run. Multiple agents can point to a single queue, as long as they connect to a launching infrastructure that supports them.
 
-You can set limits on CPU, GPU, memory, and other resources at the queue or job run level in the resource configuration. For information on setting up queues with resource limits on Kubernetes, see the [Kubernetes setup guide](/platform/launch/setup-launch-kubernetes/).
+You can set limits on CPU, GPU, memory, and other resources at the queue or job run level in the resource configuration. For information about setting up queues with resource limits on Kubernetes, see the [Kubernetes setup guide](/platform/launch/setup-launch-kubernetes/).
 
 For sweeps, include the following block in the queue configuration to limit the number of concurrent runs:
 

--- a/platform/launch/launch-faq/launch_tensorflow_gpu.mdx
+++ b/platform/launch/launch-faq/launch_tensorflow_gpu.mdx
@@ -1,8 +1,8 @@
 ---
-title: How do I make W&B Launch work with Tensorflow on GPU?
+title: How to make W&B Launch work with TensorFlow on GPU
 ---
 
-For TensorFlow jobs using GPUs, specify a custom base image for the container build. This ensures proper GPU utilization during runs. Add an image tag under the `builder.accelerator.base_image` key in the resource configuration. For example:
+To run TensorFlow jobs on GPUs with W&B Launch, specify a custom base image for the container build. This lets the resulting container access the GPU. Add an image tag under the `builder.accelerator.base_image` key in the resource configuration. For example:
 
 ```json
 {
@@ -15,4 +15,6 @@ For TensorFlow jobs using GPUs, specify a custom base image for the container bu
 }
 ```
 
-In versions prior to W&B 0.15.6, use `cuda` instead of `accelerator` as the parent key for `base_image`.
+<Note>
+In versions before W&B 0.15.6, use `cuda` instead of `accelerator` as the parent key for `base_image`.
+</Note>

--- a/platform/launch/launch-faq/launcherror_permission_denied.mdx
+++ b/platform/launch/launch-faq/launcherror_permission_denied.mdx
@@ -2,8 +2,8 @@
 title: How do I fix a "permission denied" error in Launch?
 ---
 
-If you encounter the error message `Launch Error: Permission denied`, it indicates insufficient permissions to log to the desired project. Possible causes include:
+If you see the error `Launch Error: Permission denied`, you don't have permission to log to the project. Review the following causes and resolutions:
 
-1. You are not logged in on this machine. Run [`wandb login`](/models/ref/cli/wandb-login) in the command line.
-2. The specified entity does not exist. The entity must be your username or an existing team's name. Create a team if necessary with the [Subscriptions page](https://app.wandb.ai/billing).
-3. You lack project permissions. Request the project creator to change the privacy setting to **Open** to allow logging runs to the project.
+- You aren't logged in on this machine. Run [`wandb login`](/models/ref/cli/wandb-login) in the command line.
+- The specified entity doesn't exist. The entity must be your username or the name of an existing team. If necessary, create a team on the [Subscriptions page](https://app.wandb.ai/billing).
+- You lack project permissions. Ask the project creator to change the privacy setting to **Open** so you can log runs to the project.

--- a/platform/launch/launch-faq/permissions_agent_require_kubernetes.mdx
+++ b/platform/launch/launch-faq/permissions_agent_require_kubernetes.mdx
@@ -2,4 +2,6 @@
 title: What permissions does the agent require in Kubernetes?
 ---
 
-The following Kubernetes manifest creates a role named `wandb-launch-agent` in the `wandb` namespace. This role allows the agent to create pods, configmaps, secrets, and access pod logs in the `wandb` namespace. The `wandb-cluster-role` enables the agent to create pods, access pod logs, create secrets, jobs, and check job status across any specified namespace.
+This page describes the Kubernetes permissions that the W&B Launch agent requires to run jobs in your cluster. Use this information to configure role-based access control (RBAC) for the agent before you deploy it.
+
+The following Kubernetes manifest creates a Role named `wandb-launch-agent` in the `wandb` namespace. This Role lets the agent create Pods, ConfigMaps, and Secrets, and access Pod logs in the `wandb` namespace. The `wandb-cluster-role` lets the agent create Pods, access Pod logs, create Secrets and Jobs, and check Job status across any specified namespace.

--- a/platform/launch/launch-faq/requirements_accelerator_base_image.mdx
+++ b/platform/launch/launch-faq/requirements_accelerator_base_image.mdx
@@ -2,9 +2,9 @@
 title: What requirements does the accelerator base image have?
 ---
 
-For jobs utilizing an accelerator, provide a base image that includes the necessary accelerator components. Ensure the following requirements for the accelerator image:
+For W&B Launch jobs that use an accelerator, provide a base image that includes the necessary accelerator components. This ensures that your job has the required GPU drivers, runtime libraries, and other hardware-specific dependencies to execute. The accelerator image must meet the following requirements:
 
-- Compatibility with Debian (the Launch Dockerfile uses apt-get to install Python)
-- Supported CPU and GPU hardware instruction set (confirm the CUDA version compatibility with the intended GPU)
-- Compatibility between the supplied accelerator version and the packages in the machine learning algorithm
-- Installation of packages that require additional steps for hardware compatibility
+- Compatibility with Debian (the Launch Dockerfile uses `apt-get` to install Python).
+- Supported CPU and GPU hardware instruction set (confirm the CUDA version compatibility with the intended GPU).
+- Compatibility between the supplied accelerator version and the packages in the machine learning algorithm.
+- Installation of packages that require additional steps for hardware compatibility.

--- a/platform/launch/launch-faq/restrict_access_modify_example.mdx
+++ b/platform/launch/launch-faq/restrict_access_modify_example.mdx
@@ -2,4 +2,4 @@
 title: How can admins restrict which users have modify access?
 ---
 
-Control access to certain queue fields for users who are not team administrators through [queue config templates](/platform/launch/setup-queue-advanced/). Team administrators define which fields non-admin users can view, and set the editing limits. Only team administrators have the ability to create or edit queues.
+Control access to certain queue fields for users who aren't team administrators through [queue config templates](/platform/launch/setup-queue-advanced/). Team administrators define which fields non-admin users can view, and set the editing limits. Only team administrators can create or edit queues.

--- a/platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx
+++ b/platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx
@@ -1,11 +1,11 @@
 ---
-title: Can you specify secrets for jobs/automations? For instance, an API key which
+title: Can you specify secrets for jobs or automations? For instance, an API key which
   you do not wish to be directly visible to users?
 ---
 
 Yes. Follow these steps:
 
-1. Create a Kubernetes secret in the designated namespace for the runs using the command:  
-   `kubectl create secret -n <namespace> generic <secret_name> <secret_value>`
+1. Create a Kubernetes Secret in the designated namespace for the runs:  
+   `kubectl create secret -n [NAMESPACE] generic [SECRET-NAME] [SECRET-VALUE]`
 
-2. After creating the secret, configure the queue to inject the secret when runs start. Only cluster administrators can view the secret; end users cannot see it.
+2. After you create the secret, configure the queue to inject the secret when runs start. Only cluster administrators can view the secret. End users cannot see it.

--- a/platform/launch/launch-queue-observability.mdx
+++ b/platform/launch/launch-queue-observability.mdx
@@ -3,31 +3,33 @@ title: Monitor launch queue
 description: "Monitor launch queue workloads with an interactive dashboard to spot inefficient jobs and analyze resource usage."
 ---
 
-Use the interactive **Queue monitoring dashboard** to view when a launch queue is in heavy use or idle, visualize workloads that are running, and spot inefficient jobs. The launch queue dashboard is especially useful for deciding whether or not you are effectively using your compute hardware or cloud resources.
+Use the interactive **Queue monitoring dashboard** to view when a launch queue is in heavy use or idle, visualize workloads that are running, and spot inefficient jobs. The launch queue dashboard helps you decide whether you're effectively using your compute hardware or cloud resources.
 
 For deeper analysis, the page links to the W&B experiment tracking workspace and to external infrastructure monitoring providers like Datadog, NVIDIA Base Command, or cloud consoles.
 
 <Note>
-Queue monitoring dashboards are currently available only in the W&B Multi-tenant Cloud deployment option.
+Queue monitoring dashboards are available only in the W&B Multi-tenant Cloud deployment option.
 </Note>
 
 ## Dashboard and plots
+
 Use the **Monitor** tab to view the activity of a queue that occurred during the last seven days. Use the left panel to control time ranges, grouping, and filters.
 
-The dashboard contains a number of plots answering common questions about performance and efficiency. The following sections describe UI elements of queue dashboards.
+The dashboard contains several plots that answer common questions about performance and efficiency. The following sections describe UI elements of queue dashboards.
 
 ### Job status
-The **Job status** plot shows how many jobs are running, pending, queued, or completed in each time interval. Use the **Job status** plot for identifying periods of idleness in the queue. 
+
+The **Job status** plot shows how many jobs are running, pending, queued, or completed in each time interval. Use the **Job status** plot to identify periods of idleness in the queue.
 
 <Frame>
     <img src="/images/launch/launch_obs_jobstatus.png" alt="Job status timeline"  />
 </Frame>
 
-For example, suppose you have a fixed resource (such as DGX BasePod). If you observe an idle queue with the fixed resource, this might suggest an opportunity to run lower-priority pre-emptible launch jobs such as sweeps.
+For example, suppose you have a fixed resource (such as DGX BasePod). If you observe an idle queue with the fixed resource, this might suggest an opportunity to run lower-priority preemptible launch jobs such as sweeps.
 
 On the other hand, suppose you use a cloud resource and you see periodic bursts of activity. Periodic bursts of activity might suggest an opportunity to save money by reserving resources for particular times.
 
-To the right of the plot is a key that shows which colors represent the [status of a launch job](./launch-view-jobs#check-the-status-of-a-job).
+To the right of the plot, a key shows which colors represent the [status of a launch job](./launch-view-jobs#check-the-status-of-a-job).
 
 <Note>
 `Queued` items might indicate opportunities to shift workloads to other queues. A spike in failures can identify users who might need help with their launch job setup.
@@ -37,59 +39,57 @@ To the right of the plot is a key that shows which colors represent the [status 
 
 ### Queued time
 
-The **Queued time** plots shows the amount of time (in seconds) that a launch job was on a queue for a given date or time range. 
+The **Queued time** plot shows the amount of time (in seconds) that a launch job was on a queue for a given date or time range.
 
 <Frame>
     <img src="/images/launch/launch_obs_queuedtime.png" alt="Queued time metrics"  />
 </Frame>
 
-The x-axis shows a time frame that you specify and the y-axis shows the time (in seconds) a launch job was on a launch queue. For example, suppose on a given day there are 10 launch jobs queued. The **Queue time** plot shows 600 seconds if those 10 launch jobs wait an average of 60 seconds each.
+The x-axis shows a time that you specify, and the y-axis shows the time (in seconds) a launch job was on a launch queue. For example, suppose on a given day 10 launch jobs are queued. The **Queue time** plot shows 600 seconds if those 10 launch jobs wait an average of 60 seconds each.
 
 <Note>
 Use the **Queued time** plot to identify users affected by long queue times.
 </Note>
 
-Customize the color of each job with the `Grouping` control in the left bar.
-
-which can be particularly helpful for identifying which users and jobs are feeling the pain of scarce queue capacity.
+Customize the color of each job with the **Grouping** control in the left bar, which helps you identify which users and jobs are affected by scarce queue capacity.
 
 ### Job runs
+
+The **Job runs** plot shows the start and end of every job executed in a time period, with distinct colors for each run. This lets you see at a glance which workloads the queue was processing at a given time.
 
 <Frame>
     <img src="/images/launch/launch_obs_jobruns2.png" alt="Job runs timeline"  />
 </Frame>
 
-
-This plot shows the start and end of every job executed in a time period, with distinct colors for each run. This makes it easy to see at a glance what workloads the queue was processing at a given time.  
-
-Use the Select tool in the bottom right of the panel to brush over jobs to populate details in the table below.
+Use the **Select** tool in the bottom right of the panel to brush over jobs and populate details in the table below.
 
 
 
 ### CPU and GPU usage
-Use the **GPU use by a job**, **CPU use by a job**, **GPU memory by job**, and **System memory by job** to view the efficiency of your launch jobs. 
+
+Use the **GPU use by a job**, **CPU use by a job**, **GPU memory by job**, and **System memory by job** plots to view the efficiency of your launch jobs.
 
 <Frame>
     <img src="/images/launch/launch_obs_gpu.png" alt="GPU usage metrics"  />
 </Frame>
 
 
-For example, you can use the **GPU memory by job** to view if a W&B run took a long time to complete and whether or not it used a low percentage of its CPU cores.
+For example, you can use the **GPU memory by job** plot to view whether a W&B run took a long time to complete and whether it used a low percentage of its CPU cores.
 
-The x-axis of each plot shows the duration of a W&B run (created by a launch job) in seconds. Hover your mouse over a data point to view information about a W&B run such as the run ID, the project the run belongs to, the launch job that created the W&B run and more.
+The x-axis of each plot shows the duration of a W&B run (created by a launch job) in seconds. Hover your mouse over a data point to view information about a W&B run such as the run ID, the project the run belongs to, the launch job that created the W&B run, and more.
 
 ### Errors
 
-The **Errors** panel shows errors that occurred on a given launch queue. More specifically, the Errors panel shows a timestamp of when the error occurred, the name of the launch job where the error comes from, and the error message that was created. By default, errors are ordered from latest to oldest. 
+The **Errors** panel shows errors that occurred on a given launch queue. More specifically, the Errors panel shows a timestamp of when the error occurred, the name of the launch job where the error comes from, and the error message that was created. By default, errors appear in order from latest to oldest.
 
 <Frame>
     <img src="/images/launch/launch_obs_errors.png" alt="Error logs panel"  />
 </Frame>
 
-Use the **Errors** panel to identify and unblock users. 
+Use the **Errors** panel to identify and unblock users.
 
 ## External links
 
-The queue observability dashboard's view is consistent across all queue types, but in many cases, it can be useful to jump directly into environment-specific monitors. To accomplish this, add a link from the console directly from the queue observability dashboard.
+The queue observability dashboard's view is consistent across all queue types, but it's often useful to jump directly into environment-specific monitors. To do so, add a link from the console directly from the queue observability dashboard.
 
-At the bottom of the page, click `Manage Links` to open a panel. Add the full URL of the page you want. Next, add a label. Links that you add appear in the **External Links** section.
+To add an external link, click **Manage Links** to open a panel. Add the full URL of the page you want. Next, add a label. Links that you add appear in the **External Links** section.

--- a/platform/launch/launch-terminology.mdx
+++ b/platform/launch/launch-terminology.mdx
@@ -3,34 +3,41 @@ title: Launch terms and concepts
 description: "Learn key W&B Launch concepts including jobs, queues, target resources, agents, and agent environments."
 ---
 
-With W&B Launch, you enqueue [jobs](#launch-job) onto [queues](#launch-queue) to create runs. Jobs are python scripts instrumented with W&B. Queues hold a list of jobs to execute on a [target resource](#target-resources). [Agents](#launch-agent) pull jobs from queues and execute the jobs on target resources. W&B tracks launch jobs similarly to how W&B tracks [runs](/models/runs/).
+This page defines the core terms and concepts used throughout the W&B Launch documentation. Use it as a reference when you encounter unfamiliar terms in setup guides, tutorials, or the W&B App.
 
-### Launch job
-A launch job is a specific type of [W&B Artifact](/models/artifacts/) that represents a task to complete. For example, common launch jobs include training a model or triggering a model evaluation. Job definitions include:
+With W&B Launch, you enqueue [jobs](#launch-job) onto [queues](#launch-queue) to create runs. Jobs are Python scripts instrumented with W&B. Queues hold a list of jobs to execute on a [target resource](#target-resources). [Agents](#launch-agent) pull jobs from queues and execute them on target resources. W&B tracks Launch jobs similarly to how it tracks [runs](/models/runs/).
+
+The following sections describe each of these concepts in more detail.
+
+## Launch job
+
+A Launch job is a specific type of [W&B Artifact](/models/artifacts/) that represents a task to complete. For example, common Launch jobs include training a model or triggering a model evaluation. Job definitions include:
 
 - Python code and other file assets, including at least one runnable entrypoint.
 - Information about the input (config parameter) and output (metrics logged).
-- Information about the environment. (for example, `requirements.txt`, base `Dockerfile`).
+- Information about the environment (for example, `requirements.txt`, base `Dockerfile`).
 
-There are three main kinds of job definitions:
+The three main kinds of job definitions are:
 
-| Job types | Definition | How to run this job type | 
-| ---------- | --------- | -------------- |
-|Artifact-based (or code-based) jobs| Code and other assets are saved as a W&B artifact.| To run artifact-based jobs, Launch agent must be configured with a builder. |
-|Git-based jobs|  Code and other assets are cloned from a certain commit, branch, or tag in a git repository. | To run git-based jobs, Launch agent must be configured with a builder and git repository credentials. |
-|Image-based jobs|Code and other assets are baked into a Docker image. | To run image-based jobs, Launch agent might need to be configured with image repository credentials. | 
+| Job types | Definition | How to run this job type |
+| --------- | ---------- | ------------------------ |
+| Artifact-based (or code-based) jobs | Code and other assets are saved as a W&B artifact. | To run artifact-based jobs, you must configure the Launch agent with a builder. |
+| Git-based jobs | Code and other assets are cloned from a certain commit, branch, or tag in a git repository. | To run git-based jobs, you must configure the Launch agent with a builder and git repository credentials. |
+| Image-based jobs | Code and other assets are baked into a Docker image. | To run image-based jobs, you might need to configure the Launch agent with image repository credentials. |
 
 <Note>
-While Launch jobs can perform activities not related to model training--for example, deploy a model to a Triton inference server--all jobs must call `wandb.init()` to complete successfully. This creates a run for tracking purposes in a W&B workspace.
+Although Launch jobs can perform activities not related to model training (for example, deploying a model to a Triton inference server), all jobs must call `wandb.init()` to complete successfully. This creates a run for tracking purposes in a W&B workspace.
 </Note>
 
-Find jobs you created in the W&B App under the `Jobs` tab of your project workspace. From there, jobs can be configured and sent to a [launch queue](#launch-queue) to be executed on a variety of [target resources](#target-resources).
+Find jobs you created in the W&B App under the **Jobs** tab of your project workspace. From there, you can configure jobs and send them to a [Launch queue](#launch-queue) to execute on different [target resources](#target-resources).
 
-### Launch queue
-Launch *queues* are ordered lists of jobs to execute on a specific target resource. Launch queues are first-in, first-out. (FIFO). There is no practical limit to the number of queues you can have, but a good guideline is one queue per target resource. Jobs can be enqueued with the W&B App UI, W&B CLI or Python SDK. You can then configure one or more Launch agents to pull items from the queue and execute them on the queue's target resource.
+## Launch queue
 
-### Target resources
-The compute environment that a Launch queue is configured to execute jobs on is called the *target resource*.
+Launch *queues* are ordered lists of jobs to execute on a specific target resource. Launch queues are first-in, first-out (FIFO). No practical limit applies to the number of queues you can have, but a good guideline is one queue per target resource. You can enqueue jobs with the W&B App UI, W&B CLI, or Python SDK. You can then configure one or more Launch agents to pull items from the queue and execute them on the queue's target resource.
+
+## Target resources
+
+The compute environment that a Launch queue executes jobs on is called the *target resource*.
 
 W&B Launch supports the following target resources:
 
@@ -39,16 +46,18 @@ W&B Launch supports the following target resources:
 - [AWS SageMaker](/platform/launch/setup-launch-sagemaker/)
 - [Google Cloud Vertex AI](/platform/launch/setup-vertex/)
 
-Each target resource accepts a different set of configuration parameters called *resource configurations*. Resource configurations take on default values defined by each Launch queue, but can be overridden independently by each job. See the documentation for each target resource for more details.
+Each target resource accepts a different set of configuration parameters called *resource configurations*. Resource configurations take on default values defined by each Launch queue, but each job can override them independently. See the documentation for each target resource for more details.
 
-### Launch agent
-Launch agents are lightweight, persistent programs that periodically check Launch queues for jobs to execute. When a launch agent receives a job, it first builds or pulls the image from the job definition then runs it on the target resource.
+## Launch agent
 
-One agent may poll multiple queues, however the agent must be configured properly to support all of the backing target resources for each queue it is polling.
+Launch agents are lightweight, persistent programs that periodically check Launch queues for jobs to execute. When a Launch agent receives a job, it first builds or pulls the image from the job definition, then runs it on the target resource.
 
-### Launch agent environment
-The agent environment is the environment where a launch agent is running, polling for jobs.
+One agent can poll multiple queues. However, you must configure the agent properly to support all the backing target resources for each queue it polls.
+
+## Launch agent environment
+
+The agent environment is the environment where a Launch agent is running, polling for jobs.
 
 <Note>
-The agent's runtime environment is independent of a queue's target resource. In other words, agents can be deployed anywhere as long as they are configured sufficiently to access the required target resources.
+The agent's runtime environment is independent of a queue's target resource. In other words, you can deploy agents anywhere as long as you configure them sufficiently to access the required target resources.
 </Note>

--- a/platform/launch/launch-view-jobs.mdx
+++ b/platform/launch/launch-view-jobs.mdx
@@ -3,57 +3,60 @@ title: View launch jobs
 description: "View launch job details, list available jobs, and check job statuses in the W&B App and CLI."
 ---
 
-The following page describes how to view information about launch jobs added to queues.
+This page describes how to view information about launch jobs in queues. You can inspect job details in the W&B App, list jobs from the CLI, and interpret the status of a queued run.
 
 ## View jobs
 
-View jobs added to a queue with the W&B App.
+To view jobs in a queue, use the W&B App:
 
 1. Navigate to the W&B App at https://wandb.ai/home.
-2. Select **Launch** within the **Applications** section of the left sidebar.
+2. Select **Launch** in the **Applications** section of the left sidebar.
 3. Select the **All entities** dropdown and select the entity the launch job belongs to.
 4. Expand the collapsible UI from the Launch Application page to view a list of jobs added to that specific queue.
 
 <Note>
-A run is created when the launch agent executes a launch job. In other words, each run listed corresponds to a specific job that was added to that queue.
+The launch agent creates a run when it executes a launch job. In other words, each run listed corresponds to a specific job in that queue.
 </Note>
 
-For example, the following image shows two runs that were created from a job called `job-source-launch_demo-canonical`. The job was added to a queue called `Start queue`. The first run listed in the queue called `resilient-snowball` and the second run listed is called `earthy-energy-165`.
+For example, the following image shows two runs created from a job called `job-source-launch_demo-canonical`. The job is in a queue called `Start queue`. The first run in the queue is called `resilient-snowball` and the second run is called `earthy-energy-165`.
 
 
 <Frame>
-    <img src="/images/launch/launch_jobs_status.png" alt="Launch jobs status view"  />
+    <img src="/images/launch/launch_jobs_status.png" alt="Launch jobs status view" />
 </Frame>
 
-Within the W&B App UI you can find additional information about runs created from launch jobs such as the:
-   - **Run**: The name of the W&B run assigned to that job.
-   - **Job ID**: The name of the job. 
-   - **Project**: The name of the project the run belongs to.
-   - **Status**: The status of the queued run. 
-   - **Author**: The W&B entity that created the run.
-   - **Creation date**: The timestamp when the queue was created.
-   - **Start time**: The timestamp when the job started.
-   - **Duration**: Time, in seconds, it took to complete the job’s run.
+In the W&B App UI, you can find additional information about runs created from launch jobs, such as the:
 
-## List jobs 
-View a list of jobs that exist within a project with the W&B CLI. Use the W&B job list command and provide the name of the project and entity the launch job belongs to the `--project` and `--entity` flags, respectively. 
+- **Run**: The name of the W&B run assigned to that job.
+- **Job ID**: The name of the job.
+- **Project**: The name of the project the run belongs to.
+- **Status**: The status of the queued run.
+- **Author**: The W&B entity that created the run.
+- **Creation date**: The timestamp when the queue was created.
+- **Start time**: The timestamp when the job started.
+- **Duration**: Time, in seconds, it took to complete the job's run.
+
+## List jobs
+
+View a list of jobs that exist in a project with the W&B CLI. Use the `wandb job list` command and provide the name of the project and entity the launch job belongs to with the `--project` and `--entity` flags, respectively.
+
+Replace `[ENTITY]` with your W&B entity, and replace `[PROJECT-NAME]` with the name of the project the launch job belongs to.
 
 ```bash
- wandb job list --entity your-entity --project project-name
+wandb job list --entity [ENTITY] --project [PROJECT-NAME]
 ```
 
 ## Check the status of a job
 
-The following table defines the status a queued run can have:
-
+Each queued run has a status that reflects where it is in the launch lifecycle. The following table defines the statuses a queued run can have:
 
 | Status | Description |
 | --- | --- |
 | **Idle** | The run is in a queue with no active agents. |
 | **Queued** | The run is in a queue waiting for an agent to process it. |
-| **Pending** | The run has been picked up by an agent but has not yet started. This could be due to resources being unavailable on the cluster. |
+| **Pending** | An agent has picked up the run, but it hasn't started yet. This could be due to resources being unavailable on the cluster. |
 | **Running** | The run is currently executing. |
-| **Killed** | The job was killed by the user. |
-| **Crashed** | The run stopped sending data or did not successfully start. |
-| **Failed** | The run ended with a non-zero exit code or the run failed to start. |
+| **Killed** | The user killed the job. |
+| **Crashed** | The run stopped sending data or didn't successfully start. |
+| **Failed** | The run ended with a non-zero exit code, or the run failed to start. |
 | **Finished** | The job completed successfully. |

--- a/platform/launch/set-up-launch.mdx
+++ b/platform/launch/set-up-launch.mdx
@@ -2,85 +2,95 @@
 title: Set up Launch
 description: "Set up W&B Launch by configuring a queue and deploying an agent to submit jobs to your compute infrastructure."
 ---
-This page describes the high-level steps required to set up W&B Launch:
+This page describes the high-level steps required to set up W&B Launch so that you can submit machine learning jobs to your own compute infrastructure (such as Kubernetes, Amazon SageMaker, or Vertex AI) directly from W&B. Setting up Launch enables your team to share compute resources, queue jobs, and reproduce runs across environments.
 
-1. **Set up a queue**: Queues are FIFO and possess a queue configuration. A queue's configuration controls where and how jobs are executed on a target resource.
-2. **Set up an agent**: Agents run on your machine/infrastructure and poll one or more queues for launch jobs. When a job is pulled, the agent ensures that the image is built and available. The agent then submits the job to the target resource.
+To set up Launch, you must complete the following:
+
+1. **Set up a queue**: Queues are first-in, first-out (FIFO) and possess a queue configuration. A queue's configuration controls where and how jobs run on a target resource.
+2. **Set up an agent**: Agents run on your machine or infrastructure and poll one or more queues for launch jobs. When the agent pulls a job, it ensures that the image is built and available. The agent then submits the job to the target resource.
+
+After you complete both steps, your team can submit launch jobs to the queue and run them automatically on the target resource.
 
 
 ## Set up a queue
-Launch queues must be configured to point to a specific target resource along with any additional configuration specific to that resource. For example, a launch queue that points to a Kubernetes cluster might include environment variables or set a custom namespace its launch queue configuration. When you create a queue, you will specify both the target resource you want to use and the configuration for that resource to use.
+Configure launch queues to point to a specific target resource along with any additional configuration specific to that resource. For example, a launch queue that points to a Kubernetes cluster might include environment variables or set a custom namespace in its launch queue configuration. When you create a queue, you specify both the target resource you want to use and the configuration for that resource to use.
 
-When an agent receives a job from a queue, it also receives the queue configuration. When the agent submits the job to the target resource, it includes the queue configuration along with any overrides from the job itself. For example, you can use a job configuration to specify the Amazon SageMaker instance type for that job instance only. In this case, it is common to use [queue config templates](/platform/launch/setup-queue-advanced/#configure-queue-template) as the end user interface. 
+When an agent receives a job from a queue, it also receives the queue configuration. When the agent submits the job to the target resource, it includes the queue configuration along with any overrides from the job itself. For example, you can use a job configuration to specify the Amazon SageMaker instance type for that job instance only. In this case, it's common to use [queue config templates](/platform/launch/setup-queue-advanced/#configure-queue-template) as the end user interface. 
 
 ### Create a queue
-1. Navigate to Launch App at [wandb.ai/launch](https://wandb.ai/launch). 
-2. Click the **create queue** button on the top right of the screen. 
+
+Create a queue to define where launch jobs run and how they're configured. To create a queue:
+
+1. Navigate to Launch App at [wandb.ai/launch](https://wandb.ai/launch).
+2. Click the **create queue** button on the top right of the screen.
+3. From the **Entity** dropdown menu, select the entity the queue belongs to.
+4. Provide a name for your queue in the **Queue** field.
+5. From the **Resource** dropdown, select the compute resource you want jobs added to this queue to use.
+6. Choose whether to allow **Prioritization** for this queue. If prioritization is enabled, a user on your team can define a priority for their launch job when they enqueue it. Higher priority jobs run before lower priority jobs.
+7. Provide a resource configuration in either JSON or YAML format in the **Configuration** field. The structure and semantics of your configuration document depend on the resource type that the queue points to. For more details, see the dedicated set up page for your target resource.
 
 <Frame>
     <img src="/images/launch/create-queue.gif" alt="Creating a Launch queue"  />
 </Frame>
 
-3. From the **Entity** dropdown menu, select the entity the queue will belong to. 
-4. Provide a name for your queue in the **Queue** field. 
-5. From the **Resource** dropdown, select the compute resource you want jobs added to this queue to use.
-6. Choose whether to allow **Prioritization** for this queue. If prioritization is enabled, a user on your team can define a priority for their launch job when they enqueue them. Higher priority jobs are executed before lower priority jobs.
-7. Provide a resource configuration in either JSON or YAML format in the **Configuration** field. The structure and semantics of your configuration document will depend on the resource type that the queue is pointing to. For more details, see the dedicated set up page for your target resource.
+You now have a queue that can receive launch jobs and route them to your chosen target resource. Next, set up an agent to pull jobs from this queue.
 
 ## Set up a launch agent
-Launch agents are long running processes that poll one or more launch queues for jobs. Launch agents dequeue jobs in first in, first out (FIFO) order or in priority order depending on the queues they pull from. When an agent dequeues a job from a queue, it optionally builds an image for that job. The agent then submits the job to the target resource along with configuration options specified in the queue configuration.
+Launch agents are long-running processes that poll one or more launch queues for jobs. Launch agents dequeue jobs in FIFO order or in priority order depending on the queues they pull from. When an agent dequeues a job from a queue, it optionally builds an image for that job. The agent then submits the job to the target resource along with configuration options specified in the queue configuration.
 
 <Note>
-Agents are highly flexible and can be configured to support a wide variety of use cases. The required configuration for your agent will depend on your specific use case. See the dedicated page for [Docker](/platform/launch/setup-launch-docker/), [Amazon SageMaker](/platform/launch/setup-launch-sagemaker/), [Kubernetes](/platform/launch/setup-launch-kubernetes/), or [Vertex AI](/platform/launch/setup-vertex/).
+Agents are flexible and can be configured to support many use cases. The required configuration for your agent depends on your specific use case. See the dedicated page for [Docker](/platform/launch/setup-launch-docker/), [Amazon SageMaker](/platform/launch/setup-launch-sagemaker/), [Kubernetes](/platform/launch/setup-launch-kubernetes/), or [Vertex AI](/platform/launch/setup-vertex/).
 </Note>
 
 <Note>
-W&B recommends you start agents with a service account's API key, rather than a specific user's API key. There are two benefits to using a service account's API key:
-1. The agent isn't dependent on an individual user.
-2. The author associated with a run created through Launch is viewed by Launch as the user who submitted the launch job, rather than the user associated with the agent.
+W&B recommends you start agents with a service account's API key, rather than a specific user's API key. Using a service account's API key has two benefits:
+* The agent isn't dependent on an individual user.
+* Launch views the author associated with a run created through Launch as the user who submitted the launch job, rather than the user associated with the agent.
 </Note>
 
 ### Agent configuration
-Configure the launch agent with a YAML file named `launch-config.yaml`. By default, W&B checks for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent.
 
-The contents of your launch agent's configuration file will depend on your launch agent's environment, the launch queue's target resource, Docker builder requirements, cloud registry requirements, and so forth. 
+Configure the launch agent so it knows which queues to poll, which entity to operate under, and how many jobs to run in parallel. Configure the launch agent with a YAML file named `launch-config.yaml`. By default, W&B checks for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent.
 
-Independent of your use case, there are core configurable options for the launch agent:
-* `max_jobs`: maximum number of jobs the agent can execute in parallel 
-* `entity`: the entity that the queue belongs to
-* `queues`: the name of one or more queues for the agent to watch
+The contents of your launch agent's configuration file depend on your launch agent's environment, the launch queue's target resource, Docker builder requirements, cloud registry requirements, and so forth. 
+
+Independent of your use case, the launch agent has the following core configurable options:
+* `max_jobs`: Maximum number of jobs the agent can execute in parallel.
+* `entity`: The entity that the queue belongs to.
+* `queues`: The name of one or more queues for the agent to watch.
 
 <Note>
 You can use the W&B CLI to specify universal configurable options for the launch agent (instead of the config YAML file): maximum number of jobs, W&B entity, and launch queues. See the [`wandb launch-agent`](/models/ref/cli/wandb-launch-agent) command for more information.
 </Note>
 
 
-The following YAML snippet shows how to specify core launch agent config keys:
+The following YAML snippet shows how to specify core launch agent config keys. Replace `[ENTITY-NAME]` with your W&B entity, and replace `[QUEUE-NAME]` with the name of a queue for the agent to poll.
 
 ```yaml title="launch-config.yaml"
 # Max number of concurrent runs to perform. -1 = no limit
 max_jobs: -1
 
-entity: <entity-name>
+entity: [ENTITY-NAME]
 
 # List of queues to poll.
 queues:
-  - <queue-name>
+  - [QUEUE-NAME]
 ```
 
 ### Configure a container builder
-The launch agent can be configured to build images. You must configure the agent to use a container builder if you intend to use launch jobs created from git repositories or code artifacts. See the [Create a launch job](/platform/launch/create-launch-job/) for more information on how to create a launch job. 
+
+You can configure the launch agent to build images. You must configure the agent to use a container builder if you intend to use launch jobs created from git repositories or code artifacts. See [Create a launch job](/platform/launch/create-launch-job/) for more information on how to create a launch job. 
 
 W&B Launch supports three builder options:
 
 * Docker: The Docker builder uses a local Docker daemon to build images.
-* [Kaniko](https://github.com/GoogleContainerTools/kaniko):  Kaniko is a Google project that enables image building in environments where a Docker daemon is unavailable. 
-* Noop: The agent will not try to build jobs, and instead only pull pre-built images.
+* [Kaniko](https://github.com/GoogleContainerTools/kaniko): Kaniko is a Google project that enables image building in environments where a Docker daemon is unavailable.
+* Noop: The agent doesn't try to build jobs, and instead only pulls pre-built images.
 
 <Note>
 Use the Kaniko builder if your agent is polling in an environment where a Docker daemon is unavailable (for example, a Kubernetes cluster).
 
-See the [Set up Kubernetes](/platform/launch/setup-launch-kubernetes/) for details about the Kaniko builder.
+See [Set up Kubernetes](/platform/launch/setup-launch-kubernetes/) for details about the Kaniko builder.
 </Note>
 
 To specify an image builder, include the builder key in your agent configuration. For example, the following code snippet shows a portion of the launch config (`launch-config.yaml`) that specifies to use Docker or Kaniko:
@@ -91,19 +101,23 @@ builder:
 ```
 
 ### Configure a container registry
-In some cases, you might want to connect a launch agent to a cloud registry. Common scenarios where you might want to connect a launch agent to a cloud registry include:
+
+Sometimes, you might want to connect a launch agent to a cloud registry so it can pull pre-built images or push images it builds. Common scenarios for connecting a launch agent to a cloud registry include:
 
 * You want to run a job in an environment other than where you built it, such as a powerful workstation or cluster.
-* You want to use the agent to build images and run these images on Amazon SageMaker or VertexAI.
+* You want to use the agent to build images and run these images on Amazon SageMaker or Vertex AI.
 * You want the launch agent to provide credentials to pull from an image repository.
 
-To learn more about how to configure the agent to interact with a container registry, see the [Advanced agent set](/platform/launch/setup-agent-advanced/) up page.
+To learn more about how to configure the agent to interact with a container registry, see the [Advanced agent setup page](/platform/launch/setup-agent-advanced/).
 
 ## Activate the launch agent
-Activate the launch agent with the `launch-agent` W&B CLI command:
+
+After you configure the agent, activate it so that it starts polling the queues you specified and dispatching jobs to your target resource. Activate the launch agent with the `launch-agent` W&B CLI command. Replace `[QUEUE-1]` and `[QUEUE-2]` with the names of queues for the agent to poll:
 
 ```bash
-wandb launch-agent -q <queue-1> -q <queue-2> --max-jobs 5
+wandb launch-agent -q [QUEUE-1] -q [QUEUE-2] --max-jobs 5
 ```
 
-In some use cases, you might want to have a launch agent polling queues from within a Kubernetes cluster. See the [Advanced queue set up page](/platform/launch/setup-queue-advanced/) for more information.
+Once the agent is running, the agent pulls any jobs submitted to the specified queues and forwards them to the target resource.
+
+Sometimes, you might want to have a launch agent poll queues from within a Kubernetes cluster. See the [Advanced queue set up page](/platform/launch/setup-queue-advanced/) for more information.

--- a/platform/launch/setup-agent-advanced.mdx
+++ b/platform/launch/setup-agent-advanced.mdx
@@ -4,7 +4,7 @@ description: "Configure advanced agent options for W&B Launch including Docker a
 ---
 # Advanced agent setup
 
-This guide provides information on how to set up the W&B Launch agent to build container images in different environments.
+This guide explains how to configure the W&B Launch agent to build container images in different environments, push those images to cloud container registries, and customize the build process. Use it when you need to run launch jobs that require image builds and want to control where and how the agent produces those images. This page is for administrators and operators who deploy and manage the Launch agent.
 
 <Note>
 Build is only required for git and code artifact jobs. Image jobs do not require build.
@@ -14,56 +14,62 @@ See [Create a launch job](/platform/launch/create-launch-job/) for more informat
 
 ## Builders
 
+The Launch agent supports two builders for producing container images. Choose the builder that matches the environment where the agent runs.
+
 The Launch agent can build images using [Docker](https://docs.docker.com/) or [Kaniko](https://github.com/GoogleContainerTools/kaniko).
 
-* Kaniko: builds a container image in Kubernetes without running the build as a privileged container.
-* Docker: builds a container image by executing a `docker build` command locally.
+* Kaniko: Builds a container image in Kubernetes without running the build as a privileged container.
+* Docker: Builds a container image by executing a `docker build` command locally.
 
-The builder type can be controlled by the `builder.type` key in the launch agent config to either `docker`, `kaniko`, or `noop` to turn off build. By default, the agent helm chart sets the `builder.type` to `noop`. Additional keys in the `builder` section will be used to configure the build process.
+Control the builder type with the `builder.type` key in the Launch agent config. Set it to `docker`, `kaniko`, or `noop` to turn off build. By default, the agent Helm chart sets the `builder.type` to `noop`. The agent uses additional keys in the `builder` section to configure the build process.
 
-If no builder is specified in the agent config and a working `docker` CLI is found, the agent will default to using Docker. If Docker is not available the agent will default to `noop`.
+If you don't specify a builder in the agent config and a working `docker` CLI is found, the agent defaults to Docker. If Docker isn't available, the agent defaults to `noop`.
 
 <Note>
 Use Kaniko for building images in a Kubernetes cluster. Use Docker for all other cases.
 </Note>
 
 
-## Pushing to a container registry
+## Push to a container registry
 
-The launch agent tags all images it builds with a unique source hash. The agent pushes the image to the registry specified in the `builder.destination` key.
+To run built images on your compute target, the agent must push them to a container registry that the target can pull from. The following sections explain how the agent tags and uploads images.
 
-For example, if the `builder.destination` key is set to `my-registry.example.com/my-repository`, the agent will tag and push the image to `my-registry.example.com/my-repository:<source-hash>`. If the image exists in the registry, the build is skipped.
+The Launch agent tags all images it builds with a unique source hash. The agent pushes the image to the registry specified in the `builder.destination` key.
+
+For example, if you set the `builder.destination` key to `my-registry.example.com/my-repository`, the agent tags and pushes the image to `my-registry.example.com/my-repository:[SOURCE-HASH]`. If the image exists in the registry, the agent skips the build.
 
 ### Agent configuration
 
-If you are deploying the agent via our Helm chart, the agent config should be provided in the `agentConfig` key in the `values.yaml` file.
+The agent reads its configuration from a YAML file. Where you provide that file depends on how you run the agent.
 
-If you are invoking the agent yourself with `wandb launch-agent`, you can provide the agent config as a path to a YAML file with the `--config` flag. By default, the config will be loaded from `~/.config/wandb/launch-config.yaml`.
+If you deploy the agent with the Helm chart, provide the agent config in the `agentConfig` key in the `values.yaml` file.
 
-Within your launch agent config (`launch-config.yaml`), provide the name of the target resource environment and the container registry for the `environment` and `registry` keys, respectively.
+If you invoke the agent yourself with `wandb launch-agent`, provide the agent config as a path to a YAML file with the `--config` flag. By default, the agent loads the config from `~/.config/wandb/launch-config.yaml`.
 
-The following tabs demonstrates how to configure the launch agent based on your environment and registry.
+Within your Launch agent config (`launch-config.yaml`), provide the name of the target resource environment and the container registry for the `environment` and `registry` keys, respectively.
+
+The following tabs demonstrate how to configure the Launch agent based on your environment and registry.
 
 <Tabs>
 <Tab title="AWS">
-The AWS environment configuration requires the region key. The region should be the AWS region that the agent runs in. 
+The AWS environment configuration requires the region key. Set the region to the AWS region that the agent runs in.
 
 ```yaml title="launch-config.yaml"
 environment:
   type: aws
-  region: <aws-region>
+  region: [AWS-REGION]
 builder:
-  type: <kaniko|docker>
-  # URI of the ECR repository where the agent will store images.
-  # Make sure the region matches what you have configured in your
+  type: [BUILDER-TYPE]
+  # URI of the ECR repository where the agent stores images.
+  # Make sure the region matches what you configured in your
   # environment.
-  destination: <account-id>.ecr.<aws-region>.amazonaws.com/<repository-name>
-  # If using Kaniko, specify the S3 bucket where the agent will store the
+  destination: [ACCOUNT-ID].ecr.[AWS-REGION].amazonaws.com/[REPOSITORY-NAME]
+  # If you use Kaniko, specify the S3 bucket where the agent stores the
   # build context.
-  build-context-store: s3://<bucket-name>/<path>
+  build-context-store: s3://[BUCKET-NAME]/[PATH]
 ```
 
-The agent uses boto3 to load the default AWS credentials. See the [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) for more information on how to configure default AWS credentials.
+The agent uses `boto3` to load the default AWS credentials. See the [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) for more information on how to configure default AWS credentials.
 </Tab>
 <Tab title="Google Cloud">
 The Google Cloud environment requires region and project keys. Set `region` to the region that the agent runs in. Set `project` to the Google Cloud project that the agent runs in. The agent uses `google.auth.default()` in Python to load the default credentials.
@@ -71,47 +77,47 @@ The Google Cloud environment requires region and project keys. Set `region` to t
 ```yaml title="launch-config.yaml"
 environment:
   type: gcp
-  region: <gcp-region>
-  project: <gcp-project-id>
+  region: [GCP-REGION]
+  project: [GCP-PROJECT-ID]
 builder:
-  type: <kaniko|docker>
+  type: [BUILDER-TYPE]
   # URI of the Artifact Registry repository and image name where the agent
-  # will store images. Make sure the region and project match what you have
+  # stores images. Make sure the region and project match what you
   # configured in your environment.
-  uri: <region>-docker.pkg.dev/<project-id>/<repository-name>/<image-name>
-  # If using Kaniko, specify the GCS bucket where the agent will store the
+  uri: [REGION]-docker.pkg.dev/[PROJECT-ID]/[REPOSITORY-NAME]/[IMAGE-NAME]
+  # If you use Kaniko, specify the GCS bucket where the agent stores the
   # build context.
-  build-context-store: gs://<bucket-name>/<path>
+  build-context-store: gs://[BUCKET-NAME]/[PATH]
 ```
 
 See the [`google-auth` documentation](https://google-auth.readthedocs.io/en/latest/reference/google.auth.html#google.auth.default) for more information on how to configure default Google Cloud credentials so they are available to the agent.
 </Tab>
 <Tab title="Azure">
-The Azure environment does not require any additional keys. When the agent starts, it use `azure.identity.DefaultAzureCredential()` to load the default Azure credentials.
+The Azure environment doesn't require any additional keys. When the agent starts, it uses `azure.identity.DefaultAzureCredential()` to load the default Azure credentials.
 
 ```yaml title="launch-config.yaml"
 environment:
   type: azure
 builder:
-  type: <kaniko|docker>
-  # URI of the Azure Container Registry repository where the agent will store images.
-  destination: https://<registry-name>.azurecr.io/<repository-name>
-  # If using Kaniko, specify the Azure Blob Storage container where the agent
-  # will store the build context.
-  build-context-store: https://<storage-account-name>.blob.core.windows.net/<container-name>
+  type: [BUILDER-TYPE]
+  # URI of the Azure Container Registry repository where the agent stores images.
+  destination: https://[REGISTRY-NAME].azurecr.io/[REPOSITORY-NAME]
+  # If you use Kaniko, specify the Azure Blob Storage container where the agent
+  # stores the build context.
+  build-context-store: https://[STORAGE-ACCOUNT-NAME].blob.core.windows.net/[CONTAINER-NAME]
 ```
 
-See the [`azure-identity` documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on how to configure default Azure credentials.
+See the [`azure-identity` documentation](https://learn.microsoft.com/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) for more information on how to configure default Azure credentials.
 </Tab>
 </Tabs>
 
 ## Agent permissions
 
-The agent permissions required vary by use case.
+The agent must have permission to push images to your container registry and, if you use Kaniko, to read and write build context in cloud storage. The agent permissions required vary by use case.
 
 ### Cloud registry permissions
 
-Below are the permissions that are generally required by launch agents to interact with cloud registries.
+The agent needs registry permissions so it can create repositories, upload image layers, and push tagged images. The following permissions are required for Launch agents to interact with cloud registries.
 
 <Tabs>
 <Tab title="AWS">
@@ -134,7 +140,7 @@ Below are the permissions that are generally required by launch agents to intera
             'ecr:BatchCheckLayerAvailability',
             'ecr:BatchDeleteImage',
           ],
-        'Resource': 'arn:aws:ecr:<region>:<account-id>:repository/<repository>',
+        'Resource': 'arn:aws:ecr:[REGION]:[ACCOUNT-ID]:repository/[REPOSITORY]',
       },
       {
         'Effect': 'Allow',
@@ -160,11 +166,11 @@ Add the [`AcrPush` role](https://learn.microsoft.com/azure/role-based-access-con
 
 ### Storage permissions for Kaniko
 
-The launch agent requires permission to push to cloud storage if the agent uses the Kaniko builder. Kaniko uses a context store outside of the pod running the build job.
+The Launch agent requires permission to push to cloud storage if the agent uses the Kaniko builder. Kaniko uses a context store outside of the pod that runs the build job.
 
 <Tabs>
 <Tab title="AWS">
-The recommended context store for the Kaniko builder on AWS is Amazon S3. The following policy can be used to give the agent access to an S3 bucket:
+Use Amazon S3 as the context store for the Kaniko builder on AWS. Use the following policy to give the agent access to an S3 bucket:
 
 ```json
 {
@@ -174,20 +180,20 @@ The recommended context store for the Kaniko builder on AWS is Amazon S3. The fo
       "Sid": "ListObjectsInBucket",
       "Effect": "Allow",
       "Action": ["s3:ListBucket"],
-      "Resource": ["arn:aws:s3:::<BUCKET-NAME>"]
+      "Resource": ["arn:aws:s3:::[BUCKET-NAME]"]
     },
     {
       "Sid": "AllObjectActions",
       "Effect": "Allow",
       "Action": "s3:*Object",
-      "Resource": ["arn:aws:s3:::<BUCKET-NAME>/*"]
+      "Resource": ["arn:aws:s3:::[BUCKET-NAME]/*"]
     }
   ]
 }
 ```
 </Tab>
 <Tab title="Google Cloud">
-On Google Cloud, the following IAM permissions are required for the agent to upload build contexts to GCS:
+On Google Cloud, the agent requires the following IAM permissions to upload build contexts to GCS:
 
 ```js
 storage.buckets.get;
@@ -197,20 +203,20 @@ storage.objects.get;
 ```
 </Tab>
 <Tab title="Azure">
-The [Storage Blob Data Contributor](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor) role is required in order for the agent to upload build contexts to Azure Blob Storage.
+The agent requires the [Storage Blob Data Contributor](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor) role to upload build contexts to Azure Blob Storage.
 </Tab>
 </Tabs>
 
 
-## Customizing the Kaniko build
+## Customize the Kaniko build
 
-Specify the Kubernetes Job spec that the Kaniko job uses in the `builder.kaniko-config` key of the agent configuration. For example:
+To override defaults such as caching behavior or environment variables for the build pod, customize the Kubernetes Job that Kaniko runs. Specify the Kubernetes Job spec that the Kaniko job uses in the `builder.kaniko-config` key of the agent configuration. For example:
 
 ```yaml title="launch-config.yaml"
 builder:
   type: kaniko
-  build-context-store: <my-build-context-store>
-  destination: <my-image-destination>
+  build-context-store: [MY-BUILD-CONTEXT-STORE]
+  destination: [MY-IMAGE-DESTINATION]
   build-job-name: wandb-image-build
   kaniko-config:
     spec:
@@ -224,11 +230,12 @@ builder:
               value: "my-env-var-value"
 ```
 
-## Deploy Launch agent into CoreWeave 
-Optionally deploy the W&B Launch agent to CoreWeave Cloud infrastructure. CoreWeave is a cloud infrastructure that is purpose built for GPU-accelerated workloads.
+## Deploy Launch agent into CoreWeave
 
-For information on how to deploy the Launch agent to CoreWeave, see the [CoreWeave documentation](https://docs.coreweave.com/partners/weights-and-biases#integration). 
+If your workloads benefit from GPU-accelerated infrastructure, you can deploy the Launch agent to CoreWeave Cloud. CoreWeave is a cloud infrastructure built for GPU-accelerated workloads.
+
+For information on how to deploy the Launch agent to CoreWeave, see the [CoreWeave documentation](https://docs.coreweave.com/partners/weights-and-biases#integration).
 
 <Note>
-You will need to create a [CoreWeave account](https://cloud.coreweave.com/login) in order to deploy the Launch agent into a CoreWeave infrastructure.
+You need to create a [CoreWeave account](https://cloud.coreweave.com/login) to deploy the Launch agent into a CoreWeave infrastructure.
 </Note>

--- a/platform/launch/setup-launch-docker.mdx
+++ b/platform/launch/setup-launch-docker.mdx
@@ -2,31 +2,30 @@
 title: 'Tutorial: Set up W&B Launch with Docker'
 description: "Set up W&B Launch to run ML jobs using Docker on a local machine as both the agent environment and compute target."
 ---
-The following guide describes how to configure W&B Launch to use Docker on a local machine for both the launch agent environment and for the queue's target resource.
+This tutorial describes how to configure W&B Launch to use Docker on a local machine for both the launch agent environment and for the queue's target resource. By the end, you have a working Docker-based launch queue and a local launch agent ready to run ML jobs.
 
-Using Docker to execute jobs and as the launch agent's environment on the same local machine is particularly useful if your compute is installed on a machine that does not have a cluster management system (such as Kubernetes).
-
-You can also use Docker queues to run workloads on powerful workstations.
+Using Docker to run jobs and as the launch agent's environment on the same local machine is useful if your compute is installed on a machine that doesn't have a cluster management system (such as Kubernetes). You can also use Docker queues to run workloads on workstations.
 
 <Note>
-This set up is common for users who perform experiments on their local machine, or that have a remote machine that they SSH in to, to submit launch jobs.
+This setup is common for users who run experiments on their local machine, or who SSH into a remote machine to submit launch jobs.
 </Note>
 
-When you use Docker with W&B Launch, W&B will first build an image, and then build and run a container from that image. The image is built with the Docker `docker run <image-uri>` command. The queue configuration is interpreted as additional arguments that are passed to the `docker run` command.
+When you use Docker with Launch, W&B first builds an image, and then builds and runs a container from that image. W&B builds the image with the Docker `docker run [IMAGE-URI]` command. W&B interprets the queue configuration as additional arguments passed to the `docker run` command.
 
 {/* Future: Insert diagram */}
 
 ## Configure a Docker queue
 
+A queue configuration for a Docker target resource defines how Launch translates queue options into a `docker run` command.
 
 The launch queue configuration (for a Docker target resource) accepts the same options defined in the [`docker run`](/models/ref/cli/wandb-docker-run) CLI command.
 
-The agent receives options defined in the queue configuration. The agent then merges the received options with any overrides from the launch job’s configuration to produce a final `docker run` command that is executed on the target resource (in this case, a local machine).
+The agent receives options defined in the queue configuration. The agent then merges the received options with any overrides from the launch job's configuration to produce a final `docker run` command that runs on the target resource (in this case, a local machine).
 
-There are two syntax transformations that take place:
+Two syntax transformations take place:
 
-1. Repeated options are defined in the queue configuration as a list.
-2. Flag options are defined in the queue configuration as a Boolean with the value `true`.
+- Define repeated options in the queue configuration as a list.
+- Define flag options in the queue configuration as a boolean with the value `true`.
 
 For example, the following queue configuration:
 
@@ -46,15 +45,15 @@ docker run \
   --env MY_ENV_VAR=value \
   --env MY_EXISTING_ENV_VAR \
   --volume "/mnt/datasets:/mnt/datasets" \
-  --rm <image-uri> \
+  --rm [IMAGE-URI] \
   --gpus all
 ```
 
-Volumes can be specified either as a list of strings, or a single string. Use a list if you specify multiple volumes.
+Specify volumes either as a list of strings, or as a single string. Use a list if you specify multiple volumes.
 
-Docker automatically passes environment variables, that are not assigned a value, from the launch agent environment. This means that, if the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that environment variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
+Docker passes environment variables that aren't assigned a value from the launch agent environment. If the launch agent has an environment variable `MY_EXISTING_ENV_VAR`, that variable is available in the container. This is useful if you want to use other config keys without publishing them in the queue configuration.
 
-The `--gpus` flag of the `docker run` command allows you to specify GPUs that are available to a Docker container. For more information on how to use the `gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
+The `--gpus` flag of the `docker run` command lets you specify GPUs that are available to a Docker container. For more information about the `--gpus` flag, see the [Docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu).
 
 
 <Note>
@@ -78,64 +77,65 @@ The `--gpus` flag of the `docker run` command allows you to specify GPUs that ar
 
 ## Create a queue
 
-Create a queue that uses Docker as compute resource with the W&B CLI:
+To create a queue that uses Docker as the compute resource, follow these steps:
 
 1. Navigate to the [Launch page](https://wandb.ai/launch).
-2. Click on the **Create Queue** button.
-3. Select the **Entity** you would like to create the queue in.
+2. Click the **Create Queue** button.
+3. Select the **Entity** you want to create the queue in.
 4. Enter a name for your queue in the **Name** field.
 5. Select **Docker** as the **Resource**.
 6. Define your Docker queue configuration in the **Configuration** field.
-7. Click on the **Create Queue** button to create the queue.
+7. Click the **Create Queue** button.
+
+You now have a Docker-based launch queue ready to receive jobs. Next, configure a launch agent on your local machine to pull jobs from this queue.
 
 ## Configure a launch agent on a local machine
 
-Configure the launch agent with a YAML config file named `launch-config.yaml`. By default, W&B will check for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent.
+Configure the launch agent with a YAML config file named `launch-config.yaml`. By default, W&B checks for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent.
 
 <Note>
 You can use the W&B CLI to specify core configurable options for the launch agent (instead of the config YAML file): maximum number of jobs, W&B entity, and launch queues. See the [`wandb launch-agent`](/models/ref/cli/wandb-launch-agent) command for more information.
 </Note>
 
 
-## Core agent config options
+### Core agent config options
 
 The following tabs demonstrate how to specify the core config agent options with the W&B CLI and with a YAML config file:
 
 <Tabs>
 <Tab title="W&B CLI">
 ```bash
-wandb launch-agent -q <queue-name> --max-jobs <n>
+wandb launch-agent -q [QUEUE-NAME] --max-jobs [N]
 ```
 </Tab>
 <Tab title="Config file">
 ```yaml title="launch-config.yaml"
-max_jobs: <n concurrent jobs>
+max_jobs: [N-CONCURRENT-JOBS]
 queues:
-	- <queue-name>
+	- [QUEUE-NAME]
 ```
 </Tab>
 </Tabs>
 
-## Docker image builders
+### Docker image builders
 
-The launch agent on your machine can be configured to build Docker images. By default, these images are stored on your machine’s local image repository. To enable your launch agent to build Docker images, set the `builder` key in the launch agent config to `docker`:
+You can configure the launch agent on your machine to build Docker images. By default, your machine's local image repository stores these images. To enable your launch agent to build Docker images, set the `builder` key in the launch agent config to `docker`:
 
 ```yaml title="launch-config.yaml"
 builder:
 	type: docker
 ```
 
-If you don't want the agent to build Docker images, and instead use prebuilt images from a registry, set the `builder` key in the launch agent config to `noop`
+If you don't want the agent to build Docker images, and instead use prebuilt images from a registry, set the `builder` key in the launch agent config to `noop`:
 
 ```yaml title="launch-config.yaml"
 builder:
   type: noop
 ```
 
-## Container registries
+### Container registries
 
-Launch uses external container registeries such as Dockerhub, Google Container Registry, Azure Container Registry, and Amazon ECR.  
-If you want to run a job on a different environment from where you built it, configure your agent to be able to pull from a container registry. 
+Launch uses external container registries such as Docker Hub, Google Container Registry, Azure Container Registry, and Amazon ECR. If you want to run a job on a different environment from where you built it, configure your agent to pull from a container registry, so the agent can retrieve images that weren't built locally.
 
 
-To learn more about how connect the launch agent with a cloud registry, see the [Advanced agent setup](./setup-agent-advanced#agent-configuration) page.
+To learn more about how to connect the launch agent with a cloud registry, see the [Advanced agent setup](./setup-agent-advanced#agent-configuration) page.

--- a/platform/launch/setup-launch-kubernetes.mdx
+++ b/platform/launch/setup-launch-kubernetes.mdx
@@ -2,21 +2,19 @@
 title: 'Tutorial: Set up W&B Launch on Kubernetes'
 description: "Set up W&B Launch on a Kubernetes cluster using Helm charts, Kaniko image building, and Kubernetes job specs."
 ---
-You can use W&B Launch to push ML workloads to a Kubernetes cluster, giving ML engineers a simple interface right in W&B to use the resources you already manage with Kubernetes. 
+This tutorial walks cluster administrators through setting up W&B Launch on a Kubernetes cluster so ML engineers can submit and manage training workloads directly from W&B. You can use W&B Launch to push ML workloads to a Kubernetes cluster, giving ML engineers an interface right in W&B to use the resources you already manage with Kubernetes.
 
-W&B maintains an [official Launch agent image](https://hub.docker.com/r/wandb/launch-agent) that can be deployed to your cluster with a [Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) that W&B maintains. 
+W&B maintains an [official Launch agent image](https://hub.docker.com/r/wandb/launch-agent) that you can deploy to your cluster with a [Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) that W&B maintains.
 
-W&B uses the [Kaniko](https://github.com/GoogleContainerTools/kaniko) builder to enable the Launch agent to build Docker images in a Kubernetes cluster. To learn more on how to set up Kaniko for the Launch agent, or how to turn off job building and only use prebuilt Docker images, see [Advanced agent set up](./setup-agent-advanced).
+W&B uses the [Kaniko](https://github.com/GoogleContainerTools/kaniko) builder to let the Launch agent build Docker images in a Kubernetes cluster. To learn more about how to set up Kaniko for the Launch agent, or how to turn off job building and only use prebuilt Docker images, see [Advanced agent setup](./setup-agent-advanced).
 
 <Note>
-To install Helm and apply or upgrade W&B's Launch agent Helm chart, you need `kubectl` access to the cluster with sufficient permissions to create, update, and delete Kubernetes resources. Typically, a user with cluster-admin or a custom role with equivalent permissions is required.
+To install Helm and apply or upgrade the W&B Launch agent Helm chart, you must have `kubectl` access to the cluster with sufficient permissions to create, update, and delete Kubernetes resources. Typically, this requires a user with `cluster-admin` or a custom role with equivalent permissions.
 </Note>
-
-{/* Future: insert diagram here */}
 
 ## Configure a queue for Kubernetes
 
-The Launch queue configuration for a Kubernetes target resource will resemble either a [Kubernetes Job spec](https://kubernetes.io/docs/concepts/workloads/controllers/job/) or a [Kubernetes Custom Resource spec](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+A Launch queue defines the Kubernetes workload spec that the agent uses to run each job. The Launch queue configuration for a Kubernetes target resource resembles either a [Kubernetes job spec](https://kubernetes.io/docs/concepts/workloads/controllers/job/) or a [Kubernetes custom resource spec](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
 You can control any aspect of the Kubernetes workload resource spec when you create a Launch queue.
 
@@ -41,7 +39,7 @@ namespace: wandb
 ```
 </Tab>
 <Tab title="Custom resource spec">
-In some use cases, you might want to use `CustomResource` definitions. `CustomResource` definitions are useful if, for example, you want to perform multi-node distributed training. See the tutorial for using Launch with multi-node jobs using Volcano for an example application. Another use case might be that you want to use W&B Launch with Kubeflow.
+In some use cases, you might want to use `CustomResource` definitions. For example, `CustomResource` definitions are useful when you want to perform multi-node distributed training. See the tutorial for using Launch with multi-node jobs using Volcano for an example application. Another use case is when you want to use Launch with Kubeflow.
 
 The following YAML snippet shows a sample Launch queue config that uses Kubeflow:
 
@@ -76,24 +74,24 @@ kubernetes:
 </Tab>
 </Tabs>
 
-For security reasons, W&B will inject the following resources into your Launch queue if they are not specified:
+For security reasons, W&B injects the following resources into your Launch queue if you don't specify them:
 
 - `securityContext`
 - `backOffLimit`
 - `ttlSecondsAfterFinished`
 
-The following YAML snippet demonstrates how these values will appear in your launch queue:
+The following YAML snippet shows how these values appear in your Launch queue:
 
 ```yaml title="example-spec.yaml"
 spec:
   template:
-    `backOffLimit`: 0
+    backOffLimit: 0
     ttlSecondsAfterFinished: 60
     securityContext:
-      allowPrivilegeEscalation: False,
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
-          - ALL,
+          - ALL
       seccompProfile:
         type: "RuntimeDefault"
 ```
@@ -103,36 +101,36 @@ spec:
 Create a queue in the W&B App that uses Kubernetes as its compute resource:
 
 1. Navigate to the [Launch page](https://wandb.ai/launch).
-2. Click on the **Create Queue** button.
-3. Select the **Entity** you would like to create the queue in.
+2. Click the **Create Queue** button.
+3. Select the **Entity** in which you want to create the queue.
 4. Provide a name for your queue in the **Name** field.
 5. Select **Kubernetes** as the **Resource**.
-6. Within the **Configuration** field, provide the Kubernetes Job workflow spec or Custom Resource spec you [configured in the previous section](#configure-a-queue-for-kubernetes).
+6. Within the **Configuration** field, provide the Kubernetes job workflow spec or custom resource spec you configured in [Configure a queue for Kubernetes](#configure-a-queue-for-kubernetes).
 
 ## Configure a Launch agent with Helm
 
-Use the [Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) provided by W&B to deploy the Launch agent into your Kubernetes cluster. Control the behavior of the launch agent with the `values.yaml` [file](https://github.com/wandb/helm-charts/blob/main/charts/launch-agent/values.yaml).
+With a queue in place, you next deploy the Launch agent that pulls jobs from the queue and runs them on your cluster. Use the [Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) provided by W&B to deploy the Launch agent into your Kubernetes cluster. Control the behavior of the Launch agent with the `values.yaml` [file](https://github.com/wandb/helm-charts/blob/main/charts/launch-agent/values.yaml).
 
-Specify the contents that would normally by defined in your launch agent config file (`~/.config/wandb/launch-config.yaml`) within the `launchConfig` key in the`values.yaml` file.
+Within the `launchConfig` key in the `values.yaml` file, specify the contents that you would normally define in your Launch agent config file (`~/.config/wandb/launch-config.yaml`).
 
-For example, suppose you have Launch agent config that enables you to run a Launch agent in EKS that uses the Kaniko Docker image builder:
+For example, suppose you have a Launch agent config that lets you run a Launch agent in EKS that uses the Kaniko Docker image builder. Replace `[QUEUE-NAME]`, `[MAX-CONCURRENT-JOBS]`, `[MY-REGISTRY-URI]`, and `[S3-BUCKET-URI]` with your own values:
 
 ```yaml title="launch-config.yaml"
 queues:
-	- <queue name>
-max_jobs: <n concurrent jobs>
+  - [QUEUE-NAME]
+max_jobs: [MAX-CONCURRENT-JOBS]
 environment:
-	type: aws
-	region: us-east-1
+  type: aws
+  region: us-east-1
 registry:
-	type: ecr
-	uri: <my-registry-uri>
+  type: ecr
+  uri: [MY-REGISTRY-URI]
 builder:
-	type: kaniko
-	build-context-store: <s3-bucket-uri>
+  type: kaniko
+  build-context-store: [S3-BUCKET-URI]
 ```
 
-Within your `values.yaml` file, this might look like:
+Within your `values.yaml` file, this might look like the following. Replace `[QUEUE-NAME]`, `[MAX-CONCURRENT-JOBS]`, `[AWS-REGION]`, `[MY-REGISTRY-URI]`, and `[S3-BUCKET-URI]` with your own values:
 
 ```yaml title="values.yaml"
 agent:
@@ -163,17 +161,17 @@ additionalTargetNamespaces:
 # This should be set to the literal contents of your launch agent config.
 launchConfig: |
   queues:
-    - <queue name>
-  max_jobs: <n concurrent jobs>
+    - [QUEUE-NAME]
+  max_jobs: [MAX-CONCURRENT-JOBS]
   environment:
     type: aws
-    region: <aws-region>
+    region: [AWS-REGION]
   registry:
     type: ecr
-    uri: <my-registry-uri>
+    uri: [MY-REGISTRY-URI]
   builder:
     type: kaniko
-    build-context-store: <s3-bucket-uri>
+    build-context-store: [S3-BUCKET-URI]
 
 # The contents of a git credentials file. This will be stored in a k8s secret
 # and mounted into the agent container. Set this if you want to clone private
@@ -190,4 +188,4 @@ serviceAccount:
 azureStorageAccessKey: ''
 ```
 
-For more information on registries, environments, and required agent permissions see [Advanced agent set up](./setup-agent-advanced).
+For more information about registries, environments, and required agent permissions, see [Advanced agent setup](./setup-agent-advanced).

--- a/platform/launch/setup-launch-sagemaker.mdx
+++ b/platform/launch/setup-launch-sagemaker.mdx
@@ -2,47 +2,53 @@
 title: 'Tutorial: Set up W&B Launch on SageMaker'
 description: "Configure W&B Launch to submit training jobs to Amazon SageMaker with ECR, S3, and IAM setup instructions."
 ---
-You can use W&B Launch to submit launch jobs to Amazon SageMaker to train machine learning models using provided or custom algorithms on the SageMaker platform. SageMaker takes care of spinning up and releasing compute resources, so it can be a good choice for teams without an EKS cluster.
+This tutorial shows ML engineers and platform administrators how to configure W&B Launch to submit training jobs to Amazon SageMaker. By the end, you'll have the AWS resources, IAM roles, queue configuration, and Launch agent required to run SageMaker training jobs from W&B.
 
-Launch jobs sent to a W&B Launch queue connected to Amazon SageMaker are executed as SageMaker Training Jobs with the [CreateTrainingJob API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html). Use the launch queue configuration to control arguments sent to the `CreateTrainingJob` API.
+You can use W&B Launch to submit Launch jobs to Amazon SageMaker to train machine learning models using provided or custom algorithms on the SageMaker platform. SageMaker handles compute resource provisioning and release, so it can be a good choice for teams without an EKS cluster.
 
-Amazon SageMaker [uses Docker images to execute training jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo-dockerfile.html). Images pulled by SageMaker must be stored in the Amazon Elastic Container Registry (ECR). This means that the image you use for training must be stored on ECR. 
+A W&B Launch queue connected to Amazon SageMaker runs Launch jobs as SageMaker Training Jobs with the [CreateTrainingJob API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html). Use the Launch queue configuration to control arguments sent to the `CreateTrainingJob` API.
+
+Amazon SageMaker [uses Docker images to run training jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo-dockerfile.html). You must store images pulled by SageMaker in the Amazon Elastic Container Registry (ECR). This means you must store the image you use for training on ECR.
 
 <Note>
-This guide shows how to execute SageMaker Training Jobs. For information on how to deploy to models for inference on Amazon SageMaker, see [this example Launch job](https://github.com/wandb/launch-jobs/tree/main/jobs/deploy_to_sagemaker_endpoints).
+This guide shows how to run SageMaker Training Jobs. For information about how to deploy models for inference on Amazon SageMaker, see [this example Launch job](https://github.com/wandb/launch-jobs/tree/main/jobs/deploy_to_sagemaker_endpoints).
 </Note>
 
 
 ## Prerequisites
 
-Before you get started, ensure you satisfy the following prerequisites:
+Before you get started, you must satisfy the following prerequisites:
 
-* [Decide if you want the Launch agent to build a Docker image for you.](#decide-if-you-want-the-launch-agent-to-build-a-docker-images)
-* [Set up AWS resources and gather information about S3, ECR, and Sagemaker IAM roles.](#set-up-aws-resources)
-* [Create an IAM role for the Launch agent](#create-an-iam-role-for-launch-agent).
+* [Decide if you want the Launch agent to build a Docker image for you](#decide-if-you-want-the-launch-agent-to-build-a-docker-image).
+* [Set up AWS resources and gather information about S3, ECR, and SageMaker IAM roles](#set-up-aws-resources).
+* [Create an IAM role for the Launch agent](#create-an-iam-role-for-the-launch-agent).
 
-### Decide if you want the Launch agent to build a Docker images
+The following sections describe how to complete each prerequisite.
 
-Decide if you want the W&B Launch agent to build a Docker image for you. There are two options you can choose from: 
+### Decide if you want the Launch agent to build a Docker image
 
-* Permit the launch agent build a Docker image, push the image to Amazon ECR, and submit [SageMaker Training](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html) jobs for you. This option can offer some simplicity to ML Engineers rapidly iterating over training code.  
-* The launch agent uses an existing Docker image that contains your training or inference scripts. This option works well with existing CI systems. If you choose this option, you will need to manually upload your Docker image to your container registry on Amazon ECR.
+Decide if you want the W&B Launch agent to build a Docker image for you. You can choose from two options:
+
+* Permit the Launch agent to build a Docker image, push the image to Amazon ECR, and submit [SageMaker Training](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html) jobs for you. This option can offer some simplicity to ML engineers who rapidly iterate over training code.
+* Use an existing Docker image that contains your training or inference scripts. This option works well with existing CI systems. If you choose this option, you must manually upload your Docker image to your container registry on Amazon ECR.
 
 
 ### Set up AWS resources
 
-Ensure you have the following AWS resources configured in your preferred AWS region:
+You must have the following AWS resources configured in your preferred AWS region:
 
 1. An [ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to store container images.
 2. One or more [S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to store inputs and outputs for your SageMaker Training jobs.
 3. An IAM role for Amazon SageMaker that permits SageMaker to run training jobs and interact with Amazon ECR and Amazon S3.
 
-Make a note of the ARNs for these resources. You will need the ARNs when you define the [Launch queue configuration](#configure-launch-queue-for-sagemaker).
+Record the ARNs for these resources. You need the ARNs when you define the [Launch queue configuration](#configure-launch-queue-for-sagemaker).
 
-### Create a IAM Policy for Launch agent
+### Create an IAM policy for the Launch agent
+
+The Launch agent requires an IAM policy that grants the permissions needed to submit SageMaker training jobs and, optionally, to push images to ECR. Complete the following steps to create the policy:
 
 1. From the IAM screen in AWS, create a new policy.
-2. Toggle to the JSON policy editor, then paste the following policy based on your use case. Substitute values enclosed with `<>` with your own values:
+2. Toggle to the JSON policy editor, then paste the following policy based on your use case. Substitute placeholders in `[BRACKETS]` with your own values:
 
 <Tabs>
 <Tab title="Agent submits pre-built Docker image">
@@ -58,20 +64,20 @@ Make a note of the ARNs for these resources. You will need the ARNs when you def
              "SageMaker:CreateTrainingJob",
              "SageMaker:DescribeTrainingJob"
            ],
-           "Resource": "arn:aws:sagemaker:<region>:<account-id>:*"
+           "Resource": "arn:aws:sagemaker:[REGION]:[ACCOUNT-ID]:*"
          },
          {
            "Effect": "Allow",
            "Action": "iam:PassRole",
-           "Resource": "arn:aws:iam::<account-id>:role/<RoleArn-from-queue-config>"
+           "Resource": "arn:aws:iam::[ACCOUNT-ID]:role/[ROLE-ARN-FROM-QUEUE-CONFIG]"
          },
        {
            "Effect": "Allow",
            "Action": "kms:CreateGrant",
-           "Resource": "<ARN-OF-KMS-KEY>",
+           "Resource": "[ARN-OF-KMS-KEY]",
            "Condition": {
              "StringEquals": {
-               "kms:ViaService": "SageMaker.<region>.amazonaws.com",
+               "kms:ViaService": "SageMaker.[REGION].amazonaws.com",
                "kms:GrantIsForAWSResource": "true"
              }
            }
@@ -93,12 +99,12 @@ Make a note of the ARNs for these resources. You will need the ARNs when you def
              "SageMaker:CreateTrainingJob",
              "SageMaker:DescribeTrainingJob"
            ],
-           "Resource": "arn:aws:sagemaker:<region>:<account-id>:*"
+           "Resource": "arn:aws:sagemaker:[REGION]:[ACCOUNT-ID]:*"
          },
          {
            "Effect": "Allow",
            "Action": "iam:PassRole",
-           "Resource": "arn:aws:iam::<account-id>:role/<RoleArn-from-queue-config>"
+           "Resource": "arn:aws:iam::[ACCOUNT-ID]:role/[ROLE-ARN-FROM-QUEUE-CONFIG]"
          },
           {
          "Effect": "Allow",
@@ -113,7 +119,7 @@ Make a note of the ARNs for these resources. You will need the ARNs when you def
            "ecr:BatchCheckLayerAvailability",
            "ecr:BatchDeleteImage"
          ],
-         "Resource": "arn:aws:ecr:<region>:<account-id>:repository/<repository>"
+         "Resource": "arn:aws:ecr:[REGION]:[ACCOUNT-ID]:repository/[REPOSITORY]"
        },
        {
          "Effect": "Allow",
@@ -123,10 +129,10 @@ Make a note of the ARNs for these resources. You will need the ARNs when you def
        {
            "Effect": "Allow",
            "Action": "kms:CreateGrant",
-           "Resource": "<ARN-OF-KMS-KEY>",
+           "Resource": "[ARN-OF-KMS-KEY]",
            "Condition": {
              "StringEquals": {
-               "kms:ViaService": "SageMaker.<region>.amazonaws.com",
+               "kms:ViaService": "SageMaker.[REGION].amazonaws.com",
                "kms:GrantIsForAWSResource": "true"
              }
            }
@@ -141,47 +147,49 @@ Make a note of the ARNs for these resources. You will need the ARNs when you def
 4. Give the policy a name and description.
 5. Click **Create policy**.
 
+You now have an IAM policy that you can attach to the Launch agent role in the next section.
 
-### Create an IAM role for Launch agent
 
-The Launch agent needs permission to create Amazon SageMaker training jobs. Follow the procedure below to create an IAM role:
+### Create an IAM role for the Launch agent
 
-1. From the IAM screen in AWS, create a new role. 
+The Launch agent requires permission to create Amazon SageMaker training jobs. Attaching the policy you created in the preceding section to a dedicated role lets the agent assume those permissions at runtime. Follow the procedure to create an IAM role:
+
+1. From the IAM screen in AWS, create a new role.
 2. For **Trusted Entity**, select **AWS Account** (or another option that suits your organization's policies).
-3. Scroll through the permissions screen and select the policy name you just created above. 
+3. Scroll through the permissions screen and select the policy name you created in the preceding section.
 4. Give the role a name and description.
 5. Select **Create role**.
-6. Note the ARN for the role. You will specify the ARN when you set up the launch agent.
+6. Record the ARN of the role. You specify the ARN when you set up the Launch agent.
 
 To create IAM roles, see the [AWS Identity and Access Management Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html).
 
 <Note>
-* If you want the launch agent to build images, see the [Advanced agent set up](./setup-agent-advanced) for additional permissions required.
-* The `kms:CreateGrant` permission for SageMaker queues is required only if the associated ResourceConfig has a specified VolumeKmsKeyId and the associated role does not have a policy that permits this action.
+* If you want the Launch agent to build images, see the [Advanced agent set up](./setup-agent-advanced) for additional permissions required.
+* The `kms:CreateGrant` permission for SageMaker queues is required only if the associated `ResourceConfig` has a specified `VolumeKmsKeyId` and the associated role doesn't have a policy that permits this action.
 </Note>
 
 
 
-## Configure launch queue for SageMaker
+## Configure the Launch queue for SageMaker
 
-Next, create a queue in the W&B App that uses SageMaker as its compute resource:
+With the AWS prerequisites in place, you can create the W&B Launch queue that routes jobs to SageMaker. Create a queue in the W&B App that uses SageMaker as its compute resource:
 
 1. Navigate to the [Launch App](https://wandb.ai/launch).
-3. Click on the **Create Queue** button.
-4. Select the **Entity** you would like to create the queue in.
-5. Provide a name for your queue in the **Name** field.
-6. Select **SageMaker** as the **Resource**.
-7. Within the **Configuration** field, provide information about your SageMaker job. By default, W&B will populate a YAML and JSON `CreateTrainingJob` request body:
+2. Click **Create Queue**.
+3. Select the **Entity** in which you want to create the queue.
+4. Provide a name for your queue in the **Name** field.
+5. Select **SageMaker** as the **Resource**.
+6. Within the **Configuration** field, provide information about your SageMaker job. By default, W&B populates a YAML and JSON `CreateTrainingJob` request body:
    ```json
    {
-     "RoleArn": "<REQUIRED>", 
+     "RoleArn": "[REQUIRED]", 
      "ResourceConfig": {
          "InstanceType": "ml.m4.xlarge",
          "InstanceCount": 1,
          "VolumeSizeInGB": 2
      },
      "OutputDataConfig": {
-         "S3OutputPath": "<REQUIRED>"
+         "S3OutputPath": "[REQUIRED]"
      },
      "StoppingCondition": {
          "MaxRuntimeInSeconds": 3600
@@ -190,48 +198,50 @@ Next, create a queue in the W&B App that uses SageMaker as its compute resource:
    ```
 You must at minimum specify:
 
-- `RoleArn` : ARN of the SageMaker execution IAM role (see [prerequisites](#prerequisites)). Not to be confused with the launch **agent** IAM role.
-- `OutputDataConfig.S3OutputPath` : An Amazon S3 URI specifying where SageMaker outputs will be stored.
-- `ResourceConfig`: Required specification of a resource config. Options for resource config are outlined [here](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ResourceConfig.html).
-- `StoppingCondition`: Required specification of the stopping conditions for the training job. Options outlined [here](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_StoppingCondition.html).
-7. Click on the **Create Queue** button.
+- `RoleArn`: ARN of the SageMaker execution IAM role (see [prerequisites](#prerequisites)). Don't confuse this with the Launch **agent** IAM role.
+- `OutputDataConfig.S3OutputPath`: An Amazon S3 URI that specifies where SageMaker stores outputs.
+- `ResourceConfig`: Required specification of a resource config. For resource config options, see the [AWS `ResourceConfig` documentation](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ResourceConfig.html).
+- `StoppingCondition`: Required specification of the stopping conditions for the training job. For options, see the [AWS `StoppingCondition` documentation](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_StoppingCondition.html).
+7. Click **Create Queue**.
+
+Your queue is created and ready to receive jobs after you configure a Launch agent to poll it.
 
 
-## Set up the launch agent
+## Set up the Launch agent
 
-The following section describes where you can deploy your agent and how to configure your agent based on where it is deployed.
+The following sections describe where you can deploy your agent and how to configure your agent based on where you deploy it.
 
-There are [several options for how the Launch agent is deployed for a Amazon SageMaker](#decide-where-to-run-the-launch-agent) queue: on a local machine, on an EC2 instance, or in an EKS cluster. [Configure your launch agent appropriately](#configure-a-launch-agent) based on the where you deploy your agent.
+You have [several options for how to deploy the Launch agent for an Amazon SageMaker](#decide-where-to-run-the-launch-agent) queue: on a local machine, on an EC2 instance, or in an EKS cluster. [Configure your Launch agent](#configure-a-launch-agent) based on where you deploy your agent.
 
 
 ### Decide where to run the Launch agent
 
-For production workloads and for customers who already have an EKS cluster, W&B recommends deploying the Launch agent to the EKS cluster using this Helm chart.
+For production workloads and for customers who already have an EKS cluster, W&B recommends that you deploy the Launch agent to the EKS cluster using this Helm chart.
 
-For production workloads without an current EKS cluster, an EC2 instance is a good option. Though the launch agent instance will keep running all the time, the agent doesn't need more than a `t2.micro` sized EC2 instance which is relatively affordable.
+For production workloads without a current EKS cluster, an EC2 instance is a good option. Although the Launch agent instance keeps running all the time, the agent doesn't need more than a `t2.micro` sized EC2 instance, which is affordable.
 
-For experimental or solo use cases, running the Launch agent on your local machine can be a fast way to get started.
+For experimental or solo use cases, you can run the Launch agent on your local machine as a fast way to get started.
 
-Based on your use case, follow the instructions provided in the following tabs to properly configure up your launch agent: 
+Based on your use case, follow the instructions in the following tabs to configure your Launch agent:
 <Tabs>
 <Tab title="EKS">
-W&B strongly encourages that you use the[ W&B managed helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) to install the agent in an EKS cluster.
+W&B recommends that you use the [W&B managed Helm chart](https://github.com/wandb/helm-charts/tree/main/charts/launch-agent) to install the agent in an EKS cluster.
 </Tab>
 <Tab title="EC2">
 Navigate to the Amazon EC2 Dashboard and complete the following steps:
 
 1. Click **Launch instance**.
 2. Provide a name for the **Name** field. Optionally add a tag.
-2. From the **Instance type**, select an instance type for your EC2 container. You do not need more than 1vCPU and 1GiB of memory (for example a t2.micro). 
-3. Create a key pair for your organization within the **Key pair (login)** field. You will use this key pair to [connect to your EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect.html) with SSH client at a later step.
-2. Within **Network settings**, select an appropriate security group for your organization. 
-3. Expand **Advanced details**. For **IAM instance profile**, select the launch agent IAM role you created above.
-2. Review the **Summary** field. If correct, select **Launch instance**. 
+3. From the **Instance type**, select an instance type for your EC2 container. You don't need more than 1 vCPU and 1 GiB of memory (for example, a `t2.micro`).
+4. Create a key pair for your organization within the **Key pair (login)** field. You use this key pair to [connect to your EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect.html) with SSH client at a later step.
+5. Within **Network settings**, select a security group for your organization.
+6. Expand **Advanced details**. For **IAM instance profile**, select the Launch agent IAM role you created in the preceding section.
+7. Review the **Summary** field. If correct, select **Launch instance**.
 
-Navigate to **Instances** within the left panel of the EC2 Dashboard on AWS. Ensure that the EC2 instance you created is running (see the **Instance state** column). Once you confirm your EC2 instance is running, navigate to your local machine's terminal and complete the following:
+Navigate to **Instances** within the left panel of the EC2 Dashboard on AWS. Ensure that the EC2 instance you created is running (see the **Instance state** column). After you confirm your EC2 instance is running, navigate to your local machine's terminal and complete the following:
 
-1. Select **Connect**. 
-2. Select the **SSH client** tab and following the instructions outlined to connect to your EC2 instance.
+1. Select **Connect**.
+2. Select the **SSH client** tab and follow the instructions to connect to your EC2 instance.
 3. Within your EC2 instance, install the following packages:
    ```bash
    sudo yum install python311 -y && python3 -m ensurepip --upgrade && pip3 install wandb && pip3 install wandb[launch]
@@ -247,71 +257,74 @@ Navigate to **Instances** within the left panel of the EC2 Dashboard on AWS. Ens
    newgrp docker
    ```
 
-Now you can proceed to setting up the Launch agent config.
+You can now set up the Launch agent config.
 </Tab>
 <Tab title="Local machine">
-Use the AWS config files located at `~/.aws/config`  and `~/.aws/credentials` to associate a role with an agent that is polling on a local machine. Provide the IAM role ARN that you created for the launch agent in the previous step.
+Use the AWS config files located at `~/.aws/config` and `~/.aws/credentials` to associate a role with an agent that polls on a local machine. Provide the IAM role ARN that you created for the Launch agent in the preceding step.
  
    ```yaml title="~/.aws/config"
    [profile SageMaker-agent]
-   role_arn = arn:aws:iam::<account-id>:role/<agent-role-name>
+   role_arn = arn:aws:iam::[ACCOUNT-ID]:role/[AGENT-ROLE-NAME]
    source_profile = default                                                                   
    ```
 
    ```yaml title="~/.aws/credentials"
    [default]
-   aws_access_key_id=<access-key-id>
-   aws_secret_access_key=<secret-access-key>
-   aws_session_token=<session-token>
+   aws_access_key_id=[ACCESS-KEY-ID]
+   aws_secret_access_key=[SECRET-ACCESS-KEY]
+   aws_session_token=[SESSION-TOKEN]
    ```
 
-Note that session tokens have a [max length](https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html#description) of 1 hour or 3 days depending on the principal they are associated with.
+Session tokens have a [max length](https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html#description) of 1 hour or 3 days, depending on the associated principal.
 </Tab>
 </Tabs>
 
 
-### Configure a launch agent
-Configure the launch agent with a YAML config file named `launch-config.yaml`. 
+### Configure a Launch agent
 
-By default, W&B will check for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the launch agent with the `-c` flag.
+After you decide where to run the agent, configure it so that it can poll your SageMaker queue and authenticate to AWS. Configure the Launch agent with a YAML config file named `launch-config.yaml`.
+
+By default, W&B checks for the config file in `~/.config/wandb/launch-config.yaml`. You can optionally specify a different directory when you activate the Launch agent with the `-c` flag.
 
 The following YAML snippet demonstrates how to specify the core config agent options:
 
 ```yaml title="launch-config.yaml"
 max_jobs: -1
 queues:
-  - <queue-name>
+  - [QUEUE-NAME]
 environment:
   type: aws
-  region: <your-region>
+  region: [YOUR-REGION]
 registry:
   type: ecr
-  uri: <ecr-repo-arn>
+  uri: [ECR-REPO-ARN]
 builder: 
   type: docker
 
 ```
 
-Now start the agent with `wandb launch-agent`
+Now start the agent with `wandb launch-agent`.
+
+Your Launch agent is now running and polls the SageMaker queue for jobs.
 
 
- ## (Optional) Push your launch job Docker image to Amazon ECR
+## Optional: Push your Launch job Docker image to Amazon ECR
 
 <Note>
-This section applies only if your launch agent uses existing Docker images that contain your training or inference logic. [There are two options on how your launch agent behaves.](#decide-if-you-want-the-launch-agent-to-build-a-docker-images)
+This section applies only if your Launch agent uses existing Docker images that contain your training or inference logic. [Your Launch agent supports two behavior options.](#decide-if-you-want-the-launch-agent-to-build-a-docker-image)
 </Note>
 
-Upload your Docker image that contains your launch job to your Amazon ECR repo. Your Docker image needs to be in your ECR registry before you submit new launch jobs if you are using image-based jobs.
+Upload your Docker image that contains your Launch job to your Amazon ECR repo. Your Docker image must be in your ECR registry before you submit new Launch jobs if you use image-based jobs.
 
 
 {/* The full URI to the image can then be used in job creation e.g.
 
 ```bash
-wandb job create image <your-image-uri> --p <project> ...
+wandb job create image [YOUR-IMAGE-URI] --p [PROJECT] ...
 ``` */}
 
 
 
 {/* ## Launch jobs from W&B
 
-If you go to the W&B GUI, your SageMaker Launch queue will now be active.  You can push jobs to it from the UI or CLI. */}
+If you go to the W&B GUI, your SageMaker Launch queue will now be active. You can push jobs to it from the UI or CLI. */}

--- a/platform/launch/setup-queue-advanced.mdx
+++ b/platform/launch/setup-queue-advanced.mdx
@@ -3,27 +3,30 @@ title: Configure launch queue
 description: "Configure advanced launch queue options including queue config templates with defaults, minimums, and maximums."
 ---
 
-The following page describes how to configure launch queue options.
+This page describes how to configure advanced launch queue options, including queue config templates, dynamic macros, and accelerator base images. These options help administrators enforce guardrails and tailor queues to specific compute environments.
 
 ## Set up queue config templates
-Administer and manage guardrails on compute consumption with Queue Config Templates. Set defaults, minimums, and maximum values for fields such as memory consumption, GPU, and runtime duration.
 
-After you configure a queue with config templates, members of your team can alter fields you defined only within the specified range you defined.
+Queue config templates let administrators manage guardrails on compute consumption. Set defaults, minimums, and maximum values for fields such as memory consumption, GPU, and runtime duration.
+
+After you configure a queue with config templates, members of your team can alter the fields you defined only within the range you specified.
 
 ### Configure queue template
-You can configure a queue template on an existing queue or create a new queue.  
+
+You can configure a queue template on an existing queue or on a new queue. The following procedure adds template fields to a queue's config so that team members can only set values within the limits you define.
 
 1. Navigate to the [W&B Launch App](https://wandb.ai/launch).
 2. Select **View queue** next to the name of the queue you want to add a template to.
-3. Select the **Config** tab. This will show information about your queue such as when the queue was created, the queue config, and existing launch-time overrides.
+3. Select the **Config** tab. This shows information about your queue such as when the queue was created, the queue config, and existing launch-time overrides.
 4. Navigate to the **Queue config** section.
-5. Identify the config key-values you want to create a template for. 
-6. Replace the value in the config with a template field. Template fields take the form of `{{variable-name}}`. 
-7. Click on the **Parse configuration** button. When you parse your configuration, W&B will automatically create tiles below the queue config for each template you created.
+5. Identify the config key-values you want to create a template for.
+6. Replace the value in the config with a template field. Template fields take the form of `{{variable-name}}`.
+7. Click the **Parse configuration** button. When you parse your configuration, W&B automatically creates tiles below the queue config for each template you created.
 8. For each tile generated, you must first specify the data type (string, integer, or float) the queue config can allow. To do this, select the data type from the **Type** dropdown menu.
 9. Based on your data type, complete the fields that appear within each tile.
-10. Click on **Save config**.
+10. Click **Save config**.
 
+After you save the config, the queue enforces the template constraints on subsequent launches.
 
 For example, suppose you want to create a template that limits which AWS instances your team can use. Before you add a template field, your queue config might look something similar to:
 
@@ -39,7 +42,7 @@ StoppingCondition:
   MaxRuntimeInSeconds: 3600
 ```
 
-When you add a template field for the `InstanceType`, your config will look like:
+When you add a template field for the `InstanceType`, your config looks like:
 
 ```yaml title="launch config"
 RoleArn: arn:aws:iam:region:account-id:resource-type/resource-id
@@ -54,46 +57,48 @@ StoppingCondition:
 ```
 
 
-Next, you click on **Parse configuration**. A new tile labeled `aws-instance` will appear underneath the **Queue config**. 
+Next, you click **Parse configuration**. A new tile labeled `aws-instance` appears underneath the **Queue config**. 
 
-From there, you select String as the datatype from the **Type** dropdown. This will populate fields where you can specify values a user can choose from. For example, in the following image the admin of the team configured two different AWS instance types that users can choose from (`ml.m4.xlarge` and `ml.p3.xlarge`):
+From there, you select String as the data type from the **Type** dropdown. This populates fields where you can specify values a user can choose from. For example, in the following image the team admin configured two AWS instance types that users can choose from, `ml.m4.xlarge` and `ml.p3.xlarge`:
 
 <Frame>
-    <img src="/images/launch/aws_template_example.png" alt="AWS CloudFormation template"  />
+    <img src="/images/launch/aws_template_example.png" alt="Launch queue template tile with AWS instance type options"  />
 </Frame>
 
 
 
 ## Dynamically configure launch jobs
-Queue configs can be dynamically configured using macros that are evaluated when the agent dequeues a job from the queue. You can set the following macros:
+
+You can dynamically configure queue configs using macros that the agent evaluates when it dequeues a job from the queue. Use macros to inject run-specific values into your queue config at launch time. You can set the following macros:
 
 | Macro             | Description                                           |
 |-------------------|-------------------------------------------------------|
-| `${project_name}` | The name of the project the run is being launched to. |
-| `${entity_name}`  | The owner of the project the run being launched to.   |
-| `${run_id}`       | The id of the run being launched.                     |
-| `${run_name}`     | The name of the run that is launching.                |
+| `${project_name}` | The name of the project the run launches to.          |
+| `${entity_name}`  | The owner of the project the run launches to.         |
+| `${run_id}`       | The ID of the run that launches.                      |
+| `${run_name}`     | The name of the run that launches.                    |
 | `${image_uri}`    | The URI of the container image for this run.          |
 
 <Note>
-Any custom macro not listed in the preceding table (for example `${MY_ENV_VAR}`), is substituted with an environment variable from the agent's environment.
+Any custom macro not listed in the preceding table, for example `${MY_ENV_VAR}`, is substituted with an environment variable from the agent's environment.
 </Note>
 
-## Use the launch agent to build images that execute on accelerators (GPUs)
-You might need to specify an accelerator base image if you use launch to build images that are executed in an accelerator environment.
+## Use the launch agent to build images that execute on accelerators or GPUs
 
-This accelerator base image must satisfy the following requirements:
+If you use launch to build images that run in an accelerator environment, you might need to specify an accelerator base image so that the resulting image is compatible with the target hardware.
 
-- Debian compatibility (the Launch Dockerfile uses apt-get to fetch python)
-- Compatibility CPU & GPU hardware instruction set (Make sure your CUDA version is supported by the GPU you intend on using)
-- Compatibility between the accelerator version you provide and the packages installed in your ML algorithm
-- Packages installed that require extra steps for setting up compatibility with hardware
+The accelerator base image must satisfy the following requirements:
 
-### How to use GPUs with TensorFlow
+- Debian compatibility. The Launch Dockerfile uses `apt-get` to fetch `python`.
+- Compatible CPU and GPU hardware instruction sets. Make sure your CUDA version is supported by the GPU you intend to use.
+- Compatibility between the accelerator version you provide and the packages installed in your ML algorithm.
+- Any additional steps required to set up the installed packages for compatibility with the hardware.
 
-Ensure TensorFlow properly utilizes your GPU. To accomplish this, specify a Docker image and its image tag for the `builder.accelerator.base_image` key in the queue resource configuration.
+### Use GPUs with TensorFlow
 
-For example, the `tensorflow/tensorflow:latest-gpu` base image ensures TensorFlow properly uses your GPU. This can be configured using the resource configuration in the queue.
+To ensure TensorFlow uses your GPU, specify a Docker image and its image tag for the `builder.accelerator.base_image` key in the queue resource configuration.
+
+For example, the `tensorflow/tensorflow:latest-gpu` base image ensures TensorFlow uses your GPU. You can configure this using the resource configuration in the queue.
 
 The following JSON snippet demonstrates how to specify the TensorFlow base image in your queue config:
 

--- a/platform/launch/setup-vertex.mdx
+++ b/platform/launch/setup-vertex.mdx
@@ -3,92 +3,94 @@ title: 'Tutorial: Set up W&B Launch on Vertex AI'
 description: "Set up W&B Launch on Google Cloud Vertex AI using CustomJob specs and Artifact Registry for ML workloads."
 ---
 
-You can use W&B Launch to submit jobs for execution as Vertex AI training jobs. With Vertex AI training jobs, you can train machine learning models using either provided, or custom algorithms on the Vertex AI platform. Once a launch job is initiated, Vertex AI manages the underlying infrastructure, scaling, and orchestration.
+This tutorial walks you through configuring W&B Launch to submit jobs for execution as Vertex AI training jobs, so you can offload training workloads to Google Cloud's managed infrastructure. With Vertex AI training jobs, you can train machine learning models using either provided or custom algorithms on the Vertex AI platform. After you start a launch job, Vertex AI manages the underlying infrastructure, scaling, and orchestration. This guide is for ML engineers and platform administrators who already use W&B Launch and want to run jobs on Google Cloud Vertex AI.
 
-W&B Launch works with Vertex AI through the `CustomJob` class in the `google-cloud-aiplatform` SDK. The parameters of a `CustomJob` can be controlled with the launch queue configuration. Vertex AI cannot be configured to pull images from a private registry outside of Google Cloud. This means that you must store container images in Google Cloud or in a public registry if you want to use Vertex AI with W&B Launch. See the Vertex AI documentation for more information on making container images accessible to Vertex jobs.
+W&B Launch works with Vertex AI through the `CustomJob` class in the `google-cloud-aiplatform` SDK. You can control the parameters of a `CustomJob` with the launch queue configuration. You can't configure Vertex AI to pull images from a private registry outside of Google Cloud. This means that you must store container images in Google Cloud or in a public registry if you want to use Vertex AI with W&B Launch. See the Vertex AI documentation for more information about making container images accessible to Vertex jobs.
 
 {/* Component Diagram of Launch in Vertex AI */}
 
 ## Prerequisites
 
-1. **Create or access a Google Cloud project with the Vertex AI API enabled.** See the [Google Cloud API Console docs](https://support.google.com/googleapi/answer/6158841?hl=en) for more information on enabling an API.
+Before you configure a Launch queue, make sure the following Google Cloud resources and permissions are in place:
+
+1. **Create or access a Google Cloud project with the Vertex AI API enabled.** See the [Google Cloud API Console docs](https://support.google.com/googleapi/answer/6158841?hl=en) for more information about enabling an API.
 2. **Create a Google Cloud Artifact Registry repository** to store images you want to execute on Vertex. See the [Google Cloud Artifact Registry documentation](https://cloud.google.com/artifact-registry/docs/overview) for more information.
-3. **Create a staging GCS bucket** for Vertex AI to store its metadata. Note that this bucket must be in the same region as your Vertex AI workloads in order to be used as a staging bucket. The same bucket can be used for staging and build contexts.
-4. **Create a service account** with the necessary permissions to spin up Vertex AI jobs. See the [Google Cloud IAM documentation](https://cloud.google.com/iam/docs/creating-managing-service-accounts) for more information on assigning permissions to service accounts.
-5. **Grant your service account permission to manage Vertex jobs**
+3. **Create a staging GCS bucket** for Vertex AI to store its metadata. This bucket must be in the same region as your Vertex AI workloads to serve as a staging bucket. You can use the same bucket for staging and build contexts.
+4. **Create a service account** with the necessary permissions to spin up Vertex AI jobs. See the [Google Cloud IAM documentation](https://cloud.google.com/iam/docs/creating-managing-service-accounts) for more information about assigning permissions to service accounts.
+5. **Grant your service account permission to manage Vertex jobs**, as shown in the following table:
 
 | Permission                     | Resource Scope        | Description                                                                              |
 | ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------- |
-| `aiplatform.customJobs.create` | Specified Google Cloud Project | Allows creation of new machine learning jobs within the project.                         |
-| `aiplatform.customJobs.list`   | Specified Google Cloud Project | Allows listing of machine learning jobs within the project.                              |
-| `aiplatform.customJobs.get`    | Specified Google Cloud Project | Allows retrieval of information about specific machine learning jobs within the project. |
+| `aiplatform.customJobs.create` | Specified Google Cloud Project | Lets you create new machine learning jobs within the project.                         |
+| `aiplatform.customJobs.list`   | Specified Google Cloud Project | Lets you list machine learning jobs within the project.                              |
+| `aiplatform.customJobs.get`    | Specified Google Cloud Project | Lets you retrieve information about specific machine learning jobs within the project. |
 
 <Note>
-If you want your Vertex AI workloads to assume the identity of a non-standard service account, refer to the Vertex AI documentation for instructions on service account creation and necessary permissions. The `spec.service_account` field of the launch queue configuration can be used to select a custom service account for your W&B runs.
+If you want your Vertex AI workloads to assume the identity of a non-standard service account, refer to the Vertex AI documentation for instructions about service account creation and necessary permissions. Use the `spec.service_account` field of the launch queue configuration to select a custom service account for your W&B runs.
 </Note>
 
 ## Configure a queue for Vertex AI
 
-The queue configuration for Vertex AI resources specify inputs to the `CustomJob` constructor in the Vertex AI Python SDK, and the `run` method of the `CustomJob`. Resource configurations are stored under the `spec` and `run` keys:
+With your Google Cloud prerequisites in place, the next step is to plan the queue configuration that W&B Launch uses to submit Vertex AI jobs. The queue configuration for Vertex AI resources specifies inputs to the `CustomJob` constructor in the Vertex AI Python SDK, and the `run` method of the `CustomJob`. Resource configurations are stored under the `spec` and `run` keys:
 
-- The `spec` key contains values for the named arguments of the [`CustomJob` constructor](https://cloud.google.com/vertex-ai/docs/pipelines/customjob-component) in the Vertex AI Python SDK.
-- The `run` key contains values for the named arguments of the `run` method of the `CustomJob` class in the Vertex AI Python SDK.
+- The `spec` key contains values for the named arguments of the [`CustomJob` constructor](https://cloud.google.com/vertex-ai/docs/pipelines/customjob-component) in the Vertex AI Python SDK.
+- The `run` key contains values for the named arguments of the `run` method of the `CustomJob` class in the Vertex AI Python SDK.
 
-Customizations of the execution environment happens primarily in the `spec.worker_pool_specs` list. A worker pool spec defines a group of workers that will run your job. The worker spec in the default config asks for a single `n1-standard-4` machine with no accelerators. You can change the machine type, accelerator type and count to suit your needs.
+Customization of the execution environment happens in the `spec.worker_pool_specs` list. A worker pool spec defines a group of workers that run your job. The worker spec in the default config asks for a single `n1-standard-4` machine with no accelerators. You can change the machine type, accelerator type, and count to suit your needs.
 
-For more information on available machine types and accelerator types, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
+For more information about available machine types and accelerator types, see the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec).
 
 ## Create a queue
 
-Create a queue in the W&B App that uses Vertex AI as its compute resource:
+Now that you have planned your queue configuration, create a queue in the W&B App that uses Vertex AI as its compute resource:
 
-1. Navigate to the [Launch page](https://wandb.ai/launch).
-2. Click on the **Create Queue** button.
-3. Select the **Entity** you would like to create the queue in.
-4. Provide a name for your queue in the **Name** field.
+1. Navigate to the [Launch page](https://wandb.ai/launch).
+2. Click the **Create Queue** button.
+3. Select the **Entity** you want to create the queue in.
+4. Provide a name for your queue in the **Name** field.
 5. Select **Google Cloud Vertex AI** as the **Resource**.
-6. Within the **Configuration** field, provide information about your Vertex AI `CustomJob` you defined in the previous section. By default, W&B will populate a YAML and JSON request body similar to the following:
+6. Within the **Configuration** field, provide information about your Vertex AI `CustomJob` you defined in [Configure a queue for Vertex AI](#configure-a-queue-for-vertex-ai). By default, W&B populates a YAML and JSON request body similar to the following:
 
-```yaml
-spec:
-  worker_pool_specs:
-    - machine_spec:
-        machine_type: n1-standard-4
-        accelerator_type: ACCELERATOR_TYPE_UNSPECIFIED
-        accelerator_count: 0
-      replica_count: 1
-      container_spec:
-        image_uri: ${image_uri}
-  staging_bucket: <REQUIRED>
-run:
-  restart_job_on_worker_restart: false
-```
+    ```yaml
+    spec:
+      worker_pool_specs:
+        - machine_spec:
+            machine_type: n1-standard-4
+            accelerator_type: ACCELERATOR_TYPE_UNSPECIFIED
+            accelerator_count: 0
+          replica_count: 1
+          container_spec:
+            image_uri: ${image_uri}
+      staging_bucket: [STAGING-BUCKET]
+    run:
+      restart_job_on_worker_restart: false
+    ```
 
-7. After you configure your queue, click on the **Create Queue** button.
+7. After you configure your queue, click the **Create Queue** button.
 
-You must at minimum specify:
+At minimum, you must specify the following fields:
 
-- `spec.worker_pool_specs` : non-empty list of worker pool specifications.
-- `spec.staging_bucket` : GCS bucket to be used for staging Vertex AI assets and metadata.
+- `spec.worker_pool_specs`: non-empty list of worker pool specifications.
+- `spec.staging_bucket`: GCS bucket for staging Vertex AI assets and metadata.
 
 <Warning>
-Some of the Vertex AI docs show worker pool specifications with all keys in camel case,for example, ` workerPoolSpecs`. The Vertex AI Python SDK uses snake case for these keys, for example `worker_pool_specs`.
+Some of the Vertex AI docs show worker pool specifications with all keys in camel case, for example, `workerPoolSpecs`. The Vertex AI Python SDK uses snake case for these keys, for example, `worker_pool_specs`.
 
 Every key in the launch queue configuration should use snake case.
 </Warning>
 
 ## Configure a launch agent
 
-The launch agent is configurable through a config file that is, by default, located at `~/.config/wandb/launch-config.yaml`.
+With the queue created, configure a launch agent to poll the queue and dispatch jobs to Vertex AI. The launch agent is configurable through a config file that is, by default, located at `~/.config/wandb/launch-config.yaml`.
 
 ```yaml
-max_jobs: <n-concurrent-jobs>
+max_jobs: [N-CONCURRENT-JOBS]
 queues:
-  - <queue-name>
+  - [QUEUE-NAME]
 ```
 
 If you want the launch agent to build images for you that are executed in Vertex AI, see [Advanced agent set up](./setup-agent-advanced).
 
 ## Set up agent permissions
 
-There are multiple methods to authenticate as this service account. This can be achieved through Workload Identity, a downloaded service account JSON, environment variables, the Google Cloud Platform command-line tool, or a combination of these methods.
+Finally, give the launch agent the credentials it needs to act as the service account you created in the prerequisites. Multiple methods exist to authenticate as this service account. You can authenticate through Workload Identity, a downloaded service account JSON, environment variables, the Google Cloud Platform command-line tool, or a combination of these methods.

--- a/platform/launch/sweeps-on-launch.mdx
+++ b/platform/launch/sweeps-on-launch.mdx
@@ -4,23 +4,23 @@ title: Create sweeps with W&B Launch
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/drive/1WxLKaJlltThgZyhc7dcZhDQ6cjVQDfil#scrollTo=AFEzIxA6foC7" icon="python"/>
 
-Create a hyperparameter tuning job ([sweeps](/models/sweeps/)) with W&B Launch. With sweeps on launch, a sweep scheduler is pushed to a Launch Queue with the specified hyperparameters to sweep over. The sweep scheduler starts as it is picked up by the agent, launching sweep runs onto the same queue with chosen hyperparameters. This continues until the sweep finishes or is stopped. 
+This page describes how to create a hyperparameter tuning job ([sweeps](/models/sweeps/)) with W&B Launch, so you can automate hyperparameter exploration on the same infrastructure that runs your other launch jobs. With sweeps on launch, a sweep scheduler is pushed to a Launch Queue with the specified hyperparameters to sweep over. The sweep scheduler starts as it is picked up by the agent, launching sweep runs onto the same queue with chosen hyperparameters. This continues until the sweep finishes or is stopped.
 
 You can use the default W&B Sweep scheduling engine or implement your own custom scheduler:
 
 1. Standard sweep scheduler: Use the default W&B Sweep scheduling engine that controls [W&B Sweeps](/models/sweeps/). The familiar `bayes`, `grid`, and `random` methods are available.
-2. Custom sweep scheduler: Configure the sweep scheduler to run as a job. This option enables full customization. An example of how to extend the standard sweep scheduler to include more logging can be found in the section below.
+2. Custom sweep scheduler: Configure the sweep scheduler to run as a job. This option enables full customization. The following section shows an example of how to extend the standard sweep scheduler to include more logging.
  
 <Note>
-This guide assumes that W&B Launch has been previously configured. If W&B Launch has is not configured, see the [how to get started](./#how-to-get-started) section of the launch documentation.
+This guide assumes that W&B Launch has been previously configured. If W&B Launch isn't configured, see the [how to get started](./#how-to-get-started) section of the launch documentation.
 </Note>
 
 <Note>
-We recommend you create a sweep on launch using the 'basic' method if you are a first time users of sweeps on launch. Use a custom sweeps on launch scheduler when the standard W&B scheduling engine does not meet your needs.
+We recommend you create a sweep on launch using the `basic` method if you're a first-time user of sweeps on launch. Use a custom sweeps on launch scheduler when the standard W&B scheduling engine doesn't meet your needs.
 </Note>
 
 ## Create a sweep with a W&B standard scheduler
-Create W&B Sweeps with Launch. You can create a sweep interactively with the W&B App or programmatically with the W&B CLI. For advanced configurations of Launch sweeps, including the ability to customize the scheduler, use the CLI. 
+This section describes how to create W&B Sweeps with Launch using the standard scheduling engine. You can create a sweep interactively with the W&B App or programmatically with the W&B CLI. For advanced configurations of Launch sweeps, including the ability to customize the scheduler, use the CLI.
 
 <Note>
 Before you create a sweep with W&B Launch, ensure that you first create a job to sweep over. See the [Create a Job](/platform/launch/create-launch-job/) page for more information.
@@ -30,16 +30,16 @@ Before you create a sweep with W&B Launch, ensure that you first create a job to
 <Tab title="W&B app">
 Create a sweep interactively with the W&B App.
 
-1. Navigate to your W&B project on the W&B App.  
-2. Select the sweeps icon in the project sidebar (broom image). 
-3. Next, select the **Create Sweep** button.
+1. Navigate to your W&B project on the W&B App.
+2. Select the sweeps icon in the project sidebar (broom image).
+3. Select the **Create Sweep** button.
 4. Click the **Configure Launch** button.
 5. From the **Job** dropdown menu, select the name of your job and the job version you want to create a sweep from.
-6. Select a queue to run the sweep on using the **Queue** dropdown menu.
-8. Use the **Job Priority** dropdown to specify the priority of your launch job. A launch job's priority is set to "Medium" if the launch queue does not support prioritization.
-8. (Optional) Configure override args for the run or sweep scheduler. For example, using the scheduler overrides, configure the number of concurrent runs the scheduler manages using `num_workers`.
-9. (Optional) Select a project to save the sweep to using the **Destination Project** dropdown menu.
-10. Click **Save**
+6. From the **Queue** dropdown menu, select a queue to run the sweep on.
+7. From the **Job Priority** dropdown, specify the priority of your launch job. A launch job's priority is set to "Medium" if the launch queue doesn't support prioritization.
+8. Optional: Configure override args for the run or sweep scheduler. For example, using the scheduler overrides, configure the number of concurrent runs the scheduler manages using `num_workers`.
+9. Optional: From the **Destination Project** dropdown menu, select a project to save the sweep to.
+10. Click **Save**.
 11. Select **Launch Sweep**.
 
 <Frame>
@@ -49,15 +49,15 @@ Create a sweep interactively with the W&B App.
 <Tab title="CLI">
 Programmatically create a W&B Sweep with Launch with the W&B CLI.
 
-1. Create a Sweep configuration
-2. Specify the full job name within your sweep configuration
+1. Create a Sweep configuration.
+2. Specify the full job name within your sweep configuration.
 3. Initialize a sweep agent.
 
 <Note>
 Steps 1 and 3 are the same steps you normally take when you create a W&B Sweep.
 </Note>
 
-For example, in the following code snippet, we specify `'wandb/jobs/Hello World 2:latest'` for the job value:
+For example, the following code snippet specifies `'wandb/jobs/Hello World 2:latest'` for the job value:
 
 ```yaml
 # launch-sweep-config.yaml
@@ -83,44 +83,44 @@ parameters:
 
 # scheduler:
 #   num_workers: 1  # concurrent sweep runs
-#   docker_image: <base image for the scheduler>
-#   resource: <ie. local-container...>
+#   docker_image: [BASE-IMAGE-FOR-THE-SCHEDULER]
+#   resource: [RESOURCE-TYPE-FOR-EXAMPLE-LOCAL-CONTAINER]
 #   resource_args:  # resource arguments passed to runs
 #     env: 
 #         - WANDB_API_KEY
 
 # Optional Launch Params
 # launch: 
-#    registry: <registry for image pulling>
+#    registry: [REGISTRY-FOR-IMAGE-PULLING]
 ```
 
-For information on how to create a sweep configuration, see the [Define sweep configuration](/platform/launch/sweeps-on-launch/) page.
+For information about how to create a sweep configuration, see the [Define sweep configuration](/platform/launch/sweeps-on-launch/) page.
 
-4. Next, initialize a sweep. Provide the path to your config file, the name of your job queue, your W&B entity, and the name of the project.
+4. Initialize a sweep. Provide the path to your config file, the name of your job queue, your W&B entity, and the name of the project.
 
 ```bash
-wandb launch-sweep <path/to/yaml/file> --queue <queue_name> --entity <your_entity>  --project <project_name>
+wandb launch-sweep [PATH-TO-YAML-FILE] --queue [QUEUE-NAME] --entity [YOUR-ENTITY] --project [PROJECT-NAME]
 ```
 
-For more information on W&B Sweeps, see the [Tune Hyperparameters](/models/sweeps/) chapter.
+For more information about W&B Sweeps, see the [Tune Hyperparameters](/models/sweeps/) chapter.
 </Tab>
 </Tabs>
 
 
 ## Create a custom sweep scheduler
-Create a custom sweep scheduler either with the W&B scheduler or a custom scheduler.
+This section describes how to create a custom sweep scheduler when the standard scheduling engine doesn't meet your needs. You can create a custom sweep scheduler either with the W&B scheduler or a custom scheduler.
 
 <Note>
-Using scheduler jobs requires wandb cli version >= `0.15.4`
+Using scheduler jobs requires `wandb` CLI version >= `0.15.4`
 </Note>
 
 <Tabs>
 <Tab title="W&B scheduler">
 Create a launch sweep using the W&B sweep scheduling logic as a job.
   
-  1. Identify the Wandb scheduler job in the public wandb/sweep-jobs project, or use the job name:
-  `'wandb/sweep-jobs/job-wandb-sweep-scheduler:latest'`
-  2. Construct a configuration yaml with an additional `scheduler` block that includes a `job` key pointing to this name, example below.
+  1. Identify the W&B scheduler job in the public wandb/sweep-jobs project, or use the job name:
+  `'wandb/sweep-jobs/job-wandb-sweep-scheduler:latest'`.
+  2. Construct a configuration yaml with an additional `scheduler` block that includes a `job` key pointing to this name, as shown in the following example.
   3. Use the `wandb launch-sweep` command with the new config.
 
 
@@ -142,34 +142,34 @@ parameters:
 ```
 </Tab>
 <Tab title="Custom scheduler">
-Custom schedulers can be created by creating a scheduler-job. For the purposes of this guide we will be modifying the `WandbScheduler` to provide more logging. 
+Create custom schedulers by creating a scheduler-job. For the purposes of this guide, modify the `WandbScheduler` to provide more logging.
 
   1. Clone the `wandb/launch-jobs` repo (specifically: `wandb/launch-jobs/jobs/sweep_schedulers`)
-  2. Now, we can modify the `wandb_scheduler.py` to achieve our desired increased logging. Example: Add logging to the function `_poll`. This is called once every polling cycle (configurable timing), before we launch new sweep runs. 
-  3. Run the modified file to create a job, with: `python wandb_scheduler.py --project <project> --entity <entity> --name CustomWandbScheduler`
-  4. Identify the name of the job created, either in the UI or in the output of the previous call, which will be a code-artifact job (unless otherwise specified).
-  5. Now create a sweep configuration where the scheduler points to your new job.
+  2. Modify the `wandb_scheduler.py` to achieve your desired increased logging. Example: Add logging to the function `_poll`. This is called once every polling cycle (configurable timing), before new sweep runs launch.
+  3. Run the modified file to create a job, with: `python wandb_scheduler.py --project [PROJECT] --entity [ENTITY] --name CustomWandbScheduler`
+  4. Identify the name of the job created, either in the UI or in the output of the previous call, which is a code-artifact job (unless otherwise specified).
+  5. Create a sweep configuration where the scheduler points to your new job.
 
 ```yaml
 ...
 scheduler:
-  job: '<entity>/<project>/job-CustomWandbScheduler:latest'
+  job: '[ENTITY]/[PROJECT]/job-CustomWandbScheduler:latest'
 ...
 ```
 </Tab>
 <Tab title="Optuna scheduler">
-Optuna is a hyperparameter optimization framework that uses a variety of algorithms to find the best hyperparameters for a given model (similar to W&B). In addition to the [sampling algorithms](https://optuna.readthedocs.io/en/stable/reference/samplers/index.html), Optuna also provides a variety of [pruning algorithms](https://optuna.readthedocs.io/en/stable/reference/pruners.html) that can be used to terminate poorly performing runs early. This is especially useful when running a large number of runs, as it can save time and resources. The classes are highly configurable, just pass in the expected parameters in the `scheduler.settings.pruner/sampler.args` block of the config file.
+Optuna is a hyperparameter optimization framework that uses a variety of algorithms to find the best hyperparameters for a given model (similar to W&B). In addition to the [sampling algorithms](https://optuna.readthedocs.io/en/stable/reference/samplers/index.html), Optuna also provides a variety of [pruning algorithms](https://optuna.readthedocs.io/en/stable/reference/pruners.html) that you can use to terminate poorly performing runs early. This is useful when you run many runs, as it can save time and resources. The classes are configurable. Pass in the expected parameters in the `scheduler.settings.pruner/sampler.args` block of the config file.
 
 
 
 Create a launch sweep using Optuna's scheduling logic with a job.
 
-1. First, create your own job or use a pre-built Optuna scheduler image job. 
+1. First, create your own job or use a pre-built Optuna scheduler image job.
     * See the [`wandb/launch-jobs`](https://github.com/wandb/launch-jobs/blob/main/jobs/sweep_schedulers) repo for examples on how to create your own job.
-    * To use a pre-built Optuna image, you can either navigate to `job-optuna-sweep-scheduler` in the `wandb/sweep-jobs` project or use can use the job name: `wandb/sweep-jobs/job-optuna-sweep-scheduler:latest`. 
+    * To use a pre-built Optuna image, you can either navigate to `job-optuna-sweep-scheduler` in the `wandb/sweep-jobs` project or use the job name: `wandb/sweep-jobs/job-optuna-sweep-scheduler:latest`.
     
 
-2. After you create a job, you can now create a sweep. Construct a sweep config that includes a `scheduler` block with a `job` key pointing to the Optuna scheduler job (example below).
+2. After you create a job, you can create a sweep. Construct a sweep config that includes a `scheduler` block with a `job` key pointing to the Optuna scheduler job, as shown in the following example.
 
 ```yaml
   # optuna_config_basic.yaml
@@ -200,31 +200,31 @@ Create a launch sweep using Optuna's scheduling logic with a job.
   ```
 
 
-  3. Lastly, launch the sweep to an active queue with the launch-sweep command:
+  3. Finally, launch the sweep to an active queue with the `launch-sweep` command:
   
   ```bash
-  wandb launch-sweep <config.yaml> -q <queue> -p <project> -e <entity>
+  wandb launch-sweep [CONFIG-YAML] -q [QUEUE] -p [PROJECT] -e [ENTITY]
   ```
 
 
-  For the exact implementation of the Optuna sweep scheduler job, see [wandb/launch-jobs](https://github.com/wandb/launch-jobs/blob/main/jobs/sweep_schedulers/optuna_scheduler/optuna_scheduler.py). For more examples of what is possible with the Optuna scheduler, check out [wandb/examples](https://github.com/wandb/examples/tree/master/examples/launch/launch-sweeps/optuna-scheduler).
+  For the exact implementation of the Optuna sweep scheduler job, see [wandb/launch-jobs](https://github.com/wandb/launch-jobs/blob/main/jobs/sweep_schedulers/optuna_scheduler/optuna_scheduler.py). For more examples of what's possible with the Optuna scheduler, check out [wandb/examples](https://github.com/wandb/examples/tree/master/examples/launch/launch-sweeps/optuna-scheduler).
 </Tab>
 </Tabs>
 
- Examples of what is possible with custom sweep scheduler jobs are available in the [wandb/launch-jobs](https://github.com/wandb/launch-jobs) repo under `jobs/sweep_schedulers`. This guide shows how to use the publicly available **Wandb Scheduler Job**, as well demonstrates a process for creating custom sweep scheduler jobs. 
+ Examples of custom sweep scheduler jobs are available in the [wandb/launch-jobs](https://github.com/wandb/launch-jobs) repo under `jobs/sweep_schedulers`. This guide shows how to use the publicly available **W&B Scheduler Job**, and demonstrates a process for creating custom sweep scheduler jobs.
 
 
- ## How to resume sweeps on launch
-  It is also possible to resume a launch-sweep from a previously launched sweep. Although hyperparameters and the training job cannot be changed, scheduler-specific parameters can be, as well as the queue it is pushed to.
+ ## Resume sweeps on launch
+  This section describes how to resume a launch-sweep from a previously launched sweep, which is useful when you want to continue exploring with updated scheduler settings or on a different queue. Although you can't change hyperparameters and the training job, you can change scheduler-specific parameters and the queue it is pushed to.
 
 <Note>
-If the initial sweep used a training job with an alias like 'latest', resuming can lead to different results if the latest job version has been changed since the last run.
+If the initial sweep used a training job with an alias like `latest`, resuming can lead to different results if the latest job version has changed since the last run.
 </Note>
 
-  1. Identify the sweep name/ID for a previously run launch sweep. The sweep ID is an eight character string (for example, `hhd16935`) that you can find in your project on the W&B App.
+  1. Identify the sweep name/ID for a previously run launch sweep. The sweep ID is an eight-character string (for example, `hhd16935`) that you can find in your project on the W&B App.
   2. If you change the scheduler parameters, construct an updated config file.
-  3. In your terminal, execute the following command. Replace content wrapped in `<` and `>` with your information: 
+  3. In your terminal, execute the following command. Replace content wrapped in `[` and `]` with your information:
 
 ```bash
-wandb launch-sweep <optional config.yaml> --resume_id <sweep id> --queue <queue_name>
+wandb launch-sweep [OPTIONAL-CONFIG-YAML] --resume_id [SWEEP-ID] --queue [QUEUE-NAME]
 ```

--- a/platform/launch/walkthrough.mdx
+++ b/platform/launch/walkthrough.mdx
@@ -2,33 +2,35 @@
 description: "Follow this getting started tutorial for W&B Launch covering jobs, queues, agents, and running ML workloads."
 title: 'Tutorial: W&B Launch basics'
 ---
-## What is Launch? 
+## What is Launch
 
 <Card title="Try in Colab" href="https://colab.research.google.com/drive/1wX0OSVxZJDHRsZaOaOEDx-lLUrO1hHgP" icon="python"/>
 
-Easily scale training [runs](/models/runs/) from your desktop to a compute resource like Amazon SageMaker, Kubernetes and more with W&B Launch. Once W&B Launch is configured, you can quickly run training scripts, model evaluation suites, prepare models for production inference, and more with a few clicks and commands. 
+This tutorial introduces ML practitioners and platform teams to W&B Launch, and walks you through creating a launch job, setting up a queue, connecting an agent, and submitting jobs to run. By the end, you've run a containerized ML workload through W&B Launch and have a working queue and agent that your team can reuse.
+
+Scale training [runs](/models/runs/) from your desktop to a compute resource like Amazon SageMaker, Kubernetes, and more with W&B Launch. After you configure Launch, you can run training scripts, model evaluation suites, prepare models for production inference, and more with a few clicks and commands.
 
 ## How it works
 
 Launch is composed of three fundamental components: **launch jobs**, **queues**, and **agents**.
 
-A [*launch job*](./launch-terminology#launch-job) is a blueprint for configuring and running tasks in your ML workflow. Once you have a launch job, you can add it to a [*launch queue*](./launch-terminology#launch-queue). A launch queue is a first-in, first-out (FIFO) queue where you can configure and submit your jobs to a particular compute target resource, such as Amazon SageMaker or a Kubernetes cluster. 
+A [*launch job*](./launch-terminology#launch-job) is a blueprint for configuring and running tasks in your ML workflow. Once you have a launch job, you can add it to a [*launch queue*](./launch-terminology#launch-queue). A launch queue is a first-in, first-out (FIFO) queue where you can configure and submit your jobs to a particular compute target resource, such as Amazon SageMaker or a Kubernetes cluster.
 
-As jobs are added to the queue, [*launch agents*](./launch-terminology#launch-agent) poll that queue and execute the job on the system targeted by the queue.
+As jobs are added to the queue, [*launch agents*](./launch-terminology#launch-agent) poll that queue and run the job on the system targeted by the queue.
 
 <Frame>
     <img src="/images/launch/launch_overview.png" alt="W&B Launch overview diagram"  />
 </Frame>
 
-Based on your use case, you (or someone on your team) will configure the launch queue according to your chosen [compute resource target](./launch-terminology#target-resources) (for example Amazon SageMaker) and deploy a launch agent on your own infrastructure. 
+Based on your use case, you (or someone on your team) configure the launch queue according to your chosen [compute resource target](./launch-terminology#target-resources) (for example, Amazon SageMaker) and deploy a launch agent on your own infrastructure.
 
 See the [Terms and concepts](./launch-terminology) page for more information about Launch.
 
-## How to get started
+## Get started
 
 Depending on your use case, explore the following resources to get started with W&B Launch:
 
-* If this is your first time using W&B Launch, we recommend you go through the [Launch walkthrough](#walkthrough) guide.
+* If this is your first time using W&B Launch, start with the [Launch walkthrough](#walkthrough) guide.
 * Learn how to set up [W&B Launch](/platform/launch/set-up-launch/).
 * Create a [launch job](/platform/launch/launch-terminology/#launch-job).
 * Check out the W&B Launch [public jobs GitHub repository](https://github.com/wandb/launch-jobs) for templates of common tasks like [deploying to Triton](https://github.com/wandb/launch-jobs/tree/main/jobs/deploy_to_nvidia_triton), [evaluating an LLM](https://github.com/wandb/launch-jobs/tree/main/jobs/openai_evals), or more.
@@ -39,24 +41,24 @@ Depending on your use case, explore the following resources to get started with 
 This page walks through the basics of the W&B Launch workflow.
 
 <Note>
-W&B Launch runs machine learning workloads in containers. Familiarity with containers is not required but may be helpful for this walkthrough. See the [Docker documentation](https://docs.docker.com/guides/docker-concepts/the-basics/what-is-a-container/) for a primer on containers.
+W&B Launch runs machine learning workloads in containers. Familiarity with containers isn't required but may be helpful for this walkthrough. See the [Docker documentation](https://docs.docker.com/guides/docker-concepts/the-basics/what-is-a-container/) for a primer on containers.
 </Note>
 
 ## Prerequisites
 
-Before you get started, ensure you have satisfied the following prerequisites:
+Before you get started, ensure you have satisfied the following prerequisites. These cover the account, tooling, and authentication you need to run the commands later in this walkthrough.
 
-1. Sign up for an account at https://wandb.ai/site and then log in to your W&B account. 
-2. This walkthrough requires terminal access to a machine with a working Docker CLI and engine. See the [Docker installation guide](https://docs.docker.com/engine/install/) for more information. 
+1. Sign up for an account at https://wandb.ai/site and then log in to your W&B account.
+2. This walkthrough requires terminal access to a machine with a working Docker CLI and engine. See the [Docker installation guide](https://docs.docker.com/engine/install/) for more information.
 3. Install W&B Python SDK version `0.17.1` or higher:
    ```bash
    pip install wandb>=0.17.1
    ```
-4. Within your terminal, execute `wandb login` or set the `WANDB_API_KEY` environment variable to authenticate with W&B.
+4. In your terminal, run `wandb login` or set the `WANDB_API_KEY` environment variable to authenticate with W&B.
 
 <Tabs>
 <Tab title="Log in to W&B">
-Within your terminal execute:
+In your terminal, run:
     
     ```bash
     wandb login
@@ -64,15 +66,16 @@ Within your terminal execute:
 </Tab>
 <Tab title="Environment variable">
    ```bash
-       WANDB_API_KEY=<your-api-key>
+       WANDB_API_KEY=[API-KEY]
    ```
 
-    Replace `<your-api-key>` with your W&B API key.
+    Replace `[API-KEY]` with your W&B API key.
 </Tab>
 </Tabs>
 
 ## Create a launch job
-Create a [launch job](./launch-terminology#launch-job) in one of three ways: with a Docker image, from a git repository or from local source code:
+
+A launch job is the blueprint for the workload you want Launch to run, so you need one before you can submit work to a queue. Create a [launch job](./launch-terminology#launch-job) in one of three ways: with a Docker image, from a git repository, or from local source code:
 
 <Tabs>
 <Tab title="With a Docker image">
@@ -82,9 +85,9 @@ To run a pre-made container that logs a message to W&B, open a terminal and run 
 wandb launch --docker-image wandb/job_hello_world:main --project launch-quickstart
 ```
 
-The preceding command downloads and runs the container image `wandb/job_hello_world:main`. 
+The preceding command downloads and runs the container image `wandb/job_hello_world:main`.
 
-Launch configures the container to report everything logged with `wandb` to the `launch-quickstart` project. The container logs a message to W&B and displays a link to the newly created run in W&B. Click the link to view the run in the W&B UI.
+Launch configures the container to report everything logged with `wandb` to the `launch-quickstart` project. The container logs a message to W&B and displays a link to the run in W&B. Click the link to view the run in the W&B UI.
 </Tab>
 <Tab title="From a git repository">
 To launch the same hello-world job from its [source code in the W&B Launch jobs repository](https://github.com/wandb/launch-jobs), run the following command:
@@ -96,15 +99,15 @@ wandb launch --uri https://github.com/wandb/launch-jobs.git \\
 --entry-point "python job.py"
 ```
 The command does the following:
-1. Clone the [W&B Launch jobs repository](https://github.com/wandb/launch-jobs) to a temporary directory.
-2. Create a job named **hello-world-git** in the **hello** project. This job tracks the exact source code and configuration used to run execute the code.
-3. Build a container image from the `jobs/hello_world` directory and the `Dockerfile.wandb`.
-4. Start the container and run the `job.py` python script.
+1. Clones the [W&B Launch jobs repository](https://github.com/wandb/launch-jobs) to a temporary directory.
+2. Creates a job named **hello-world-git** in the **hello** project. This job tracks the exact source code and configuration used to run the code.
+3. Builds a container image from the `jobs/hello_world` directory and the `Dockerfile.wandb`.
+4. Starts the container and runs the `job.py` python script.
 
-The console output shows the image build and execution. The output of the container should be nearly identical to the previous example.
+The console output shows the image build and run. The output of the container should be nearly identical to the previous example.
 </Tab>
 <Tab title="From local source code">
-Code not versioned in a git repository can be launched by specifying a local directory path to the `--uri` argument. 
+You can launch code that isn't versioned in a git repository by specifying a local directory path to the `--uri` argument.
 
 Create an empty directory and add a Python script named `train.py` with the following content:
 
@@ -128,25 +131,25 @@ From within the directory, run the following command:
    ```
 
 The command does the following:
-1. Log the contents of the current directory to W&B as a Code Artifact.
-2. Create a job named **hello-world-code** in the **launch-quickstart** project.
-3. Build a container image by copying `train.py` and `requirements.txt` into a base image and `pip install` the requirements.
-4. Start the container and run `python train.py`.
+1. Logs the contents of the current directory to W&B as a Code Artifact.
+2. Creates a job named **hello-world-code** in the **launch-quickstart** project.
+3. Builds a container image by copying `train.py` and `requirements.txt` into a base image and `pip install` the requirements.
+4. Starts the container and runs `python train.py`.
 </Tab>
 </Tabs>
 
 ## Create a queue
 
-Launch is designed to help teams build workflows around shared compute. In the examples so far, the `wandb launch` command has executed a container synchronously on the local machine. Launch queues and agents enable asynchronous execution of jobs on shared resources and advanced features like prioritization and hyperparameter optimization. To create a basic queue, follow these steps:
+With a launch job in place, the next step is to create a queue that defines where and how jobs run. Launch is designed to help teams build workflows around shared compute. In the examples so far, the `wandb launch` command has run a container synchronously on the local machine. Launch queues and agents enable asynchronous runs of jobs on shared resources and advanced features like prioritization and hyperparameter optimization. To create a basic queue, follow these steps:
 
 1. Navigate to [wandb.ai/launch](https://wandb.ai/launch) and click the **Create a queue** button.
-2. Select an **Entity** to associate the queue with. 
+2. Select an **Entity** to associate the queue with.
 3. Enter a **Queue name**.
 4. Select **Docker** as the **Resource**.
-5. Leave **Configuration** blank, for now.
-6. Click **Create queue** :rocket:
+5. Leave **Configuration** blank.
+6. Click **Create queue**.
 
-After clicking the button, the browser will redirect to the **Agents** tab of the queue view. The queue remains in the **Not active** state until an agent starts polling.
+After you click the button, the browser redirects to the **Agents** tab of the queue view. The queue remains in the **Not active** state until an agent starts polling.
 
 <Frame>
     <img src="/images/launch/create_docker_queue.gif" alt="Docker queue creation"  />
@@ -156,32 +159,36 @@ For advanced queue configuration options, see the [advanced queue setup page](/p
 
 ## Connect an agent to the queue
 
-The queue view displays an **Add an agent** button in a red banner at the top of the screen if the queue has no polling agents. Click the button to view copy the command to run an agent. The command should look like the following:
+A queue stays idle until an agent polls it, so you must connect an agent before any jobs can run. The queue view displays an **Add an agent** button in a red banner at the top of the screen if the queue has no polling agents. Click the button to view and copy the command to run an agent. The command should look like the following:
 
 ```bash
-wandb launch-agent --queue <queue-name> --entity <entity-name>
+wandb launch-agent --queue [QUEUE-NAME] --entity [ENTITY-NAME]
 ```
 
-Run the command in a terminal to start the agent. The agent polls the specified queue for jobs to run. Once received, the agent downloads or builds and then executes a container image for the job, as if the `wandb launch` command was run locally.
+Replace `[QUEUE-NAME]` with the name of your queue and `[ENTITY-NAME]` with your W&B entity. Run the command in a terminal to start the agent. The agent polls the specified queue for jobs to run. After it receives a job, the agent downloads or builds and then runs a container image for the job, as if you had run the `wandb launch` command locally.
 
 Navigate back to [the Launch page](https://wandb.ai/launch) and verify that the queue now shows as **Active**.
 
 ## Submit a job to the queue
 
-Navigate to your new **launch-quickstart** project in your W&B account and open the jobs tab from the navigation on the left side of the screen.
+With a queue and a polling agent in place, you can now submit one of the launch jobs you created earlier and watch it run on the shared compute. Navigate to your **launch-quickstart** project in your W&B account and open the jobs tab from the navigation on the left side of the screen.
 
-The **Jobs** page displays a list of W&B Jobs that were created from previously executed runs. Click on your launch job to view source code, dependencies, and any runs created from the job. After completing this walkthrough there should be three jobs in the list.
+The **Jobs** page displays a list of jobs created from previous runs. Click your launch job to view source code, dependencies, and any runs created from the job. After you complete this walkthrough, the list contains three jobs.
 
 
-Pick one of the new jobs and follow these instructions to submit it to the queue:
+Pick one of the jobs and follow these instructions to submit it to the queue:
 
-1. Click the **Launch** button to submit the job to a queue. The **Launch** drawer will appear. 
-2. Select the **Queue** you created earlier and click **Launch**. 
+1. Click the **Launch** button to submit the job to a queue. The **Launch** drawer appears.
+2. Select the **Queue** you created earlier and click **Launch**.
 
-This submits the job to the queue. The agent polling this queue picks up and executes the job. The progress of the job can be monitored from the W&B UI or by inspecting the output of the agent in the terminal.
+This submits the job to the queue. The agent polling this queue picks up and runs the job. You can monitor the progress of the job from the W&B UI or by inspecting the output of the agent in the terminal.
 
 The `wandb launch` command can push jobs to the queue directly by specifying the `--queue` argument. For example, to submit the hello-world container job to the queue, run the following command:
 
    ```bash
-   wandb launch --docker-image wandb/job_hello_world:main --project launch-quickstart --queue <queue-name>
+   wandb launch --docker-image wandb/job_hello_world:main --project launch-quickstart --queue [QUEUE-NAME]
    ```
+
+   Replace `[QUEUE-NAME]` with the name of your queue.
+
+You now have a complete W&B Launch workflow in place: a launch job, a queue, a polling agent, and a job running asynchronously on shared compute. You can reuse this pattern for your own training, evaluation, and inference workloads.

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -3,9 +3,9 @@ title: Use the W&B MCP Server
 description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
 ---
 
-Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation, so it can answer questions about your runs, traces, evaluations, and artifacts without copy-paste. For a full list of what you can do with the server, see the [W&B MCP Server capabilities](#w&b-mcp-server-capabilities) section.
+Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation. With this access, your agent can answer questions about your runs, traces, evaluations, and artifacts without copy-paste. For a full list of what you can do with the server, see the [W&B MCP Server capabilities](#w&b-mcp-server-capabilities) section.
 
-It integrates natively with most IDEs, coding clients, and chat agents, including:
+It integrates directly with most IDEs, coding clients, and chat agents, including:
 
 - Cursor
 - Visual Studio Code (VS Code)
@@ -17,7 +17,7 @@ It integrates natively with most IDEs, coding clients, and chat agents, includin
 
 ## Deployment types
 
-You can use either the hosted MCP server or set up a local version if you need more isolation and flexibility. Using the local version requires your client to use a different URL to access the server.
+The W&B MCP Server is available in two deployment options. Use the hosted server for the fastest setup, or set up a local version if you need more isolation and flexibility. The local version requires your client to use a different URL to access the server.
 
 <CardGroup cols={2}>
   <Card title="Hosted server (recommended)">
@@ -38,7 +38,7 @@ If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server isn'
 
 ## Prerequisites
 
-Before you configure any client:
+Before you configure any client, make sure you have the following in place:
 
 - Create a W&B API key at [wandb.ai/authorize](https://wandb.ai/authorize).
 - Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
@@ -55,19 +55,19 @@ The URL depends on your type of W&B deployment:
 | Deployment | Server URL |
 |------------|------------|
 | Multi-tenant Cloud | `https://mcp.withwandb.com/mcp` |
-| Dedicated Cloud | `https://<your-instance>/mcp` |
-| Self-Managed | `https://<your-instance>/mcp` |
+| Dedicated Cloud | `https://[YOUR-INSTANCE]/mcp` |
+| Self-Managed | `https://[YOUR-INSTANCE]/mcp` |
 
-For Dedicated Cloud or Self-Managed, replace `https://mcp.withwandb.com/mcp` with `https://<your-instance>/mcp` and keep everything else the same. The client configurations below use the Multi-tenant URL.
+For Dedicated Cloud or Self-Managed, replace `https://mcp.withwandb.com/mcp` with `https://[YOUR-INSTANCE]/mcp` and keep everything else the same. The following client configurations use the Multi-tenant URL.
 
 <Tabs>
 <Tab title="Claude Code">
 
-Run the following command in your terminal, replacing the bearer token with your W&B API key:
+Register the W&B MCP server with Claude Code, replacing the bearer token with your W&B API key:
 
 ```bash
 claude mcp add --transport http wandb https://mcp.withwandb.com/mcp \
-  --header "Authorization: Bearer <your-wandb-api-key>"
+  --header "Authorization: Bearer [YOUR-WANDB-API-KEY]"
 ```
 
 Add `--scope user` to configure Claude Code globally. Omit it to configure only the current project.
@@ -76,7 +76,7 @@ Verify the connection by asking `List my W&B entities.` The agent should call `l
 </Tab>
 <Tab title="Claude Desktop">
 
-Claude Desktop's built-in custom connectors interface does not support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your bearer token.
+Claude Desktop's built-in custom connectors interface doesn't support API key authentication for remote MCP servers. To work around this, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm proxy to connect Claude Desktop to the W&B remote MCP server. The proxy runs locally and forwards requests to `https://mcp.withwandb.com/mcp` with your bearer token.
 
 You need [Node.js](https://nodejs.org/) installed on your system.
 
@@ -85,7 +85,7 @@ Open your Claude Desktop config file in a text editor. You can find the config f
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add the following to the JSON object in your config file, replacing `<your-wandb-api-key>` with your W&B API key:
+Add the following to the JSON object in your config file, replacing `[YOUR-WANDB-API-KEY]` with your W&B API key:
 
 ```json
 {
@@ -100,7 +100,7 @@ Add the following to the JSON object in your config file, replacing `<your-wandb
         "Authorization:${AUTH_HEADER}"
       ],
       "env": {
-        "AUTH_HEADER": "Bearer <your-wandb-api-key>"
+        "AUTH_HEADER": "Bearer [YOUR-WANDB-API-KEY]"
       }
     }
   }
@@ -113,10 +113,10 @@ Restart Claude Desktop to activate the new configuration. Verify the connection 
 </Tab>
 <Tab title="Codex">
 
-Export your W&B API key as an environment variable, then run:
+Export your W&B API key as an environment variable, then register the server with Codex:
 
 ```bash
-export WANDB_API_KEY=<your-wandb-api-key>
+export WANDB_API_KEY=[YOUR-WANDB-API-KEY]
 codex mcp add wandb \
   --url https://mcp.withwandb.com/mcp \
   --bearer-token-env-var WANDB_API_KEY
@@ -142,7 +142,7 @@ To configure Cursor manually:
           "transport": "http",
           "url": "https://mcp.withwandb.com/mcp",
           "headers": {
-            "Authorization": "Bearer <your-wandb-api-key>",
+            "Authorization": "Bearer [YOUR-WANDB-API-KEY]",
             "Accept": "application/json, text/event-stream"
           }
         }
@@ -222,7 +222,7 @@ Open your global or workspace `mcp.json` (for example, `~/.vscode/mcp.json` or `
       "type": "http",
       "url": "https://mcp.withwandb.com/mcp",
       "headers": {
-        "Authorization": "Bearer <your-wandb-api-key>"
+        "Authorization": "Bearer [YOUR-WANDB-API-KEY]"
       }
     }
   }
@@ -247,7 +247,7 @@ Common reasons to run locally:
 - **Active development** on the server itself.
 - **STDIO-only clients** or clients that require a local process.
 
-For Dedicated Cloud or Self-Managed users, the hosted path is preferred. Only use a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server isn't yet enabled on your instance or one of the reasons above applies. Set a `WANDB_BASE_URL` environment variable to your instance URL.
+For Dedicated Cloud or Self-Managed users, prefer the hosted path. Only use a local install from [wandb/wandb-mcp-server](https://github.com/wandb/wandb-mcp-server) if the hosted server isn't yet enabled on your instance or one of the preceding reasons applies. Set a `WANDB_BASE_URL` environment variable to your instance URL.
 
 ### Local prerequisites
 
@@ -287,16 +287,16 @@ pip install git+https://github.com/wandb/wandb-mcp-server
 
 ### Configure your client
 
-Select your MCP client and then run the following configuration, replacing `<your-wandb-api-key>` with your W&B API key as necessary:
+After installing the server, configure your client to launch it. Select your MCP client and then run the following configuration, replacing `[YOUR-WANDB-API-KEY]` with your W&B API key as necessary:
 
 <Tabs>
 <Tab title="Claude Code">
 
-Run the following command. Add `--scope user` for a global configuration.
+Register the local server with Claude Code. Add `--scope user` for a global configuration.
 
 ```bash
 claude mcp add wandb \
-  -e WANDB_API_KEY=<your-wandb-api-key> \
+  -e WANDB_API_KEY=[YOUR-WANDB-API-KEY] \
   -e WANDB_BASE_URL=https://your-wandb-instance.example.com \
   -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
@@ -321,7 +321,7 @@ Add the following JSON. Use the full path to `uvx` because Claude Desktop may no
         "wandb_mcp_server"
       ],
       "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_API_KEY": "[YOUR-WANDB-API-KEY]",
         "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
       }
     }
@@ -335,7 +335,7 @@ Restart Claude Desktop to apply the configuration.
 
 ```bash
 codex mcp add wandb \
-  --env WANDB_API_KEY=<your-wandb-api-key> \
+  --env WANDB_API_KEY=[YOUR-WANDB-API-KEY] \
   --env WANDB_BASE_URL=https://your-wandb-instance.example.com \
   -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
@@ -355,7 +355,7 @@ Add the following to your `mcp.json` configuration:
         "wandb_mcp_server"
       ],
       "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_API_KEY": "[YOUR-WANDB-API-KEY]",
         "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
       }
     }
@@ -380,7 +380,7 @@ Add the following to your `.vscode/mcp.json` or global MCP configuration:
         "wandb_mcp_server"
       ],
       "env": {
-        "WANDB_API_KEY": "<your-wandb-api-key>",
+        "WANDB_API_KEY": "[YOUR-WANDB-API-KEY]",
         "WANDB_BASE_URL": "https://your-wandb-instance.example.com"
       }
     }
@@ -426,7 +426,7 @@ For the complete command-line reference and advanced options, see the [wandb-mcp
 
 ## W&B MCP Server capabilities
 
-Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following example prompts demonstrate some of the tasks you can ask your agent to perform when it is connected to the W&B MCP Server:
+Use the MCP server to analyze experiments, debug traces, create reports, manage registry and artifacts, and answer questions from the W&B docs. The following example prompts demonstrate some of the tasks you can ask your agent to perform when it's connected to the W&B MCP Server:
 
 - "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`."
 - "How did the latency of my hiring agent's predict traces evolve over the last month?"
@@ -436,7 +436,7 @@ Use the MCP server to analyze experiments, debug traces, create reports, manage 
 
 ### Available tools
 
-The server offers several tools for various purposes. The following table lists each tool's name, when the agent should use it, and a concrete prompt you can use to invoke that tool.
+The server offers several tools grouped by purpose. The following table lists each tool's name, when the agent should use it, and a concrete prompt you can use to invoke that tool.
 
 <Tabs>
   <Tab title="Discovery">
@@ -457,7 +457,7 @@ The server offers several tools for various purposes. The following table lists 
     | `query_wandb_tool` | The question is about runs, sweeps, configs, summaries, or artifacts in W&B Models. Runs a GraphQL query. | "Show me the top 5 runs by `eval/accuracy` in `your-team/your-project`." |
     | `get_run_history_tool` | The question is about training curves, metric trends over time, or any time-series logged to a run. | "Plot the loss curve for run `abc123` in `your-team/your-project`." |
     | `compare_runs_tool` | The question is what changed between two runs, or which of two runs is better. Returns config diff, metric delta, and optional aligned history. | "Compare runs `abc123` and `def456` in `your-team/your-project`." |
-    | `diagnose_run_tool` | The question is whether a run converged, is overfitting, or hit NaN values. Returns actionable recommendations. | "Is run `abc123` in `your-team/your-project` overfitting?" |
+    | `diagnose_run_tool` | The question is whether a run converged, is overfitting, or hit NaN values. Returns specific recommendations. | "Is run `abc123` in `your-team/your-project` overfitting?" |
   </Tab>
   <Tab title="Weave traces">
     Tools that query and aggregate LLM traces and evaluations.
@@ -465,7 +465,7 @@ The server offers several tools for various purposes. The following table lists 
     | Tool | Use when | Example prompt |
     |------|----------|----------------|
     | `query_weave_traces_tool` | Trace data is required (LLM calls, evaluations, agent runs). Start with `detail_level="summary"` and escalate to `"full"` only for specific traces. | "Show me failed traces in `your-team/your-project` from the last 24 hours." |
-    | `count_weave_traces_tool` | The question is how many traces or how many errors, and the trace data itself is not needed. | "How many traces failed in `your-team/your-project` this week?" |
+    | `count_weave_traces_tool` | The question is how many traces or how many errors, and the trace data itself isn't needed. | "How many traces failed in `your-team/your-project` this week?" |
     | `resolve_trace_roots_tool` | After `query_weave_traces_tool` finds child traces, to map each back to its root session or workflow in one batched call. | "Find LLM calls that contain `rate limit` and tell me which sessions they belong to." |
     | `summarize_evaluation_tool` | The question is how an eval went, what the pass rate is, or which tasks fail most. Aggregates `Evaluation.evaluate` hierarchies. | "Summarize the most recent eval in `your-team/your-project`." |
   </Tab>
@@ -511,7 +511,7 @@ This pattern keeps token usage low for broad questions and lets the agent escala
 
 ## Usage tips
 
-The following practices and workflows help you get better results from the W&B MCP Server. Start with the general practices, then read the subsection that matches your workload for more specific advice and multi-step tool chains.
+The following sections describe practices and workflows that help you get better results from the W&B MCP Server. Start with the general practices, then read the section that matches your workload for more specific advice and multi-step tool chains.
 
 ### General best practices
 
@@ -526,7 +526,7 @@ Follow these practices regardless of your use case:
 
 Follow these practices when working with Weave traces:
 
-- **Start with the schema.** Call `infer_trace_schema_tool` before `query_weave_traces_tool` so the agent knows which fields and filter values are valid.
+- **Start with the schema.** Call `infer_trace_schema_tool` before `query_weave_traces_tool` to provide the agent with the valid fields and filter values.
 - **Pick the right `detail_level`.** Use `schema` to browse, `summary` (the default) for analysis, and `full` only when drilling into a small number of specific traces.
 - **Chain `resolve_trace_roots_tool`.** After a child-trace query, pass the resulting `trace_id` list to `resolve_trace_roots_tool` to map each trace to its root session in one batched call.
 - **Prefer `summarize_evaluation_tool` for evals.** It aggregates the `Evaluation.evaluate` and `predict_and_score` hierarchy automatically. Only fall back to `query_weave_traces_tool` for raw trace data.
@@ -548,7 +548,7 @@ For end-to-end workflows, see [Diagnose a bad training run](#diagnose-a-bad-trai
 
 Follow these practices for non-multi-tenant deployments:
 
-- Prefer the hosted server on your instance at `https://<your-instance>/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server isn't yet enabled.
+- Prefer the hosted server on your instance at `https://[YOUR-INSTANCE]/mcp`. It exposes the same tools as the Multi-tenant server with no client-side `WANDB_BASE_URL` needed. Only fall back to a local install if the hosted server isn't yet enabled.
 - When you do run locally against your instance, set `WANDB_BASE_URL` to your instance URL in the client's `env` block. Without it, the server targets `api.wandb.ai` and the server returns no data.
 - Rate limits on Dedicated Cloud are separate from Multi-tenant. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for defaults and how to request changes.
 
@@ -562,7 +562,7 @@ Follow these practices when running the server on your own machine:
 
 ## Recommended workflows
 
-Most real questions need more than one tool. Ask your agent to follow one of these chains.
+Most real questions need more than one tool. The following workflows show common multi-step tool chains you can ask your agent to perform.
 
 ### Explore an unfamiliar project
 
@@ -607,7 +607,7 @@ Use the following table to help you diagnose and resolve issues using the W&B MC
 | Symptom | Cause and fix |
 |---------|---------------|
 | `401 Unauthorized` or `Invalid API key` | Your W&B API key is missing, malformed, or not authorized for the target entity or team. Regenerate a key at [wandb.ai/authorize](https://wandb.ai/authorize) and confirm it is passed as a bearer token or set in `WANDB_API_KEY`. |
-| Empty results for queries you expect to succeed | The team/entity or project name is incorrect, or the API key does not have access. Confirm both with the agent and retry. |
-| `404 Not Found` or `connection refused` on `https://<your-instance>/mcp` | The hosted MCP server is not yet enabled on your Dedicated Cloud or Self-Managed instance, or the client is pointed at the wrong URL. Contact [W&B support](mailto:support@wandb.com) to request enablement, then confirm the URL in [Connection URL](#connection-url). |
+| Empty results for queries you expect to succeed | The team, entity, or project name is incorrect, or the API key doesn't have access. Confirm both with the agent and retry. |
+| `404 Not Found` or `connection refused` on `https://[YOUR-INSTANCE]/mcp` | The hosted MCP server isn't yet enabled on your Dedicated Cloud or Self-Managed instance, or the client is pointed at the wrong URL. Contact [W&B support](mailto:support@wandb.com) to request enablement, then confirm the URL in [Connection URL](#connection-url). |
 | `429 Too Many Requests` on Dedicated Cloud | You have hit your instance's rate limits. See [Dedicated Cloud rate limits](/platform/hosting/hosting-options/dedicated-cloud/rate-limits) for how to request higher limits. |
-| Local server cannot find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |
+| Local server can't find `uvx` in Claude Desktop | Use the full path to `uvx` in the `command` field of `claude_desktop_config.json`. |

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -3,63 +3,75 @@ description: Overview of W&B secrets, how they work, and how to get started usin
 title: Manage secrets
 ---
 
-W&B Secret Manager allows you to securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. Configure and manage team secrets in [team settings](/platform/app/settings-page/teams). W&B features can read team secret values, removing the need to paste them or store them in code, training scripts, or plain-text automation configuration.
+W&B Secret Manager lets you securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. W&B features can read team secret values, which removes the need to paste them or store them in code, training scripts, or plain-text automation configuration. This page is for W&B Admins who need to create, rotate, delete, or manage access to team secrets used by webhook automations, Weave Playground, sandboxes, and LLM evaluation jobs.
 
-Secrets are stored and managed in each team's Secret Manager, in the **Team secrets** section of the [team settings](/platform/app/settings-page/teams/).
+Secrets live in each team's Secret Manager, in the **Team secrets** section of the [team settings](/platform/app/settings-page/teams/).
 
 <Note>
 * Only W&B Admins can create, edit, or delete a secret.
 * Secrets are included as a core part of W&B, including in [W&B Server deployments](/platform/hosting/) that you host in Azure, Google Cloud, or AWS. Connect with your W&B account team to discuss how you can use secrets in W&B if you use a different deployment type.
-* In W&B Server, you are responsible for configuring security measures that satisfy your security needs. 
+* In W&B Server, you are responsible for configuring security measures that satisfy your security needs.
 
-  - W&B strongly recommends that you store secrets in a W&B instance of a cloud provider's secrets manager provided by AWS, Google Cloud, or Azure, which are configured with advanced security capabilities.
+  - W&B strongly recommends that you store secrets in a W&B instance of a cloud provider's secrets manager from AWS, Google Cloud, or Azure, which include advanced security capabilities.
 
-  - W&B recommends against using a Kubernetes cluster as the backend of your secrets store unless you are unable to use a W&B instance of a cloud secrets manager (AWS, Google Cloud, or Azure), and you understand how to prevent security vulnerabilities that can occur if you use a cluster.
+  - W&B recommends against using a Kubernetes cluster as the backend of your secrets store. Use a cluster only if you can't use a W&B instance of a cloud secrets manager (AWS, Google Cloud, or Azure) and you understand how to prevent the security vulnerabilities that can occur.
 </Note>
 
 ## Where team secrets are used
 
-Team secrets can be used in W&B in multiple contexts. After you [add a secret](#add-a-secret), a feature like W&B Automations can access the secret by name.
+You can use team secrets in W&B in multiple contexts. After you [add a secret](#add-a-secret), a feature like W&B Automations can access the secret by name.
 
-- **Webhook automations**: When an automation sends an HTTP request to a [webhook](/models/automations/create-automations/webhook/), you can attach team secrets for authentication headers and for values referenced in the payload. Automations can be scoped to a [project](/models/automations/automation-events/#project) or a [Registry](/models/automations/automation-events/#registry). Registry-scoped automations that call a webhook use the same team webhooks and team secrets as project-scoped webhook automations.
-- **Weave Playground**: Provider credentials are supplied as named team secrets. See [Add provider credentials and information](/weave/guides/tools/playground#add-provider-credentials-and-information).
+- **Webhook automations**: When an automation sends an HTTP request to a [webhook](/models/automations/create-automations/webhook/), you can attach team secrets for authentication headers and for values referenced in the payload. You can scope automations to a [project](/models/automations/automation-events/#project) or a [Registry](/models/automations/automation-events/#registry). Registry-scoped automations that call a webhook use the same team webhooks and team secrets as project-scoped webhook automations.
+- **Weave Playground**: Supply provider credentials as named team secrets. See [Add provider credentials and information](/weave/guides/tools/playground#add-provider-credentials-and-information).
 - **Sandboxes**: Securely provide team secrets to your sandboxes to make them available as environment variables. See [Secrets in sandboxes](/sandboxes/secrets).
-- **LLM evaluation jobs:** Some benchmarks need API keys or tokens stored as team secrets. See the [Evaluation benchmark catalog](/models/launch/evaluations).
+- **LLM evaluation jobs**: Some benchmarks need API keys or tokens stored as team secrets. See the [Evaluation benchmark catalog](/models/launch/evaluations).
 
 ## Add a secret
+
+Add a secret when you want to make a sensitive value available to W&B features without exposing it in code or configuration. After you complete these steps, the secret is available by name to the team features described in [Where team secrets are used](#where-team-secrets-are-used).
+
 To add a secret:
 
-1. If an external service gives you a token or API key, obtain that value through that service's normal flow. If necessary, save the sensitive string securely, such as in a password manager, before you paste it into W&B Secret Manager.
-1. Log in to W&B and go to the team's **Settings** page.
+1. If an external service gives you a token or API key, obtain that value through that service's normal flow. If necessary, save the sensitive string securely, such as in a password manager, before you paste it into W&B Secret Manager. Saving a backup matters because, after creation, W&B no longer reveals the secret's value.
+1. Sign in to W&B and go to the team's **Settings** page.
 1. In the **Team Secrets** section, click **New secret**.
-1. Using letters, numbers, and underscores (`_`), provide a name for the secret.
+1. Provide a name for the secret, using letters, numbers, and underscores (`_`).
 1. Paste the sensitive string into the **Secret** field.
 1. Click **Add secret**.
 
 When you configure a webhook for an automation, select which team secrets the webhook may use. For field names, access tokens, and payload variables, see [Create a webhook automation](/models/automations/create-automations/webhook).
 
 <Note>
-Once you create a secret, you can access that secret in a [webhook automation's payload](/models/automations/create-automations/webhook/) using the format `${SECRET_NAME}`.
+After you create a secret, you can access that secret in a [webhook automation's payload](/models/automations/create-automations/webhook/) using the format `${SECRET_NAME}`.
 </Note>
 
 ## Rotate a secret
+
+Rotate a secret when its value changes (for example, when an upstream credential is regenerated or when you suspect the existing value has been compromised). Because W&B doesn't reveal a secret's current value after creation, rotation is also the way to replace a value you no longer have a copy of.
+
 To rotate a secret and update its value:
+
 1. Click the pencil icon in the secret's row to open the secret's details.
-1. Set **Secret** to the new value. Optionally click **Reveal secret** to verify the new value.
+1. Set **Secret** to the new value. Optionally, click **Reveal secret** to verify the new value.
 1. Click **Add secret**. The secret's value updates and no longer resolves to the previous value.
 
 <Note>
 After a secret is created or updated, you can no longer reveal its current value. Instead, rotate the secret to a new value.
 </Note>
 
-Rotating or replacing a secret can affect every feature that still expects the old value. Update [webhook automations](/models/automations/create-automations/webhook), [sandboxes](/sandboxes/secrets) that inject the secret, [evaluation jobs](/models/launch/evaluations), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), or other consumers before you rely on the new value everywhere.
+Rotating or replacing a secret can affect every feature that still expects the old value. Before you rely on the new value everywhere, update [webhook automations](/models/automations/create-automations/webhook), [sandboxes](/sandboxes/secrets) that inject the secret, [evaluation jobs](/models/launch/evaluations), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), or other consumers.
 
 ## Delete a secret
+
+Delete a secret when no team feature uses it. Because deletion is immediate and permanent, confirm that no automations, sandboxes, or other consumers still reference the secret before you proceed (see [Manage access to secrets](#manage-access-to-secrets)).
+
 To delete a secret:
+
 1. Click the trash icon in the secret's row.
 1. Read the confirmation dialog, then click **Delete**. The secret is deleted immediately and permanently.
 
 ## Manage access to secrets
-A team's secrets can be referenced by name in [webhook automations](/models/automations/create-automations/webhook), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), [sandboxes](/sandboxes/secrets), [LLM evaluation jobs](/models/launch/evaluations), and other team-scoped features that select secrets by name.
 
-Before you remove a secret, update or remove every automation, job, sandbox configuration, or Playground flow that uses it so they do not stop working.
+You can reference a team's secrets by name in [webhook automations](/models/automations/create-automations/webhook), [Weave Playground](/weave/guides/tools/playground#add-provider-credentials-and-information), [sandboxes](/sandboxes/secrets), [LLM evaluation jobs](/models/launch/evaluations), and other team-scoped features that select secrets by name.
+
+Before you remove a secret, update or remove every automation, job, sandbox configuration, or Playground flow that uses it so they don't stop working.

--- a/platform/wb-skills.mdx
+++ b/platform/wb-skills.mdx
@@ -16,7 +16,7 @@ For a full list of supported agents, see the [W&B Skills CLI documentation](http
 
 ## W&B Skills capabilities
 
-Skills covers both the [W&B Models SDK](/models/ref) (training runs, metrics, artifacts, sweeps) and the [Weave SDK](/weave/reference/python-sdk) (traces, evaluations, scorers). Includes helper libraries, reference docs, and data analysis patterns.
+Skills covers both the [W&B Models SDK](/models/ref) (training runs, metrics, artifacts, sweeps) and the [Weave SDK](/weave/reference/python-sdk) (traces, evaluations, scorers). It includes helper libraries, reference docs, and data analysis patterns so your agent can handle the following workflows.
 
 | Workflow | Capabilities |
 |----------|-------------|
@@ -28,21 +28,23 @@ Skills covers both the [W&B Models SDK](/models/ref) (training runs, metrics, ar
 Skills requires the following:
 
 * [Node.js](https://nodejs.org/) (for the `npx` command).
-* A W&B API key. Create one at [wandb.ai/authorize](https://wandb.ai/authorize) and then set it as an environment variable:
-    ```shell
-    export WANDB_API_KEY=<your-api-key>
+* A W&B API key. Create one at [wandb.ai/authorize](https://wandb.ai/authorize) and then set it as an environment variable. Replace `[YOUR-API-KEY]` with your API key:
+    ```bash
+    export WANDB_API_KEY=[YOUR-API-KEY]
     ```
-* (Optional) Set your W&B project name as a `WANDB_PROJECT` environment variable. This allows your agent to target the correct W&B project without you specifying it each time.
+* Optional: Set your W&B project name as a `WANDB_PROJECT` environment variable. This lets your agent target the correct W&B project without you specifying it each time.
 
 ## Install W&B Skills
 
-To install W&B Skills globally, run the following command with the `--global` flag:
+Choose a global installation to make Skills available to all your projects, or a project-specific installation to scope Skills to a single project.
+
+To install W&B Skills globally for all your projects, use the `--global` flag:
 
 ```bash
 npx skills add wandb/skills --skill '*' --yes --global
 ```
 
-To install Skills for a specific project, run the following command from your project directory:
+To install Skills only for the current project, run the install command from your project directory without the `--global` flag:
 
 ```bash
 npx skills add wandb/skills --skill '*' --yes
@@ -54,7 +56,9 @@ You can also install Skills for specific agents using the `--agent` flag:
 npx skills add wandb/skills --agent claude-code --skill '*' --yes --global
 ```
 
-For list of `--agent` and `--skill` options, see the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents).
+For a list of `--agent` and `--skill` options, see the [skills CLI documentation](https://github.com/vercel-labs/skills#supported-agents).
+
+After installation completes, your agent has access to W&B Skills and is ready to handle W&B-related tasks.
 
 ## Use W&B Skills
 
@@ -69,7 +73,7 @@ Once installed, you can ask the agent to perform W&B-related tasks for your proj
 
 ## Usage tips
 
-Skills performs better when you use more specific queries versus broader open-ended questions. The following table provides some recommended example prompts versus prompts that are too vague.
+Skills performs better with specific queries than with broad, open-ended questions. The following table compares recommended prompts with prompts that are too vague.
 
 | Recommended | Not recommended |
 |-------------|-----------------|


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to 83 files under `platform/`. The run was fully automated; no technical content changes were intended.

## Files edited

- `platform/app/settings-page.mdx`
- `platform/app/settings-page/billing-settings.mdx`
- `platform/app/settings-page/emails.mdx`
- `platform/app/settings-page/storage.mdx`
- `platform/app/settings-page/team-settings.mdx`
- `platform/app/settings-page/teams.mdx`
- `platform/app/settings-page/user-settings.mdx`
- `platform/hosting.mdx`
- `platform/hosting/data-security/data-encryption.mdx`
- `platform/hosting/data-security/ip-allowlisting.mdx`
- `platform/hosting/data-security/presigned-urls.mdx`
- `platform/hosting/data-security/private-connectivity.mdx`
- `platform/hosting/data-security/secure-storage-connector.mdx`
- `platform/hosting/enterprise-licenses.mdx`
- `platform/hosting/env-vars.mdx`
- `platform/hosting/export-data-from-dedicated-cloud.mdx`
- `platform/hosting/hosting-options.mdx`
- `platform/hosting/hosting-options/dedicated-cloud.mdx`
- `platform/hosting/hosting-options/dedicated-cloud/export-data.mdx`
- `platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx`
- `platform/hosting/hosting-options/dedicated-cloud/regions.mdx`
- `platform/hosting/hosting-options/dedicated_regions.mdx`
- `platform/hosting/hosting-options/multi_tenant_cloud.mdx`
- `platform/hosting/hosting-options/self-managed.mdx`
- `platform/hosting/iam/access-management-intro.mdx`
- `platform/hosting/iam/access-management/manage-organization.mdx`
- `platform/hosting/iam/access-management/restricted-projects.mdx`
- `platform/hosting/iam/advanced_env_vars.mdx`
- `platform/hosting/iam/automate_iam.mdx`
- `platform/hosting/iam/identity_federation.mdx`
- `platform/hosting/iam/ldap.mdx`
- `platform/hosting/iam/org_team_struct.mdx`
- `platform/hosting/iam/scim.mdx`
- `platform/hosting/iam/service-accounts.mdx`
- `platform/hosting/iam/sso.mdx`
- `platform/hosting/managing-bucket-storage.mdx`
- `platform/hosting/monitoring-usage/audit-logging.mdx`
- `platform/hosting/monitoring-usage/mobile-app.mdx`
- `platform/hosting/monitoring-usage/org_dashboard.mdx`
- `platform/hosting/monitoring-usage/slack-alerts.mdx`
- `platform/hosting/privacy-settings.mdx`
- `platform/hosting/self-managed/disable-automatic-app-version-updates.mdx`
- `platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx`
- `platform/hosting/self-managed/operator.mdx`
- `platform/hosting/self-managed/rate-limits.mdx`
- `platform/hosting/self-managed/ref-arch.mdx`
- `platform/hosting/self-managed/requirements.mdx`
- `platform/hosting/server-upgrade-process.mdx`
- `platform/hosting/smtp.mdx`
- `platform/launch/add-job-to-queue.mdx`
- `platform/launch/create-launch-job.mdx`
- `platform/launch/job-inputs.mdx`
- `platform/launch/launch-faq/best_practices_launch_effectively.mdx`
- `platform/launch/launch-faq/build_container_launch.mdx`
- `platform/launch/launch-faq/clicking_launch_without_going_ui.mdx`
- `platform/launch/launch-faq/control_push_queue.mdx`
- `platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact.mdx`
- `platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me.mdx`
- `platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment.mdx`
- `platform/launch/launch-faq/launch_build_images.mdx`
- `platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker.mdx`
- `platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job.mdx`
- `platform/launch/launch-faq/launch_tensorflow_gpu.mdx`
- `platform/launch/launch-faq/launcherror_permission_denied.mdx`
- `platform/launch/launch-faq/permissions_agent_require_kubernetes.mdx`
- `platform/launch/launch-faq/requirements_accelerator_base_image.mdx`
- `platform/launch/launch-faq/restrict_access_modify_example.mdx`
- `platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx`
- `platform/launch/launch-queue-observability.mdx`
- `platform/launch/launch-terminology.mdx`
- `platform/launch/launch-view-jobs.mdx`
- `platform/launch/set-up-launch.mdx`
- `platform/launch/setup-agent-advanced.mdx`
- `platform/launch/setup-launch-docker.mdx`
- `platform/launch/setup-launch-kubernetes.mdx`
- `platform/launch/setup-launch-sagemaker.mdx`
- `platform/launch/setup-queue-advanced.mdx`
- `platform/launch/setup-vertex.mdx`
- `platform/launch/sweeps-on-launch.mdx`
- `platform/launch/walkthrough.mdx`
- `platform/mcp-server.mdx`
- `platform/secrets.mdx`
- `platform/wb-skills.mdx`

## Recommendations for technical review

### Prerequisites
- Add explicit prerequisites sections to pages that currently assume context: required roles (org/billing/team/instance admin), license entitlement (Enterprise), plan tier, deployment type, and any tooling/CLI versions. Affected pages include `billing-settings.mdx`, `team-settings.mdx`, `teams.mdx`, `user-settings.mdx`, `data-encryption.mdx`, `ip-allowlisting.mdx`, `presigned-urls.mdx`, `private-connectivity.mdx`, `secure-storage-connector.mdx`, `enterprise-licenses.mdx`, `export-data-from-dedicated-cloud.mdx`, `dedicated-cloud/export-data.mdx`, `dedicated-cloud/rate-limits.mdx`, `dedicated_regions.mdx`, `self-managed.mdx`, `scim.mdx`, `service-accounts.mdx`, `identity_federation.mdx`, `ldap.mdx`, `audit-logging.mdx`, `mobile-app.mdx`, `org_dashboard.mdx`, `slack-alerts.mdx`, `kubernetes-airgapped.mdx`, `operator.mdx`, `ref-arch.mdx`, `requirements.mdx`, `server-upgrade-process.mdx`, `smtp.mdx`, `add-job-to-queue.mdx`, `create-launch-job.mdx`, `set-up-launch.mdx`, `setup-agent-advanced.mdx`, `setup-launch-docker.mdx`, `setup-launch-kubernetes.mdx`, `setup-launch-sagemaker.mdx`, `setup-queue-advanced.mdx`, `setup-vertex.mdx`, `sweeps-on-launch.mdx`, `walkthrough.mdx`, `mcp-server.mdx`, `secrets.mdx`, and `wb-skills.mdx`.
- Define or link first-mention terms used as if known: **AISE** / **Account Solutions Engineer**, **BYOB**, **CMEK**, **JWT**, **OIDC**, **STIG**, **launch agent**, **builder**, **queue config**, **service account**, **shared responsibility model**, **magic links**, **restricted projects**, **team-level service account**.

### Verification steps
- Several procedures lack "what you should see" outcomes (post-upload avatar state, post-team-creation confirmation, post-license-apply CLI/UI checks, post-upgrade verification, post-LDAP test, post-SCIM mutation `GET`, post-SSO sign-in landing, GPU/Launch image build success). Add expected-result lines or pointers throughout the platform pages noted above, especially in `team-settings.mdx`, `teams.mdx`, `enterprise-licenses.mdx`, `server-upgrade-process.mdx`, `ldap.mdx`, `scim.mdx`, `sso.mdx`, `smtp.mdx`, `add-job-to-queue.mdx`, `create-launch-job.mdx`, `set-up-launch.mdx`, `setup-launch-docker.mdx`, `setup-launch-sagemaker.mdx`, `setup-launch-kubernetes.mdx`, `setup-vertex.mdx`, `sweeps-on-launch.mdx`, `walkthrough.mdx`, `mcp-server.mdx`, and `wb-skills.mdx`.

### Technical accuracy — UI labels and product naming
- Verify literal UI strings (case, hyphenation, button names) match current product. Examples flagged: `Settings`, `+ Add Email`, `Delete Emails`, `Log in Methods` vs. `Login methods` (`emails.mdx`); `Update License` (`enterprise-licenses.mdx`); `Connect Github` vs. `GitHub` (`user-settings.mdx`); `Manage Links`, `Manage notifications`, `Run failed alert`, `Stop runs` (`launch-queue-observability.mdx`, `mobile-app.mdx`); **Members** / **Users** tabs and **Subscriptions** link target (`teams.mdx`, `org_dashboard.mdx`, `launcherror_permission_denied.mdx`); **Pin specific version** toggle (`disable-automatic-app-version-updates.mdx`).
- Standardize role/term casing: **admin** vs. **administrator**, **View-Only** vs. **View-only**, **auto-provisioning** vs. **auto provisioning**, **Multi-tenant Cloud** vs. **Multi-Tenant Cloud**, **Self-Managed** vs. **Self-managed**, **launch agent** vs. **Launch agent**, **project-level roles** vs. **project level roles** (`manage-organization.mdx`, `restricted-projects.mdx`, `org_team_struct.mdx`, multiple launch pages).
- Verify hostname/URL patterns: `https://<org-name>.io/console/settings/` vs. `https://<org-name>.wandb.io/...`, `https://wandb.ai/home`, `https://wandb.ai/account-settings/<organization>/settings`, `https://[ORG-NAME].io/org/dashboard/` (`manage-organization.mdx`, `org_dashboard.mdx`).
- Confirm `support@wandb.com` vs. `support@wandb.ai` canonical address (`secure-storage-connector.mdx`, `emails.mdx`, `hosting-options/dedicated-cloud/rate-limits.mdx`).

### Technical accuracy — content correctness
- `billing-settings.mdx`: confirm metered metric name post `ingest → import` substitution and verify sub-step lettering renders under Mintlify.
- `emails.mdx`: confirm primary-email indicator (sunglasses emoji vs. icon/badge), `<Icon icon="ellipsis-vertical">` overflow menu, and the Auth0 add-email flow.
- `secure-storage-connector.mdx`: reconcile `<wb-cw-principal>` vs. `<cw-wandb-principal>`; fix broken anchors `#configure-byob` and `#configure-team-level-byob`; resolve CoreWeave bucket path-style vs. virtual-hosted contradiction; confirm `TLS 1.3 is required` for CoreWeave endpoint.
- `enterprise-licenses.mdx`: empty `[Kubernetes Operator]()` link target; `.mdx` extension in internal link; clarify `-e OTHER_ENV_VARS` placeholder; reconcile **System Settings** vs. **System Console**.
- `presigned-urls.mdx`: confirm expiration values (1h read, 24h write) and Azure `scid` vs. AWS/GCS `X-User` parameter.
- `private-connectivity.mdx`: verify availability framing changed from "coming soon" to "is offered."
- `advanced_env_vars.mdx`: fix `WANDB_IDENTITY_TOKEN_FILE` description — "Java Web Tokens (JWTs)" should be "JSON Web Tokens"; clarify whether value is a file or directory path; verify truncated `GORILLA_DISABLE_PERSONAL_ENTITY` link; confirm `SESSION_LENGTH` default and `GORILLA_USE_IDENTIFIER_CLAIMS` allowed character set.
- `automate_iam.mdx`: confirm consolidated Tip wording preserves the original endpoint categories; verify `Multi-tenant Cloud` capitalization is canonical.
- `ldap.mdx`: `LOCAL_LDAP_BASE_DN` example appears to duplicate `ATTRIBUTES` example rather than show a real base DN; `BIND_DN` example is split oddly across backticks; clarify whether `LOGIN` is required despite the table marking it optional.
- `sso.mdx`: fix YAML vs. shell assignment for `GORILLA_OIDC_SECRET`; verify ampersand handling in `[YOUR-W-AND-B-HOST]`; correct `containers logs` → `container's logs`; reconcile duplicate `LOCAL_RESTORE` Notes; promote nested `## Find your customer namespace` out of `<Tab>`.
- `scim.mdx`: verify the "Deactivate User Response (Multi-tenant)" tab actually contains a response payload (current example looks like a request); confirm member key casing (PascalCase vs. lowercase); reconcile **Add to Registry** parameter table (`add`) with example (`replace`); confirm **Remove from Registry** uses `remove`.
- `service-accounts.mdx`: validate the Warning's team-scoped logging-restrictions phrasing.
- `audit-logging.mdx`: confirm `numDays` casing matches the API; verify `#exclude-pii` anchor resolves; verify 7-day cap behavior on Multi-tenant Cloud; replace `demo:p@55w0rd` example with neutral placeholder.
- `mobile-app.mdx`: verify App Store ID `6755162576` and Multi-tenant-only availability; confirm Stop runs feature merits a Caution.
- `kubernetes-airgapped.mdx`: confirm `wandb/megabinary` content list; verify OpenShift `runAsUser: 1000` example under `restricted` SCC; reconcile core component list (weave images?); confirm `bitnamilegacy/redis` recommendation post Bitnami licensing changes; confirm service-account names `wandb-app`/`wandb-console`; reorder MySQL (Step 5) before operator install (Step 4) if database must precede CR apply.
- `operator.mdx`: verify pin behavior — security patches, ongoing reconciliation, and reverse procedure to unpin or change version.
- `requirements.mdx`: confirm ARM is unsupported for all roles (worker, control plane, MySQL); reconcile example ingress configuration with `/traces` (`wandb-weave-trace`) path; verify "multi-master" → "multi-primary" preference.
- `ref-arch.mdx`: confirm whether `sort_buffer_size` should be quoted in the MySQL settings list.
- `server-upgrade-process.mdx`: Terraform step 3 prose mentions `terraform plan` but code block runs `terraform init`; reconcile and standardize Helm placeholders inside code blocks; consider Kubernetes Operator upgrade path.
- `smtp.mdx`: confirm `noreply@wandb.com` is the current default sender; document whether restart is required; clarify TLS/STARTTLS and port choice.
- `presigned-urls.mdx`, `data-encryption.mdx`, `private-connectivity.mdx`, `ip-allowlisting.mdx`: provide concrete support paths instead of "Contact your W&B team."

### Technical accuracy — launch content
- `add-job-to-queue.mdx`: confirm `wandb.Run.config` casing; confirm `Medium` default-priority literal; verify SageMaker `ml.m4.xlarge`/`ml.p3.xlarge` examples are still representative; verify CLI line-continuation rendering across shells.
- `create-launch-job.mdx`: reconcile narrative ("`hello-world-git`" in `hello` project) with `--job-name "hello-world"` / `--project "hello-world"` flags.
- `job-inputs.mdx`: confirm corrected `exclude`-list semantics matches SDK behavior; fix JSON Schema example trailing comma; reconcile `schema=Schema` vs. `input_schema=s` in the Pydantic example; verify `wandb-core` README link.
- `set-up-launch.mdx`: bash example uses unquoted `[QUEUE-1]`/`[QUEUE-2]` placeholders that shells treat as globs — document quoting.
- `setup-agent-advanced.mdx`: confirm Google Cloud builder key `uri` vs. `destination` (AWS/Azure); fix AWS IAM policy JSON-vs.-Python-dict syntax in `yaml` fence; switch IAM permission blocks from `js` to `text`; reconcile Azure `AcrPush` requirement for the Docker builder.
- `setup-launch-docker.mdx`: correct conflation of `docker build` vs. `docker run` in the build description; fix `docker run` example with `--gpus all` placement; verify YAML indentation (tabs vs. spaces).
- `setup-launch-kubernetes.mdx`: validate Pass-6 YAML fixes to `example-spec.yaml` (removed backticks, removed trailing commas, `False` → `false`); confirm placeholder names.
- `setup-launch-sagemaker.mdx`: align the "create a launch job in **hello**" vs. `--project launch-quickstart` mismatch; resolve numbered-list rendering around the intervening bullets; align "yaml/json" claim with JSON-only example; replace `[REQUIRED]` placeholders with explicit `[ROLE-ARN]`/`[S3-OUTPUT-PATH]`; switch `~/.aws/config`/`credentials` fences from `yaml` to `ini`.
- `setup-queue-advanced.mdx`: reconcile macro rewrite ("project the run launches to") and `aws-instance` tile name vs. YAML variable `{{aws_instance}}`.
- `setup-vertex.mdx`: complete the truncated "Set up agent permissions" section; supply Vertex AI documentation hyperlink; clarify cross-reference to the queue config vs. `CustomJob` definition.
- `sweeps-on-launch.mdx`: fix self-referential link `[Define sweep configuration](/platform/launch/sweeps-on-launch/)`; confirm `wandb` CLI ≥ `0.15.4` prerequisite; clarify scheduler YAML placeholders.
- `walkthrough.mdx`: confirm trailing-space line continuation in the git-repository `wandb launch` example renders correctly.
- `launch-faq/build_container_launch.mdx`: the central build-action table is malformed (empty body, no separator row) — populate with job-type × base-image matrix.
- `launch-faq/launch_tensorflow_gpu.mdx`: confirm the `0.15.6` `cuda` vs. `accelerator` cutoff is still current.
- `launch-faq/permissions_agent_require_kubernetes.mdx`: page references a manifest that isn't present — link or include.
- `launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx`: `kubectl create secret generic` syntax is incorrect — use `--from-literal=KEY=VALUE`.
- `launch-faq.mdx`: page body is empty (frontmatter only) — write the FAQ entries.

### Technical accuracy — MCP and Skills
- `mcp-server.mdx`: confirm `#w&b-mcp-server-capabilities` anchor resolves under Mintlify (likely strips `&`); confirm `Authorization:${AUTH_HEADER}` no-space pattern is intentional; verify intentional trailing space in `` `Bearer ` ``; standardize Codex `--bearer-token-env-var` vs. `--env`; reconcile per-client requirement for `WANDB_API_KEY`.
- `wb-skills.mdx`: confirm Node.js minimum version; confirm `WANDB_PROJECT` is the correct variable; standardize "Skills" subject-verb agreement; reconcile global install with vs. without `--agent`.

### Missing content (recurring)
- Standardize placeholder convention — many JSON/YAML samples mix `<angle-bracket>`, `snake_case`, `xxxxxxxx`, and `[BRACKET-STYLE-UPPERCASE]` placeholders within the same page; coordinate prose updates so all placeholders follow the CoreWeave bracket-uppercase pattern.
- Several pages reference broken or asymmetric anchors and links (e.g., `#configure-byob`, `#deploy-wb-server-within-Self-Managed-cloud-accounts`, `#exclude-pii-when-fetching-audit-logs`, `#supported-agents`, `#how-to-get-started`, `/models/automations/create-automations/slack/`, `/models/integrations`). Run a link-checker pass.
- Several pages should be promoted to first-class structure: H2 sectioning on `ip-allowlisting.mdx`, `private-connectivity.mdx`, `requirements.mdx`, `setup-queue-advanced.mdx`; relocate "Personally identifiable information (PII)" out of "Audit log schema" (`audit-logging.mdx`); promote nested `## Find your customer namespace` (`sso.mdx`).
- Add troubleshooting sections to pages currently lacking them: `secure-storage-connector.mdx` (AWS/Azure/S3-compatible), `ldap.mdx`, `managing-bucket-storage.mdx`, `set-up-launch.mdx`, `setup-launch-sagemaker.mdx`.
- Several pages assume external references but provide no link (CMEK process, BYOB overview, role definitions, rate-limit increase scoping, billing-roles reference, Vertex AI documentation, Slack legacy OAuth scope source). Add canonical links.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
