### PR TITLE
style: apply /style-guide pass to models/app

### DIFF
--- a/models/app/console-logs.mdx
+++ b/models/app/console-logs.mdx
@@ -1,12 +1,7 @@
 ---
 title: Console logs
 description: "View and debug console log messages including info, warnings, and errors from your W&B experiment runs."
-keywords:
-  - run logs
-  - wandb logging
-  - debug runs
-  - log filtering
-  - stdout capture
+keywords: ["run logs", "wandb logging", "debug runs", "log filtering", "stdout capture"]
 ---
 
 When you run an experiment, you might notice messages printed to your console. W&B captures console logs and displays them in the W&B App. Use these messages to debug and monitor the behavior of your experiment.

--- a/models/app/console-logs.mdx
+++ b/models/app/console-logs.mdx
@@ -26,43 +26,17 @@ Within the W&B App you can modify the fields shown in the console logs table. */
 
 ## Types of console logs
 
-W&B captures several types of console logs: informational messages, warnings, and errors, with a prefix to indicate the log's severity. The prefix helps you scan logs and identify the messages most relevant to debugging.
+W&B captures three types of console logs and adds a prefix to indicate each log's severity. The prefix helps you scan logs and identify the messages most relevant to debugging. The following table summarizes each type, ordered from most to least severe.
 
-### Informational messages
-
-Informational messages provide updates about the run's progress and status. They're typically prefixed with `wandb:`.
-
-```text
-wandb: Starting Run: abc123
-wandb: Run data is saved locally in ./wandb/run-20240125_120000-abc123
-```
-
-### Warning messages
-
-Warnings about potential issues that don't stop execution are prefixed with `WARNING:`.
-
-```text
-WARNING Found .wandb file, not streaming tensorboard metrics.
-WARNING These runs were logged with a previous version of wandb.
-```
-
-### Error messages
-
-Error messages for serious issues are prefixed with `ERROR:`. These indicate problems that might prevent the run from completing successfully.
-
-```text
-ERROR Unable to save notebook session history.
-ERROR Failed to save notebook.
-```
+| Severity | Prefix | Description | Example |
+| --- | --- | --- | --- |
+| Error | `ERROR` | Serious issues that might prevent the run from completing successfully. | `ERROR Failed to save notebook.` |
+| Warning | `WARNING` | Potential issues that don't stop execution. | `WARNING Found .wandb file, not streaming tensorboard metrics.` |
+| Info | `wandb:` | Updates about the run's progress and status. | `wandb: Starting Run: abc123` |
 
 ## Console log settings
 
-To control which types of console output W&B captures and displays, pass a `wandb.Settings` object to `wandb.init()` when you initialize a run. Within `wandb.Settings`, you can set the following parameters to control console log behavior:
-
-- `show_errors`: If set to `True`, error messages are displayed in the W&B App. If set to `False`, error messages aren't shown.
-- `silent`: If set to `True`, W&B suppresses all console output. This is useful for production environments where you want to minimize console noise.
-- `show_warnings`: If set to `True`, warning messages are displayed in the W&B App. If set to `False`, warning messages aren't shown.
-- `show_info`: If set to `True`, informational messages are displayed in the W&B App. If set to `False`, informational messages aren't shown.
+To control which types of console output W&B captures and displays, pass a `wandb.Settings` object to `wandb.init()` when you initialize a run. The relevant parameters are `show_errors`, `show_warnings`, `show_info`, and `silent`. For details on each parameter and its default value, see the [`wandb.Settings` reference](/models/ref/python/experiments/settings).
 
 The following example shows how to configure these settings:
 
@@ -112,7 +86,7 @@ The console logs look similar to the following:
 
 W&B automatically adds timestamps to each console log entry. This lets you track when each log message was generated.
 
-To show or hide timestamps in the console logs, select the **Timestamp visible** drop-down list on the console page.
+To show or hide timestamps in the console logs, select the **Timestamp visible** drop-down list on the console logs page.
 
 ## Search console logs
 
