### PR TITLE
feat(cursor): chain /style-guide after /author-docs via shared rule

### DIFF
--- a/.cursor/rules/chain-style-guide-after-author-docs.mdc
+++ b/.cursor/rules/chain-style-guide-after-author-docs.mdc
@@ -1,0 +1,27 @@
+---
+description: Always run /style-guide immediately after /author-docs to enforce style consistency
+alwaysApply: true
+---
+
+# Chain `/style-guide` after `/author-docs`
+
+When the `/author-docs` skill is used to generate or substantially rewrite documentation, you MUST invoke the `/style-guide` skill on the resulting draft before committing, opening a PR, or marking the task complete.
+
+This rule reinforces Step 8 (Self-review) of the `author-docs` skill, which requires a style pass. The `style-guide` skill applies the Google Developer Style Guide and W&B-specific conventions through structured editing passes that catch issues a single drafting pass misses.
+
+## When this applies
+
+- After any `/author-docs` invocation that produces a new doc or a major rewrite.
+- Before committing, opening a PR, or telling the user the work is done.
+- Even when the draft looks polished. The structured passes catch consistency issues that are easy to miss.
+
+## What to do
+
+1. Finish drafting the document with `/author-docs`.
+2. Immediately invoke `/style-guide` on the drafted file (pass the file path as the argument).
+3. Address the recommendations from the style passes.
+4. Only then proceed to commit, PR, or completion.
+
+## If `/style-guide` is unavailable
+
+Stop and tell the user before proceeding. Do not silently skip the style pass or fall back to applying `AGENTS.md` ad-hoc — the structured multi-pass workflow is the point.

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,9 @@ go.mod
 go.sum
 
 # Misc
-# Cursor editor local rules and config (per-developer)
-.cursor
+# Cursor editor local config (per-developer), except team-shared rules
+.cursor/*
+!.cursor/rules/
 
 .DS_Store
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,6 @@ go.mod
 go.sum
 
 # Misc
-# Cursor editor local config (per-developer), except team-shared rules
-.cursor/*
-!.cursor/rules/
 
 .DS_Store
 .env.local


### PR DESCRIPTION
## Summary

Adds a Cursor rule that requires the `/style-guide` skill to run after `/author-docs` whenever docs are generated or substantially rewritten.

The `/author-docs` skill already says the style pass is "required, not optional" in its Step 8 (Self-review), but that instruction only enters context when the skill itself is being read. Adding a Cursor rule with `alwaysApply: true` keeps the requirement in context across skill boundaries, so the agent can't drop it after handing off from `/author-docs` to other steps.

## Changes

- **New rule** (`.cursor/rules/chain-style-guide-after-author-docs.mdc`): short, focused rule that fires after `/author-docs` and requires the style pass before commit, PR, or completion. Includes an explicit fallback ("stop and tell the user") if `/style-guide` is unavailable, rather than silently skipping.
- **.gitignore**: Removed `.cursor` 

## Before / after

**Before**: The style pass requirement lived inside the `/author-docs` skill. If the agent finished `/author-docs` and moved on to commits or PR creation without re-reading the skill, the style pass could quietly get skipped.

**After**: The rule is always in context. The agent has to run `/style-guide` (or stop and flag that it's unavailable) before declaring the work done.

## Test plan

- [ ] Open this repo in Cursor, start a fresh chat, and verify the rule is listed as an active workspace rule.
- [ ] Invoke `/author-docs` on a small doc task and confirm the agent runs `/style-guide` as a follow-up step before opening a PR.
- [ ] Confirm `.cursor/settings.json` is still effectively per-developer (no longer ignored, but already tracked — unchanged behavior).