@@ -124,7 +98,7 @@ To quickly locate relevant entries, use the search bar on the console logs page 
 Parameters prefixed by `x_` (such as `x_label`) are in public preview. Create a [GitHub issue in the W&B repository](https://github.com/wandb/wandb) to provide feedback.
 </Warning>
 
-You can filter console logs based on the labels you pass as arguments for `x_label` in `wandb.Settings`. Enter the label in the search bar on the console log page.
+You can filter console logs based on the labels you pass as arguments for `x_label` in `wandb.Settings`. Enter the label in the search bar on the console logs page.
 
 ```python
 import wandb

--- a/models/app/console-logs.mdx
+++ b/models/app/console-logs.mdx
@@ -1,21 +1,28 @@
 ---
 title: Console logs
 description: "View and debug console log messages including info, warnings, and errors from your W&B experiment runs."
+keywords:
+  - run logs
+  - wandb logging
+  - debug runs
+  - log filtering
+  - stdout capture
 ---
 
+When you run an experiment, you might notice messages printed to your console. W&B captures console logs and displays them in the W&B App. Use these messages to debug and monitor the behavior of your experiment.
 
-When you run an experiment, you may notice various messages printed to your console. W&B captures console logs and displays them in the W&B App. Use these messages to debug and monitor the behavior of your experiment.
+The following sections describe how to view, configure, search, filter, download, and copy console logs for your runs.
 
 ## View console logs
 
-Access console logs for a run in the W&B App:
+Access console logs for a run in the W&B App to inspect messages produced during the run.
 
 1. Navigate to your project in the W&B App.
 2. Select a run within the **Runs** table.
 3. Click the **Logs** tab in the project sidebar.
 
 <Note>
-W&B stores a maximum of 100,000 lines of your logs for a run. In the W&B App, a maximum of 10,000 lines of your logs display at once. Scroll through the logs to display older lines to view all stored lines of logs.
+W&B stores a maximum of 100,000 lines of your logs for a run. In the W&B App, a maximum of 10,000 lines of your logs display at once. To view all stored lines, scroll through the logs to display older lines.
 </Note>
 
 {/* ## Console log fields
@@ -24,10 +31,11 @@ Within the W&B App you can modify the fields shown in the console logs table. */
 
 ## Types of console logs
 
-W&B captures several types of console logs: informational messages, warnings, and errors, with a prefix to indicate the log's severity.
+W&B captures several types of console logs: informational messages, warnings, and errors, with a prefix to indicate the log's severity. The prefix helps you scan logs and identify the messages most relevant to debugging.
 
 ### Informational messages
-Informational messages provide updates about the run's progress and status. They are typically prefixed with `wandb:`.
+
+Informational messages provide updates about the run's progress and status. They're typically prefixed with `wandb:`.
 
 ```text
 wandb: Starting Run: abc123
@@ -35,15 +43,17 @@ wandb: Run data is saved locally in ./wandb/run-20240125_120000-abc123
 ```
 
 ### Warning messages
-Warnings about potential issues that don't stop execution are prefixed with `WARNING:`
+
+Warnings about potential issues that don't stop execution are prefixed with `WARNING:`.
 
 ```text
 WARNING Found .wandb file, not streaming tensorboard metrics.
 WARNING These runs were logged with a previous version of wandb.
 ```
 
-### Error messages 
-Error messages for serious issues are prefixed with `ERROR:`. These indicate problems that may prevent the run from completing successfully.
+### Error messages
+
+Error messages for serious issues are prefixed with `ERROR:`. These indicate problems that might prevent the run from completing successfully.
 
 ```text
 ERROR Unable to save notebook session history.
@@ -52,12 +62,12 @@ ERROR Failed to save notebook.
 
 ## Console log settings
 
-Within your code, pass the `wandb.Settings` object to `wandb.init()` to configure how W&B handles console logs. Within `wandb.Settings`, you can set the following parameters to control console log behavior:
+To control which types of console output W&B captures and displays, pass a `wandb.Settings` object to `wandb.init()` when you initialize a run. Within `wandb.Settings`, you can set the following parameters to control console log behavior:
 
-- `show_errors`: If set to `True`, error messages are displayed in the W&B App. If set to `False`, error messages are not shown.
-- `silent`: If set to `True`, all W&B console output will be suppressed. This is useful for production environments where you want to minimize console noise.
-- `show_warnings`: If set to `True`, warning messages are displayed in the W&B App. If set to `False`, warning messages are not shown.
-- `show_info`: If set to `True`, informational messages are displayed in the W&B App. If set to `False`, informational messages are not shown.
+- `show_errors`: If set to `True`, error messages are displayed in the W&B App. If set to `False`, error messages aren't shown.
+- `silent`: If set to `True`, W&B suppresses all console output. This is useful for production environments where you want to minimize console noise.
+- `show_warnings`: If set to `True`, warning messages are displayed in the W&B App. If set to `False`, warning messages aren't shown.
+- `show_info`: If set to `True`, informational messages are displayed in the W&B App. If set to `False`, informational messages aren't shown.
 
 The following example shows how to configure these settings:
 
@@ -77,19 +87,19 @@ with wandb.init(settings=settings) as run:
 
 ## Custom logging
 
-W&B captures console logs from your application, but it does not interfere with your own logging setup. You can use Python's built-in `print()` function or the `logging` module to log messages.
+If you already have your own logging setup, you can continue to use it alongside W&B. W&B captures console logs from your application, but it doesn't interfere with your own logging setup. You can use Python's built-in `print()` function or the `logging` module to log messages.
 
 ```python
 import wandb
 
 with wandb.init(project="my-project") as run:
     for i in range(100, 1000, 100):
-        # This will log to W&B and print to console
+        # Logs to W&B and prints to console
         run.log({"epoch": i, "loss": 0.1 * i})
         print(f"epoch: {i} loss: {0.1 * i}")
 ```
 
-The console logs will look similar to the following:
+The console logs look similar to the following:
 
 ```text
 1 epoch:  100 loss: 1.3191105127334595
@@ -103,15 +113,15 @@ The console logs will look similar to the following:
 9 epoch:  900 loss: 0.28154927492141724
 ```
 
-## Time stamps
+## Timestamps
 
-Time stamps are automatically added to each console log entry. This allows you to track when each log message was generated.
+W&B automatically adds timestamps to each console log entry. This lets you track when each log message was generated.
 
-You can toggle the time stamps in the console logs on or off. Within the console page select the **Timestamp visible** dropdown in the top left corner. You can choose to show or hide the time stamps.
+To show or hide timestamps in the console logs, select the **Timestamp visible** drop-down list on the console page.
 
 ## Search console logs
 
-Use the search bar at the top of the console logs page to filter logs by keywords. You can search for specific terms, labels, or error messages.
+To quickly locate relevant entries, use the search bar on the console logs page to filter logs by keywords. You can search for specific terms, labels, or error messages.
 
 ## Filter with custom labels
 
@@ -119,17 +129,17 @@ Use the search bar at the top of the console logs page to filter logs by keyword
 Parameters prefixed by `x_` (such as `x_label`) are in public preview. Create a [GitHub issue in the W&B repository](https://github.com/wandb/wandb) to provide feedback.
 </Warning>
 
-You can filter console logs based on the labels you pass as arguments for `x_label` in `wandb.Settings` in the UI search bar located at the top of the console log page. 
+You can filter console logs based on the labels you pass as arguments for `x_label` in `wandb.Settings`. Enter the label in the search bar on the console log page.
 
 ```python
 import wandb
 
 # Initialize a run in the primary node
 with wandb.init(
-    entity="entity",
-    project="project",
+    entity="[ENTITY-NAME]",
+    project="[PROJECT-NAME]",
     settings=wandb.Settings(
-        x_label="custom_label"  # (Optional) Custom label for filtering logs
+        x_label="[CUSTOM-LABEL]"  # (Optional) Custom label for filtering logs
     )
 ) as run:
     # Your code here
@@ -137,19 +147,18 @@ with wandb.init(
 
 ## Download console logs
 
-Download console logs for a run in the W&B App:
+To save logs locally for offline analysis or sharing, download console logs for a run in the W&B App:
 
 1. Navigate to your project in the W&B App.
 2. Select a run within the **Runs** table.
 3. Click the **Logs** tab in the project sidebar.
-4. Click the download button in the top right corner of the console logs page.
-
+4. Click the download button on the console logs page.
 
 ## Copy console logs
 
-Copy console logs for a run in the W&B App:
+To paste logs into another tool or message, copy console logs for a run in the W&B App:
 
 1. Navigate to your project in the W&B App.
 2. Select a run within the **Runs** table.
 3. Click the **Logs** tab in the project sidebar.
-4. Click the copy button in the top right corner of the console logs page.
+4. Click the copy button on the console logs page.

--- a/models/app/features/cascade-settings.mdx
+++ b/models/app/features/cascade-settings.mdx
@@ -1,9 +1,17 @@
 ---
 title: Manage workspace, section, and panel settings
 description: "Manage workspace, section, and panel settings in the W&B App, including layout and line plot configuration options."
+keywords:
+  - workspace layout
+  - line plot defaults
+  - panel organization
+  - section settings
+  - x-axis options
 ---
 
-Within a given workspace page there are three different setting levels: workspaces, sections, and panels. [Workspace settings](#workspace-settings) apply to the entire workspace. [Section settings](#section-settings) apply to all panels within a section. [Panel settings](#panel-settings) apply to individual panels. 
+A workspace page has three different setting levels: workspaces, sections, and panels. [Workspace settings](#workspace-settings) apply to the entire workspace. [Section settings](#section-settings) apply to all panels within a section. [Panel settings](#panel-settings) apply to individual panels.
+
+This page describes how to configure each level of settings so that you can control your workspace's layout, organize panels, and customize how data is displayed. The following sections describe each setting level in turn.
 
 ## Workspace settings
 
@@ -18,13 +26,15 @@ To edit settings that apply to the overall structure of this workspace:
     <img src="/images/app_ui/workspace_settings.png" alt="Workspace settings gear icon"  />
 </Frame>
 
+The workspace settings panel opens, where you can apply the changes described in the following sections.
+
 <Note>
-After customizing your workspace, you can use _workspace templates_ to quickly create new workspaces with the same settings. Refer to [Workspace templates](/models/track/workspaces/#workspace-templates).
+After customizing your workspace, you can use _workspace templates_ to create new workspaces with the same settings. Refer to [Workspace templates](/models/track/workspaces/#workspace-templates).
 </Note>
 
 ### Workspace layout options
 
-Configure a workspaces layout to define the overall structure of the workspace. This includes sectioning logic and panel organization. 
+Configure a workspace's layout to define the overall structure of the workspace. This includes sectioning logic and panel organization.
 
 <Frame>
     <img src="/images/app_ui/workspace_layout_settings.png" alt="Workspace layout options"  />
@@ -36,7 +46,7 @@ This table describes each workspace layout option.
 
 | Workspace setting | Description |
 | ----- | ----- |
-| **Hide empty sections during search** |  Hide sections that do not contain any panels when searching for a panel.|
+| **Hide empty sections during search** | Hide sections that don't contain any panels when searching for a panel. |
 | **Sort panels alphabetically** | Sort panels in your workspaces alphabetically. |
 | **Section organization** | Remove all existing sections and panels and repopulate them with new section names. Groups the newly populated sections either by first or last prefix. |
 
@@ -45,6 +55,7 @@ W&B suggests that you organize sections by grouping the first prefix rather than
 </Note>
 
 ### Line plots options
+
 Set global defaults and custom rules for line plots in a workspace by modifying the **Line plots** workspace settings.
 
 <Frame>
@@ -56,26 +67,26 @@ You can edit two main settings within **Line plots** settings: **Data** and **Di
 
 | Line plot setting | Description |
 | ----- | ----- |
-| **X axis** |  The scale of the x-axis in line plots. The x-axis is set to **Step** by default. See the following table for the list of x-axis options. |
-| **Range** |  Minimum and maximum settings to display for x axis. |
+| **X axis** | The scale of the x-axis in line plots. The x-axis is set to **Step** by default. See the following table for the list of x-axis options. |
+| **Range** | Minimum and maximum settings to display for the x-axis. |
 | **Smoothing** | Change the smoothing on the line plot. For more information about smoothing, see [Smooth line plots](/models/app/features/panels/line-plot/smoothing/). |
 | **Outliers** | Rescale to exclude outliers from the default plot min and max scale. |
-| **Point aggregation method** | Improve data visualization accuracy and performance. See [Point aggregation](/models/app/features/panels/line-plot/sampling/) for more information. |
+| **Point aggregation method** | Improve data visualization accuracy and performance. For more information, see [Point aggregation](/models/app/features/panels/line-plot/sampling/). |
 | **Max number of runs or groups** | Limit the number of runs or groups displayed on the line plot. |
 
-In addition to **Step**, there are other options for the x-axis:
+Besides **Step**, the x-axis supports the following options:
 
 | X axis option | Description |
 | ------------- | ----------- |
-| **Relative Time (Wall)**| Timestamp since the process starts. For example, suppose start a run and resume that run the next day. If you then log something, the recorded point is 24 hours.|
+| **Relative Time (Wall)** | Timestamp since the process starts. For example, suppose you start a run and resume that run the next day. If you then log something, the recorded point is 24 hours. |
 | **Relative Time (Process)** | Timestamp inside the running process. For example, suppose you start a run and let it continue for 10 seconds. The next day you resume that run. The point is recorded as 10 seconds. |
 | **Wall Time** | Minutes elapsed since the start of the first run on the graph. |
-| **Step** | Increments each time you call `wandb.Run.log()`.|
+| **Step** | Increments each time you call `wandb.Run.log()`. |
 
 
 
 <Note>
-For information on how to edit an individual line plot, see [Edit line panel settings](/models/app/features/panels/line-plot/#edit-line-panel-settings) in Line plots.
+For information about how to edit an individual line plot, see [Edit line panel settings](/models/app/features/panels/line-plot/#edit-line-panel-settings) in Line plots.
 </Note>
 
 
@@ -83,11 +94,11 @@ Within the **Display preferences** tab, you can toggle the following settings:
 
 | Display preference | Description |
 | ----- | ----- |
-| **Remove legends from all panels** | Remove the panel's legend |
-| **Display colored run names in tooltips** | Show the runs as colored text within the tooltip |
-| **Only show highlighted run in companion chart tooltip** | Display only highlighted runs in chart tooltip |
-| **Number of runs shown in tooltips** | Display the number of runs in the tooltip |
-| **Display full run names on the primary chart tooltip**| Display the full name of the run in the chart tooltip |
+| **Remove legends from all panels** | Remove the panel's legend. |
+| **Display colored run names in tooltips** | Show the runs as colored text within the tooltip. |
+| **Only show highlighted run in companion chart tooltip** | Display only highlighted runs in chart tooltip. |
+| **Number of runs shown in tooltips** | Display the number of runs in the tooltip. |
+| **Display full run names on the primary chart tooltip** | Display the full name of the run in the chart tooltip. |
 
 
 
@@ -96,7 +107,7 @@ Within the **Display preferences** tab, you can toggle the following settings:
 
 Section settings apply to all panels within that section. Within a workspace section you can sort panels, rearrange panels, and rename the section name.
 
-Modify section settings by selecting the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu in the upper right corner of a section.
+To modify section settings, select the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu in the upper right corner of a section.
 
 <Frame>
     <img src="/images/app_ui/section_settings.png" alt="Section settings menu"  />
@@ -106,9 +117,9 @@ From the dropdown, you can edit the following settings that apply to the entire 
 
 | Section setting | Description |
 | ----- | ----- |
-| **Rename a section** | Rename the name of the section |
-| **Sort panels A-Z** | Sort panels within a section alphabetically |
-| **Rearrange panels** | Select and drag a panel within a section to manually order your panels |
+| **Rename a section** | Rename the name of the section. |
+| **Sort panels A-Z** | Sort panels within a section alphabetically. |
+| **Rearrange panels** | Select and drag a panel within a section to manually order your panels. |
 
 The following animation demonstrates how to rearrange panels within a section:
 
@@ -117,14 +128,14 @@ The following animation demonstrates how to rearrange panels within a section:
 </Frame>
 
 <Note>
-In addition to the settings described in the preceding table, you can also edit how sections appear in your workspaces such as **Add section below**, **Add section above**, **Delete section**, and **Add section to report**.
+Besides the settings described in the preceding table, you can also edit how sections appear in your workspaces such as **Add section below**, **Add section above**, **Delete section**, and **Add section to report**.
 </Note>
 
 ## Panel settings
 
 Customize an individual panel's settings to compare multiple lines on the same plot, calculate custom axes, rename labels, and more. To edit a panel's settings:
 
-1. Hover your mouse over the panel you want to edit. 
+1. Hover over the panel you want to edit.
 2. Select the pencil icon that appears.
 <Frame>
     <img src="/images/app_ui/panel_settings.png" alt="Panel edit icon"  />
@@ -134,4 +145,4 @@ Customize an individual panel's settings to compare multiple lines on the same p
     <img src="/images/app_ui/panel_settings_modal.png" alt="Panel settings modal"  />
 </Frame>
 
-For a complete list of settings you can apply to a panel, see [Edit line panel settings](/models/app/features/panels/line-plot/#edit-line-panel-settings).
+Your changes apply to that panel only and take effect when you save them. For a complete list of settings you can apply to a panel, see [Edit line panel settings](/models/app/features/panels/line-plot/#edit-line-panel-settings).

--- a/models/app/features/cascade-settings.mdx
+++ b/models/app/features/cascade-settings.mdx
@@ -1,12 +1,7 @@
 ---
 title: Manage workspace, section, and panel settings
 description: "Manage workspace, section, and panel settings in the W&B App, including layout and line plot configuration options."
-keywords:
-  - workspace layout
-  - line plot defaults
-  - panel organization
-  - section settings
-  - x-axis options
+keywords: ["workspace layout", "line plot defaults", "panel organization", "section settings", "x-axis options"]
 ---
 
 A workspace page has three different setting levels: workspaces, sections, and panels. [Workspace settings](#workspace-settings) apply to the entire workspace. [Section settings](#section-settings) apply to all panels within a section. [Panel settings](#panel-settings) apply to individual panels.

--- a/models/app/features/custom-charts.mdx
+++ b/models/app/features/custom-charts.mdx
@@ -1,42 +1,52 @@
 ---
 title: Custom charts overview
 description: Create custom charts in W&B projects with Vega visualizations
+keywords:
+  - Vega
+  - wandb.plot_table
+  - precision-recall curve
+  - ROC curve
+  - GraphQL query
 ---
 
-Create custom charts in your W&B project. Log arbitrary tables of data and visualize them exactly how you want. Control details of fonts, colors, and tooltips with the power of [Vega](https://vega.github.io/vega/).
+Custom charts let you visualize logged data exactly how you want, beyond the defaults W&B provides. Use them when you need to plot relationships, distributions, or model evaluation metrics that the built-in panels don't cover, such as precision-recall curves, custom histograms, or overlays of multiple experiments.
 
-* Code: Try an example [Colab Colab notebook](https://tiny.cc/custom-charts).
+Create custom charts in your W&B project. Log arbitrary tables of data and visualize them exactly how you want. Control details of fonts, colors, and tooltips with [Vega](https://vega.github.io/vega/).
+
+* Code: Try an example [Colab notebook](https://tiny.cc/custom-charts).
 * Video: Watch a [walkthrough video](https://www.youtube.com/watch?v=3-N9OV6bkSM).
-* Example: Quick Keras and Sklearn [demo notebook](https://colab.research.google.com/drive/1g-gNGokPWM2Qbc8p1Gofud0_5AoZdoSD?usp=sharing)
+* Example: Quick Keras and Sklearn [demo notebook](https://colab.research.google.com/drive/1g-gNGokPWM2Qbc8p1Gofud0_5AoZdoSD?usp=sharing).
 
 <Frame>
     <img src="/images/app_ui/supported_charts.png" alt="Supported charts from vega.github.io/vega" max-width="90%"  />
 </Frame>
 
-### How it works
+## How it works
 
 1. **Log data**: From your script, log [config](/models/track/config/) and summary data.
-2. **Customize the chart**: Pull in logged data with a [GraphQL](https://graphql.org) query. Visualize the results of your query with [Vega](https://vega.github.io/vega/), a powerful visualization grammar.
+2. **Customize the chart**: Pull in logged data with a [GraphQL](https://graphql.org) query. Visualize the results of your query with [Vega](https://vega.github.io/vega/), a visualization grammar.
 3. **Log the chart**: Call your own preset from your script with `wandb.plot_table()`.
 
 <Frame>
     <img src="/images/app_ui/pr_roc.png" alt="PR and ROC curves"  />
 </Frame>
 
-If you do not see the expected data, the column you are looking for might not be logged in the selected runs. Save your chart, go back out to the runs table, and verify selected runs using the **eye** icon.
+If you don't see the expected data, the column you're looking for might not be logged in the selected runs. Save your chart, go back out to the runs table, and verify selected runs using the **eye** icon.
 
 
 ## Log charts from a script
 
-### Builtin presets
+The following sections describe two ways to log charts directly from your training script: built-in chart presets that cover common visualizations, and custom presets that let you reuse your own Vega specifications.
 
-W&B has a number of builtin chart presets that you can log directly from your script. These include line plots, scatter plots, bar charts, histograms, PR curves, and ROC curves.
+### Built-in presets
+
+W&B has several built-in chart presets that you can log directly from your script. These include line plots, scatter plots, bar charts, histograms, PR curves, and ROC curves.
 
 <Tabs>
 <Tab title="Line plot">
 `wandb.plot.line()`
 
-  Log a custom line plot—a list of connected and ordered points (x,y) on arbitrary axes x and y.
+  Log a custom line plot, a list of connected and ordered points (x,y) on arbitrary axes x and y.
 
   ```python
   with wandb.init() as run:
@@ -62,7 +72,7 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 <Tab title="Scatter plot">
 `wandb.plot.scatter()`
 
-  Log a custom scatter plot—a list of points (x, y) on a pair of arbitrary axes x and y.
+  Log a custom scatter plot, a list of points (x, y) on a pair of arbitrary axes x and y.
 
   ```python
   with wandb.init() as run:
@@ -82,7 +92,7 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 <Tab title="Bar chart">
 `wandb.plot.bar()`
 
-  Log a custom bar chart—a list of labeled values as bars—natively in a few lines:
+  Log a custom bar chart (a list of labeled values as bars):
 
   ```python
   with wandb.init() as run:
@@ -108,7 +118,7 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 <Tab title="Histogram">
 `wandb.plot.histogram()`
 
-  Log a custom histogram—sort list of values into bins by count/frequency of occurrence—natively in a few lines. Let's say I have a list of prediction confidence scores (`scores`) and want to visualize their distribution:
+  Log a custom histogram (sort a list of values into bins by count or frequency of occurrence). For example, suppose you have a list of prediction confidence scores (`scores`) and want to visualize their distribution:
 
   ```python
   with wandb.init() as run:
@@ -139,10 +149,10 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 
   You can log this whenever your code has access to:
 
-  * a model's predicted scores (`predictions`) on a set of examples
-  * the corresponding ground truth labels (`ground_truth`) for those examples
-  * (optionally) a list of the labels/class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, etc.)
-  * (optionally) a subset (still in list format) of the labels to visualize in the plot
+  * A model's predicted scores (`predictions`) on a set of examples.
+  * The corresponding ground truth labels (`ground_truth`) for those examples.
+  * `labels` (Optional): A list of the labels or class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, and so on).
+  * `classes_to_plot` (Optional): A subset (still in list format) of the labels to visualize in the plot.
 
   <Frame>
     <img src="/images/app_ui/demo_average_precision_lines.png" alt="Precision-recall curves"  />
@@ -173,10 +183,10 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 
   You can log this whenever your code has access to:
 
-  * a model's predicted scores (`predictions`) on a set of examples
-  * the corresponding ground truth labels (`ground_truth`) for those examples
-  * (optionally) a list of the labels/ class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, etc.)
-  * (optionally) a subset (still in list format) of these labels to visualize on the plot
+  * A model's predicted scores (`predictions`) on a set of examples.
+  * The corresponding ground truth labels (`ground_truth`) for those examples.
+  * `labels` (Optional): A list of the labels or class names (`labels=["cat", "dog", "bird"...]` if label index 0 means cat, 1 = dog, 2 = bird, and so on).
+  * `classes_to_plot` (Optional): A subset (still in list format) of these labels to visualize on the plot.
 
   <Frame>
     <img src="/images/app_ui/demo_custom_chart_roc_curve.png" alt="ROC curve"  />
@@ -188,7 +198,7 @@ W&B has a number of builtin chart presets that you can log directly from your sc
 
 ### Custom presets
 
-Tweak a builtin preset, or create a new preset, then save the chart. Use the chart ID to log data to that custom preset directly from your script. [Try an example Google Colab notebook](https://tiny.cc/custom-charts).
+Tweak a built-in preset, or create a new preset, then save the chart. Use the chart ID to log data to that custom preset directly from your script. [Try an example Google Colab notebook](https://tiny.cc/custom-charts).
 
 ```python
 # Create a table with the columns to plot
@@ -214,17 +224,17 @@ my_custom_chart = wandb.plot_table(
 
 ## Log data
 
-You can log the following data types from your script and use them in a custom chart:
+Before you can visualize anything in a custom chart, your script must log the underlying data in a format the chart editor can query. You can log the following data types from your script and use them in a custom chart:
 
-* **Config**: Initial settings of your experiment (your independent variables). This includes any named fields you've logged as keys to `wandb.Run.config` at the start of your training. For example: `wandb.Run.config.learning_rate = 0.0001`
-* **Summary**: Single values logged during training (your results or dependent variables). For example, `wandb.Run.log({"val_acc" : 0.8})`. If you write to this key multiple times during training via `wandb.Run.log()`, the summary is set to the final value of that key.
-* **History**: The full time series of the logged scalar is available to the query via the `history` field
-* **summaryTable**: If you need to log a list of multiple values, use a `wandb.Table()` to save that data, then query it in your custom panel.
-* **historyTable**: If you need to see the history data, then query `historyTable` in your custom chart panel. Each time you call `wandb.Table()` or log a custom chart, you're creating a new table in history for that step.
+* **Config**: Initial settings of your experiment (your independent variables). This includes any named fields you've logged as keys to `wandb.Run.config` at the start of your training. For example, `wandb.Run.config.learning_rate = 0.0001`.
+* **Summary**: Single values logged during training (your results or dependent variables). For example, `wandb.Run.log({"val_acc" : 0.8})`. If you write to this key multiple times during training through `wandb.Run.log()`, the summary is set to the final value of that key.
+* **History**: The full time series of the logged scalar is available to the query through the `history` field.
+* **`summaryTable`**: If you need to log a list of multiple values, use a `wandb.Table()` to save that data, then query it in your custom panel.
+* **`historyTable`**: If you need to see the history data, then query `historyTable` in your custom chart panel. Each time you call `wandb.Table()` or log a custom chart, you're creating a new table in history for that step.
 
-### How to log a custom table
+### Log a custom table
 
-Use `wandb.Table()` to log your data as a 2D array. Typically each row of this table represents one data point, and each column denotes the relevant fields/dimensions for each data point which you'd like to plot. As you configure a custom panel, the whole table will be accessible via the named key passed to `wandb.Run.log()`(`custom_data_table` below), and the individual fields will be accessible via the column names (`x`, `y`, and `z`). You can log tables at multiple time steps throughout your experiment. The maximum size of each table is 10,000 rows. [Try an example a Google Colab](https://tiny.cc/custom-charts).
+Use `wandb.Table()` to log your data as a 2D array. Typically, each row of this table represents one data point, and each column denotes the relevant fields or dimensions for each data point that you want to plot. As you configure a custom panel, the whole table is accessible through the named key passed to `wandb.Run.log()` (`custom_data_table` in the following example). The individual fields are accessible through the column names (`x`, `y`, and `z`). You can log tables at multiple time steps throughout your experiment. The maximum size of each table is 10,000 rows. [Try an example Google Colab notebook](https://tiny.cc/custom-charts).
 
 
 
@@ -239,7 +249,7 @@ with wandb.init() as run:
 
 ## Customize the chart
 
-Add a new custom chart to get started, then edit the query to select data from your visible runs. The query uses [GraphQL](https://graphql.org) to fetch data from the config, summary, and history fields in your runs.
+After you log data, build a chart in the W&B app by choosing which logged values to pull in and how to render them. Add a new custom chart to get started, then edit the query to select data from your visible runs. The query uses [GraphQL](https://graphql.org) to fetch data from the config, summary, and history fields in your runs.
 
 ### Build the GraphQL query
 
@@ -277,38 +287,42 @@ Custom charts use this GraphQL-based panel query. [Query panels](/models/app/fea
 
 Select a **Chart** in the upper right corner to start with a default preset. Next, select **Chart fields** to map the data you're pulling in from the query to the corresponding fields in your chart.
 
-The following image shows an example on how to select a metric then mapping that into the bar chart fields below.
+The following image shows how to select a metric and then map it into the bar chart fields.
 
 <Frame>
     <img src="/images/app_ui/demo_make_a_custom_chart_bar_chart.gif" alt="Creating a custom bar chart" max-width="90%"  />
 </Frame>
 
-### How to edit Vega
+### Edit Vega
 
-Click **Edit** at the top of the panel to go into [Vega](https://vega.github.io/vega/) edit mode. Here you can define a [Vega specification](https://vega.github.io/vega/docs/specification/) that creates an interactive chart in the UI. You can change any aspect of the chart. For example, you can change the title, pick a different color scheme, show curves as a series of points instead of as connected lines. You can also make changes to the data itself, such as using a Vega transform to bin an array of values into a histogram. The panel preview will update interactively, so you can see the effect of your changes as you edit the Vega spec or query. Refer to the [Vega documentation and tutorials ](https://vega.github.io/vega/).
+Click **Edit** at the top of the panel to go into [Vega](https://vega.github.io/vega/) edit mode. Here you can define a [Vega specification](https://vega.github.io/vega/docs/specification/) that creates an interactive chart in the UI. You can change any aspect of the chart. For example, you can change the title, pick a different color scheme, or show curves as a series of points instead of as connected lines. You can also make changes to the data itself, such as using a Vega transform to bin an array of values into a histogram. The panel preview updates interactively, so you can see the effect of your changes as you edit the Vega spec or query. For more information, see the [Vega documentation and tutorials](https://vega.github.io/vega/).
 
 **Field references**
 
-To pull data into your chart from W&B, add template strings of the form `"${field:<field-name>}"` anywhere in your Vega spec. This will create a dropdown in the **Chart Fields** area on the right side, which users can use to select a query result column to map into Vega.
+To pull data into your chart from W&B, add template strings of the form `"${field:<field-name>}"` anywhere in your Vega spec. This creates a dropdown in the **Chart fields** area on the right side, which you can use to select a query result column to map into Vega.
 
 To set a default value for a field, use this syntax: `"${field:<field-name>:<placeholder text>}"`
 
-### Saving chart presets
+### Save chart presets
 
-Apply any changes to a specific visualization panel with the button at the bottom of the modal. Alternatively, you can save the Vega spec to use elsewhere in your project. To save the reusable chart definition, click **Save as** at the top of the Vega editor and give your preset a name.
+Saving a preset lets you reuse the same Vega definition across panels and projects, rather than recreating it each time. Apply any changes to a specific visualization panel with the button at the bottom of the modal. Alternatively, you can save the Vega spec to use elsewhere in your project. To save the reusable chart definition, click **Save as** at the top of the Vega editor and give your preset a name.
 
 ## Articles and guides
 
-1. [The W&B Machine Learning Visualization IDE](https://wandb.ai/wandb/posts/reports/The-W-B-Machine-Learning-Visualization-IDE--VmlldzoyNjk3Nzg)
-2. [Visualizing NLP Attention Based Models](https://wandb.ai/kylegoyette/gradientsandtranslation2/reports/Visualizing-NLP-Attention-Based-Models-Using-Custom-Charts--VmlldzoyNjg2MjM)
-3. [Visualizing The Effect of Attention on Gradient Flow](https://wandb.ai/kylegoyette/gradientsandtranslation/reports/Visualizing-The-Effect-of-Attention-on-Gradient-Flow-Using-Custom-Charts--VmlldzoyNjg1NDg)
-4. [Logging arbitrary curves](https://wandb.ai/stacey/presets/reports/Logging-Arbitrary-Curves--VmlldzoyNzQyMzA)
+The following articles show end-to-end examples and deeper explorations of custom charts in practice.
+
+* [The W&B Machine Learning Visualization IDE](https://wandb.ai/wandb/posts/reports/The-W-B-Machine-Learning-Visualization-IDE--VmlldzoyNjk3Nzg)
+* [Visualizing NLP Attention Based Models](https://wandb.ai/kylegoyette/gradientsandtranslation2/reports/Visualizing-NLP-Attention-Based-Models-Using-Custom-Charts--VmlldzoyNjg2MjM)
+* [Visualizing The Effect of Attention on Gradient Flow](https://wandb.ai/kylegoyette/gradientsandtranslation/reports/Visualizing-The-Effect-of-Attention-on-Gradient-Flow-Using-Custom-Charts--VmlldzoyNjg1NDg)
+* [Logging arbitrary curves](https://wandb.ai/stacey/presets/reports/Logging-Arbitrary-Curves--VmlldzoyNzQyMzA)
 
 
 ## Common use cases
 
-* Customize bar plots with error bars
-* Show model validation metrics which require custom x-y coordinates (like precision-recall curves)
-* Overlay data distributions from two different models/experiments as histograms
-* Show changes in a metric via snapshots at multiple points during training
-* Create a unique visualization not yet available in W&B (and hopefully share it with the world)
+Custom charts are most useful when the default panels can't represent what you need to show. Typical examples include:
+
+* Customizing bar plots with error bars
+* Showing model validation metrics that require custom x-y coordinates (like precision-recall curves)
+* Overlaying data distributions from two different models or experiments as histograms
+* Showing changes in a metric through snapshots at multiple points during training
+* Creating a unique visualization not yet available in W&B and sharing it with others

--- a/models/app/features/custom-charts.mdx
+++ b/models/app/features/custom-charts.mdx
@@ -224,8 +224,8 @@ Before you can visualize anything in a custom chart, your script must log the un
 * **Config**: Initial settings of your experiment (your independent variables). This includes any named fields you've logged as keys to `wandb.Run.config` at the start of your training. For example, `wandb.Run.config.learning_rate = 0.0001`.
 * **Summary**: Single values logged during training (your results or dependent variables). For example, `wandb.Run.log({"val_acc" : 0.8})`. If you write to this key multiple times during training through `wandb.Run.log()`, the summary is set to the final value of that key.
 * **History**: The full time series of the logged scalar is available to the query through the `history` field.
-* **`summaryTable`**: If you need to log a list of multiple values, use a `wandb.Table()` to save that data, then query it in your custom panel.
-* **`historyTable`**: If you need to see the history data, then query `historyTable` in your custom chart panel. Each time you call `wandb.Table()` or log a custom chart, you're creating a new table in history for that step.
+* **summaryTable**: If you need to log a list of multiple values, use a `wandb.Table()` to save that data, then query it in your custom panel.
+* **historyTable**: If you need to see the history data, then query `historyTable` in your custom chart panel. Each time you call `wandb.Table()` or log a custom chart, you're creating a new table in history for that step.
 
 ### Log a custom table
 
@@ -300,11 +300,11 @@ To set a default value for a field, use this syntax: `"${field:<field-name>:<pla
 
 ### Save chart presets
 
-Saving a preset lets you reuse the same Vega definition across panels and projects, rather than recreating it each time. Apply any changes to a specific visualization panel with the button at the bottom of the modal. Alternatively, you can save the Vega spec to use elsewhere in your project. To save the reusable chart definition, click **Save as** at the top of the Vega editor and give your preset a name.
+Save a preset to reuse the same Vega definition across panels and projects instead of recreating it each time. Apply changes to a specific visualization panel with the button at the bottom of the modal. Alternatively, you can save the Vega spec to reuse it elsewhere in your project. To save the reusable chart definition, click **Save as** at the top of the Vega editor and give your preset a name.
 
-## Articles and guides
+## Reports and guides
 
-The following articles show end-to-end examples and deeper explorations of custom charts in practice.
+The following reports show end-to-end examples and deeper explorations of custom charts in practice.
 
 * [The W&B Machine Learning Visualization IDE](https://wandb.ai/wandb/posts/reports/The-W-B-Machine-Learning-Visualization-IDE--VmlldzoyNjk3Nzg)
 * [Visualizing NLP Attention Based Models](https://wandb.ai/kylegoyette/gradientsandtranslation2/reports/Visualizing-NLP-Attention-Based-Models-Using-Custom-Charts--VmlldzoyNjg2MjM)
@@ -314,7 +314,7 @@ The following articles show end-to-end examples and deeper explorations of custo
 
 ## Common use cases
 
-Custom charts are most useful when the default panels can't represent what you need to show. Typical examples include:
+Custom charts are useful when the default panels can't represent what you need to show. For example:
 
 * Customizing bar plots with error bars
 * Showing model validation metrics that require custom x-y coordinates (like precision-recall curves)

--- a/models/app/features/custom-charts.mdx
+++ b/models/app/features/custom-charts.mdx
@@ -1,12 +1,7 @@
 ---
 title: Custom charts overview
 description: Create custom charts in W&B projects with Vega visualizations
-keywords:
-  - Vega
-  - wandb.plot_table
-  - precision-recall curve
-  - ROC curve
-  - GraphQL query
+keywords: ["Vega", "wandb.plot_table", "precision-recall curve", "ROC curve", "GraphQL query"]
 ---
 
 Custom charts let you visualize logged data exactly how you want, beyond the defaults W&B provides. Use them when you need to plot relationships, distributions, or model evaluation metrics that the built-in panels don't cover, such as precision-recall curves, custom histograms, or overlays of multiple experiments.

--- a/models/app/features/custom-charts/walkthrough.mdx
+++ b/models/app/features/custom-charts/walkthrough.mdx
@@ -69,7 +69,7 @@ Update the Vega spec to customize the visualization:
     <img src="/images/app_ui/customize_vega_spec_for_pr_curve.png" alt="PR curve Vega spec" />
 </Frame>
 
-Saving a preset lets you reuse the same chart configuration on other panels in the project. To save this as a preset that you can use elsewhere in this project, click **Save as** at the top of the page. Here's what the result looks like, along with an ROC curve.
+Save a preset to reuse the same chart configuration on other panels in the project. To save this as a preset that you can use elsewhere in this project, click **Save as** at the top of the page. Here's what the result looks like, along with an ROC curve.
 
 <Frame>
     <img src="/images/general/custom-charts-2.png" alt="PR curve chart" />
@@ -87,7 +87,7 @@ Histograms can visualize numerical distributions to help you understand larger d
 
 To create your own version of the custom composite histogram panel:
 
-1. Create a new Custom Chart panel in your Workspace or Report (by adding a **Custom Chart** visualization). Click **Edit** in the top right to modify the Vega spec starting from any built-in panel type.
+1. Create a new custom chart panel in your workspace or report (by adding a **Custom Chart** visualization). Click **Edit** in the top right to modify the Vega spec starting from any built-in panel type.
 2. Replace that built-in Vega spec with the [starter code for a composite histogram in Vega](https://gist.github.com/staceysv/9bed36a2c0c2a427365991403611ce21). You can modify the main title, axis titles, input domain, and any other details directly in this Vega spec [using Vega syntax](https://vega.github.io/). For example, you can change the colors or add a third histogram.
 3. Modify the query in the right panel to load the correct data from your wandb logs. Add the field `summaryTable` and set the corresponding `tableKey` to `class_scores` to fetch the `wandb.Table` logged by your run. This lets you populate the two histogram bin sets (`red_bins` and `blue_bins`) through the dropdown menus with the columns of the `wandb.Table` logged as `class_scores`. For example, you can choose the `animal` class prediction scores for the red bins and `plant` for the blue bins.
 4. You can keep making changes to the Vega spec and query until the plot you see in the preview rendering matches what you want. After you're done, click **Save as** in the top and give your custom plot a name so you can reuse it. Then click **Apply from panel library** to finish your plot.

--- a/models/app/features/custom-charts/walkthrough.mdx
+++ b/models/app/features/custom-charts/walkthrough.mdx
@@ -1,14 +1,21 @@
 ---
 description: Tutorial of using the custom charts feature in the W&B UI
 title: 'Tutorial: Use custom charts'
+keywords:
+  - custom charts
+  - Vega spec
+  - historyTable
+  - summaryTable
+  - composite histogram
 ---
 
-Use custom charts to control the data you're loading into a panel and its visualization.
+Custom charts let you control both the data loaded into a panel and how it's visualized. This tutorial walks you through logging data, building a query, customizing the chart's Vega specification, and saving the result for reuse. It's intended for users who want to go beyond the default chart types and tailor visualizations to specific data.
 
+By the end of this tutorial, you'll have a working custom chart in your project that you can save as a preset and a bonus composite histogram you can adapt to your own data.
 
-## 1. Log data to W&B
+## Log data to W&B
 
-First, log data in your script. Use [wandb.Run.config](/models/track/config/) for single points set at the beginning of training, like hyperparameters. Use [wandb.Run.log()](/models/track/log/) for multiple points over time, and log custom 2D arrays with `wandb.Table()`. We recommend logging up to 10,000 data points per logged key.
+Before you can visualize anything in a custom chart, your run needs to log the data you want to display. Use [wandb.Run.config](/models/track/config/) for single points set at the beginning of training, like hyperparameters. Use [wandb.Run.log()](/models/track/log/) for multiple points over time, and log custom 2D arrays with `wandb.Table()`. We recommend logging up to 10,000 data points per logged key.
 
 ```python
 with wandb.init() as run: 
@@ -20,14 +27,16 @@ with wandb.init() as run:
   )
 ```
 
-[Try a quick example notebook](https://bit.ly/custom-charts-colab) to log the data tables, and in the next step we'll set up custom charts. See what the resulting charts look like in the [live report](https://app.wandb.ai/demo-team/custom-charts/reports/Custom-Charts--VmlldzoyMTk5MDc).
+[Try a quick example notebook](https://bit.ly/custom-charts-colab) to log the data tables, and in the next step you'll set up custom charts. See what the resulting charts look like in the [live report](https://app.wandb.ai/demo-team/custom-charts/reports/Custom-Charts--VmlldzoyMTk5MDc).
 
-## 2. Create a query
+With your data logged, you're ready to pull it into a custom chart panel.
 
-Once you've logged data to visualize, go to your project page and click the **`+`** button to add a new panel, then select **Custom Chart**. You can follow along in the [custom charts demo workspace](https://app.wandb.ai/demo-team/custom-charts).
+## Create a query
+
+A query tells the custom chart which logged data to load. After you've logged data to visualize, go to your project page and click the **`+`** button to add a new panel, then select **Custom Chart**. You can follow along in the [custom charts demo workspace](https://app.wandb.ai/demo-team/custom-charts).
 
 <Frame>
-    <img src="/images/app_ui/create_a_query.png" alt="Blank custom chart"  />
+    <img src="/images/app_ui/create_a_query.png" alt="Blank custom chart" />
 </Frame>
 
 ### Add a query
@@ -37,61 +46,63 @@ Once you've logged data to visualize, go to your project page and click the **`+
 
 ### Set Vega fields
 
-Now that the query is loading in these columns, they're available as options to select in the Vega fields dropdown menus:
+With the query in place, you can map your logged columns to the chart's visual encodings using the Vega fields dropdown menus:
 
 <Frame>
-    <img src="/images/app_ui/set_vega_fields.png" alt="Pulling in columns from the query results to set Vega fields"  />
+    <img src="/images/app_ui/set_vega_fields.png" alt="Pulling in columns from the query results to set Vega fields" />
 </Frame>
 
 * **x-axis:** runSets_historyTable_r (recall)
 * **y-axis:** runSets_historyTable_p (precision)
 * **color:** runSets_historyTable_c (class label)
 
-## 3. Customize the chart
+## Customize the chart
 
-Now that looks pretty good, but I'd like to switch from a scatter plot to a line plot. Click **Edit** to change the Vega spec for this built in chart. Follow along in the [custom charts demo workspace](https://app.wandb.ai/demo-team/custom-charts).
+The default visualization is a good starting point, but you can edit the Vega spec to change the chart type, add titles, and refine the appearance. To switch from a scatter plot to a line plot, click **Edit** to change the Vega spec for this built-in chart. Follow along in the [custom charts demo workspace](https://app.wandb.ai/demo-team/custom-charts).
 
 <Frame>
-    <img src="/images/general/custom-charts-1.png" alt="Custom chart selection"  />
+    <img src="/images/general/custom-charts-1.png" alt="Custom chart selection" />
 </Frame>
 
-I updated the Vega spec to customize the visualization:
+Update the Vega spec to customize the visualization:
 
-* add titles for the plot, legend, x-axis, and y-axis (set “title” for each field)
-* change the value of “mark” from “point” to “line”
-* remove the unused “size” field
+* Add titles for the plot, legend, x-axis, and y-axis (set "title" for each field).
+* Change the value of "mark" from "point" to "line".
+* Remove the unused "size" field.
 
 <Frame>
-    <img src="/images/app_ui/customize_vega_spec_for_pr_curve.png" alt="PR curve Vega spec"  />
+    <img src="/images/app_ui/customize_vega_spec_for_pr_curve.png" alt="PR curve Vega spec" />
 </Frame>
 
-To save this as a preset that you can use elsewhere in this project, click **Save as** at the top of the page. Here's what the result looks like, along with an ROC curve:
+Saving a preset lets you reuse the same chart configuration on other panels in the project. To save this as a preset that you can use elsewhere in this project, click **Save as** at the top of the page. Here's what the result looks like, along with an ROC curve.
 
 <Frame>
-    <img src="/images/general/custom-charts-2.png" alt="PR curve chart"  />
+    <img src="/images/general/custom-charts-2.png" alt="PR curve chart" />
 </Frame>
 
 ## Bonus: composite histograms
 
-Histograms can visualize numerical distributions to help us understand larger datasets. Composite histograms show multiple distributions across the same bins, letting us compare two or more metrics across different models or across different classes within our model. For a semantic segmentation model detecting objects in driving scenes, we might compare the effectiveness of optimizing for accuracy versus intersection over union (IOU), or we might want to know how well different models detect cars (large, common regions in the data) versus traffic signs (much smaller, less common regions). In the[ demo Colab](https://bit.ly/custom-charts-colab), you can compare the confidence scores for two of the ten classes of living things.
+This section shows how to build a more advanced custom chart, a composite histogram that overlays two distributions in the same view, to demonstrate what's possible after you're comfortable editing the Vega spec.
+
+Histograms can visualize numerical distributions to help you understand larger datasets. Composite histograms show multiple distributions across the same bins, letting you compare two or more metrics across different models or across different classes within your model. For a semantic segmentation model detecting objects in driving scenes, you might compare the effectiveness of optimizing for accuracy versus Intersection over Union (IoU), or you might want to know how well different models detect cars (large, common regions in the data) versus traffic signs (much smaller, less common regions). In the [demo Colab](https://bit.ly/custom-charts-colab), you can compare the confidence scores for two of the ten classes of living things.
 
 <Frame>
-    <img src="/images/app_ui/composite_histograms.png" alt="Composite histogram"  />
+    <img src="/images/app_ui/composite_histograms.png" alt="Composite histogram" />
 </Frame>
 
 To create your own version of the custom composite histogram panel:
 
-1. Create a new Custom Chart panel in your Workspace or Report (by adding a “Custom Chart” visualization). Hit the “Edit” button in the top right to modify the Vega spec starting from any built-in panel type.
-2. Replace that built-in Vega spec with my [MVP code for a composite histogram in Vega](https://gist.github.com/staceysv/9bed36a2c0c2a427365991403611ce21). You can modify the main title, axis titles, input domain, and any other details directly in this Vega spec [using Vega syntax](https://vega.github.io/) (you could change the colors or even add a third histogram :)
-3. Modify the query in the right hand side to load the correct data from your wandb logs. Add the field `summaryTable` and set the corresponding `tableKey` to `class_scores` to fetch the `wandb.Table` logged by your run. This will let you populate the two histogram bin sets (`red_bins` and `blue_bins`) via the dropdown menus with the columns of the `wandb.Table` logged as `class_scores`. For my example, I chose the `animal` class prediction scores for the red bins and `plant` for the blue bins.
-4. You can keep making changes to the Vega spec and query until you’re happy with the plot you see in the preview rendering. Once you’re done, click **Save as** in the top and give your custom plot a name so you can reuse it. Then click **Apply from panel library** to finish your plot.
+1. Create a new Custom Chart panel in your Workspace or Report (by adding a **Custom Chart** visualization). Click **Edit** in the top right to modify the Vega spec starting from any built-in panel type.
+2. Replace that built-in Vega spec with the [starter code for a composite histogram in Vega](https://gist.github.com/staceysv/9bed36a2c0c2a427365991403611ce21). You can modify the main title, axis titles, input domain, and any other details directly in this Vega spec [using Vega syntax](https://vega.github.io/). For example, you can change the colors or add a third histogram.
+3. Modify the query in the right panel to load the correct data from your wandb logs. Add the field `summaryTable` and set the corresponding `tableKey` to `class_scores` to fetch the `wandb.Table` logged by your run. This lets you populate the two histogram bin sets (`red_bins` and `blue_bins`) through the dropdown menus with the columns of the `wandb.Table` logged as `class_scores`. For example, you can choose the `animal` class prediction scores for the red bins and `plant` for the blue bins.
+4. You can keep making changes to the Vega spec and query until the plot you see in the preview rendering matches what you want. After you're done, click **Save as** in the top and give your custom plot a name so you can reuse it. Then click **Apply from panel library** to finish your plot.
 
-Here’s what my results look like from a very brief experiment: training on only 1000 examples for one epoch yields a model that’s very confident that most images are not plants and very uncertain about which images might be animals.
+Here's an example result from a brief experiment: training on only 1,000 examples for one epoch yields a model that's confident that most images are not plants and uncertain about which images might be animals.
 
 <Frame>
-    <img src="/images/general/custom-charts-3.png" alt="Chart configuration"  />
+    <img src="/images/general/custom-charts-3.png" alt="Chart configuration" />
 </Frame>
 
 <Frame>
-    <img src="/images/general/custom-charts-4.png" alt="Chart result"  />
+    <img src="/images/general/custom-charts-4.png" alt="Chart result" />
 </Frame>

--- a/models/app/features/custom-charts/walkthrough.mdx
+++ b/models/app/features/custom-charts/walkthrough.mdx
@@ -1,12 +1,7 @@
 ---
 description: Tutorial of using the custom charts feature in the W&B UI
 title: 'Tutorial: Use custom charts'
-keywords:
-  - custom charts
-  - Vega spec
-  - historyTable
-  - summaryTable
-  - composite histogram
+keywords: ["custom charts", "Vega spec", "historyTable", "summaryTable", "composite histogram"]
 ---
 
 Custom charts let you control both the data loaded into a panel and how it's visualized. This tutorial walks you through logging data, building a query, customizing the chart's Vega specification, and saving the result for reuse. It's intended for users who want to go beyond the default chart types and tailor visualizations to specific data.

--- a/models/app/features/panels.mdx
+++ b/models/app/features/panels.mdx
@@ -2,9 +2,15 @@
 title: Panels
 sidebartitle: Overview
 description: Use and customize workspace panels to visualize your logged data
+keywords:
+  - workspace panels
+  - quick add
+  - full-screen mode
+  - panel sections
+  - embed panel
 ---
 
-Use workspace panel visualizations to explore your [logged data](/models/ref/python/experiments/run.md/#method-runlog) by key, visualize the relationships between hyperparameters and output metrics, and more. 
+Use workspace panel visualizations to explore your [logged data](/models/ref/python/experiments/run.md/#method-runlog) by key, visualize the relationships between hyperparameters and output metrics, and more. This page describes how to choose a workspace mode, add and configure panels, organize them into sections, and share them with collaborators. 
 
 ## Workspace modes
 
@@ -12,18 +18,20 @@ W&B projects support two different workspace modes. The icon next to the workspa
 
 | Icon | Workspace mode |
 | --- | --- |
-| <img src="/images/app_ui/automated_workspace.svg" alt="automated workspace icon" width="32px"  /> | **Automated workspaces** automatically generate panels for all keys logged in the project. Choose an automatic workspace:<ul><li>To get started quickly by visualizing all available data for the project.</li><li>For a smaller projects that log fewer keys.</li><li>For more broad analysis.</li></ul>If you delete a panel from an automatic workspace, you can use [Quick add](#quick-add) to recreate it. |
-| <img src="/images/app_ui/manual_workspace.svg" alt="manual workspace icon" width="32px"  /> | **Manual workspaces** start as blank slates and display only those panels intentionally added by users. Choose a manual workspace:<ul><li>When you care mainly about a fraction of the keys logged in the project.</li><li>For more focused analysis.</li><li>To improve the performance of a workspace, avoiding loading panels that are less useful to you.</li></ul>Use [Quick add](#quick-add) to easily populate a manual workspace and its sections with useful visualizations rapidly. |
+| <img src="/images/app_ui/automated_workspace.svg" alt="automated workspace icon" width="32px"  /> | **Automated workspaces** automatically generate panels for all keys logged in the project. Choose an automatic workspace:<ul><li>To get started quickly by visualizing all available data for the project.</li><li>For smaller projects that log fewer keys.</li><li>For more broad analysis.</li></ul>If you delete a panel from an automatic workspace, you can use [Quick add](#quick-add) to recreate it. |
+| <img src="/images/app_ui/manual_workspace.svg" alt="manual workspace icon" width="32px"  /> | **Manual workspaces** start as blank slates and display only the panels you intentionally add. Choose a manual workspace:<ul><li>When you care mainly about a fraction of the keys logged in the project.</li><li>For more focused analysis.</li><li>To improve the performance of a workspace by avoiding loading panels that are less useful to you.</li></ul>Use [Quick add](#quick-add) to quickly populate a manual workspace and its sections with useful visualizations. |
 
 To change how a workspace generates panels, [reset the workspace](#reset-a-workspace).
 
 <Note>
 **Undo changes to your workspace**
 
-To undo changes to your workspace, click the Undo button (arrow that points left) or type **CMD + Z** (macOS) or **CTRL + Z** (Windows / Linux).
+To undo changes to your workspace, click the Undo button (arrow that points left) or press `Cmd+Z` (macOS) or `Ctrl+Z` (Windows or Linux).
 </Note>
 
 ## Reset a workspace
+
+Resetting a workspace lets you change its mode or clear its panels to start fresh.
 
 To reset a workspace:
 
@@ -32,7 +40,9 @@ To reset a workspace:
 
 ## Configure the workspace layout
 
-To configure the workspace layout, click **Settings** near the top of the workspace, then click **Workspace layout**.
+Workspace layout settings control how panels and sections are organized and displayed across the whole workspace.
+
+To configure the workspace layout, click **Settings** near the top of the workspace, then click **Workspace layout**. The following settings are available:
 
 - **Hide empty sections during search** (turned on by default)
 - **Sort panels alphabetically** (turned off by default)
@@ -44,7 +54,8 @@ To configure defaults for the workspace's line plots, refer to [Line plots](/mod
 
 ### Configure a section's layout
 
-To configure the layout of a section, click its gear icon, then click **Display preferences**.
+To configure the layout of a section, click its gear icon, then click **Display preferences**. The following settings are available:
+
 - **Turn on or off colored run names in tooltips** (turned on by default)
 - **Only show highlighted run in companion chart tooltips** (turned off by default)
 - **Number of runs shown in tooltips** (a single run, all runs, or **Default**)
@@ -52,7 +63,7 @@ To configure the layout of a section, click its gear icon, then click **Display 
 
 ## View a panel in full-screen mode
 
-In full-screen mode, the run selector displays and panels use full-fidelity sampling mode plots with 10,000 buckets, rather than 1000 buckets otherwise.
+Full-screen mode gives a panel more space and higher-fidelity sampling, which is useful for closer inspection of your data. In full-screen mode, the run selector displays and panels use full-fidelity sampling mode plots with 10,000 buckets, rather than the usual 1,000.
 
 To view a panel in full-screen mode:
 
@@ -61,27 +72,35 @@ To view a panel in full-screen mode:
     <Frame>
     <img src="/images/app_ui/panel_fullscreen.png" alt="Full-screen panel"  />
     </Frame>
-1. When you [share the panel](#share-a-panel) while viewing it in full-screen mode, the resulting link opens in full-screen mode automatically.
 
-- To get back to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page.
+When you [share the panel](#share-a-panel) while viewing it in full-screen mode, the resulting link opens in full-screen mode automatically.
+
+When you work in full-screen mode, use the following tips:
+
+- To return to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page.
 - To navigate through a section's panels without exiting full-screen mode, use either the **Previous** and **Next** buttons below the panel or the left and right arrow keys.
-- To reclaim more space for the panel, minimize the run selector with **Cmd+.** (macOS) or **Ctrl+.** (Windows/Linux).
+- To reclaim more space for the panel, minimize the run selector with `Cmd+.` (macOS) or `Ctrl+.` (Windows or Linux).
 - When you view an image from a [media panel](/models/app/features/panels/media) in full-screen mode, keyboard shortcuts can zoom in or out, reset zoom, or zoom to fit. See [Keyboard shortcuts](/models/app/keyboard-shortcuts#media-panels).
 
 See [Keyboard shortcuts](/models/app/keyboard-shortcuts) for other full-screen and panel shortcuts.
 
 ## Add panels
 
-This section shows various ways to add panels to your workspace.
+The following sections describe ways to add panels to your workspace.
 
 ### Add a panel manually
 
-Add panels to your workspace one at a time, either globally or at the section level.
+Adding a panel manually lets you choose exactly which type of visualization to create and configure its settings before it appears in the workspace. Add panels to your workspace one at a time, either globally or at the section level.
 
-1. To add a panel globally, click **Add panels** in the control bar near the panel search field.
-1. To add a panel directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
+To start adding a panel, do one of the following:
+
+- To add a panel globally, click **Add panels** in the control bar near the panel search field.
+- To add a panel directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
+
+Then, complete the following steps:
+
 1. Select the type of panel to add, such as a chart. The panel's configuration details appear, with defaults selected.
-1. Optionally, customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section below, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
+1. Optional: Customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
 1. Click **Apply**.
 
 <Frame>
@@ -93,60 +112,71 @@ Add panels to your workspace one at a time, either globally or at the section le
 Use **Quick add** to add a panel automatically for each key you select, either globally or at the section level.
 
 <Note>
-For an automated workspace with no deleted panels, the **Quick add** option is not visible because the workspace already includes panels for all logged keys. You can use **Quick add** to re-add a panel that you deleted.
+For an automated workspace with no deleted panels, the **Quick add** option isn't visible because the workspace already includes panels for all logged keys. You can use **Quick add** to re-add a panel that you deleted.
 </Note>
 
-1. To use **Quick add** to add a panel globally, click **Add panels** in the control bar near the panel search field, then click **Quick add**.
-1. To use **Quick add** to add a panel directly to a section, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, click **Add panels**, then click **Quick add**.
-1. A list of panels appears. Each panel with a checkmark is already included in the workspace.
-    - To add all available panels, click the **Add `<N>` panels** button at the top of the list. The **Quick Add** list closes and the new panels display in the workspace.
-    - To add an individual panel from the list, hover over the panel's row, then click **Add**. Repeat this step for each panel you want to add, then click the **X** at the top right to close the **Quick Add** list. The new panels display in the workspace.
-1. Optionally, customize the panel's settings.
+To open **Quick add**, do one of the following:
+
+- To use **Quick add** to add a panel globally, click **Add panels** in the control bar near the panel search field, then click **Quick add**.
+- To use **Quick add** to add a panel directly to a section, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, click **Add panels**, then click **Quick add**.
+
+A list of panels appears. Each panel with a checkmark is already included in the workspace. To add panels from the list:
+
+- To add all available panels, click the **Add `[N]` panels** button at the top of the list. The **Quick Add** list closes and the new panels display in the workspace.
+- To add an individual panel from the list, hover over the panel's row, then click **Add**. Repeat this step for each panel you want to add, then click the **X** at the top right to close the **Quick Add** list. The new panels display in the workspace.
+
+Optional: Customize the panel's settings.
 
 ## Share a panel
 
-This section shows how to share a panel using a link.
+Sharing a panel lets you send a focused view of a specific visualization to collaborators without requiring them to navigate the full workspace. The following procedure shows how to share a panel using a link.
 
-To share a panel using a link, you can either:
+To share a panel using a link, do one of the following:
 
 - While viewing the panel in full-screen mode, copy the URL from the browser.
-- Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu and select **Copy panel URL**.
+- Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Copy panel URL**.
 
 Share the link with the user or team. When they access the link, the panel opens in [full-screen mode](#view-a-panel-in-full-screen-mode).
 
 To return to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page.
 
 ### Compose a panel's full-screen link programmatically
-In certain situations, such as when [creating an automation](/models/automations/), it can be useful to include the panel's full-screen URL. This section shows the format for a panel's full-screen URL. In the following example, replace the entity, project, panel, and section names in brackets.
+
+When you [create an automation](/models/automations/) or similar workflow, it can be useful to include the panel's full-screen URL. The following format shows a panel's full-screen URL. In the following example, replace the entity, project, panel, and section names in brackets.
 
 ```text
-https://wandb.ai/<ENTITY_NAME>/<PROJECT_NAME>?panelDisplayName=<PANEL_NAME>&panelSectionName=<SECTON_NAME>
+https://wandb.ai/[ENTITY_NAME]/[PROJECT_NAME]?panelDisplayName=[PANEL_NAME]&panelSectionName=[SECTION_NAME]
 ```
 
 If multiple panels in the same section have the same name, this URL opens the first panel with the name.
 
 ### Embed or share a panel on social media
+
 To embed a panel in a website or share it on social media, the panel must be viewable by anyone with the link. If a project is private, only members of the project can view the panel. If the project is public, anyone with the link can view the panel.
 
 To get the code to embed or share a panel on social media:
 
 1. From the workspace, hover over the panel, then click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
 1. Click the **Share** tab.
-1. Change **Only those who are invited have access** to **Anyone with the link can view**. Otherwise, the choices in the next step are not available.
+1. Change **Only those who are invited have access** to **Anyone with the link can view**. Otherwise, the choices in the next step aren't available.
 1. Choose **Share on Twitter**, **Share on Reddit**, **Share on LinkedIn**, or **Copy embed link**.
 
 ### Email a panel report
+
 To email a single panel as a stand-alone report:
+
 1. Hover over the panel, then click the panel's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
 1. Click **Share panel in report**.
 1. Select the **Invite** tab.
 1. Enter an email address or username.
-1. Optionally, change **can view** to **can edit**.
-1. Click **Invite**. W&B sends an email to the user with a clickable link to the report that contains only the panel you are sharing. 
+1. Optional: Change **can view** to **can edit**.
+1. Click **Invite**. W&B sends an email to the user with a clickable link to the report that contains only the panel you're sharing. 
 
-Unlike when you [share a panel](#share-a-panel), the recipient cannot get to the workspace from this report.
+Unlike when you [share a panel](#share-a-panel), the recipient can't get to the workspace from this report.
 
 ## Manage panels
+
+After you add panels to a workspace, you can edit, move, duplicate, or remove them to keep your visualizations organized and up to date.
 
 ### Edit a panel
 
@@ -154,14 +184,14 @@ To edit a panel:
 
 1. Click its pencil icon.
 1. Modify the panel's settings.
-1. To change the panel to a different type, select the type and then configure the settings.
+1. Optional: To change the panel to a different type, select the type and then configure the settings.
 1. Click **Apply**.
 
 ### Move a panel
 
 To move a panel to a different section, you can use the drag handle on the panel. To select the new section from a list instead:
 
-1. If necessary, create a new section by clicking **Add section** after the last section.
+1. Optional: Create a new section by clicking **Add section** after the last section.
 1. Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu for the panel.
 1. Click **Move**, then select a new section.
 
@@ -180,8 +210,8 @@ If desired, you can [customize](#edit-a-panel) or [move](#move-a-panel) the dupl
 
 To remove a panel:
 
-1. Hover your mouse over the panel.
-1. Select the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
+1. Hover over the panel.
+1. Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
 1. Click **Delete**.
 
 To remove all panels from a manual workspace, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Clear all panels**.
@@ -190,7 +220,7 @@ To remove all panels from an automatic or manual workspace, you can [reset the w
 
 ## Manage sections
 
-By default, sections in a workspace reflect the logging hierarchy of your keys. However, in a manual workspace, sections appear only after you start adding panels.
+Sections group related panels together, making it easier to scan large workspaces. By default, sections in a workspace reflect the logging hierarchy of your keys. However, in a manual workspace, sections appear only after you start adding panels.
 
 ### Add a section
 
@@ -199,20 +229,25 @@ To add a section, click **Add section** after the last section.
 To add a new section before or after an existing section, you can instead click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **New section below** or **New section above**.
 
 <Warning>
-Do not name a section "Section". Panels in this section will not render until the section is renamed, due to a known limitation.
+Don't name a section "Section". Because of a known limitation, panels in this section don't render until you rename the section.
 </Warning>
 
 ### Manage a section's panels
-Sections with a large number of panels are paginated by default. The default number of panels on a page depend on the panel's configuration and on the sizes of the panels in the section.
 
-1. To resize a panel, hover over it, click the drag handle, and drag it to adjust the panel's size. Resizing one panel resizes all panels in the section.
-1. If a section is paginated, you can customize the number of panels to show on a page:
-  1. At the top of the section, click **1 to `<X>` of `<Y>`**, where `<X>` is the number of visible panels and `<Y>` is the total number of panels.
-  1. Choose how many panels to show per page, up to 100.
-1. To delete a panel from a section:
-  1. Hover over the panel, then click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
-  1. Click **Delete**.
-  
+Within a section, you can resize panels, control pagination, and delete individual panels. Sections with many panels are paginated by default. The default number of panels on a page depends on the panel's configuration and on the sizes of the panels in the section.
+
+To resize a panel, hover over it, click the drag handle, and drag it to adjust the panel's size. Resizing one panel resizes all panels in the section.
+
+If a section is paginated, you can customize the number of panels to show on a page:
+
+1. At the top of the section, click **1 to `[X]` of `[Y]`**, where `[X]` is the number of visible panels and `[Y]` is the total number of panels.
+1. Choose how many panels to show per page, up to 100.
+
+To delete a panel from a section:
+
+1. Hover over the panel, then click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu.
+1. Click **Delete**.
+
 If you reset a workspace to an automated workspace, all deleted panels appear again.
 
 ### Rename a section
@@ -220,7 +255,7 @@ If you reset a workspace to an automated workspace, all deleted panels appear ag
 To rename a section, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Rename section**.
 
 <Warning>
-Do not name a section "Section". Panels in this section will not render until the section is renamed, due to a known limitation.
+Don't name a section "Section". Because of a known limitation, panels in this section don't render until you rename the section.
 </Warning>
 
 ### Delete a section

--- a/models/app/features/panels.mdx
+++ b/models/app/features/panels.mdx
@@ -2,12 +2,7 @@
 title: Panels
 sidebartitle: Overview
 description: Use and customize workspace panels to visualize your logged data
-keywords:
-  - workspace panels
-  - quick add
-  - full-screen mode
-  - panel sections
-  - embed panel
+keywords: ["workspace panels", "quick add", "full-screen mode", "panel sections", "embed panel"]
 ---
 
 Use workspace panel visualizations to explore your [logged data](/models/ref/python/experiments/run.md/#method-runlog) by key, visualize the relationships between hyperparameters and output metrics, and more. This page describes how to choose a workspace mode, add and configure panels, organize them into sections, and share them with collaborators. 

--- a/models/app/features/panels.mdx
+++ b/models/app/features/panels.mdx
@@ -21,12 +21,12 @@ To change how a workspace generates panels, [reset the workspace](#reset-a-works
 <Note>
 **Undo changes to your workspace**
 
-To undo changes to your workspace, click the Undo button (arrow that points left) or press `Cmd+Z` (macOS) or `Ctrl+Z` (Windows or Linux).
+To undo changes to your workspace, click the Undo button (arrow that points left) or press **Cmd+Z** (macOS) or **Ctrl+Z** (Windows or Linux).
 </Note>
 
 ## Reset a workspace
 
-Resetting a workspace lets you change its mode or clear its panels to start fresh.
+Reset a workspace to change its mode or clear its panels to start fresh.
 
 To reset a workspace:
 
@@ -58,7 +58,7 @@ To configure the layout of a section, click its gear icon, then click **Display 
 
 ## View a panel in full-screen mode
 
-Full-screen mode gives a panel more space and higher-fidelity sampling, which is useful for closer inspection of your data. In full-screen mode, the run selector displays and panels use full-fidelity sampling mode plots with 10,000 buckets, rather than the usual 1,000.
+Full-screen mode gives a panel more space, which is useful for closer inspection of your data. In full-screen mode, the run selector displays.
 
 To view a panel in full-screen mode:
 
@@ -74,7 +74,7 @@ When you work in full-screen mode, use the following tips:
 
 - To return to a panel's workspace from full-screen mode, click the left-pointing arrow at the top of the page.
 - To navigate through a section's panels without exiting full-screen mode, use either the **Previous** and **Next** buttons below the panel or the left and right arrow keys.
-- To reclaim more space for the panel, minimize the run selector with `Cmd+.` (macOS) or `Ctrl+.` (Windows or Linux).
+- To reclaim more space for the panel, minimize the run selector with **Cmd+.** (macOS) or **Ctrl+.** (Windows or Linux).
 - When you view an image from a [media panel](/models/app/features/panels/media) in full-screen mode, keyboard shortcuts can zoom in or out, reset zoom, or zoom to fit. See [Keyboard shortcuts](/models/app/keyboard-shortcuts#media-panels).
 
 See [Keyboard shortcuts](/models/app/keyboard-shortcuts) for other full-screen and panel shortcuts.
@@ -85,15 +85,10 @@ The following sections describe ways to add panels to your workspace.
 
 ### Add a panel manually
 
-Adding a panel manually lets you choose exactly which type of visualization to create and configure its settings before it appears in the workspace. Add panels to your workspace one at a time, either globally or at the section level.
+Add panels to your workspace one at a time, either globally or at the section level.
 
-To start adding a panel, do one of the following:
-
-- To add a panel globally, click **Add panels** in the control bar near the panel search field.
-- To add a panel directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
-
-Then, complete the following steps:
-
+1. To add a panel globally, click **Add panels** in the control bar near the panel search field.
+1. To add a panel directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
 1. Select the type of panel to add, such as a chart. The panel's configuration details appear, with defaults selected.
 1. Optional: Customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
 1. Click **Apply**.
@@ -124,9 +119,7 @@ Optional: Customize the panel's settings.
 
 ## Share a panel
 
-Sharing a panel lets you send a focused view of a specific visualization to collaborators without requiring them to navigate the full workspace. The following procedure shows how to share a panel using a link.
-
-To share a panel using a link, do one of the following:
+Share a panel to send collaborators directly to a focused view of a specific visualization without navigating to the full workspace. To share a panel using a link, do one of the following:
 
 - While viewing the panel in full-screen mode, copy the URL from the browser.
 - Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Copy panel URL**.

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -1,15 +1,20 @@
 ---
 description: Visualize metrics, customize axes, and compare categorical data as bars.
 title: Bar plots
+keywords:
+  - bar chart
+  - box plot
+  - violin plot
+  - categorical data
 ---
 
-A bar plot presents categorical data with rectangular bars which can be plotted vertically or horizontally. Bar plots show up by default with `wandb.Run.log()` when all logged values are of length one.
+A bar plot presents categorical data with rectangular bars that you can plot vertically or horizontally. Use bar plots to visualize metrics, compare categorical data, and customize axes for your runs. Bar plots appear by default with `wandb.Run.log()` when all logged values are of length one.
 
 <Frame>
-    <img src="/images/app_ui/bar_plot.png" alt="Plotting Box and horizontal Bar plots in W&B"  />
+    <img src="/images/app_ui/bar_plot.png" alt="Box and horizontal bar plots in W&B"  />
 </Frame>
 
-Customize with chart settings to limit max runs to show, group runs by any config and rename labels.
+Use chart settings to limit the maximum number of runs shown, group runs by any config, and rename labels.
 
 <Frame>
     <img src="/images/app_ui/bar_plot_custom.png" alt="Customized bar plot"  />
@@ -17,13 +22,15 @@ Customize with chart settings to limit max runs to show, group runs by any confi
 
 ## Customize bar plots
 
-You can also create **Box** or **Violin** Plots to combine many summary statistics into one chart type.
+You can also create **Box** or **Violin** plots to combine many summary statistics into one chart type.
 
-1. Group runs via runs table.
-2. Click 'Add panel' in the workspace.
-3. Add a standard 'Bar Chart' and select the metric to plot.
-4. Under the 'Grouping' tab, pick 'box plot' or 'Violin', etc. to plot either of these styles.
+To create a box or violin plot:
+
+1. Group runs through the runs table.
+2. In the workspace, click **Add panel**.
+3. Add a standard **Bar Chart** and select the metric to plot.
+4. Under the **Grouping** tab, pick **Box** or **Violin** to plot either of these styles.
 
 <Frame>
-    <img src="/images/app_ui/bar_plots.gif" alt="Customize Bar Plots"  />
+    <img src="/images/app_ui/bar_plots.gif" alt="Customizing a bar plot with grouping options"  />
 </Frame>

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -1,11 +1,7 @@
 ---
 description: Visualize metrics, customize axes, and compare categorical data as bars.
 title: Bar plots
-keywords:
-  - bar chart
-  - box plot
-  - violin plot
-  - categorical data
+keywords: ["bar chart", "box plot", "violin plot", "categorical data"]
 ---
 
 A bar plot presents categorical data with rectangular bars that you can plot vertically or horizontally. Use bar plots to visualize metrics, compare categorical data, and customize axes for your runs. Bar plots appear by default with `wandb.Run.log()` when all logged values are of length one.

--- a/models/app/features/panels/code.mdx
+++ b/models/app/features/panels/code.mdx
@@ -45,11 +45,11 @@ In addition to setting code saving programmatically, you can configure defaults 
 
 By default, W&B disables code saving for all teams. Before you can turn it on for a team, an organization admin must turn it on for the organization. See the [Organization](#organization) section.
 
-Team admins open the team **Settings** page, go to the **Privacy** section, and configure **Enable code saving by default** for runs in that team. This option is available only when an organization admin hasn't enforced code saving restrictions for the whole organization. For navigation steps, see [Configure privacy settings for a team](/platform/hosting/privacy-settings#configure-privacy-settings-for-a-team).
+A team admin can open the team **Settings** page, go to the **Privacy** section, and configure **Enable code saving by default** for runs in that team. This option is available only when an organization admin hasn't enforced code saving restrictions for the whole organization. For navigation steps, see [Configure privacy settings for a team](/platform/hosting/privacy-settings#configure-privacy-settings-for-a-team).
 
 #### Organization
 
-Organization admins open organization **Settings**, go to the **Privacy** section, and can turn on **Enforce default code saving restrictions** so code saving stays off by default for every team. While this enforcement is on, team admins can't turn on **Enable code saving by default** for a team. For the full list of organization controls, see [Enforce privacy settings for all teams](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams).
+An organization admin can open organization **Settings**, go to the **Privacy** section, and activate **Enforce default code saving restrictions** so code saving stays off by default for every team. While this enforcement is active, team admins can't turn on **Enable code saving by default** for a team. For the full list of organization controls, see [Enforce privacy settings for all teams](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams).
 
 ## Code comparer
 

--- a/models/app/features/panels/code.mdx
+++ b/models/app/features/panels/code.mdx
@@ -1,12 +1,7 @@
 ---
 title: Save and diff code
 description: "Enable code saving, compare code across W&B runs with the code comparer, and capture Jupyter session history."
-keywords:
-  - log_code
-  - code_dir
-  - code comparer
-  - Jupyter notebook history
-  - reproducibility
+keywords: ["log_code", "code_dir", "code comparer", "Jupyter notebook history", "reproducibility"]
 ---
 
 This page explains how to enable code saving so you can compare the code used across W&B runs and review the cells executed in Jupyter sessions. Saving code makes it easier to reproduce experiments and understand how changes to your training code affect results.

--- a/models/app/features/panels/code.mdx
+++ b/models/app/features/panels/code.mdx
@@ -1,17 +1,27 @@
 ---
 title: Save and diff code
 description: "Enable code saving, compare code across W&B runs with the code comparer, and capture Jupyter session history."
+keywords:
+  - log_code
+  - code_dir
+  - code comparer
+  - Jupyter notebook history
+  - reproducibility
 ---
 
-By default, W&B only saves the latest git commit hash. You can turn on more code features to compare the code between your experiments dynamically in the UI.
+This page explains how to enable code saving so you can compare the code used across W&B runs and review the cells executed in Jupyter sessions. Saving code makes it easier to reproduce experiments and understand how changes to your training code affect results.
 
-Starting with `wandb` version 0.8.28, W&B can save the code from your main training file where you call `wandb.init()`. 
+By default, W&B only saves the latest Git commit hash. You can turn on more code features to compare the code between your experiments in the UI.
+
+Starting with `wandb` version 0.8.28, W&B can save the code from your main training file where you call `wandb.init()`.
 
 ## Save library code
 
-When you enable code saving, W&B saves the code from the file that called `wandb.init()`. To save additional library code, you have three options:
+When you enable code saving, W&B saves the code from the file that called `wandb.init()`. To save additional library code, you have three options.
 
-### Call `wandb.Run.log_code(".")` after calling `wandb.init()`
+### Call `log_code` after `wandb.init`
+
+Call `wandb.Run.log_code(".")` after `wandb.init()`:
 
 ```python
 import wandb
@@ -20,7 +30,9 @@ with wandb.init() as run:
   run.log_code(".")
 ```
 
-### Pass a settings object to `wandb.init()` with `code_dir` set
+### Pass a settings object with `code_dir`
+
+Pass a settings object to `wandb.init()` with `code_dir` set:
 
 ```python
 import wandb
@@ -28,26 +40,30 @@ import wandb
 wandb.init(settings=wandb.Settings(code_dir="."))
 ```
 
-This captures all python source code files in the current directory and all subdirectories as an [artifact](/models/ref/python/experiments/artifact). For more control over the types and locations of source code files that are saved, see the [reference docs](/models/ref/python/experiments/run#log_code).
+This captures all Python source code files in the current directory and all subdirectories as an [artifact](/models/ref/python/experiments/artifact). For more control over the types and locations of source code files that W&B saves, see the [reference docs](/models/ref/python/experiments/run#log_code).
 
 ### Set code saving in the UI
 
-In addition to setting code saving programmatically, you can configure defaults in the UI at the scope of a team or the organization. Team and organization controls are documented in [Configure privacy settings](/platform/hosting/privacy-settings).
+In addition to setting code saving programmatically, you can configure defaults in the UI at the team or organization level. The following sections describe the team-level and organization-level settings.
 
 #### Team
-> By default, W&B disables code saving for all teams. Before you can turn it on for a team, an organization admin must turn it on for the organization. See the [Organization](#organization) section.
 
-Team admins open the team **Settings** page, go to the **Privacy** section, and configure **Enable code saving by default** for runs in that team. This option is available only when an organization admin has not enforced code saving restrictions for the whole organization. For navigation steps, see [Configure privacy settings for a team](/platform/hosting/privacy-settings#configure-privacy-settings-for-a-team).
+By default, W&B disables code saving for all teams. Before you can turn it on for a team, an organization admin must turn it on for the organization. See the [Organization](#organization) section.
+
+Team admins open the team **Settings** page, go to the **Privacy** section, and configure **Enable code saving by default** for runs in that team. This option is available only when an organization admin hasn't enforced code saving restrictions for the whole organization. For navigation steps, see [Configure privacy settings for a team](/platform/hosting/privacy-settings#configure-privacy-settings-for-a-team).
 
 #### Organization
 
-Organization admins open organization **Settings**, go to the **Privacy** section, and can turn on **Enforce default code saving restrictions** so code saving stays off by default for every team. While this enforcement is on, team admins cannot turn on **Enable code saving by default** for a team. For the full list of organization controls, see [Enforce privacy settings for all teams](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams).
+Organization admins open organization **Settings**, go to the **Privacy** section, and can turn on **Enforce default code saving restrictions** so code saving stays off by default for every team. While this enforcement is on, team admins can't turn on **Enable code saving by default** for a team. For the full list of organization controls, see [Enforce privacy settings for all teams](/platform/hosting/privacy-settings#enforce-privacy-settings-for-all-teams).
 
 ## Code comparer
-Compare code used in different W&B runs:
+
+The code comparer panel displays the code from different W&B runs side by side in the workspace.
+
+To compare code used in different W&B runs:
 
 1. Select the **Add panels** button in the top right corner of the page.
-2. Expand **TEXT AND CODE** dropdown and select **Code**.
+2. Expand the **TEXT AND CODE** dropdown and select **Code**.
 
 
 <Frame>
@@ -56,10 +72,11 @@ Compare code used in different W&B runs:
 
 ## Jupyter session history
 
-W&B saves the history of code executed in your Jupyter notebook session. When you call **wandb.init()** inside of Jupyter, W&B adds a hook to automatically save a Jupyter notebook containing the history of code executed in your current session. 
+W&B saves the history of code executed in your Jupyter notebook session. When you call `wandb.init()` inside of Jupyter, W&B adds a hook to automatically save a Jupyter notebook that contains the history of code executed in your current session.
 
+To view the saved notebook history for a run:
 
-1. Navigate to your project workspaces that contains your code.
+1. Navigate to the project workspace that contains your code.
 2. Select the **Artifacts** tab in the project sidebar.
 3. Expand the **code** artifact.
 4. Select the **Files** tab.
@@ -68,7 +85,7 @@ W&B saves the history of code executed in your Jupyter notebook session. When yo
     <img src="/images/app_ui/jupyter_session_history.gif" alt="Jupyter session history"  />
 </Frame>
 
-This displays the cells that were run in your session along with any outputs created by calling iPython’s display method. This enables you to see exactly what code was run within Jupyter in a given run. When possible W&B also saves the most recent version of the notebook which you would find in the code directory as well.
+This displays the cells that ran in your session along with any outputs created by calling IPython's `display` method. This lets you see exactly what code ran within Jupyter in a given run. When possible, W&B also saves the most recent version of the notebook, which you find in the code directory as well.
 
 <Frame>
     <img src="/images/app_ui/jupyter_session_history_display.png" alt="Jupyter session output"  />

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -1,6 +1,12 @@
 ---
 description: Visualize metrics, customize axes, and compare multiple lines on a plot
 title: Line plots overview
+keywords:
+  - line plot
+  - multi-metric panel
+  - run comparer
+  - x-axis
+  - NaN
 ---
 
 import LinePlotCaptureGroups from "/snippets/_includes/line-plot-capture-groups.mdx";
@@ -19,11 +25,11 @@ For [runs](/models/runs) that execute on [CoreWeave Kubernetes Service (CKS)](ht
 
 ## Add a line plot
 
-This section shows how to create a line plot for a single metric or multiple metrics.
+The following sections describe how to create a line plot for a single metric or multiple metrics.
 
 <Tabs>
 <Tab title="Single-metric line plot">
-In an [automatic workspace](/models/app/features/panels#workspace-modes), a single-metric line plot is created automatically for each logged metric. Follow these steps to re-add a line plot that was deleted from an automatic workspace, or to add a line plot to a manual workspace.
+In an [automatic workspace](/models/app/features/panels#workspace-modes), W&B creates a single-metric line plot automatically for each logged metric. Follow these steps to re-add a line plot that was deleted from an automatic workspace, or to add a line plot to a manual workspace.
 
 1. Navigate to your workspace.
 1. To add a line plot globally, click **Add panels** in the control bar near the panel search field.
@@ -31,12 +37,12 @@ In an [automatic workspace](/models/app/features/panels#workspace-modes), a sing
     To add a line plot directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
 1. To add a single-metric plot with default settings, click **Quick panel builder**.
     1. In the **Single-key panels** tab, hover over a metric, then click **Add**. Repeat this step for each panel you want to add.
-    1. Click **Create &lt;number&gt; panels**.
+    1. Click **Create [NUMBER] panels**.
 1. To add a custom line plot instead, click **Line plot**.
     1. Configure the line plot's data, grouping, and display preferences using the corresponding tabs. For details, see [Edit line plot settings](#edit-line-plot-settings).
-    1. To add calculated expressions to the x or y axis, click **Expressions**. [JavaScript regular expressions](https://www.w3schools.com/js/js_regexp.asp) are supported.
-Select the type of panel to add, such as a chart. The panel's configuration details appear with selected defaults.
-1. Optionally, customize the panel and its display preferences. Configuration options depend on the type of panel you select. To learn more about the options for each type of panel, refer to the relevant section below, such as [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
+    1. To add calculated expressions to the x-axis or y-axis, click **Expressions**. [JavaScript regular expressions](https://www.w3schools.com/js/js_regexp.asp) are supported.
+1. Select the type of panel to add, such as a chart. The panel's configuration details appear with selected defaults.
+1. Optionally, customize the panel and its display preferences. Configuration options depend on the type of panel you select. For more information about the options for each type of panel, see [Line plots](/models/app/features/panels/line-plot/) or [Bar plots](/models/app/features/panels/bar-plot/).
 1. Click **Apply**.
 </Tab>
 <Tab title="Multi-metric line plot">
@@ -45,7 +51,7 @@ Select the type of panel to add, such as a chart. The panel's configuration deta
 This feature is in preview, available by invitation only. To request enrollment, contact [support](mailto:support@wandb.com) or your AISE.
 </Note>
 
-In an [automatic workspace](/models/app/features/panels#workspace-modes), a single-metric line plot is created automatically for each logged metric. This section shows how to create a single line plot that shows multiple metrics together, defined by a JavaScript regular expression. You can optionally consolidate many single-metric plots into a single multi-metric plot. This can improve the performance of a workspace with many logged metrics, and can help you analyze the results of your runs efficiently.
+In an [automatic workspace](/models/app/features/panels#workspace-modes), W&B creates a single-metric line plot automatically for each logged metric. This section shows how to create a single line plot that shows multiple metrics together, defined by a JavaScript regular expression. You can optionally consolidate many single-metric plots into a single multi-metric plot. This can improve the performance of a workspace with many logged metrics, and can help you analyze the results of your runs.
 
 1. Navigate to your workspace.
 1. To add a line plot globally, click **Add panels** in the control bar near the panel search field.
@@ -53,15 +59,16 @@ In an [automatic workspace](/models/app/features/panels#workspace-modes), a sing
     To add a line plot directly to a section instead, click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **+ Add panels**.
 1. Click **Quick panel builder**, then click the **Multi-metric panels** tab.
 1. In **Regex** enter an expression in [JavaScript regular expression](https://www.w3schools.com/js/js_regexp.asp) format. As you type, the UI updates to show which metrics match the expression. By default, the plot name shows the regular expression used by the plot. The plot includes lines for all metrics that match the expression, including metrics logged in the future.
-1. To optionally remove duplicate single-metric panels when the multi-metric plot is created, toggle **Clean up auto-generated panels**. A preview shows which panels will be cleaned up. <Note>When this option is turned on, a single-metric plot will not be created for a newly logged metric that matches the expression. Instead, it will be included only in this multi-metric plot.</Note>
-1. Click **Create &lt;number&gt; panels**.
+1. To optionally remove duplicate single-metric panels when the multi-metric plot is created, toggle **Clean up auto-generated panels**. A preview shows which panels are cleaned up. <Note>When this option is turned on, W&B doesn't create a single-metric plot for a newly logged metric that matches the expression. Instead, it appears only in this multi-metric plot.</Note>
+1. Click **Create [NUMBER] panels**.
 
-### More about multi-metric regular expressions
+### Multi-metric regular expressions
 
-Multi-metric line plots use [JavaScript regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) to match metric names. These section demonstrate some common use cases and gives more details about how the regular expressions work, such as how capture groups affect the panels that are created.
+Multi-metric line plots use [JavaScript regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) to match metric names. The following sections describe common use cases and provide more details about how the regular expressions work, such as how capture groups affect the panels that W&B creates.
 
 #### Common use cases
-This section shows some ways you can use multi-metric panels to help you analyze your experiment results.
+
+The following examples show some ways you can use multi-metric panels to help you analyze your experiment results.
 
 **Compare metrics across layers or model components**
 Instead of creating separate panels for each layer's metrics, you can view them together in a single panel. For example, if you log metrics with consistent naming, like `layer_0_loss`, `layer_1_loss`, and `layer_2_loss` in this Python example code, you can use the regex `layer_\d+_loss` to display all layer losses on one plot.
@@ -78,13 +85,14 @@ with wandb.init(project="multi-layer-model") as run:
 
 **Group related metrics by prefix or suffix**
 Match all metrics that share a common naming pattern. For example:
-- `train_.*` matches all training metrics like `train_loss`, `train_accuracy`, `train_f1_score`
-- `.*_accuracy` matches accuracy metrics across different datasets like `train_accuracy`, `val_accuracy`, `test_accuracy`
+- `train_.*` matches all training metrics like `train_loss`, `train_accuracy`, `train_f1_score`.
+- `.*_accuracy` matches accuracy metrics across different datasets like `train_accuracy`, `val_accuracy`, `test_accuracy`.
 
 **Match specific metric variations**
 Use alternation to match only the metrics you want. For example, the non-capture group `(?:layer_0|layer_10)_loss` matches only the first and tenth layer losses, excluding intermediate layers.
 
-#### Understanding capture groups
+#### Capture groups
+
 <LinePlotCaptureGroups/>
 
 </Tab>
@@ -92,9 +100,10 @@ Use alternation to match only the metrics you want. For example, the non-capture
 
 ## Edit line plot settings
 
-This section shows how to edit the settings for an individual line plot panel, all line plot panels in a section, or all line plot panels in a workspace. For comprehensive details about line plot settings, see [Line plot reference](/models/app/features/panels/line-plot/reference).
+The following sections describe how to edit the settings for an individual line plot panel, all line plot panels in a section, or all line plot panels in a workspace. For details about line plot settings, see [Line plot reference](/models/app/features/panels/line-plot/reference).
 
 ### Individual line plot
+
 A line plot's individual settings override the line plot settings for the section or the workspace. To customize a line plot:
 
 1. Navigate to your workspace.
@@ -117,9 +126,10 @@ To customize the default settings for all line plots in a section, overriding wo
 
 1. Navigate to your workspace.
 1. Click the section's gear icon to open its settings.
-1. Within the drawer that appears, select the **Data** or **Display preferences** tabs to configure the default settings for the section. For details about each **Data** setting, see the [Line plot reference](/models/app/features/panels/line-plot/reference). For details about each display preference, refer to [Configure section layout](../#configure-section-layout).
+1. Within the drawer that appears, select the **Data** or **Display preferences** tabs to configure the default settings for the section. For details about each **Data** setting, see the [Line plot reference](/models/app/features/panels/line-plot/reference). For details about each display preference, see [Configure section layout](../#configure-section-layout).
 
-### All line plots in a workspace 
+### All line plots in a workspace
+
 To customize the default settings for all line plots in a workspace:
 
 1. Navigate to your workspace.
@@ -127,13 +137,13 @@ To customize the default settings for all line plots in a workspace:
 1. Click **Line plots**.
 1. Within the drawer that appears, select the **Data** or **Display preferences** tabs to configure the default settings for the workspace.
     - For details about each **Data** setting, see the [Line plot reference](/models/app/features/panels/line-plot/reference).
-    - For details about each **Display preferences** section, refer to [Workspace display preferences](../#configure-workspace-layout). At the workspace level, you can configure the default **Zooming** behavior for line plots. This setting controls whether to synchronize zooming across line plots with a matching x-axis key. Disabled by default.
+    - For details about each **Display preferences** section, see [Workspace display preferences](../#configure-workspace-layout). At the workspace level, you can configure the default **Zooming** behavior for line plots. This setting controls whether to sync zooming across line plots with a matching x-axis key. Deactivated by default.
 
 ## Visualize average values on a plot
 
-If you have several different experiments and you'd like to see the average of their values on a plot, you can use the Grouping feature in the table. Click "Group" above the run table and select "All" to show averaged values in your graphs.
+If you have several different experiments and you want to see the average of their values on a plot, you can use the Grouping feature in the table. Click **Group** above the run table and select **All** to show averaged values in your graphs.
 
-Here is what the graph looks like before averaging:
+The following image shows the graph before averaging, with one line per run:
 
 <Frame>
     <img src="/images/app_ui/demo_precision_lines.png" alt="Individual precision lines"  />
@@ -147,7 +157,7 @@ The following image shows a graph that represents average values across runs usi
 
 ## Visualize NaN value on a plot
 
-You can also plot `NaN` values including PyTorch tensors on a line plot with `wandb.Run.log()`. For example:
+To track metrics that might sometimes be undefined, such as a loss that returns `NaN`, you can log them and W&B renders them on the line plot. You can also plot `NaN` values including PyTorch tensors on a line plot with `wandb.Run.log()`. For example:
 
 ```python
 with wandb.init() as run:
@@ -161,18 +171,20 @@ with wandb.init() as run:
 
 ## Compare multiple metrics on one chart
 
+To compare multiple metrics from one or more runs side by side, add a **Run comparer** panel to your workspace.
+
 <Frame>
     <img src="/images/app_ui/visualization_add.gif" alt="Adding visualization panels"  />
 </Frame>
 
 1. Navigate to your workspace.
 1. Select the **Add panels** button in the top right corner of the page.
-1. From the drawer that appears, expand the Evaluation dropdown.
-1. Select **Run comparer**
+1. From the drawer that appears, expand the **Evaluation** dropdown.
+1. Select **Run comparer**.
 
 ## Change the colors of the lines
 
-Sometimes the default color of runs is not helpful for comparison. To help overcome this, wandb provides two instances with which one can manually change the colors.
+If the default color of runs isn't helpful for comparison, W&B provides two ways to change the colors: from the run table or from a chart's legend settings.
 
 <Tabs>
 <Tab title="From the run table">
@@ -182,7 +194,7 @@ Each run is given a random color by default upon initialization.
 <img src="/images/app_ui/line_plots_run_table_random_colors.png" alt="Random colors given to runs"  />
 </Frame>
 
-  Upon clicking any of the colors, a color palette appears from which we can manually choose the color we want.
+  Upon clicking any of the colors, a color palette appears from which you can choose the color you want.
 
 <Frame>
 <img src="/images/app_ui/line_plots_run_table_color_palette.png" alt="The color palette"  />
@@ -190,7 +202,7 @@ Each run is given a random color by default upon initialization.
 </Tab>
 <Tab title="From the chart legend settings">
 1. Navigate to your workspace.
-1. Hover your mouse over the panel you want to edit its settings for.
+1. Hover your mouse over the panel whose settings you want to edit.
 1. Select the pencil icon that appears.
 1. Choose the **Legend** tab.
 
@@ -202,7 +214,7 @@ Each run is given a random color by default upon initialization.
 
 ## Visualize on different x axes
 
-If you'd like to see the absolute time that an experiment has taken, or see what day an experiment ran, you can switch the x axis. Here's an example of switching from steps to relative time and then to wall time.
+By default, line plots use training steps as the x-axis, but you can switch to a different x-axis to view your data from another perspective. If you want to see the absolute time that an experiment has taken, or see what day an experiment ran, you can switch the x-axis. The following example shows switching from steps to relative time and then to wall time.
 
 <Frame>
     <img src="/images/app_ui/howto_use_relative_time_or_wall_time.gif" alt="X-axis time options"  />
@@ -221,7 +233,7 @@ For more details, see [Customize log axes](/models/track/log/customize-logging-a
 
 ## Zoom
 
-Click and drag a rectangle to zoom vertically and horizontally at the same time. This changes the x-axis and y-axis zoom.
+To inspect a specific region of a line plot more closely, you can zoom in on both axes at once. Click and drag a rectangle to zoom vertically and horizontally at the same time. This changes the x-axis and y-axis zoom.
 
 <Frame>
     <img src="/images/app_ui/line_plots_zoom.gif" alt="Plot zoom functionality"  />
@@ -229,16 +241,17 @@ Click and drag a rectangle to zoom vertically and horizontally at the same time.
 
 ## Hide chart legend
 
-Turn off the legend in the line plot with this simple toggle:
+If the chart legend is taking up space you want to use for the plot, you can turn it off. Turn off the legend in the line plot with this toggle:
 
 <Frame>
     <img src="/images/app_ui/demo_hide_legend.gif" alt="Hide legend toggle"  />
 </Frame>
 
 ## Create a run metrics notification
+
 Use [Automations](/models/automations/) to notify your team when a run metric meets a condition you specify. An automation can post to a Slack channel or run a webhook.
 
-From a line plot, you can quickly create a [run metrics notification](/models/automations/automation-events/#run-events) for the metric it shows:
+From a line plot, you can create a [run metrics notification](/models/automations/automation-events/#run-events) for the metric it shows:
 
 1. Navigate to your workspace.
 1. Hover over the panel, then click the bell icon.

--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -1,12 +1,7 @@
 ---
 description: Visualize metrics, customize axes, and compare multiple lines on a plot
 title: Line plots overview
-keywords:
-  - line plot
-  - multi-metric panel
-  - run comparer
-  - x-axis
-  - NaN
+keywords: ["line plot", "multi-metric panel", "run comparer", "x-axis", "NaN"]
 ---
 
 import LinePlotCaptureGroups from "/snippets/_includes/line-plot-capture-groups.mdx";

--- a/models/app/features/panels/line-plot/reference.mdx
+++ b/models/app/features/panels/line-plot/reference.mdx
@@ -1,12 +1,15 @@
 ---
 title: Line plot reference
 description: "Reference for line plot panel settings including x-axis, y-axis, smoothing, aggregation, and grouping options."
+keywords: ["EMA smoothing", "Gaussian smoothing", "full fidelity", "legend template", "expressions"]
 ---
 import LinePlotCaptureGroups from "/snippets/_includes/line-plot-capture-groups.mdx";
 
 This page provides comprehensive details for line plot settings. For more details about working with line plots, see the [Line plots overview](/models/app/features/panels/line-plot).
 
 ## Data settings
+
+Data settings control which metrics appear on the plot and how data points are sampled, smoothed, and aggregated.
 
 ### X-axis
 
@@ -25,14 +28,13 @@ Available time-based x-axis options:
 
 ### Y-axis
 
-Set the y-axis variables to any integer or float value you logged with`wandb.Run.log()`. Specify a single value, array of values, or histogram of values. If you logged more than 1500 points for a variable, W&B samples down to 1500 points.
+Set the y-axis variables to any integer or float value you logged with `wandb.Run.log()`. Specify a single value, array of values, or histogram of values. If you logged more than 1,500 points for a variable, W&B samples down to 1,500 points.
 
 <Note>
 Customize the color of your y-axis lines by changing the run color in the runs table.
 </Note>
 
-Available y-axis options:
-* **Y range**: Default is from the smallest positive value of your metrics (inclusive of 0) to the largest value of your metrics. You can customize the minimum and maximum values.
+The **Y range** option defaults to the range from the smallest positive value of your metrics (inclusive of 0) to the largest value of your metrics. You can customize the minimum and maximum values.
 
 ### Point aggregation method
 
@@ -45,7 +47,7 @@ Choose the sampling mode for displaying data points:
 Set the [smoothing coefficient](/support/models/articles/what-formula-do-you-use-for-your-smoothi) between 0 and 1, where 0 is no smoothing and 1 is maximum smoothing.
 
 Available smoothing methods:
-* **Time weighted EMA** (default): a technique for smoothing time series data by exponentially decaying the weight of previous points.
+* **Time-weighted EMA** (default): an exponential moving average (EMA) technique for smoothing time series data by exponentially decaying the weight of previous points.
 * **Running average**: replaces a point with the average of points in a window before and after the given x value.
 * **Gaussian**: computes a weighted average of the points, where the weights correspond to a gaussian distribution with the standard deviation specified as the smoothing parameter.
 * **No smoothing**
@@ -64,7 +66,7 @@ Rescale the plot to exclude outliers from the default plot min and max scale. Th
 By default, plots include only the first 10 runs or groups of runs in the run list or run set. Change the sort order to control which runs or groups to display.
 
 <Note>
-A workspace is limited to displaying a maximum of 1000 runs, regardless of its configuration.
+A workspace is limited to displaying a maximum of 1,000 runs, regardless of its configuration.
 </Note>
 
 ### Chart type
@@ -78,20 +80,20 @@ Choose the plot style:
     <Frame>
         <img src="/images/app_ui/plot_style_area_plot.png" alt="Area plot style"  />
     </Frame>
-- **Percentage area plot:**
+- **Percentage area plot**
     <Frame>
         <img src="/images/app_ui/plot_style_percentage_plot.png" alt="Percentage plot style"  />
     </Frame>
 
-Configure the chart type in the **Data** tab. Refer to [](/models/app/features/panels/line-plot#individual-line-plot).
+Configure the chart type in the **Data** tab. Refer to [Individual line plot](/models/app/features/panels/line-plot#individual-line-plot).
 
 ## Grouping settings
 Aggregate all runs by turning on grouping, or group over an individual variable. When you turn on grouping in the runs table, the groups automatically populate into the graph.
 
-- **Group runs**: Turn on run grouping in the plot. Required to configure the shaded range in the plot, below.
+- **Group runs**: Turn on run grouping in the plot. Required to configure the shaded range in the plot.
 - **Group by**: Optionally select a column. All runs with the same value in that column are grouped together.
 - **Aggregation**: The value of the line on the graph. Options are mean, median, min, and max of the group.
-- **Range**: Configure the shaded area of a full-fidelity line plot. Options are Min/Max, Std Dev, Std Err or None.
+- **Range**: Configure the shaded area of a full-fidelity line plot. Options are Min/Max, Std Dev, Std Err, or None.
 
 ## Chart settings
 Configure titles and legend visibility:
@@ -146,23 +148,23 @@ Supported values inside `[[ ]]`:
 
 Formulate math expressions to create or transform line plots from your logged metrics, config values, and summary statistics. For example, you can compute the difference between two metrics, rescale a metric by a config value, or plot the logarithm of a metric. Expressions are evaluated at each step that you log.
 
-The following sections show how to reference values in expressions and describe the operators and functions you can use in custom expressions. In a line plot, you can use an expression for the x axis, y axis, or both.
+The following sections show how to reference values in expressions and describe the operators and functions you can use in custom expressions. In a line plot, you can use an expression for the x-axis, y-axis, or both.
 
-See the [Example expressions](#example-expressions) section below for common use cases and example expressions.
+See [Example expressions](#example-expressions) for common use cases and example expressions.
 
 ### Create new line plots with expressions
 
 1. Navigate to your project's workspace.
 1. Click the **+ Add panel** button and select **Line plot**.
 1. Click the **Data** tab. Select the data you want to plot on the line plot for both the x and y axes.
-1. Click on the **Expressions** tab.
+1. Click the **Expressions** tab.
 1. In the **Y-axis** field or **X-axis** field, enter your expression.
 1. Click **Apply** to save your settings and view the line plot.
 
 ### Transform existing line plots with expressions
 1. Open the line plot you want to transform.
 1. Click the gear icon in the upper right corner of the plot to edit the panel.
-1. Click on the **Expressions** tab.
+1. Click the **Expressions** tab.
 1. In the **Y-axis** field or **X-axis** field, enter your expression.
 1. Click **Apply** to save your settings and view the updated line plot.
 
@@ -192,7 +194,7 @@ The following table describes how to reference logged metrics, config parameters
 | ---------------- |---------------------------------------|----------------------------------------| -------------------------------------- |
 | Metric           | `${metric_name}`                      | Reference a logged metric by name.                     | `${val/accuracy}`, `${"accuracy"}` |
 | Config parameter | `${config:param_name}`                | Reference config values using the `${config:}` prefix. | `${config:lr}`, `${config:batch_size}` |
-| Summary statistic | `${summary:stat_name}`               | Reference summary fields using the `summary: prefix`   | `${summary:final_accuracy}`, `${summary:best_loss}` |
+| Summary statistic | `${summary:stat_name}`               | Reference summary fields using the `${summary:}` prefix.   | `${summary:final_accuracy}`, `${summary:best_loss}` |
 
 
 Use `${...}` to escape any metric name, config parameter, or summary field that includes special characters or spaces such as `/`, `-`, or spaces. 
@@ -202,7 +204,7 @@ For example, if you log a metric named `val/accuracy`, reference it as `${val/ac
 
 #### Nested configs
 
-Acccess nested config values using dot notation and the following syntax: 
+Access nested config values using dot notation and the following syntax: 
 
 ```javascript
 ${config:parent.child.grandchild}

--- a/models/app/features/panels/line-plot/sampling.mdx
+++ b/models/app/features/panels/line-plot/sampling.mdx
@@ -1,12 +1,7 @@
 ---
 title: Point aggregation
 description: "Understand the two point aggregation modes for W&B line plots: full fidelity bucketed sampling and random sampling."
-keywords:
-  - full fidelity
-  - random sampling
-  - line plot aggregation
-  - bucketed sampling
-  - downsampling
+keywords: ["full fidelity", "random sampling", "line plot aggregation", "bucketed sampling", "downsampling"]
 ---
 
 

--- a/models/app/features/panels/line-plot/sampling.mdx
+++ b/models/app/features/panels/line-plot/sampling.mdx
@@ -1,37 +1,46 @@
 ---
 title: Point aggregation
 description: "Understand the two point aggregation modes for W&B line plots: full fidelity bucketed sampling and random sampling."
+keywords:
+  - full fidelity
+  - random sampling
+  - line plot aggregation
+  - bucketed sampling
+  - downsampling
 ---
 
 
-Use point aggregation methods within your line plots for improved data visualization accuracy and performance. There are two types of point aggregation modes: [full fidelity](#full-fidelity) and [random sampling](#random-sampling). W&B uses full fidelity mode by default.
+Use point aggregation methods within your line plots for improved data visualization accuracy and performance. This page explains the two available aggregation modes and how to configure each one, so you can choose the right tradeoff between detail and rendering speed for your workspace. Two types of point aggregation modes are available: [full fidelity](#full-fidelity) and [random sampling](#random-sampling). W&B uses full fidelity mode by default.
 
 ## Full fidelity
 
+Full fidelity is the default aggregation method and preserves the extreme values in your data. This section explains how full fidelity works, its main advantages, and how to turn it on for a single chart or an entire workspace.
+
 When you use full fidelity mode, W&B breaks the x-axis into dynamic buckets. The number of points per line adapts to chart size and the number of runs. It calculates the minimum and maximum values within each bucket (used for optional shading) and uses the last value in each bucket (not the average) to draw the primary line.
 
-There are three main advantages to using full fidelity mode for point aggregation:
+Full fidelity mode for point aggregation has three main advantages:
 
 * Preserve extreme values and spikes: retain extreme values and spikes in your data.
 * Configure how minimum and maximum points render: use the W&B App to interactively decide whether you want to show extreme (min/max) values as a shaded area.
-* Explore your data without losing data fidelity: W&B recalculates x-axis bucket sizes when you zoom into specific data points. This helps ensure that you can explore your data without losing accuracy. Caching is used to store previously computed aggregations to help reduce loading times which is particularly useful if you are navigating through large datasets.
+* Explore your data without losing data fidelity: W&B recalculates x-axis bucket sizes when you zoom into specific data points. This helps ensure that you can explore your data without losing accuracy. W&B caches previously computed aggregations to help reduce loading times, which is useful when you navigate through large datasets.
 
 ### Turn on full fidelity
+
 W&B uses full fidelity mode by default. To configure it manually, follow these steps:
 
 <Tabs>
 <Tab title="All charts in a workspace">
 1. Navigate to your workspace.
-3. Select the gear icon on the top right corner of the screen next to the left of the **Add panels** button.
-4. From the UI slider that appears, select **Line plots**
-5. Choose **Full fidelity** from the **Point aggregation** section.
-6. Configure the **Smoothing** algorithm and settings.
-7. Set **Aggregation** to **Mean**, **Min**, or **Max**.
-8. Click **Apply**.
+2. Select the gear icon on the top right corner of the screen next to the left of the **Add panels** button.
+3. From the UI slider that appears, select **Line plots**.
+4. Choose **Full fidelity** from the **Point aggregation** section.
+5. Configure the **Smoothing** algorithm and settings.
+6. Set **Aggregation** to **Mean**, **Min**, or **Max**.
+7. Click **Apply**.
 </Tab>
 <Tab title="Individual chart in a workspace">
 1. Navigate to your workspace.
-2. Select on the **Workspace** icon on the left tab
+2. Select the **Workspace** icon on the left tab.
 3. Hover over the line plot panel you want to configure, then click the gear icon.
 4. Within the modal that appears, set **Point aggregation method** to **Full fidelity**.
 5. Configure the **Smoothing** algorithm and settings.
@@ -41,18 +50,18 @@ W&B uses full fidelity mode by default. To configure it manually, follow these s
 
 ### Configure shading
 
-The shaded areas of a full-fidelity line plot can show:
-- **Min/Max**: For each X-axis point, shade the area between the minimum and maximum values. The shaded area shows all points from the lowest to the highest value in each bucket:
+Shading visualizes the variability within each bucket so you can see how much points spread around the line. The shaded areas of a full-fidelity line plot can show:
+- **Min/Max**: For each x-axis point, shade the area between the minimum and maximum values. The shaded area shows all points from the lowest to the highest value in each bucket:
     ```math
     \text{Min/Max Range} = [\min(x_1, x_2, \ldots, x_n),\ \max(x_1, x_2, \ldots, x_n)]
     ```
     where $x_1, x_2, \ldots, x_n$ are the values in a given bucket.
 
-- **Standard deviation**: For each X-axis point, calculate the variability of the values using standard deviation, and shade the resulting area.
+- **Standard deviation**: For each x-axis point, calculate the variability of the values using standard deviation, and shade the resulting area.
     ```math
     SD = \sqrt{\frac{1}{n}\sum_{i=1}^{n}(x_i - \overline{x})^2}
     ```
-- **Standard error**: For each X-axis point, calculate the likelihood of a sampling error by dividing the value by the square root of the sample size:
+- **Standard error**: For each x-axis point, calculate the likelihood of a sampling error by dividing the value by the square root of the sample size:
     ```math
     SE = \frac{SD}{\sqrt{n}}
     ```
@@ -90,14 +99,14 @@ W&B uses dynamic binning to divide the x-axis into buckets. The number of points
 - **Maximum**: The highest value in that bucket (used for shading).
 - **Line value**: The last value in that bucket, used to draw the line.
 
-W&B plots values in buckets in a way that preserves full data representation and includes extreme values in every plot. The line is drawn from the last value in each bucket. When you zoom in far enough, full fidelity mode can render every data point without additional aggregation; the exact threshold depends on the current chart dimensions and number of runs.
+W&B plots values in buckets in a way that preserves full data representation and includes extreme values in every plot. The line is drawn from the last value in each bucket. When you zoom in far enough, full fidelity mode can render every data point without additional aggregation. The exact threshold depends on the current chart dimensions and number of runs.
 
 
 To zoom in on a line plot, follow these steps:
 
-1. Navigate to your W&B project
-2. Select on the **Workspace** icon on the left tab
-3. Optionally add a line plot panel to your workspace or navigate to an existing line plot panel.
+1. Navigate to your W&B project.
+2. Select the **Workspace** icon on the left tab.
+3. Optional: Add a line plot panel to your workspace or navigate to an existing line plot panel.
 4. Click and drag to select a specific region to zoom in on.
 
 <Note>
@@ -105,44 +114,47 @@ To zoom in on a line plot, follow these steps:
 
 When you use Line Plot Grouping, W&B applies the following based on the mode selected:
 
-- **Non-windowed sampling (grouping)**: Aligns points across runs on the x-axis. The average is taken if multiple points share the same x-value; otherwise, they appear as discrete points.
+- **Non-windowed sampling (grouping)**: Aligns points across runs on the x-axis. W&B takes the average if multiple points share the same x-value. Otherwise, they appear as discrete points.
 - **Windowed sampling (grouping and expressions)**: Divides the x-axis either into 250 buckets or the number of points in the longest line (whichever is smaller). W&B takes an average of points within each bucket.
 - **Full fidelity (grouping and expressions)**: Similar to non-windowed sampling, but fetches up to 500 points per run to balance performance and detail.
 </Note>
 
 ## Random sampling
 
-Random sampling uses 1500 randomly sampled points to render line plots. Because sampling drops points, it make spotting outliers or spikes more difficult.
+Random sampling is an alternative aggregation method that prioritizes rendering speed over data fidelity. Use it when you need faster chart performance and you don't need to preserve every extreme value.
+
+Random sampling uses 1,500 randomly sampled points to render line plots. Because sampling drops points, spotting outliers or spikes becomes more difficult.
 
 <Warning>
-Random sampling samples non-deterministically. This means that random sampling sometimes excludes important outliers or spikes in the data and therefore reduces data accuracy.
+Random sampling samples non-deterministically. As a result, random sampling sometimes excludes outliers or spikes in the data and therefore reduces data accuracy.
 </Warning>
 
 
 ### Enable random sampling
+
 By default, W&B uses full fidelity mode. To enable random sampling, follow these steps:
 
 <Tabs>
 <Tab title="All charts in a workspace">
-1. Navigate to your W&B project
-2. Select on the **Workspace** icon on the left tab
+1. Navigate to your W&B project.
+2. Select the **Workspace** icon on the left tab.
 3. Select the gear icon on the top right corner of the screen next to the left of the **Add panels** button.
-4. From the UI slider that appears, select **Line plots**
-5. Choose **Random sampling** from the **Point aggregation** section
+4. From the UI slider that appears, select **Line plots**.
+5. Choose **Random sampling** from the **Point aggregation** section.
 </Tab>
 <Tab title="Individual chart in a workspace">
-1. Navigate to your W&B project
-2. Select on the **Workspace** icon on the left tab
-3. Select the line plot panel you want to enable random sampling for
-4. Within the modal that appears, select **Random sampling** from the **Point aggregation method** section
+1. Navigate to your W&B project.
+2. Select the **Workspace** icon on the left tab.
+3. Select the line plot panel you want to enable random sampling for.
+4. Within the modal that appears, select **Random sampling** from the **Point aggregation method** section.
 </Tab>
 </Tabs>
 
 
 
-### Access non sampled data
+### Access non-sampled data
 
-You can access the complete history of metrics logged during a run using the [W&B Run API](/models/ref/python/public-api/runs). The following example demonstrates how to retrieve and process the loss values from a specific run:
+If random sampling drops points you need, you can still access the complete, unsampled metric history programmatically. You can access the complete history of metrics logged during a run using the [W&B Run API](/models/ref/python/public-api/runs). The following example demonstrates how to retrieve and process the loss values from a specific run:
 
 
 ```python

--- a/models/app/features/panels/line-plot/smoothing.mdx
+++ b/models/app/features/panels/line-plot/smoothing.mdx
@@ -1,12 +1,7 @@
 ---
 description: In line plots, use smoothing to see trends in noisy data.
 title: Smooth line plots
-keywords:
-  - TWEMA
-  - EMA
-  - Gaussian smoothing
-  - running average
-  - smoothing algorithm
+keywords: ["TWEMA", "EMA", "Gaussian smoothing", "running average", "smoothing algorithm"]
 ---
 
 Smoothing helps you spot trends in noisy line plots by reducing point-to-point variation, making the underlying signal easier to read. This page describes the smoothing algorithms W&B supports, when each one is most useful, and how to control whether the original data remains visible.

--- a/models/app/features/panels/line-plot/smoothing.mdx
+++ b/models/app/features/panels/line-plot/smoothing.mdx
@@ -106,7 +106,7 @@ To see this algorithm applied to live data, see the [EMA section of the interact
 
 ## Hide original data
 
-Comparing the smoothed line to the raw data can help you judge how aggressively smoothing alters the signal. By default, the original unsmoothed data displays in the plot as a faint line in the background. Click **Show Original** to turn this off.
+Compare the smoothed line to the raw data to judge how aggressively smoothing alters the signal. By default, the original unsmoothed data displays in the plot as a faint line in the background. Click **Show Original** to turn this off.
 
 <Frame>
     <img src="/images/app_ui/demo_wandb_smoothing_turn_on_and_off_original_data.gif" alt="Toggling the display of the original unsmoothed data in a line plot" />

--- a/models/app/features/panels/line-plot/smoothing.mdx
+++ b/models/app/features/panels/line-plot/smoothing.mdx
@@ -1,28 +1,36 @@
 ---
 description: In line plots, use smoothing to see trends in noisy data.
 title: Smooth line plots
+keywords:
+  - TWEMA
+  - EMA
+  - Gaussian smoothing
+  - running average
+  - smoothing algorithm
 ---
+
+Smoothing helps you spot trends in noisy line plots by reducing point-to-point variation, making the underlying signal easier to read. This page describes the smoothing algorithms W&B supports, when each one is most useful, and how to control whether the original data remains visible.
 
 W&B supports several types of smoothing:
 
-- [Time weighted exponential moving average (TWEMA) smoothing](#time-weighted-exponential-moving-average-twema-smoothing-default) 
+- [Time weighted exponential moving average (TWEMA) smoothing](#time-weighted-exponential-moving-average-twema-smoothing-default)
 - [Gaussian smoothing](#gaussian-smoothing)
 - [Running average](#running-average-smoothing)
 - [Exponential moving average (EMA) smoothing](#exponential-moving-average-ema-smoothing)
 
-See these live in an [interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc).
+To see these algorithms applied to real data, see this [interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc).
 
 <Frame>
-    <img src="/images/app_ui/beamer_smoothing.gif" alt="Demo of various smoothing algorithms"  />
+    <img src="/images/app_ui/beamer_smoothing.gif" alt="Comparison of various smoothing algorithms applied to a noisy line plot" />
 </Frame>
 
-## Time Weighted Exponential Moving Average (TWEMA) smoothing (Default)
+## Time weighted exponential moving average (TWEMA) smoothing (default)
 
-The Time Weighted Exponential Moving Average (TWEMA) smoothing algorithm is a technique for smoothing time series data by exponentially decaying the weight of previous points. For details about the technique, see [Exponential Smoothing](https://www.wikiwand.com/en/Exponential_smoothing). The range is 0 to 1. There is a de-bias term added so that early values in the time series are not biased towards zero.
+The time-weighted exponential moving average (TWEMA) smoothing algorithm is a technique for smoothing time series data by exponentially decaying the weight of previous points. For details about the technique, see [Exponential Smoothing](https://www.wikiwand.com/en/Exponential_smoothing). The range is 0 to 1. A debias term is added so that early values in the time series aren't biased towards zero.
 
 The TWEMA algorithm takes the density of points on the line (the number of `y` values per unit of range on x-axis) into account. This allows consistent smoothing when displaying multiple lines with different characteristics simultaneously.
 
-Here is sample code for how this works under the hood:
+The following sample code shows how this works under the hood:
 
 ```javascript
 const smoothingWeight = Math.min(Math.sqrt(smoothingParam || 0), 0.999);
@@ -42,48 +50,49 @@ return yValues.map((yPoint, index) => {
 });
 ```
 
-Here's what this looks like [in the app](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc):
+To see this algorithm applied to live data, see the [TWEMA section of the interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc).
 
 <Frame>
-    <img src="/images/app_ui/weighted_exponential_moving_average.png" alt="Demo of TWEMA smoothing"  />
+    <img src="/images/app_ui/weighted_exponential_moving_average.png" alt="Line plot with TWEMA smoothing applied" />
 </Frame>
 
 ## Gaussian smoothing
 
-Gaussian smoothing (or Gaussian kernel smoothing) computes a weighted average of the points, where the weights correspond to a gaussian distribution with the standard deviation specified as the smoothing parameter. The smoothed value is calculated for every input x value, based on the points occurring both before and after it.
+Gaussian smoothing (or Gaussian kernel smoothing) computes a weighted average of the points, where the weights correspond to a Gaussian distribution with the standard deviation specified as the smoothing parameter. W&B calculates the smoothed value for every input `x` value, based on the points that occur both before and after it.
 
-Here's what this looks like [in the app](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc#3.-gaussian-smoothing):
+To see this algorithm applied to live data, see the [Gaussian smoothing section of the interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc#3.-gaussian-smoothing).
 
 <Frame>
-    <img src="/images/app_ui/gaussian_smoothing.png" alt="Demo of gaussian smoothing"  />
+    <img src="/images/app_ui/gaussian_smoothing.png" alt="Line plot with Gaussian smoothing applied" />
 </Frame>
 
 ## Running average smoothing
 
-Running average is a smoothing algorithm that replaces a point with the average of points in a window before and after the given x value. See ["Boxcar Filter" on Wikipedia](https://en.wikipedia.org/wiki/Moving_average). The selected parameter for running average tells Weights and Biases the number of points to consider in the moving average.
+Running average is a smoothing algorithm that replaces a point with the average of points in a window before and after the given `x` value. See ["Boxcar Filter" on Wikipedia](https://en.wikipedia.org/wiki/Moving_average). The selected parameter for running average specifies the number of points to consider in the moving average.
 
-Consider using Gaussian Smoothing instead if your points are spaced unevenly on the x-axis.
+If your points are spaced unevenly on the x-axis, use Gaussian smoothing instead, because a fixed-width window can produce misleading averages when point density varies.
 
-Here's what this looks like [in the app](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc#4.-running-average):
+To see this algorithm applied to live data, see the [running average section of the interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc#4.-running-average).
 
 <Frame>
-    <img src="/images/app_ui/running_average.png" alt="Demo of running average smoothing"  />
+    <img src="/images/app_ui/running_average.png" alt="Line plot with running average smoothing applied" />
 </Frame>
 
-## Exponential Moving Average (EMA) smoothing
+## Exponential moving average (EMA) smoothing
 
-The Exponential Moving Average (EMA) smoothing algorithm is a rule of thumb technique for smoothing time series data using the exponential window function. For details about the technique, see [Exponential Smoothing](https://www.wikiwand.com/en/Exponential_smoothing). The range is 0 to 1. A debias term is added so that early values in the time series are not biases towards zero.
+The exponential moving average (EMA) smoothing algorithm is a heuristic technique for smoothing time series data using the exponential window function. For details about the technique, see [Exponential Smoothing](https://www.wikiwand.com/en/Exponential_smoothing). The range is 0 to 1. A debias term is added so that early values in the time series aren't biased towards zero.
 
-In many situations, EMA smoothing is applied to a full scan of history, rather than bucketing first before smoothing. This often produces more accurate smoothing.
+In most cases, EMA smoothing applies to a full scan of history, rather than bucketing first before smoothing. This typically produces more accurate smoothing.
 
-In the following situations, EMA smoothing is after bucketing instead:
+In the following situations, EMA smoothing is applied after bucketing instead:
+
 - Sampling
 - Grouping
 - Expressions
 - Non-monotonic x-axes
 - Time-based x-axes
 
-Here is sample code for how this works under the hood:
+The following sample code shows how this works under the hood:
 
 ```javascript
   data.forEach(d => {
@@ -94,16 +103,16 @@ Here is sample code for how this works under the hood:
     smoothedData.push(last / debiasWeight);
 ```
 
-Here's what this looks like [in the app](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc):
+To see this algorithm applied to live data, see the [EMA section of the interactive W&B report](https://wandb.ai/carey/smoothing-example/reports/W-B-Smoothing-Features--Vmlldzo1MzY3OTc).
 
 <Frame>
-    <img src="/images/app_ui/exponential_moving_average.png" alt="Demo of EMA smoothing"  />
+    <img src="/images/app_ui/exponential_moving_average.png" alt="Line plot with EMA smoothing applied" />
 </Frame>
 
 ## Hide original data
 
-By default, the original unsmoothed data displays in the plot as a faint line in the background. Click **Show Original** to turn this off.
+Comparing the smoothed line to the raw data can help you judge how aggressively smoothing alters the signal. By default, the original unsmoothed data displays in the plot as a faint line in the background. Click **Show Original** to turn this off.
 
 <Frame>
-    <img src="/images/app_ui/demo_wandb_smoothing_turn_on_and_off_original_data.gif" alt="Turn on or off original data"  />
+    <img src="/images/app_ui/demo_wandb_smoothing_turn_on_and_off_original_data.gif" alt="Toggling the display of the original unsmoothed data in a line plot" />
 </Frame>

--- a/models/app/features/panels/media.mdx
+++ b/models/app/features/panels/media.mdx
@@ -1,6 +1,12 @@
 ---
 title: Media panels
 description: "Add and configure media panels for images, video, audio, 3D objects, and point clouds in a W&B workspace."
+keywords:
+  - media panel
+  - point cloud
+  - bounding box
+  - segmentation mask
+  - compare mode
 ---
 
 A media panel visualizes [logged keys for media objects](/models/track/log/media/), including 3D objects, audio, images, video, or point clouds. This page shows how to add and manage media panels in a workspace.
@@ -10,79 +16,99 @@ A media panel visualizes [logged keys for media objects](/models/track/log/media
 </Frame>
 
 ## Add a media panel
-To add a media panel for a logged key using the default configuration, use Quick Add. You can add a media panel globally or to a specific section.
+
+You can add a media panel using Quick Add (which applies the default configuration) or by adding it manually so you can configure it as you create it. In either case, you can add the panel globally to the workspace or to a specific section.
+
+To add a media panel for a logged key using the default configuration, use Quick Add:
 
 1. **Global**: Click **Add panels** in the control bar near the panel search field.
 1. **Section**: Click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Add panels**.
 1. In the list of available panels, find the key for the panel, then click **Add**. Repeat this step for each media panel you want to add, then click the **X** at the top right to close the **Quick Add** list.
 1. Optionally, [configure the panel](#configure-a-media-panel).
 
-You can add a media panel globally or to a specific section:
+To add a media panel manually so that you can configure it during creation:
+
 1. **Global**: Click **Add panels** in the control bar near the panel search field.
 1. **Section**: Click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Add panels**.
 1. Click the **Media** section to expand it.
-1. Select the type of media the panel visualizes, 3d objects, images, video, or audio. The panel configuration screen displays. Configure the panel, then click **Apply**. Refer to [Configure a media panel](#configure-a-media-panel).
+1. Select the type of media the panel visualizes, 3D objects, images, video, or audio. The panel configuration screen displays. Configure the panel, then click **Apply**. Refer to [Configure a media panel](#configure-a-media-panel).
 
 ## Configure a media panel
-Panels for all media types have the same options.
 
-When you add a media panel manually, its configuration page opens after you select the type of media. To update the configuration for an existing panel, hover over the panel, then click the gear icon that appears at the top right. This section describes the settings available in each tab.
+Panels for all media types have the same options, so the following steps apply regardless of which media type you're working with.
+
+When you add a media panel manually, its configuration page opens after you select the type of media. To update the configuration for an existing panel, hover over the panel, then click the gear icon that appears at the top right. The following sections describe the settings available in each tab.
 
 ### Overlays
-This tab appears for images and point clouds logged with segmentation masks or bounding boxes.
+
+This tab appears for images and point clouds logged with segmentation masks or bounding boxes. Use it to:
+
 - Search and filter overlays by name.
 - Customize overlay colors.
 
 ### Sync
-This tab appears in the workspace and section settings.
+
+This tab appears in the workspace and section settings, and provides the following settings:
+
 - **Sync slider by key**: Configure whether the step sliders for videos in the section move in sync.
-- **Autoplay videos**: Configure whether videos start playing when the page is loaded. 
+- **Autoplay videos**: Configure whether videos start playing when the page loads.
 - **Loop videos**: Configure whether videos in the section restart automatically and play continuously until stopped. Not customizable at the section level. Appears only if the workspace has video media panels.
 
 ### Display
-Customize the panel's overall appearance and behavior.
+
+Customize the panel's overall appearance and behavior:
+
 - Configure the panel's title.
 - Select the media keys to visualize.
 - Customize the panel's slider and playback behavior.
   - Configure the slider key, which defaults to **Step**.
   - Set **Stride length** to the number of steps to advance for each click of the slider.
-  - Turn on or off **Snap to existing step**. If it is turned on, the stepper advances to the next existing step after **Stride length**. Otherwise, it advances by **Stride length** even if that does not align with an existing step.
+  - Turn on or off **Snap to existing step**. If it's turned on, the stepper advances to the next existing step after **Stride length**. Otherwise, it advances by **Stride length** even if that doesn't align with an existing step.
 - **Images**: Turn on or off smoothing.
-- **3d objects**: Configure the background color and point color.
+- **3D objects**: Configure the background color and point color.
 
 ### Layout
-Customize the display of the panel's individual items.
+
+Customize the display of the panel's individual items:
 
 - Optionally limit the **Max runs to include** in the panel.
 - Optionally specify a **Media display limit** to limit the number of media items to include per run.
 - Set **Panel mode**:
     - **Gallery** (default): Specify the number of columns and whether the grid shows a single item per run (default), step, or index.
     - **Grid**: Specify the number of columns, the x axis (defaults to **Log Step**), and the y axis (defaults to **Run**).
-    - **Compare**: Compare up to 4 media items side by side, optionally fanning out by step or index. See [Compare mode](#compare-mode) for details.
-- **Use original size**: If off (default), images and videos in the panel are scaled to appear the same size. No effect in **Compare** mode.
-- **Fit to available space**: If on (default), images and videos in the panel are scaled to take up as much room as possible in the panel. In **Gallery** mode, each image fills the panel width. In **Grid** mode, each image fills the grid width. No effect in **Compare** mode.
+    - **Compare**: Compare up to four media items side by side, optionally fanning out by step or index. See [Compare mode](#compare-mode) for details.
+- **Use original size**: If off (default), W&B scales images and videos in the panel to appear the same size. No effect in **Compare** mode.
+- **Fit to available space**: If on (default), W&B scales images and videos in the panel to take up as much room as possible in the panel. In **Gallery** mode, each image fills the panel width. In **Grid** mode, each image fills the grid width. No effect in **Compare** mode.
 - **Right-handed system**: If on, point clouds use the right-handed system for plotting points, rather than the default left-handed system.
 
 ### All media panels in a section
+
+Configure section-level defaults when you want every media panel in a section to share the same settings, overriding any workspace-level defaults.
+
 To customize the default settings for all media panels in a section, overriding workspace settings for media panels:
+
 1. Click the section's gear icon to open its settings.
 1. Click **Media settings**.
-1. Within the drawer that appears, click the **Display**, **Layout**, or **Sync** tab to configure the default media settings for the section. You can configure settings for images, videos, audio, and 3d objects. The settings that appear depend on the section's current media panels.
+1. Within the drawer that appears, click the **Display**, **Layout**, or **Sync** tab to configure the default media settings for the section. You can configure settings for images, videos, audio, and 3D objects. The settings that appear depend on the section's current media panels.
 
 Refer to [Configure a media panel](#configure-a-media-panel) for details about a specific setting for **Display** or **Layout** media setting. The **Sync** tab is available only at the section or workspace level, not for individual media panels.
 
 When **Step slider syncing** is turned on, the section's media panels with the same step slider are kept in sync. To turn on step slider syncing:
 
-    1. Click the **Sync** tab.
-    1. Turn on **Sync slider by key (Step)**.
+1. Click the **Sync** tab.
+1. Turn on **Sync slider by key (Step)**.
 
-### All media panels in a workspace 
+### All media panels in a workspace
+
+Configure workspace-level defaults when you want a consistent baseline for media panels across every section in the workspace.
+
 To customize the default settings for all media panels in a workspace:
+
 1. Click the workspace's settings, which has a gear with the label **Settings**.
 1. Click **Media settings**.
-1. Within the drawer that appears, click the **Display** or **Layout** tab to configure the default media settings for the workspace. You can configure settings for images, videos, audio, and 3d objects. The settings that appear depend on the workspace's current media panels.
+1. Within the drawer that appears, click the **Display** or **Layout** tab to configure the default media settings for the workspace. You can configure settings for images, videos, audio, and 3D objects. The settings that appear depend on the workspace's current media panels.
 
-With the exception of the **Sync** tab, refer to [Configure a media panel](#configure-a-media-panel) for details about a setting. The **Sync** tab is available only at the section or workspace level, not for individual media panels.
+Except for the **Sync** tab, refer to [Configure a media panel](#configure-a-media-panel) for details about a setting. The **Sync** tab is available only at the section or workspace level, not for individual media panels.
 
 When **Step slider syncing** is turned on, the section's media panels with the same step slider are kept in sync. To turn on step slider syncing:
 
@@ -93,7 +119,7 @@ For details about each setting, refer to [Configure a media panel](#configure-a-
 
 ## Compare mode
 
-Compare mode lets you select 2 to 4 images or videos from any combination of runs, steps, or indices and view them in a single grid. You can compare media without downloading files or switching tabs.
+Compare mode lets you select two to four images or videos from any combination of runs, steps, or indices and view them in a single grid. You can compare media without downloading one or more files or switching tabs.
 
 Use compare mode to:
 
@@ -105,32 +131,36 @@ Use compare mode to:
 Compare mode is useful for image or video generation workflows like diffusion or generative models, multimodal evaluation, vision experiments, and other workflows where you log media and need to compare it across runs, steps, or indices.
 
 To use compare mode:
+
 1. Open a media panel in your workspace (for images or video).
 1. Set **Panel mode** to **Compare**.
-1. Configure the grid's dimensions and density by specifying the number of columns and the fan out mode. The best grid geometry depends how your runs log media.
+1. Configure the grid's dimensions and density by specifying the number of columns and the fan-out mode. The best grid geometry depends on how your runs log media.
     - **Number of columns**: How many items to show per row, from `1` to `4`.
-    - **Fan out**: Control the granularity of media to display per grid row. The best setting depends on how many media items you log per step per run, and whether you need a quick "vibe check" or deep analysis.
-        - **None**: (default): No fan-out. Each grid column represents a run, and each grid row represents a logged image or video.
-            <Frame>![Screenshot showing a media panel in compare mode with two runs and no fan out](/images/models/compare-mode-fan-out-none.png)</Frame>
+    - **Fan out**: Control the granularity of media to display per grid row. The best setting depends on how many media items you log per step per run, and whether you need a quick spot check or deep analysis.
+        - **None** (default): No fan-out. Each grid column represents a run, and each grid row represents a logged image or video.
+            <Frame>![Media panel in compare mode with two runs and no fan out](/images/models/compare-mode-fan-out-none.png)</Frame>
         - **Step**: Fan out along the step axis. Each grid column represents a run, and each grid row shows the first image or video logged at a run:step combination.
-            <Frame>![Screenshot showing a media panel in compare mode with two runs and fan out by step](/images/models/compare-mode-fan-out-by-step.png)</Frame>
+            <Frame>![Media panel in compare mode with two runs and fan out by step](/images/models/compare-mode-fan-out-by-step.png)</Frame>
         - **Index**: Fan out along the index axis, useful when you log several items per step (for example, `run.log({"images": [img0, img1, img2, img3]})`). Each row cell shows the image or video logged at a given run:step:index combination.
-            <Frame>![Screenshot showing a media panel in compare mode with two runs and fan out by index](/images/models/compare-mode-fan-out-by-index.png)</Frame>
+            <Frame>![Media panel in compare mode with two runs and fan out by index](/images/models/compare-mode-fan-out-by-index.png)</Frame>
 1. Configure whether a given variable affects a single tile (**Individual**) or all tiles (**Linked**).
     - **Media key**: Defaults to **Linked**.
     - **Run**: Defaults to **Individual**.
     - **Step**: Defaults to **Linked**.
     - **Index**: Defaults to **Linked**.
 
-Your selection is saved so you can return to the same comparison later without reconfiguring the panel.
+W&B saves your selection so you can return to the same comparison later without reconfiguring the panel.
 
 ## Interact with a media panel
+
+After you add and configure a media panel, use the following interactions to step through, compare, and inspect logged media:
+
 - To configure a media panel, hover over it and click the gear icon at the top.
-- To move a media panel's step slider, use **CMD + left or right arrow key** (macOS) or **Ctrl + left or right arrow key** (Windows / Linux). If **Sync slider by key** is turned on for the section or workspace, moving the step slider in one media panel also moves the step slider in other media panels with the same step slider key.
+- To move a media panel's step slider, use **Cmd + left or right arrow key** (macOS) or **Ctrl + left or right arrow key** (Windows or Linux). If **Sync slider by key** is turned on for the section or workspace, moving the step slider in one media panel also moves the step slider in other media panels with the same step slider key.
 - Use the stepper at the top of a media panel to step through media runs. To move the step slider, use the UI controls.
 - Click a media panel to view it in full-screen mode. Click the arrow button at the top of the panel to exit full-screen mode.
 - To navigate through a section's panels without exiting full-screen mode, use either the **Previous** and **Next** buttons below the panel or the left and right arrow keys.
 - When viewing an image in full-screen mode, click the zoom control at the top right to zoom in or out. By default, images zoom to fit. Click and drag to pan a zoomed-in image. You can also zoom in, zoom out, reset to 100% zoom, or zoom to fit using keyboard shortcuts. See [Keyboard shortcuts](/models/app/keyboard-shortcuts#media-panels).
-- For an image that was logged with segmentation masks, you can customize their appearance or turn each one on or off. Hover over the panel, then click the lower gear icon.
-- For an image or point cloud that was logged with bounding boxes, you can customize their appearance or turn each one on or off. Hover over the panel, then click the lower gear icon.
+- For an image logged with segmentation masks, you can customize their appearance or turn each one on or off. Hover over the panel, then click the lower gear icon.
+- For an image or point cloud logged with bounding boxes, you can customize their appearance or turn each one on or off. Hover over the panel, then click the lower gear icon.
 - Use the media controls to play, pause, or stop video playback. If **Sync video playback** is turned on, all videos in the section play in sync. If **Loop videos** is turned on, videos in the section restart automatically and play continuously until stopped.

--- a/models/app/features/panels/media.mdx
+++ b/models/app/features/panels/media.mdx
@@ -1,12 +1,7 @@
 ---
 title: Media panels
 description: "Add and configure media panels for images, video, audio, 3D objects, and point clouds in a W&B workspace."
-keywords:
-  - media panel
-  - point cloud
-  - bounding box
-  - segmentation mask
-  - compare mode
+keywords: ["media panel", "point cloud", "bounding box", "segmentation mask", "compare mode"]
 ---
 
 A media panel visualizes [logged keys for media objects](/models/track/log/media/), including 3D objects, audio, images, video, or point clouds. This page shows how to add and manage media panels in a workspace.

--- a/models/app/features/panels/parallel-coordinates.mdx
+++ b/models/app/features/panels/parallel-coordinates.mdx
@@ -1,10 +1,7 @@
 ---
 description: Compare results across machine learning experiments
 title: Parallel coordinates
-keywords:
-  - parallel coordinates
-  - hyperparameter comparison
-  - sweep visualization
+keywords: ["parallel coordinates", "hyperparameter comparison", "sweep visualization"]
 ---
 
 Parallel coordinates charts summarize the relationship between large numbers of hyperparameters and model metrics at a glance.

--- a/models/app/features/panels/parallel-coordinates.mdx
+++ b/models/app/features/panels/parallel-coordinates.mdx
@@ -1,31 +1,41 @@
 ---
 description: Compare results across machine learning experiments
 title: Parallel coordinates
+keywords:
+  - parallel coordinates
+  - hyperparameter comparison
+  - sweep visualization
 ---
 
 Parallel coordinates charts summarize the relationship between large numbers of hyperparameters and model metrics at a glance.
 
 <Frame>
-    <img src="/images/app_ui/parallel_coordinates.gif" alt="Parallel coordinates plot"  />
+    <img src="/images/app_ui/parallel_coordinates.gif" alt="Parallel coordinates plot" />
 </Frame>
 
-* **Axes**: Different hyperparameters from [`wandb.Run.config`](/models/tables/evaluate-models) and metrics from [`wandb.Run.log()`](/models/tables/evaluate-models).
-* **Lines**: Each line represents a single run. Mouse over a line to see a tooltip with details about the run. All lines that match the current filters will be shown, but if you turn off the eye, lines will be grayed out.
+A parallel coordinates panel has the following components:
+
+* **Axes**: Hyperparameters from [`wandb.Run.config`](/models/tables/evaluate-models) and metrics from [`wandb.Run.log()`](/models/tables/evaluate-models).
+* **Lines**: Each line represents a single run. Hover over a line to see a tooltip with details about the run. All lines matching the current filters appear. If you turn off the eye icon for a run, its line is dimmed.
 
 ## Create a parallel coordinates panel
 
-1. Navigate to the landing page for your workspace
-2. Click **Add Panels**
-3. Select **Parallel coordinates**
+To add a parallel coordinates panel to your workspace:
+
+1. Navigate to the landing page for your workspace.
+2. Click **Add Panels**.
+3. Select **Parallel coordinates**.
 
 ## Panel settings
 
-To configure the panel, click the edit button in the upper right corner of the panel.
+To configure the panel, click the edit button in the upper-right corner of the panel.
 
-* **Tooltip**: On hover, a legend shows up with info on each run
-* **Titles**: Edit the axis titles to be more readable
-* **Gradient**: Customize the gradient to be any color range you like
-* **Log scale**: Each axis can be set to view on a log scale independently
-* **Flip axis**: Switch the axis direction— this is useful when you have both accuracy and loss as columns
+You can adjust the following settings:
 
-[Interact with a live parallel coordinates panel](https://app.wandb.ai/example-team/sweep-demo/reports/Zoom-in-on-Parallel-Coordinates-Charts--Vmlldzo5MTQ4Nw)
+* **Tooltip**: On hover, a legend appears with information about each run.
+* **Titles**: Edit the axis titles to make them more readable.
+* **Gradient**: Customize the gradient to any color range.
+* **Log scale**: Set each axis to use a log scale independently.
+* **Flip axis**: Switch the axis direction. This is useful when you have both accuracy and loss as columns.
+
+For an interactive example, see [a live parallel coordinates panel](https://app.wandb.ai/example-team/sweep-demo/reports/Zoom-in-on-Parallel-Coordinates-Charts--Vmlldzo5MTQ4Nw).

--- a/models/app/features/panels/parameter-importance.mdx
+++ b/models/app/features/panels/parameter-importance.mdx
@@ -2,12 +2,7 @@
 description: Visualize the relationships between your model's hyperparameters and
   output metrics
 title: Parameter importance
-keywords:
-  - hyperparameter importance
-  - feature importance
-  - random forest
-  - correlation
-  - sweeps
+keywords: ["hyperparameter importance", "feature importance", "random forest", "correlation", "sweeps"]
 ---
 
 The parameter importance panel helps you discover which of your hyperparameters are the best predictors of, and highly correlated to, desirable values of your metrics. Use this panel to focus future hyperparameter searches on the parameters that matter most for model performance.

--- a/models/app/features/panels/parameter-importance.mdx
+++ b/models/app/features/panels/parameter-importance.mdx
@@ -2,32 +2,40 @@
 description: Visualize the relationships between your model's hyperparameters and
   output metrics
 title: Parameter importance
+keywords:
+  - hyperparameter importance
+  - feature importance
+  - random forest
+  - correlation
+  - sweeps
 ---
 
-Discover which of your hyperparameters were the best predictors of, and highly correlated to desirable values of your metrics.
+The parameter importance panel helps you discover which of your hyperparameters are the best predictors of, and highly correlated to, desirable values of your metrics. Use this panel to focus future hyperparameter searches on the parameters that matter most for model performance.
 
 
 <Frame>
     <img src="/images/general/parameter-importance-1.png" alt="Parameter importance panel"  />
 </Frame>
 
-**Correlation** is the linear correlation between the hyperparameter and the chosen metric (in this case val_loss). So a high correlation means that when the hyperparameter has a higher value, the metric also has higher values and vice versa. Correlation is a great metric to look at but it can't capture second order interactions between inputs and it can get messy to compare inputs with wildly different ranges.
+**Correlation** is the linear correlation between the hyperparameter and the chosen metric (in this case, `val_loss`). A high correlation means that when the hyperparameter has a higher value, the metric also has higher values, and vice versa. Correlation is a useful metric, but it can't capture second-order interactions between inputs, and it can get messy when you compare inputs with different ranges.
 
-Therefore W&B also calculates an **importance** metric. W&B trains a random forest with the hyperparameters as inputs and the metric as the target output and report the feature importance values for the random forest.
+W&B also calculates an **importance** metric. W&B trains a random forest with the hyperparameters as inputs and the metric as the target output, then reports the feature importance values for the random forest.
 
-The idea for this technique was inspired by a conversation with [Jeremy Howard](https://twitter.com/jeremyphoward) who has pioneered the use of random forest feature importances to explore hyperparameter spaces at [Fast.ai](https://fast.ai). W&B highly recommends you check out this [lecture](https://course18.fast.ai/lessonsml1/lesson4.html) (and these [notes](https://forums.fast.ai/t/wiki-lesson-thread-lesson-4/7540)) to learn more about the motivation behind this analysis.
+A conversation with [Jeremy Howard](https://twitter.com/jeremyphoward) inspired this technique. Jeremy pioneered the use of random forest feature importances to explore hyperparameter spaces at [Fast.ai](https://fast.ai). For more information about the motivation behind this analysis, see the [Fast.ai lesson 4 lecture](https://course18.fast.ai/lessonsml1/lesson4.html) and the [Fast.ai lesson 4 forum notes](https://forums.fast.ai/t/wiki-lesson-thread-lesson-4/7540).
 
-Hyperparameter importance panel untangles the complicated interactions between highly correlated hyperparameters. In doing so, it helps you fine tune your hyperparameter searches by showing you which of your hyperparameters matter the most in terms of predicting model performance.
+The hyperparameter importance panel untangles the complicated interactions between highly correlated hyperparameters. In doing so, it helps you fine-tune your hyperparameter searches by showing you which of your hyperparameters matter the most for predicting model performance.
 
-## Creating a hyperparameter importance panel
+## Create a hyperparameter importance panel
+
+To add a hyperparameter importance panel to your workspace:
 
 1. Navigate to your W&B project.
-2. Select **Add panels** button.
-3. Expand the **CHARTS** dropdown, choose **Parallel coordinates** from the dropdown.
+2. Select the **Add panels** button.
+3. Expand the **CHARTS** dropdown, then choose **Parallel coordinates** from the dropdown.
 
 
 <Note>
-If an empty panel appears, make sure that your runs are ungrouped
+If an empty panel appears, make sure that your runs are ungrouped.
 </Note>
 
 
@@ -35,43 +43,45 @@ If an empty panel appears, make sure that your runs are ungrouped
     <img src="/images/app_ui/hyperparameter_importance_panel.gif" alt="Automatic parameter visualization"  />
 </Frame>
 
-With the parameter manager, we can manually set the visible and hidden parameters.
+With the parameter manager, you can manually set the visible and hidden parameters.
 
 <Frame>
     <img src="/images/app_ui/hyperparameter_importance_panel_manual.gif" alt="Manually setting the visible and hidden fields"  />
 </Frame>
 
-## Interpreting a hyperparameter importance panel
+## Interpret a hyperparameter importance panel
+
+The following sections describe how to read the importance and correlation values shown in the panel so you can act on them in your next sweep.
 
 <Frame>
     <img src="/images/general/parameter-importance-4.png" alt="Feature importance analysis"  />
 </Frame>
 
-This panel shows you all the parameters passed to the [wandb.Run.config](/models/track/config/) object in your training script. Next, it shows the feature importances and correlations of these config parameters with respect to the model metric you select (`val_loss` in this case).
+This panel shows you all the parameters passed to the [`wandb.Run.config`](/models/track/config/) object in your training script. It also shows the feature importances and correlations of these config parameters with respect to the model metric you select (`val_loss` in this case).
 
 ### Importance
 
-The importance column shows you the degree to which each hyperparameter was useful in predicting the chosen metric. Imagine a scenario were you start tuning a plethora of hyperparameters and using this plot to hone in on which ones merit further exploration. The subsequent sweeps can then be limited to the most important hyperparameters, thereby finding a better model faster and cheaper.
+The importance column shows you the degree to which each hyperparameter was useful in predicting the chosen metric. Imagine a scenario where you start tuning many hyperparameters and use this plot to focus on which ones merit further exploration. You can then limit subsequent sweeps to the most important hyperparameters, which helps you find a better model faster and at lower cost.
 
 <Note>
-W&B calculate importances using a tree based model rather than a linear model as the former are more tolerant of both categorical data and data that's not normalized.
+W&B calculates importances using a tree-based model rather than a linear model, because tree-based models are more tolerant of both categorical data and data that isn't normalized.
 </Note>
 
-In the preceding image, you can see that `epochs, learning_rate, batch_size` and `weight_decay` were fairly important.
+In the preceding image, you can see that `epochs`, `learning_rate`, `batch_size`, and `weight_decay` were important.
 
 ### Correlations
 
-Correlations capture linear relationships between individual hyperparameters and metric values. They answer the question of whether there a significant relationship between using a hyperparameter, such as the SGD optimizer, and the `val_loss` (the answer in this case is yes). Correlation values range from -1 to 1, where positive values represent positive linear correlation, negative values represent negative linear correlation and a value of 0 represents no correlation. Generally a value greater than 0.7 in either direction represents strong correlation.
+Correlations capture linear relationships between individual hyperparameters and metric values. They answer the question of whether a relationship exists between using a hyperparameter, such as the SGD optimizer, and the `val_loss` (in this case, the answer is yes). Correlation values range from -1 to 1, where positive values represent positive linear correlation, negative values represent negative linear correlation, and a value of 0 represents no correlation. Generally, a value greater than 0.7 in either direction represents strong correlation.
 
-You might use this graph to further explore the values that are have a higher correlation to our metric (in this case you might pick stochastic gradient descent or adam over rmsprop or nadam) or train for more epochs.
+You might use this graph to further explore the values that have a higher correlation to your metric (in this case you might pick stochastic gradient descent or `adam` over `rmsprop` or `nadam`) or train for more epochs.
 
 
 <Note>
-* correlations show evidence of association, not necessarily causation.
-* correlations are sensitive to outliers, which might turn a strong relationship to a moderate one, specially if the sample size of hyperparameters tried is small.
-* and finally, correlations only capture linear relationships between hyperparameters and metrics. If there is a strong polynomial relationship, it won't be captured by correlations.
+* Correlations show evidence of association, not necessarily causation.
+* Correlations are sensitive to outliers, which might turn a strong relationship into a moderate one, especially when the sample size of hyperparameters tried is small.
+* Correlations only capture linear relationships between hyperparameters and metrics. Correlations don't capture strong polynomial relationships.
 </Note>
 
-The disparities between importance and correlations result from the fact that importance accounts for interactions between hyperparameters, whereas correlation only measures the affects of individual hyperparameters on metric values. Secondly, correlations capture only the linear relationships, whereas importances can capture more complex ones.
+The disparities between importance and correlations result because importance accounts for interactions between hyperparameters, whereas correlation only measures the effects of individual hyperparameters on metric values. Correlations also capture only linear relationships, whereas importances can capture more complex ones.
 
-As you can see both importance and correlations are powerful tools for understanding how your hyperparameters influence model performance.
+Together, importance and correlations help you understand how your hyperparameters influence model performance.

--- a/models/app/features/panels/query-panels.mdx
+++ b/models/app/features/panels/query-panels.mdx
@@ -2,12 +2,7 @@
 description: Some features on this page are in beta, hidden behind a feature flag.
   Add `weave-plot` to your bio on your profile page to unlock all related features.
 title: Query panels overview
-keywords:
-  - query expressions
-  - Weave panels
-  - ad-hoc queries
-  - runs object
-  - join tables
+keywords: ["query expressions", "Weave panels", "ad-hoc queries", "runs object", "join tables"]
 ---
 
 

--- a/models/app/features/panels/query-panels.mdx
+++ b/models/app/features/panels/query-panels.mdx
@@ -2,22 +2,28 @@
 description: Some features on this page are in beta, hidden behind a feature flag.
   Add `weave-plot` to your bio on your profile page to unlock all related features.
 title: Query panels overview
+keywords:
+  - query expressions
+  - Weave panels
+  - ad-hoc queries
+  - runs object
+  - join tables
 ---
 
 
 <Note>
-Looking for W&B Weave? W&B's suite of tools for Generative AI application building? Find the docs for weave here: [wandb.me/weave](https://wandb.github.io/weave/?utm_source=wandb_docs&utm_medium=docs&utm_campaign=weave-nudge).
+Looking for W&B Weave, W&B's suite of tools for generative AI application building? See the [Weave documentation](https://wandb.github.io/weave/?utm_source=wandb_docs&utm_medium=docs&utm_campaign=weave-nudge).
 </Note>
 
-Use query panels to query and interactively visualize your data.
+Use query panels to query and interactively visualize your data. With a query panel, you can pull specific runs, artifacts, tables, and other W&B objects into a single view and explore them as tables or plots without leaving your workspace or report. This page is for users who want to compose ad hoc queries against logged W&B data and surface the results inside a workspace or report.
 
 A query panel combines three pieces:
 
-1. **[Expression](#expressions)**: The data you select.
-1. **[Configuration](#configurations)**: Optional settings for the panel, such as the panel type and options from the gear menu.
-1. **[Result panel](#result-panels)**: How to show the results, such as in a table or plot.
+- **[Expression](#expressions)**: The data you select.
+- **[Configuration](#configurations)**: Optional settings for the panel, such as the panel type and options from the gear menu.
+- **[Result panel](#result-panels)**: How to show the results, such as in a table or plot.
 
-For a broad set of interactive examples you can try, see a public [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2). For a guided walkthrough of query syntax, see the [Query panel tutorial report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2). Generated types and ops are listed in the [query expression language overview](/models/ref/query-panel).
+For a set of interactive examples you can try, see a public [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2). For a guided walkthrough of query syntax, see the [Query panel tutorial report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2). Generated types and ops are listed in the [query expression language overview](/models/ref/query-panel).
 
 <Frame>
     <img src="/images/weave/pretty_panel.png" alt="Query panel"  />
@@ -29,45 +35,48 @@ See the [Keras XLA benchmark report](http://wandb.me/keras-xla-benchmark) to see
 
 ## Create a query panel
 
-Add a query to your workspace or within a report.
+Add a query panel so you have a surface to write expressions against and visualize the results. You can add one to a project workspace or within a report.
 
 <Tabs>
 <Tab title="Project workspace">
-1. Navigate to your project's workspace. 
-  2. In the upper right hand corner, click `Add panel`.
-  3. From the dropdown, select `Query panel`.
+1. Navigate to your project's workspace.
+2. In the upper-right corner, click **Add panel**.
+3. From the dropdown menu, select **Query panel**.
 </Tab>
 <Tab title="W&B Report">
-Type and select `/Query panel`.
+- Type and select **/Query panel**.
 
 <Frame>
     <img src="/images/weave/add_weave_panel_report_1.png" alt="Query panel option"  />
 </Frame>
 
 Alternatively, you can associate a query with a set of runs:
-1. Within your report, type and select `/Panel grid`.
-2. Click the `Add panel` button.
-3. From the dropdown, select `Query panel`.
+1. Within your report, type and select **/Panel grid**.
+2. Click the **Add panel** button.
+3. From the dropdown menu, select **Query panel**.
 </Tab>
 </Tabs>
   
 
 ## Query components
 
+The following sections describe the three pieces that make up a query panel: the expression that selects data, the configuration that controls how the panel behaves, and the result panel that renders the output.
+
 ### Expressions
 
-Use query expressions to query your data stored in W&B such as runs, artifacts, models, tables, and more. 
+Use query expressions to query your data stored in W&B such as runs, artifacts, models, tables, and more.
 
 #### Example: Query a table
-Suppose you want to query a W&B Table. In your training code you log a table called `"cifar10_sample_table"`:
+
+Suppose you want to query a W&B Table. In your training code, you log a table called `"cifar10_sample_table"`:
 
 ```python
 import wandb
 with wandb.init() as run:
-  run.log({"cifar10_sample_table":<MY_TABLE>})
+  run.log({"cifar10_sample_table":[MY-TABLE]})
 ```
 
-Within the query panel you can query your table with:
+Within the query panel, you can query your table with:
 ```python
 runs.summary["cifar10_sample_table"]
 ```
@@ -77,13 +86,13 @@ runs.summary["cifar10_sample_table"]
 
 Breaking this down:
 
-* `runs` is a variable automatically injected in Query Panel Expressions when the Query Panel is in a Workspace. Its "value" is the list of runs which are visible for that particular Workspace. [Read about the different attributes available within a run here](/models/track/public-api-guide/#understanding-the-different-attributes).
-* `summary` is an op which returns the Summary object for a Run. Ops are _mapped_, meaning this op is applied to each Run in the list, resulting in a list of Summary objects.
-* `["cifar10_sample_table"]` is a Pick op (denoted with brackets), with a key of `cifar10_sample_table`. Since Summary objects act like dictionaries or maps, this operation picks that field from each Summary object.
+* `runs` is a variable automatically injected in query panel expressions when the query panel is in a workspace. Its value is the list of runs visible for that workspace. For details about the different attributes available within a run, see [Understanding the different attributes](/models/track/public-api-guide/#understanding-the-different-attributes).
+* `summary` is an op that returns the Summary object for a run. Ops are *mapped*, meaning this op is applied to each run in the list, resulting in a list of Summary objects.
+* `["cifar10_sample_table"]` is a Pick op (denoted with brackets) with a key of `cifar10_sample_table`. Because Summary objects act like dictionaries or maps, this operation picks that field from each Summary object.
 
 ### Configurations
 
-Select the gear icon on the upper left corner of the panel to expand the query configuration. This allows the user to configure the type of panel and the parameters for the result panel.
+In the upper-left corner of the panel, click the gear icon to expand the query configuration. The configuration lets you set the type of panel and the parameters for the result panel.
 
 <Frame>
     <img src="/images/weave/weave_panel_config.png" alt="Panel configuration menu"  />
@@ -91,20 +100,20 @@ Select the gear icon on the upper left corner of the panel to expand the query c
 
 #### Panel options
 
-The configuration menu can include options that change how table-style results are combined or loaded. Exact labels and availability can depend on your expression and panel type. Use the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2) for concrete setups.
+The configuration menu can include options that change how the panel combines or loads table-style results. Exact labels and availability depend on your expression and panel type. For concrete setups, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
 
 **Concat**
 
-Use **Concat** in the configuration when you want compatible table-style results merged so the panel treats them as a single table for viewing and downstream operations. Expression-level row merging (for example `concat` and `join` in the query) is separate from this setting. See [Combine tables in expressions](#combine-tables-in-expressions).
+Use **Concat** in the configuration when you want the panel to merge compatible table-style results and treat them as a single table for viewing and downstream operations. Expression-level row merging (for example, `concat` and `join` in the query) is separate from this setting. For more information, see [Combine tables in expressions](#combine-tables-in-expressions).
 
 **Paginate**
 
-Use **Paginate** when a table result may be too large to render at once. Pagination loads rows in chunks so the panel stays responsive. Pair this option with expressions that return large row lists. For patterns that work well with pagination, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
+Use **Paginate** when a table result might be too large to render at once. Pagination loads rows in chunks so the panel stays responsive. Pair this option with expressions that return large row lists. For patterns that work well with pagination, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
 
 
 ### Result panels
 
-Finally, the query result panel renders the result of the query expression, using the selected query panel, configured by the configuration to display the data in an interactive form. The following images shows a Table and a Plot of the same data.
+The query result panel renders the result of the query expression, using the selected query panel, configured to display the data in an interactive form. The following images show a Table and a Plot of the same data.
 
 <Frame>
     <img src="/images/weave/result_panel_table.png" alt="Table result panel"  />
@@ -116,18 +125,22 @@ Finally, the query result panel renders the result of the query expression, usin
 
 ### Step through run history
 
-In tables and plots built from `runs` or `runs.history`, the app can show a **step** control (for example a slider) so you can move through logged steps and inspect metrics, text, or media over the course of your runs. Once the expression is changed, edit the query panel's configuration and change the 'Render As' to 'Stepper.' The control can follow a different metric instead of `_step`  if it better matches how you logged data. For sample expressions, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
+In tables and plots built from `runs` or `runs.history`, the app can show a **step** control (for example, a slider) so you can move through logged steps and inspect metrics, text, or media over the course of your runs. After you change the expression, edit the query panel's configuration and change **Render As** to **Stepper**. The control can follow a different metric instead of `_step` if it better matches how you logged data. For sample expressions, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
 
 ## Basic operations
-The following common operations you can make within your query panels.
+
+After a query panel renders results, you can refine what you see by sorting, filtering, mapping, or grouping the rows. The following are common operations you can perform within your query panels.
+
 ### Sort
+
 Sort from the column options:
 <Frame>
     <img src="/images/weave/weave_sort.png" alt="Column sort options"  />
 </Frame>
 
 ### Filter
-You can either filter directly in the query or using the filter button in the top left corner (second image)
+
+You can either filter directly in the query or use the filter button in the upper-left corner of the panel.
 <Frame>
     <img src="/images/weave/weave_filter_1.png" alt="Query filter syntax"  />
 </Frame>
@@ -136,7 +149,8 @@ You can either filter directly in the query or using the filter button in the to
 </Frame>
 
 ### Map
-Map operations iterate over lists and apply a function to each element in the data. You can do this directly with a panel query  or by inserting a new column from the column options.
+
+Map operations iterate over lists and apply a function to each element in the data. You can do this directly with a panel query or by inserting a new column from the column options.
 <Frame>
     <img src="/images/weave/weave_map.png" alt="Map operation query"  />
 </Frame>
@@ -144,8 +158,9 @@ Map operations iterate over lists and apply a function to each element in the da
     <img src="/images/weave/weave_map.gif" alt="Map column insertion"  />
 </Frame>
 
-### Groupby
-You can groupby using a query or from the column options.
+### Group by
+
+You can group by using a query or from the column options.
 <Frame>
     <img src="/images/weave/weave_groupby.png" alt="Group by query"  />
 </Frame>
@@ -155,10 +170,11 @@ You can groupby using a query or from the column options.
 
 ### Combine tables in expressions
 
-Use `concat`, `join`, and related ops in your expression when you need to stack or merge row lists from tables. See [Join](#join) for a full example. The **Concat** and **Paginate** items in [Panel options](#panel-options) are separate controls on how the UI merges and loads table results.
+Use `concat`, `join`, and related ops in your expression when you need to stack or merge row lists from tables. See [Join](#join) for a full example. The **Concat** and **Paginate** items in [Panel options](#panel-options) are separate controls for how the UI merges and loads table results.
 
 ### Join
-It is also possible to join tables directly in the query. Consider the following query expression:
+
+You can also join tables directly in the query. Consider the following query expression:
 ```python
 project("luis_team_test", "weave_example_queries").runs.summary["short_table_0"].table.rows.concat.join(\
 project("luis_team_test", "weave_example_queries").runs.summary["short_table_1"].table.rows.concat,\
@@ -174,33 +190,34 @@ The table on the left is generated from:
 project("luis_team_test", "weave_example_queries").\
 runs.summary["short_table_0"].table.rows.concat.join
 ```
-The table in the right is generated from:
+The table on the right is generated from:
 ```python
 project("luis_team_test", "weave_example_queries").\
 runs.summary["short_table_1"].table.rows.concat
 ```
 Where:
-* `(row) => row["Label"]` are selectors for each table, determining which column to join on
-* `"Table1"` and `"Table2"` are the names of each table when joined
-* `true` and `false` are for left and right inner/outer join settings
+* `(row) => row["Label"]` are selectors for each table, determining which column to join on.
+* `"Table1"` and `"Table2"` are the names of each table when joined.
+* `true` and `false` are for left and right inner/outer join settings.
 
 
 ## Runs object
-Use query panels to access the `runs` object. Run objects store records of your experiments. You can find more details in [Accessing runs object](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#3.-accessing-runs-object) but, as quick overview, `runs` object has available:
-* `summary`: A dictionary of information that summarizes the run's results. This can be scalars like accuracy and loss, or large files. By default, `wandb.Run.log()` sets the summary to the final value of a logged time series. You can set the contents of the summary directly. Think of the summary as the run's outputs.
-* `history`: A list of dictionaries meant to store values that change while the model is training such as loss. The command `wandb.Run.log()` appends to this object.
-* `config`: A dictionary of the run's configuration information, such as the hyperparameters for a training run or the preprocessing methods for a run that creates a dataset Artifact. Think of these as the run's "inputs"
+
+Use query panels to access the `runs` object. Run objects store records of your experiments. For more details, see [Accessing runs object](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#3.-accessing-runs-object). As a quick overview, the `runs` object has the following available:
+* `summary`: A dictionary of information that summarizes the run's results. The summary can contain scalars like accuracy and loss, or large files. By default, `wandb.Run.log()` sets the summary to the final value of a logged time series. You can set the contents of the summary directly. Think of the summary as the run's outputs.
+* `history`: A list of dictionaries meant to store values that change while the model is training, such as loss. The command `wandb.Run.log()` appends to this object.
+* `config`: A dictionary of the run's configuration information, such as the hyperparameters for a training run or the preprocessing methods for a run that creates a dataset artifact. Think of these as the run's inputs.
 <Frame>
     <img src="/images/weave/weave_runs_object.png" alt="Runs object structure"  />
 </Frame>
 
-## Access Artifacts
+## Access artifacts
 
-Artifacts are a core concept in W&B. They are a versioned, named collection of files and directories. Use Artifacts to track model weights, datasets, and any other file or directory. Artifacts are stored in W&B and can be downloaded or used in other runs. You can find more details and examples in [Accessing artifacts](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#4.-accessing-artifacts). Artifacts are normally accessed from the `project` object:
-* `project.artifactVersion()`: returns the specific artifact version for a given name and version within a project
-* `project.artifact("")`: returns the artifact for a given name within a project. You can then use `.versions` to get a list of all versions of this artifact
-* `project.artifactType()`: returns the `artifactType` for a given name within a project. You can then use `.artifacts` to get a list of all artifacts with this type
-* `project.artifactTypes`: returns a list of all artifact types under the project
+Artifacts are a core concept in W&B. They are a versioned, named collection of files and directories. Use artifacts to track model weights, datasets, and any other file or directory. W&B stores artifacts, and you can download them or use them in other runs. For more details and examples, see [Accessing artifacts](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#4.-accessing-artifacts). You normally access artifacts from the `project` object:
+* `project.artifactVersion()`: Returns the specific artifact version for a given name and version within a project.
+* `project.artifact("")`: Returns the artifact for a given name within a project. You can then use `.versions` to get a list of all versions of this artifact.
+* `project.artifactType()`: Returns the `artifactType` for a given name within a project. You can then use `.artifacts` to get a list of all artifacts with this type.
+* `project.artifactTypes`: Returns a list of all artifact types under the project.
 <Frame>
     <img src="/images/weave/weave_artifacts.png" alt="Artifact access methods"  />
 </Frame>

--- a/models/app/features/panels/query-panels/embedding-projector.mdx
+++ b/models/app/features/panels/query-panels/embedding-projector.mdx
@@ -1,23 +1,32 @@
 ---
-description: W&B's Embedding Projector allows users to plot multi-dimensional embeddings
+description: W&B's Embedding Projector lets you plot multi-dimensional embeddings
   on a 2D plane using common dimension reduction algorithms like PCA, UMAP, and t-SNE.
 title: Embed objects
+keywords:
+  - embedding projector
+  - 2D projection
+  - dimension reduction
+  - vector visualization
 ---
 
 <Frame>
     <img src="/images/weave/embedding_projector.png" alt="Embedding projector"  />
 </Frame>
 
-[Embeddings](https://developers.google.com/machine-learning/crash-course/embeddings/video-lecture) are used to represent objects (people, images, posts, words, etc...) with a list of numbers - sometimes referred to as a _vector_. In machine learning and data science use cases, embeddings can be generated using a variety of approaches across a range of applications. This page assumes the reader is familiar with embeddings and is interested in visually analyzing them inside of W&B.
+[Embeddings](https://developers.google.com/machine-learning/crash-course/embeddings/video-lecture) represent objects such as people, images, posts, or words with a list of numbers, sometimes referred to as a _vector_. In machine learning and data science use cases, you can generate embeddings using a variety of approaches across a range of applications. This page assumes you're familiar with embeddings and want to visually analyze them inside W&B.
+
+This guide shows you how to log embeddings to W&B and use the Embedding Projector to plot them on a 2D plane with dimension reduction algorithms such as PCA, UMAP, and t-SNE. Visualizing embeddings this way helps you explore clusters, inspect relationships between data points, and validate that your embeddings capture the structure you expect.
 
 ## Embedding examples
 
-- [Live Interactive Demo Report](https://wandb.ai/timssweeney/toy_datasets/reports/Feature-Report-W-B-Embeddings-Projector--VmlldzoxMjg2MjY4?accessToken=bo36zrgl0gref1th5nj59nrft9rc4r71s53zr2qvqlz68jwn8d8yyjdz73cqfyhq) 
-- [Example Colab](https://colab.research.google.com/drive/1DaKL4lZVh3ETyYEM1oJ46ffjpGs8glXA#scrollTo=D--9i6-gXBm_).
+The following resources demonstrate the Embedding Projector in action before you try it yourself:
 
-### Hello World
+- [Live interactive demo report](https://wandb.ai/timssweeney/toy_datasets/reports/Feature-Report-W-B-Embeddings-Projector--VmlldzoxMjg2MjY4?accessToken=bo36zrgl0gref1th5nj59nrft9rc4r71s53zr2qvqlz68jwn8d8yyjdz73cqfyhq)
+- [Example Colab](https://colab.research.google.com/drive/1DaKL4lZVh3ETyYEM1oJ46ffjpGs8glXA#scrollTo=D--9i6-gXBm_)
 
-W&B allows you to log embeddings using the `wandb.Table` class. Consider the following example of 3 embeddings, each consisting of 5 dimensions:
+### Hello world
+
+This minimal example shows the smallest amount of code needed to log embeddings and view them in the projector. W&B lets you log embeddings using the `wandb.Table` class. Consider the following example of three embeddings, each consisting of five dimensions:
 
 ```python
 import wandb
@@ -35,7 +44,7 @@ with wandb.init(project="embedding_tutorial") as run:
   run.finish()
 ```
 
-After running the above code, the W&B dashboard will have a new Table containing your data. You can select `2D Projection` from the upper right panel selector to plot the embeddings in 2 dimensions. Smart default will be automatically selected, which can be easily overridden in the configuration menu accessed by clicking the gear icon. In this example, we automatically use all 5 available numeric dimensions.
+After you run the preceding code, the W&B dashboard contains a new Table with your data. Select **2D Projection** from the upper-right panel selector to plot the embeddings in two dimensions. W&B automatically selects smart defaults, which you can override in the configuration menu by clicking the gear icon. In this example, W&B uses all five available numeric dimensions.
 
 <Frame>
     <img src="/images/app_ui/weave_hello_world.png" alt="2D projection example"  />
@@ -43,7 +52,7 @@ After running the above code, the W&B dashboard will have a new Table containing
 
 ### Digits MNIST
 
-While the above example shows the basic mechanics of logging embeddings, typically you are working with many more dimensions and samples. Let's consider the MNIST Digits dataset ([UCI ML hand-written digits dataset](https://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits)[s](https://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits)) made available via [SciKit-Learn](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_digits.html). This dataset has 1797 records, each with 64 dimensions. The problem is a 10 class classification use case. We can convert the input data to an image for visualization as well.
+The next example demonstrates a more realistic workflow with higher-dimensional data and richer overlays. While the preceding example shows the basic mechanics of logging embeddings, you typically work with many more dimensions and samples. Consider the MNIST Digits dataset ([UCI ML hand-written digits dataset](https://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits)) made available through [SciKit-Learn](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_digits.html). This dataset has 1,797 records, each with 64 dimensions. The problem is a 10-class classification use case. You can also convert the input data to an image for visualization.
 
 ```python
 import wandb
@@ -70,7 +79,7 @@ with wandb.init(project="embedding_tutorial") as run:
   run.log({"digits": df})
 ```
 
-After running the above code, again we are presented with a Table in the UI. By selecting `2D Projection` we can configure the definition of the embedding, coloring, algorithm (PCA, UMAP, t-SNE), algorithm parameters, and even overlay (in this case we show the image when hovering over a point). In this particular case, these are all "smart defaults" and you should see something very similar with a single click on `2D Projection`. ([Interact with this embedding tutorial example](https://wandb.ai/timssweeney/embedding_tutorial/runs/k6guxhum?workspace=user-timssweeney)).
+After you run the preceding code, the UI again presents a Table. Select **2D Projection** to configure the embedding definition, coloring, algorithm (PCA, UMAP, t-SNE), algorithm parameters, and overlay. In this case, W&B shows the image when you hover over a point. These are all smart defaults, and you should see something similar with a single click of **2D Projection**. [Interact with this embedding tutorial example](https://wandb.ai/timssweeney/embedding_tutorial/runs/k6guxhum?workspace=user-timssweeney).
 
 <Frame>
     <img src="/images/weave/embedding_projector.png" alt="MNIST digits projection"  />
@@ -78,10 +87,10 @@ After running the above code, again we are presented with a Table in the UI. By 
 
 ## Logging options
 
-You can log embeddings in a number of different formats:
+The following sections describe the supported ways to structure embedding data when you log it to W&B. You can log embeddings in several formats:
 
-1. **Single Embedding Column:** Often your data is already in a "matrix"-like format. In this case, you can create a single embedding column - where the data type of the cell values can be `list[int]`, `list[float]`, or `np.ndarray`.
-2. **Multiple Numeric Columns:** In the above two examples, we use this approach and create a column for each dimension. We currently accept python `int` or `float` for the cells.
+- **Single embedding column:** Often your data is already in a matrix-like format. In this case, you can create a single embedding column, where the data type of the cell values can be `list[int]`, `list[float]`, or `np.ndarray`.
+- **Multiple numeric columns:** The preceding two examples use this approach and create a column for each dimension. W&B accepts Python `int` or `float` for the cells.
 
 <Frame>
     <img src="/images/weave/logging_options.png" alt="Single embedding column"  />
@@ -90,17 +99,17 @@ You can log embeddings in a number of different formats:
     <img src="/images/weave/logging_option_image_right.png" alt="Multiple numeric columns"  />
 </Frame>
 
-Furthermore, just like all tables, you have many options regarding how to construct the table:
+Just like all tables, you have several options for how to construct the table:
 
-1. Directly from a **dataframe** using `wandb.Table(dataframe=df)`
-2. Directly from a **list of data** using `wandb.Table(data=[...], columns=[...])`
-3. Build the table **incrementally row-by-row** (great if you have a loop in your code). Add rows to your table using `table.add_data(...)`
-4. Add an **embedding column** to your table (great if you have a list of predictions in the form of embeddings): `table.add_col("col_name", ...)`
-5. Add a **computed column** (great if you have a function or model you want to map over your table): `table.add_computed_columns(lambda row, ndx: {"embedding": model.predict(row)})`
+- Directly from a **dataframe** using `wandb.Table(dataframe=df)`.
+- Directly from a **list of data** using `wandb.Table(data=[...], columns=[...])`.
+- Build the table **incrementally row by row** (great if you have a loop in your code). Add rows to your table using `table.add_data(...)`.
+- Add an **embedding column** to your table (great if you have a list of predictions in the form of embeddings): `table.add_col("col_name", ...)`.
+- Add a **computed column** (great if you have a function or model you want to map over your table): `table.add_computed_columns(lambda row, ndx: {"embedding": model.predict(row)})`.
 
 ## Plotting options
 
-After selecting `2D Projection`, you can click the gear icon to edit the rendering settings. In addition to selecting the intended columns (see above), you can select an algorithm of interest (along with the desired parameters). Below you can see the parameters for UMAP and t-SNE respectively.
+After you log your embeddings, you can adjust how they are projected and rendered. After you select **2D Projection**, click the gear icon to edit the rendering settings. Besides selecting the intended columns (see preceding sections), you can select an algorithm of interest along with the desired parameters. The following images show the parameters for UMAP and t-SNE.
 
 <Frame>
     <img src="/images/weave/plotting_options_left.png" alt="UMAP parameters"  />
@@ -110,5 +119,5 @@ After selecting `2D Projection`, you can click the gear icon to edit the renderi
 </Frame>
 
 <Note>
-Note: we currently downsample to a random subset of 1000 rows and 50 dimensions for all three algorithms.
+W&B downsamples to a random subset of 1,000 rows and 50 dimensions for all three algorithms.
 </Note>

--- a/models/app/features/panels/query-panels/embedding-projector.mdx
+++ b/models/app/features/panels/query-panels/embedding-projector.mdx
@@ -2,11 +2,7 @@
 description: W&B's Embedding Projector lets you plot multi-dimensional embeddings
   on a 2D plane using common dimension reduction algorithms like PCA, UMAP, and t-SNE.
 title: Embed objects
-keywords:
-  - embedding projector
-  - 2D projection
-  - dimension reduction
-  - vector visualization
+keywords: ["embedding projector", "2D projection", "dimension reduction", "vector visualization"]
 ---
 
 <Frame>

--- a/models/app/features/panels/run-comparer.mdx
+++ b/models/app/features/panels/run-comparer.mdx
@@ -1,11 +1,7 @@
 ---
 description: "Use the Run Comparer panel to view and compare configuration and metric differences across W&B experiment runs."
 title: Compare run metrics
-keywords:
-  - run comparer
-  - diff only
-  - hyperparameter comparison
-  - experiment comparison
+keywords: ["run comparer", "diff only", "hyperparameter comparison", "experiment comparison"]
 ---
 
 Use the Run Comparer to see differences and similarities across runs in your project. This helps you quickly identify how configuration changes affect metrics so you can decide which experiments to pursue further.

--- a/models/app/features/panels/run-comparer.mdx
+++ b/models/app/features/panels/run-comparer.mdx
@@ -1,26 +1,34 @@
 ---
 description: "Use the Run Comparer panel to view and compare configuration and metric differences across W&B experiment runs."
 title: Compare run metrics
+keywords:
+  - run comparer
+  - diff only
+  - hyperparameter comparison
+  - experiment comparison
 ---
 
-Use the Run Comparer to see differences and similarities across runs in your project. 
+Use the Run Comparer to see differences and similarities across runs in your project. This helps you quickly identify how configuration changes affect metrics so you can decide which experiments to pursue further.
 
 ## Add a Run Comparer panel
+
+Add the Run Comparer panel to your workspace before you can use it to compare runs.
 
 1. Select the **Add panels** button in the top right corner of the page.
 1. From the **Evaluation** section, select **Run comparer**.
 
 ## Use Run Comparer
-Run Comparer shows the configuration and logged metrics for the 10 first visible runs in the project, one column per run.
 
-- To change the runs to compare, you can search, filter, group, or sort the list of runs on the left-hand side. The Run Comparer updates automatically.
-- Use the search field at the top of the Run Comparer to filter or search for a configuration key or a metadata key such as the Python version or the run's creation time.
-- To quickly see differences and hide identical values, toggle **Diff only** at the top of the panel.
+Run Comparer shows the configuration and logged metrics for the first 10 visible runs in the project, one column per run. After you add the panel, use the following options to explore and refine your comparison:
+
+- To change the runs to compare, search, filter, group, or sort the list of runs on the left. The Run Comparer updates automatically.
+- To filter or search for a configuration key or a metadata key such as the Python version or the run's creation time, use the search field at the top of the Run Comparer.
+- To see differences and hide identical values, toggle **Diff only** at the top of the panel.
 - To adjust the column width or row height, use the formatting buttons at the top of the panel.
-- To copy any configuration or metric's value, hover your mouse over the value, then click the copy button. The entire value is copied, even if it is too long to display on the screen.
+- To copy any configuration or metric's value, hover over the value, then click the copy button. The entire value is copied, even if it's too long to display on the screen.
 
 <Note>
-By default, Run Comparer does not differentiate runs with different values for [`job_type`](/models/ref/python/functions/init). This means that it is possible to compare runs that are not comparable within a project. For example, you could compare a training run to a model evaluation run. A training run could contain run logs, hyperparameters, training loss metrics, and the model itself. An evaluation run could use the model to check the model's performance on new training data.
+By default, Run Comparer doesn't differentiate runs with different values for [`job_type`](/models/ref/python/functions/init). This means you can compare runs that aren't comparable within a project. For example, you could compare a training run to a model evaluation run. A training run could contain run logs, hyperparameters, training loss metrics, and the model itself. An evaluation run could use the model to check the model's performance on new training data.
 
 When you search, filter, group, or sort the list of runs in the Runs Table, the Run Comparer automatically updates to compare the first 10 runs. Filter or search within the Runs Table to compare similar runs, such as by filtering or sorting the list by `job_type`. Learn more about [filtering runs](/models/runs/filter-runs/).
 </Note>

--- a/models/app/features/panels/scatter-plot.mdx
+++ b/models/app/features/panels/scatter-plot.mdx
@@ -1,11 +1,7 @@
 ---
 title: Scatter plots
 description: "Create and customize scatter plots in W&B to compare runs and visualize relationships between experiment metrics."
-keywords:
-  - frontier line
-  - hyperparameter comparison
-  - run comparison
-  - panel settings
+keywords: ["frontier line", "hyperparameter comparison", "run comparison", "panel settings"]
 ---
 
 Use scatter plots in W&B to compare runs and visualize relationships between experiment metrics. Scatter plots help you spot trends, outliers, and trade-offs across many runs, which is useful when tuning hyperparameters or comparing model variants.

--- a/models/app/features/panels/scatter-plot.mdx
+++ b/models/app/features/panels/scatter-plot.mdx
@@ -1,13 +1,18 @@
 ---
 title: Scatter plots
 description: "Create and customize scatter plots in W&B to compare runs and visualize relationships between experiment metrics."
+keywords:
+  - frontier line
+  - hyperparameter comparison
+  - run comparison
+  - panel settings
 ---
 
-This page shows how to use scatter plots in W&B.
+Use scatter plots in W&B to compare runs and visualize relationships between experiment metrics. Scatter plots help you spot trends, outliers, and trade-offs across many runs, which is useful when tuning hyperparameters or comparing model variants.
 
-## Use case 
+## Use case
 
-Use scatter plots to compare multiple runs and visualize the performance of an experiment:
+Use scatter plots to compare multiple runs and visualize the performance of an experiment. With a scatter plot, you can:
 
 - Plot lines for minimum, maximum, and average values.
 - Customize metadata tooltips.
@@ -18,12 +23,12 @@ Use scatter plots to compare multiple runs and visualize the performance of an e
 
 ## Example
 
-The following example shows a scatter plot displaying validation accuracy for different models over several weeks of experimentation. The tooltip includes batch size, dropout, and axis values. A line also shows the running average of validation accuracy. 
+The following example shows a scatter plot displaying validation accuracy for different models over several weeks of experimentation. The tooltip includes batch size, dropout, and axis values. A line also shows the running average of validation accuracy.
 
 [See a live example →](https://app.wandb.ai/l2k2/l2k/reports?view=carey%2FScatter%20Plot)
 
 <Frame>
-    <img src="/images/general/scatter-plots-1.png" alt="Validation accuracy scatter plot"  />
+    <img src="/images/general/scatter-plots-1.png" alt="Validation accuracy scatter plot" />
 </Frame>
 
 ## Create a scatter plot
@@ -36,17 +41,20 @@ To create a scatter plot in the W&B UI:
 4. In the **Add panels** menu, select **Scatter plot**.
 5. Set the `x` and `y` axes to plot the data you want to view. Optionally, set maximum and minimum ranges for your axes or add a `z` axis.
 6. Click **Apply** to create the scatter plot.
-7. View the new scatter plot in the Charts panel.
+
+The new scatter plot appears in the **Charts** panel, displaying the data you configured.
 
 ## Frontier line display options
 
-The _frontier line_ on a scatter plot is a line that connects the highest and lowest y-axis values seen so far for the data in the plot. You can tune how that line and the surrounding points appear from the plot settings.
+The _frontier line_ on a scatter plot connects the highest and lowest y-axis values observed so far for the data in the plot. You can tune how the line and the surrounding points appear from the plot settings to emphasize the frontier.
 
 To configure frontier line display options:
 
 1. Hover over the scatter plot panel, then click the gear icon to open the panel settings drawer.
-1. Select the **Annotations** tab.
-1. Set the desired options:
+2. Select the **Annotations** tab.
+3. Set the options:
    - **Show run labels**: Toggle whether to show a label with the run name or group name.
-   - **Dim non-frontier points**: Toggle whether to reduce the visual weight of points that are not on the frontier line so the frontier stands out.
-1. Click **Apply** to save your changes.
+   - **Dim non-frontier points**: Toggle whether to reduce the visual weight of points that aren't on the frontier line so the frontier stands out.
+4. Click **Apply** to save your changes.
+
+The scatter plot updates to reflect your annotation choices.

--- a/models/app/keyboard-shortcuts.mdx
+++ b/models/app/keyboard-shortcuts.mdx
@@ -1,21 +1,27 @@
 ---
 description: Learn about the keyboard shortcuts available in W&B.
 title: Keyboard shortcuts
+keywords:
+  - hotkeys
+  - LEET
+  - quick search
+  - undo redo
+  - panel navigation
 ---
 
-W&B supports keyboard shortcuts to help you navigate and interact with experiments, workspaces, and data more efficiently. This reference guide covers keyboard shortcuts for the W&B App and the W&B LEET (Lightweight Experiment Exploration Tool) terminal UI.
+W&B supports keyboard shortcuts to help you navigate and interact with experiments, workspaces, and data more efficiently. This guide covers keyboard shortcuts for the W&B App and the W&B LEET (Lightweight Experiment Exploration Tool) terminal UI.
 
 <Tabs>
 <Tab title="App">
 
-These keyboard shortcuts work in the W&B App.
+The following tables list keyboard shortcuts available in the W&B App, grouped by where they apply.
 
 ## Workspace management
 
 | Shortcut | Description |
 |----------|-------------|
 | **Cmd+Z** (macOS) / **Ctrl+Z** (Windows/Linux) | Undo a change you've made in the UI, such as a modification to the workspace or a panel. |
-| **Cmd+Shift+Z** (macOS) / **Ctrl+Y** (Windows/Linux) | Redo a change you previously undid in the workspace. |
+| **Cmd+Shift+Z** (macOS) / **Ctrl+Y** (Windows/Linux) | Redo a change you undid in the workspace. |
 
 ## Navigation
 
@@ -31,37 +37,39 @@ These keyboard shortcuts work in the W&B App.
 
 | Shortcut | Description |
 |----------|-------------|
-| **Left Arrow / Right Arrow** | Step through panels in a section when in full screen mode. |
+| **Left Arrow / Right Arrow** | When in full-screen mode, step through panels in a section. |
 | **Esc** | Exit full-screen panel view and return to the workspace. |
-| **Cmd+Left Arrow / Cmd+Right Arrow** (macOS)<br/>**Ctrl+Left Arrow / Ctrl+Right Arrow** (Windows/Linux) | When viewing a media panel in full screen mode, move the step slider. |
+| **Cmd+Left Arrow / Cmd+Right Arrow** (macOS)<br/>**Ctrl+Left Arrow / Ctrl+Right Arrow** (Windows/Linux) | When viewing a media panel in full-screen mode, move the step slider. |
 
 ## Media panels
 
 | Shortcut | Description |
 |----------|-------------|
-| **Cmd + +/-** (macOS)<br />**Ctrl + +/-** (Windows/Linux) | When viewing an image in full-screen, zoom in or out.<br/>When zoomed in, click and drag to pan the image. |
-| **Cmd + 0** (macOS)<br />**Ctrl + 0** (Windows/Linux) | When viewing an image in full-screen, reset to 100% zoom. |
-| **Shift + L** | When viewing an image in full-screen, zoom to fit. |
+| **Cmd + +/-** (macOS)<br/>**Ctrl + +/-** (Windows/Linux) | When viewing an image in full-screen, zoom in or out.<br/>When zoomed in, click and drag to pan the image. |
+| **Cmd+0** (macOS)<br/>**Ctrl+0** (Windows/Linux) | When viewing an image in full-screen, reset to 100% zoom. |
+| **Shift+L** | When viewing an image in full-screen, zoom to fit. |
 
 ## Reports
 
 | Shortcut | Description |
 |----------|-------------|
 | **Delete / Backspace** | Remove the selected panel grid from the report. |
-| **Enter** | Insert a Markdown block after typing "/mark" in a report. |
+| **Enter** | Insert a Markdown block after typing `/mark` in a report. |
 | **Esc** | Exit the report editor. |
 | **Tab** | Navigate between interactive elements in a report. |
 
 ## Notes
 
+Keep the following points in mind when using keyboard shortcuts in the W&B App:
+
 - Most keyboard shortcuts use **Cmd** on macOS and **Ctrl** on Windows/Linux.
 - The W&B App implements custom handling for some browser default shortcuts.
-- Some shortcuts are context-sensitive and only work in specific areas of the application.
+- Some shortcuts are context-sensitive and only work in specific areas of the app.
 
 </Tab>
 <Tab title="LEET">
 
-These keyboard shortcuts work in the W&B LEET (Lightweight Experiment Exploration Tool) terminal UI. To launch LEET, run `wandb beta leet` in your terminal. For more information, see [`wandb beta leet`](/models/ref/cli/wandb-beta/wandb-beta-leet/).
+The following keyboard shortcuts work in the W&B LEET (Lightweight Experiment Exploration Tool) terminal UI, which lets you explore experiments without leaving the command line. To launch LEET, run `wandb beta leet` in your terminal. For more information, see [`wandb beta leet`](/models/ref/cli/wandb-beta/wandb-beta-leet/).
 
 {/* <LEETShortcuts /> */}
 

--- a/models/app/keyboard-shortcuts.mdx
+++ b/models/app/keyboard-shortcuts.mdx
@@ -1,12 +1,7 @@
 ---
 description: Learn about the keyboard shortcuts available in W&B.
 title: Keyboard shortcuts
-keywords:
-  - hotkeys
-  - LEET
-  - quick search
-  - undo redo
-  - panel navigation
+keywords: ["hotkeys", "LEET", "quick search", "undo redo", "panel navigation"]
 ---
 
 W&B supports keyboard shortcuts to help you navigate and interact with experiments, workspaces, and data more efficiently. This guide covers keyboard shortcuts for the W&B App and the W&B LEET (Lightweight Experiment Exploration Tool) terminal UI.


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide plus W&B documentation conventions) across `models/app` in an automated multi-pass edit. Each file received all 8 passes (context, structure, language, terminology, considerate writing, formatting, polish, audit). No technical content, API references, or code samples were altered.

## Files edited

- `models/app/console-logs.mdx`
- `models/app/features/cascade-settings.mdx`
- `models/app/features/custom-charts.mdx`
- `models/app/features/custom-charts/walkthrough.mdx`
- `models/app/features/panels.mdx`
- `models/app/features/panels/bar-plot.mdx`
- `models/app/features/panels/code.mdx`
- `models/app/features/panels/line-plot.mdx`
- `models/app/features/panels/line-plot/reference.mdx`
- `models/app/features/panels/line-plot/sampling.mdx`
- `models/app/features/panels/line-plot/smoothing.mdx`
- `models/app/features/panels/media.mdx`
- `models/app/features/panels/parallel-coordinates.mdx`
- `models/app/features/panels/parameter-importance.mdx`
- `models/app/features/panels/query-panels.mdx`
- `models/app/features/panels/query-panels/embedding-projector.mdx`
- `models/app/features/panels/run-comparer.mdx`
- `models/app/features/panels/scatter-plot.mdx`
- `models/app/keyboard-shortcuts.mdx`

## Recommendations for technical review

The style editor flagged the following items for SME review. Each is outside the scope of a style-only pass and was not changed during this run.

### Prerequisites

Several pages have no Prerequisites section. Confirm whether to add explicit prerequisites for:

- W&B account, SDK version, or required Python packages (`console-logs.mdx`, `code.mdx`, `embedding-projector.mdx`, `parameter-importance.mdx`, `scatter-plot.mdx`, `panels.mdx`).
- Jupyter or IPython for session-history workflows (`code.mdx`).
- Logged runs with specific config or metric shape (`bar-plot.mdx`, `parallel-coordinates.mdx`, `parameter-importance.mdx`, `run-comparer.mdx`, `scatter-plot.mdx`).
- Pre-existing logged media before adding a media panel (`media.mdx`).
- Permissions, beta-feature flags, or plan tier (`panels.mdx`, `query-panels.mdx`, `line-plot.mdx`).

### Verification steps

Many procedures end without a "what you should see" cue. Consider adding brief expected-outcome sentences for:

- View and configure console logs (`console-logs.mdx`).
- Workspace and panel settings (`cascade-settings.mdx`).
- Quick add, manual add, reset, and email-report flows (`panels.mdx`).
- Code comparer and Jupyter notebook procedures (`code.mdx`).
- Full-fidelity and random-sampling enable and zoom procedures (`sampling.mdx`).
- Smoothing algorithm adjustments (`smoothing.mdx`).
- Add a line plot and run-metrics notification (`line-plot.mdx`).
- Add a media panel and section-default workflows (`media.mdx`).
- Create a parallel coordinates panel (`parallel-coordinates.mdx`).
- Create a hyperparameter importance panel (`parameter-importance.mdx`).
- Create a query panel (`query-panels.mdx`).
- Create and configure a scatter plot (`scatter-plot.mdx`).

### Technical accuracy

UI labels and click paths to validate against the live product:

- **Add panel**, **Bar Chart**, **Grouping**, **Box**, **Violin** (`bar-plot.mdx`).
- **Settings**, **Privacy**, **Enable code saving by default**, **Enforce default code saving restrictions** (`code.mdx`).
- **Expressions** tab labels and the "Create [NUMBER] panels" button text (`reference.mdx`, `line-plot.mdx`).
- **Annotations** tab, **Show run labels**, **Dim non-frontier points** (`scatter-plot.mdx`).
- **Add panels** location, **Evaluation** section, and **Run comparer** vs. **Run Comparer** casing (`run-comparer.mdx`).
- Action menu path "Workspaces > Charts > action menu > Add panels > Scatter plot" (`scatter-plot.mdx`).
- **Render As** > **Stepper** (`query-panels.mdx`).
- Section settings UI controls (**Add section above/below**, **Delete section**) (`cascade-settings.mdx`).
- Modifier-key casing (`Cmd` vs. `CMD`) (`media.mdx`, `keyboard-shortcuts.mdx`).
- **Share on Twitter** vs. **Share on X** (`panels.mdx`).
- Gear vs. pencil icon affordance for the same edit action (`line-plot.mdx`, `query-panels.mdx`).
- Parallel coordinates "eye icon" / visibility toggle and "edit button" labels (`parallel-coordinates.mdx`).

Other technical claims to validate:

- 100,000 stored / 10,000 displayed line limits for console logs (`console-logs.mdx`).
- `wandb.Settings` parameters (`show_errors`, `silent`, `show_warnings`, `show_info`) and whether `x_label` is still preview (`console-logs.mdx`).
- `wandb.Table` 10,000-row limit and `wandb.plot_table()` `vega_spec_name` example (`custom-charts.mdx`).
- Sampling thresholds: 1,500 points for random sampling, 500 for full-fidelity grouping, and the 1,000-run workspace limit (`reference.mdx`, `sampling.mdx`).
- Code-comparer flow including the `wandb` 0.8.28+ version threshold and `log_code` / `code_dir` behavior (`code.mdx`).
- Whether step 3 of "Create a hyperparameter importance panel" should pick **Parameter importance** instead of **Parallel coordinates** (`parameter-importance.mdx`).
- Whether the random-sampling **Apply** step is required (`sampling.mdx`).
- Join example: `"false", "false"` strings vs. boolean values (`query-panels.mdx`).
- Frontier line definition: running min/max envelope vs. Pareto boundary (`scatter-plot.mdx`).
- Public SDK surface for `table.add_col` and `add_computed_columns` (`embedding-projector.mdx`).
- "Compute the exponential of the loss" prose contradicts the `sqrt(loss*100)+sqrt(loss*100000)` code (`reference.mdx`).
- Whether the TWEMA JavaScript snippet's `VIEWPORT_SCALE` and `rangeOfX` are stable values and whether the EMA snippet's closing brace is intentionally truncated (`smoothing.mdx`).
- Whether the orphan "Select the type of panel..." text really belongs in the Single-metric line plot procedure (`line-plot.mdx`).
- LEET tab is empty pending the `<LEETShortcuts />` component; confirm rollout (`keyboard-shortcuts.mdx`).
- Whether the full-screen sampling note ("10,000 buckets, rather than the usual 1,000") applies to all panel types or only line plots (`panels.mdx`).

### Missing content

- Define "section organization prefix", "custom rules", "workspace templates", "panel generation mode (automatic/manual)", and "companion chart tooltip" before using them (`cascade-settings.mdx`).
- Document the `Add section above`, `Add section below`, `Delete section`, and `Add section to report` controls (`cascade-settings.mdx`).
- Clarify when to use built-in chart presets vs. the full custom-chart workflow, and add troubleshooting for empty charts, missing fields, and Vega errors (`custom-charts.mdx`).
- Describe Y-axis vs. X-axis expression specifics and surface the commented-out legend examples (`reference.mdx`).
- Clarify the relationship between line-plot grouping modes (Non-windowed, Windowed, Full fidelity) and aggregation modes (`sampling.mdx`).
- Add comparison or decision guidance across the four smoothing algorithms (`smoothing.mdx`).
- Address how the three "Save library code" options interact and which to choose (`code.mdx`).
- Define a custom-axis expressions overview scope (`line-plot.mdx`).
- Clarify scoping (per user, per project, per org) for saved chart presets and run-comparer behavior (`custom-charts.mdx`, `run-comparer.mdx`).
- Add point-cloud panel guidance and reconcile the two gear-icon references (`media.mdx`).
- Describe what the parallel coordinates color gradient encodes (`parallel-coordinates.mdx`).
- Define or link "parameter manager" (`parameter-importance.mdx`).
- Add a `wandb.Table` link in the embedding projector intro and document behavior beyond the 1,000-row downsampling threshold (`embedding-projector.mdx`).
- Reconcile commented-out Note blocks (`query-panels.mdx`, `reference.mdx`).
- Cover z-axis behavior, axis ranges and log scale, tooltip metadata, and min/max/average overlays for scatter plots (`scatter-plot.mdx`).
- Define "Sections" and "Quick add" before they appear in the Workspace modes table (`panels.mdx`).
- Document drag-handle steps for moving panels and resolve the orphan "Optional: Customize the panel's settings" instruction in Quick add (`panels.mdx`).
- Confirm intentional duplication of the "Don't name a section 'Section'" warning (`panels.mdx`) and the `Esc` shortcut documentation (`keyboard-shortcuts.mdx`).

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
