### PR TITLE
style: add frontmatter keywords to platform pages

### DIFF
--- a/platform/app/settings-page.mdx
+++ b/platform/app/settings-page.mdx
@@ -3,6 +3,7 @@ description: Use the W&B Settings page to customize your individual
   user profile or team settings.
 title: Settings
 sidebarTitle: Overview
+keywords: ["account settings", "profile settings", "API keys", "user preferences", "team configuration"]
 ---
 
 Use the W&B Settings page to customize your individual user profile and manage settings for the teams you belong to. The following sections summarize what you can configure at each level, with links to the detailed pages.

--- a/platform/app/settings-page/billing-settings.mdx
+++ b/platform/app/settings-page/billing-settings.mdx
@@ -1,6 +1,7 @@
 ---
 description: "View plan details, monitor usage, and configure usage and spending alerts for your W&B organization's billing."
 title: Manage billing settings
+keywords: ["subscription", "invoices", "payment method", "usage alerts", "spending limits"]
 ---
 
 The **Billing** settings page lets organization and billing admins review the current plan, monitor usage, configure usage and spending alerts, manage payment methods, and access invoices. Use this page to keep your organization within its usage limits and to stay informed about upcoming charges.

--- a/platform/app/settings-page/emails.mdx
+++ b/platform/app/settings-page/emails.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Add, delete, and manage email addresses and login methods in your W&B profile settings page."
 title: Manage email settings
+keywords: ["login methods", "primary email", "add email address", "Auth0"]
 ---
 
 In your W&B **Settings** page, the Emails dashboard lets you add, delete, and manage email types and primary email addresses.

--- a/platform/app/settings-page/storage.mdx
+++ b/platform/app/settings-page/storage.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Manage W&B data storage consumption using reference artifacts, external buckets, and TTL deletion policies."
 title: Manage storage
+keywords: ["storage limit", "TTL policy", "storage quota", "data retention", "reduce storage"]
 ---
 
 This page describes how to manage your W&B data storage so you can stay within your storage limit. If you're approaching or exceeding your storage limit, you have multiple ways to manage your data. The best option depends on your account type and your current project setup.

--- a/platform/app/settings-page/team-settings.mdx
+++ b/platform/app/settings-page/team-settings.mdx
@@ -2,6 +2,7 @@
 description: Manage a team's members, avatar, alerts, and privacy settings with the
   Team Settings page.
 title: Manage team settings
+keywords: ["team privacy", "team alerts", "team avatar", "team admin"]
 ---
 
 import EnterpriseOnly from "/snippets/_includes/enterprise-only.mdx";

--- a/platform/app/settings-page/teams.mdx
+++ b/platform/app/settings-page/teams.mdx
@@ -1,6 +1,7 @@
 ---
 description: Collaborate with your colleagues, share results, and track all the experiments across your team. Manage team settings including members, alerts, and privacy.
 title: Team settings
+keywords: ["create team", "team roles", "team workspace", "BYOB team"]
 ---
 
 import EnterpriseOnly from "/snippets/_includes/enterprise-only.mdx";

--- a/platform/app/settings-page/user-settings.mdx
+++ b/platform/app/settings-page/user-settings.mdx
@@ -3,6 +3,7 @@ description: Manage your profile information, account defaults, alerts, particip
   in beta products, GitHub integration, storage usage, account activation, and create
   teams in your user settings.
 title: Manage user settings
+keywords: ["API key", "GitHub integration", "beta features", "delete account"]
 ---
 
 import ApiKeyCreate from "/snippets/_includes/api-key-create.mdx";

--- a/platform/hosting.mdx
+++ b/platform/hosting.mdx
@@ -3,6 +3,7 @@ title: Deployment options overview
 description: "Compare W&B deployment options including Multi-tenant Cloud, Dedicated Cloud, and Self-Managed installations."
 sidebarTitle: Overview
 no_list: true
+keywords: ["hosting options", "deployment comparison", "on-premises", "SaaS"]
 ---
 You can deploy W&B in various ways to meet your organization's infrastructure and security requirements. This page helps administrators and platform decision-makers compare the available deployment options, so you can choose the one that best fits your security, scale, and operational needs.
 

--- a/platform/hosting/data-security/data-encryption.mdx
+++ b/platform/hosting/data-security/data-encryption.mdx
@@ -1,6 +1,7 @@
 ---
 title: Data encryption in Dedicated Cloud
 description: "Learn how W&B encrypts data in Dedicated Cloud using cloud-native keys and the customer-managed encryption key policy."
+keywords: ["CMEK", "encryption keys", "KMS", "data at rest"]
 ---
 
 This page describes how W&B encrypts the W&B-managed database and object storage in [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), and explains W&B's policy on customer-managed encryption keys. This page is intended for security and compliance teams evaluating Dedicated Cloud for use with sensitive AI workloads.

--- a/platform/hosting/data-security/ip-allowlisting.mdx
+++ b/platform/hosting/data-security/ip-allowlisting.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure IP allowlisting for Dedicated Cloud
 description: "Restrict access to a W&B Dedicated Cloud instance to authorized IP addresses using IP allowlisting."
+keywords: ["IP whitelist", "IP restrictions", "network access control", "access restriction"]
 ---
 
 This page explains how IP allowlisting works on W&B [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) and how to request it for your instance. Use IP allowlisting to restrict access to your Dedicated Cloud instance to an authorized list of IP addresses, so that only traffic from approved locations can reach the W&B APIs and the W&B app UI.

--- a/platform/hosting/data-security/presigned-urls.mdx
+++ b/platform/hosting/data-security/presigned-urls.mdx
@@ -1,6 +1,7 @@
 ---
 title: Access BYOB using pre-signed URLs
 description: "Understand how W&B uses pre-signed URLs for blob storage access, including team-level access control and audit logging."
+keywords: ["signed URLs", "S3 presigned", "blob storage access", "SAS tokens"]
 ---
 
 W&B uses pre-signed URLs to simplify access to blob storage from your AI workloads or user browsers. This page explains how pre-signed URLs work in W&B. It also outlines the access controls, network restrictions, and audit logging that administrators should configure to secure blob storage access.

--- a/platform/hosting/data-security/private-connectivity.mdx
+++ b/platform/hosting/data-security/private-connectivity.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure private connectivity to Dedicated Cloud
 description: "Connect to a W&B Dedicated Cloud instance over a private network using AWS PrivateLink, GCP, or Azure Private Link."
+keywords: ["PrivateLink", "VPC endpoint", "Azure Private Link", "private endpoint"]
 ---
 
 This document explains how to connect to a W&B Dedicated Cloud instance over a cloud provider's secure private network, so that traffic between your environment and W&B avoids the public internet. It's intended for cloud and security administrators who manage Dedicated Cloud instances and want to harden network access for AI workloads and user traffic.

--- a/platform/hosting/data-security/secure-storage-connector.mdx
+++ b/platform/hosting/data-security/secure-storage-connector.mdx
@@ -1,6 +1,7 @@
 ---
 title: Bring your own bucket (BYOB)
 description: "Store W&B artifacts and data in your own cloud storage buckets using the Bring Your Own Bucket (BYOB) feature."
+keywords: ["custom bucket", "S3 bucket", "GCS bucket", "Azure blob storage"]
 ---
 
 import ByobContextNote from "/snippets/_includes/byob-context-note.mdx";

--- a/platform/hosting/enterprise-licenses.mdx
+++ b/platform/hosting/enterprise-licenses.mdx
@@ -1,6 +1,7 @@
 ---
 title: Enterprise licenses
 description: Learn about W&B Enterprise licenses, what features they include, and how to obtain and configure them.
+keywords: ["license key", "apply license", "HIPAA", "custom roles", "SCIM provisioning"]
 ---
 
 An Enterprise license unlocks W&B features designed for organizations that need enhanced capabilities in areas of security, compliance, or administration. See the list of [Enterprise features](#enterprise-features).

--- a/platform/hosting/env-vars.mdx
+++ b/platform/hosting/env-vars.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Configure a self-managed W&B Server installation using environment variables for database, storage, Redis, and IAM settings."
 title: Configure environment variables
+keywords: ["GORILLA variables", "server config vars", "W&B Server env vars", "configuration code"]
 ---
 
 In addition to configuring instance-level settings through the System Settings admin UI, W&B also provides a way to configure these values in code using environment variables. This page lists the environment variables you can set to control database, storage, Redis, identity provider, and other instance-level behavior for a self-managed W&B Server deployment. You can use these variables to manage configuration as code instead of through the admin UI. For IAM-specific variables, see [advanced configuration for IAM](./iam/advanced_env_vars).

--- a/platform/hosting/export-data-from-dedicated-cloud.mdx
+++ b/platform/hosting/export-data-from-dedicated-cloud.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Export runs, metrics, artifacts, and reports from a W&B Dedicated Cloud instance using the W&B SDK API."
 title: Export data from Dedicated Cloud
+keywords: ["migrate data", "data portability", "backup W&B data", "import export API"]
 ---
 
 To export the data managed in your Dedicated Cloud instance, you can use the W&B SDK API to extract runs, metrics, artifacts, and more with the [Import and Export API](/models/ref/python/public-api/). The following table covers some of the key exporting use cases.

--- a/platform/hosting/hosting-options.mdx
+++ b/platform/hosting/hosting-options.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deployment options
 description: "Choose between W&B deployment types: Multi-tenant Cloud, Dedicated Cloud, and Self-Managed for your organization."
+keywords: ["self-hosted", "deployment comparison", "SaaS vs self-managed", "W&B hosting options"]
 ---
 The following sections describe the different ways you can deploy W&B, so you can choose the deployment model that best fits your organization's security, compliance, and operational needs. The options range from W&B-managed shared infrastructure to fully self-managed deployments in your own environment.
 

--- a/platform/hosting/hosting-options/dedicated-cloud.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Learn about W&B Dedicated Cloud deployment features including compliance, data security, IAM, and maintenance policies."
 title: Dedicated Cloud
+keywords: ["isolated infrastructure", "single-tenant", "dedicated instance", "compliance features"]
 ---
 
 W&B Dedicated Cloud is a fully managed platform with dedicated, isolated infrastructure, deployed in W&B's AWS, Google Cloud, or Azure cloud accounts. Each Dedicated Cloud instance has its own isolated network, compute, and storage from other W&B Dedicated Cloud instances. W&B stores your W&B-specific metadata and data in isolated cloud storage and processes it using isolated cloud compute services.

--- a/platform/hosting/hosting-options/dedicated-cloud/export-data.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/export-data.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Export runs, metrics, artifacts, and reports from a W&B Dedicated Cloud instance using the Python SDK API."
 title: Export data from Dedicated Cloud
+keywords: ["migrate data", "data portability", "backup data", "data migration"]
 ---
 
 Export the data managed in your W&B Dedicated Cloud instance, such as runs, metrics, artifacts, and reports, when you need a portable copy for backup, migration, or external analysis. To extract this data, use the W&B SDK API with the [Import and Export API](/models/ref/python/public-api/). The following table covers some key export use cases.

--- a/platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/rate-limits.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rate limits
 description: Default rate limits on Dedicated Cloud and how to request changes
+keywords: ["API rate limit", "throughput limit", "SDK throttling", "429 error", "rate limit increase"]
 ---
 import RateLimitsDefaultsAndNotification from "/snippets/_includes/rate-limits-defaults-and-notification.mdx";
 

--- a/platform/hosting/hosting-options/dedicated-cloud/regions.mdx
+++ b/platform/hosting/hosting-options/dedicated-cloud/regions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Supported Dedicated Cloud regions
 description: "View all supported AWS, Google Cloud, and Azure regions available for W&B Dedicated Cloud instances."
+keywords: ["data residency", "cloud regions", "AWS region list", "Azure region list", "EU region"]
 ---
 
 AWS, Google Cloud, and Azure support cloud computing services in multiple locations worldwide. Global regions help ensure that you satisfy requirements such as data residency, compliance, latency, and cost efficiency. W&B supports many of the available global regions for Dedicated Cloud. The following sections list the supported regions for each cloud provider.

--- a/platform/hosting/hosting-options/dedicated_regions.mdx
+++ b/platform/hosting/hosting-options/dedicated_regions.mdx
@@ -1,6 +1,7 @@
 ---
 title: Supported Dedicated Cloud regions
 description: "View all supported AWS, Google Cloud, and Azure regions available for W&B Dedicated Cloud deployments."
+keywords: ["data residency", "available regions", "GCP region", "EU data residency", "region list"]
 ---
 
 This page lists the AWS, Google Cloud, and Azure regions that W&B supports for Dedicated Cloud deployments. Consult these tables when you're choosing a region for a new Dedicated Cloud instance, so you can satisfy requirements such as data residency and compliance, latency, and cost efficiency.

--- a/platform/hosting/hosting-options/multi_tenant_cloud.mdx
+++ b/platform/hosting/hosting-options/multi_tenant_cloud.mdx
@@ -1,6 +1,7 @@
 ---
 title: Multi-tenant Cloud
 description: "Learn about W&B Multi-tenant Cloud, a fully managed deployment on Google Cloud with built-in compliance and data security."
+keywords: ["shared cloud", "SaaS deployment", "Google Cloud hosted", "free tier"]
 ---
 
 This page describes W&B Multi-tenant Cloud, including its architecture, compliance posture, data security options, and identity and access management capabilities, so you can decide whether it fits your organization's hosting requirements.

--- a/platform/hosting/hosting-options/self-managed.mdx
+++ b/platform/hosting/hosting-options/self-managed.mdx
@@ -2,6 +2,7 @@
 description: Deploy W&B Self-Managed on cloud or on-premises infrastructure
 title: W&B Self-Managed deployment overview
 sidebarTitle: Deployment overview
+keywords: ["self-hosted W&B", "on-premises deployment", "private cloud", "W&B Server", "helm chart"]
 ---
 
 

--- a/platform/hosting/iam/access-management-intro.mdx
+++ b/platform/hosting/iam/access-management-intro.mdx
@@ -1,6 +1,7 @@
 ---
 title: Access management
 description: "Manage users, teams, roles, and project visibility as an organization or team admin in W&B."
+keywords: ["user management", "RBAC", "role-based access", "organization admin", "access control"]
 ---
 
 This page introduces how access management works in W&B, including how to administer users and teams, maintain admin access to your organization, and control who can view individual projects. It's intended for organization admins, team admins, and project owners.

--- a/platform/hosting/iam/access-management/manage-organization.mdx
+++ b/platform/hosting/iam/access-management/manage-organization.mdx
@@ -1,6 +1,7 @@
 ---
 title: Manage your organization
 description: "Manage users, teams, roles, seats, and billing within a W&B organization as an organization admin."
+keywords: ["invite users", "org admin", "add team members", "user seats"]
 ---
 This page describes how to administer a W&B organization, including how to invite users, manage teams, assign roles and seats, and configure billing. Use these procedures to keep your organization's membership, access, and team structure aligned with how your company uses W&B.
 

--- a/platform/hosting/iam/access-management/restricted-projects.mdx
+++ b/platform/hosting/iam/access-management/restricted-projects.mdx
@@ -1,6 +1,7 @@
 ---
 description: Manage project access using visibility scopes and project-level roles
 title: Manage access control for projects
+keywords: ["project visibility", "restricted project", "project roles", "project permissions"]
 ---
 
 Define the scope of a W&B project to limit who can view, edit, and submit W&B runs to it. This page is for team and organization admins, and project owners, who need to control access to sensitive workflows or limit collaboration to a specific group of users.

--- a/platform/hosting/iam/advanced_env_vars.mdx
+++ b/platform/hosting/iam/advanced_env_vars.mdx
@@ -1,6 +1,7 @@
 ---
 title: Advanced IAM configuration
 description: "Configure advanced IAM options for W&B with environment variables for SSO, session length, OIDC, and LDAP settings."
+keywords: ["OIDC configuration", "session timeout", "JWT settings", "identity provider", "IAM env vars"]
 ---
 
 In addition to basic [environment variables](../env-vars), you can use environment variables to configure advanced IAM options for your [Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud) or [Self-Managed](/platform/hosting/hosting-options/self-managed) instance. Use these variables to customize SSO behavior, session expiration, OIDC and LDAP integration, and other identity-related settings to match your organization's security and access requirements.

--- a/platform/hosting/iam/automate_iam.mdx
+++ b/platform/hosting/iam/automate_iam.mdx
@@ -1,6 +1,7 @@
 ---
 title: Automate user and team management
 description: "Automate user and team management at scale in W&B using the SCIM API and the Python SDK API."
+keywords: ["bulk provisioning", "Okta sync", "Microsoft Entra", "identity provider sync", "auto-provision users"]
 ---
 
 This page describes how to automate user and team management at scale using the [SCIM API](/platform/hosting/iam/scim) and the [Python SDK API](/models/ref/python/public-api).

--- a/platform/hosting/iam/identity_federation.mdx
+++ b/platform/hosting/iam/identity_federation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use federated identities with SDK
 description: "Use identity federation with JSON Web Tokens (JWTs) to authenticate with the W&B SDK and CLI without API keys."
+keywords: ["JWT authentication", "RFC 7523", "federated login", "keyless auth", "token-based auth"]
 ---
 
 Use identity federation to sign in to the W&B SDK and CLI with your organizational credentials, instead of using a long-lived API key. If your W&B organization admin has configured SSO for your organization, you already use those credentials to sign in to the W&B app UI. Identity federation is like SSO for the W&B SDK, but uses JSON Web Tokens (JWTs) directly. Use identity federation as an alternative to API keys.

--- a/platform/hosting/iam/ldap.mdx
+++ b/platform/hosting/iam/ldap.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure SSO with LDAP
 description: "Configure LDAP-based SSO authentication for W&B Server including connection parameters and environment variables."
+keywords: ["Active Directory", "LDAP bind", "directory service", "distinguished name", "anonymous bind"]
 ---
 
 This guide is for W&B Admins who enable LDAP-based single sign-on (SSO) for W&B Server, so that users can authenticate against an existing LDAP directory instead of managing separate W&B credentials. It explains how to configure the LDAP connection from the W&B App system settings UI or with environment variables. It also describes the required and optional configuration parameters, including the address, base distinguished name, and attributes. You can set up either an anonymous bind, or bind with an administrator DN and password.

--- a/platform/hosting/iam/org_team_struct.mdx
+++ b/platform/hosting/iam/org_team_struct.mdx
@@ -1,6 +1,7 @@
 ---
 title: Identity and access management (IAM)
 description: "Understand the three IAM scopes in W&B (organizations, teams, and projects) and how they map to your company."
+keywords: ["IAM scopes", "org structure", "access hierarchy", "permissions model", "user roles"]
 ---
 
 W&B Platform has three IAM scopes within W&B: [Organizations](#organization), [Teams](#team), and [Projects](#project). Understanding how these scopes nest helps you plan how to structure access, group users, and organize AI work across your company.

--- a/platform/hosting/iam/scim.mdx
+++ b/platform/hosting/iam/scim.mdx
@@ -1,6 +1,7 @@
 ---
 title: Manage users, groups, and roles with SCIM
 description: "Use the SCIM API to manage users, groups, and custom roles in a W&B organization with automated provisioning."
+keywords: ["SCIM 2.0", "Okta provisioning", "automatic user sync", "group sync", "directory provisioning"]
 ---
 
 <Note>

--- a/platform/hosting/iam/service-accounts.mdx
+++ b/platform/hosting/iam/service-accounts.mdx
@@ -2,6 +2,7 @@
 description: Manage automated or non-interactive workflows using org and team scoped service accounts
 displayed_sidebar: default
 title: Use service accounts to automate workflows
+keywords: ["bot account", "CI/CD auth", "automated workflows", "non-interactive login", "service account API key"]
 ---
 
 import ServiceAccountBenefits from "/snippets/_includes/service-account-benefits.mdx";

--- a/platform/hosting/iam/sso.mdx
+++ b/platform/hosting/iam/sso.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure SSO with OIDC
 description: "Configure SSO using OpenID Connect with identity providers like Okta, Azure AD, and AWS Cognito for W&B instances."
+keywords: ["Keycloak", "Auth0 SSO", "Google SSO", "Entra ID", "OIDC provider"]
 ---
 
 This guide is for administrators of W&B Dedicated Cloud or Self-Managed instances who want to enable single sign-on (SSO) using an OpenID Connect (OIDC) compatible identity provider. By the end, you've configured your identity provider, connected it to W&B so that users can sign in through your organization's existing identity system, and you can manage user identities and group memberships through providers like Okta, Keycloak, Auth0, Google, and Entra.

--- a/platform/hosting/managing-bucket-storage.mdx
+++ b/platform/hosting/managing-bucket-storage.mdx
@@ -1,6 +1,7 @@
 ---
 title: Manage bucket storage and costs
 description: Understand how W&B uses object storage, how deletion maps to bucket bytes, and how to reduce usage on Self-Managed, Dedicated Cloud, and Bring Your Own Bucket deployments.
+keywords: ["storage cleanup", "garbage collection", "artifact deletion", "bucket bytes", "S3 costs"]
 ---
 
 When you use [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector), [W&B Dedicated Cloud](/platform/hosting/hosting-options/dedicated-cloud), or [W&B Self-Managed](/platform/hosting/hosting-options/self-managed), your team often pays cloud storage providers directly. This page explains what occupies your bucket, how W&B removes objects after deletion in the app or API, and what you should expect. Use it to understand bucket usage, plan cleanup, and set realistic expectations for when storage is reclaimed.

--- a/platform/hosting/monitoring-usage/audit-logging.mdx
+++ b/platform/hosting/monitoring-usage/audit-logging.mdx
@@ -1,6 +1,7 @@
 ---
 title: Track user activity with audit logs
 description: "Access, fetch, and analyze W&B audit logs across deployment types, including the log schema and tracked actions."
+keywords: ["audit trail", "compliance logging", "user activity log", "PII filtering", "log schema"]
 ---
 
 Use W&B audit logs to track user activity within your organization and to conform to your enterprise governance requirements. This page is for organization-level admins who need to access, fetch, and analyze audit log data across W&B deployment types. Audit logs are available in JSON format. Refer to [Audit log schema](#audit-log-schema).

--- a/platform/hosting/monitoring-usage/mobile-app.mdx
+++ b/platform/hosting/monitoring-usage/mobile-app.mdx
@@ -1,6 +1,7 @@
 ---
 title: W&B Mobile App (iOS)
 description: From your iPhone or iPad, track training runs, review console logs, view line plots and system metrics, search project panels with regular expressions, and explore your W&B Models projects.
+keywords: ["iPhone app", "iPad app", "iOS app", "App Store", "mobile monitoring"]
 ---
 
 <Columns cols={4}>

--- a/platform/hosting/monitoring-usage/org_dashboard.mdx
+++ b/platform/hosting/monitoring-usage/org_dashboard.mdx
@@ -1,6 +1,7 @@
 ---
 title: View organization activity
 description: "View user status, activity, and usage trends in the W&B organization dashboard across deployment types."
+keywords: ["admin overview", "user audit", "export user list", "organization metrics", "CSV export"]
 ---
 
 This page describes how to view activity in your W&B organization, including user status, activity trends over time, and how to export user details as a CSV. Organization admins use this information to audit access, monitor adoption, and report on usage. Select your deployment type in each section to continue.

--- a/platform/hosting/monitoring-usage/slack-alerts.mdx
+++ b/platform/hosting/monitoring-usage/slack-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Slack alerts
 description: "Create and configure a Slack application to receive W&B Server alerts, notifications, and monitoring updates."
+keywords: ["Slack webhook", "Slack app", "OAuth scopes", "server notifications", "Slack integration"]
 ---
 
 Integrate W&B Server with [Slack](https://slack.com/) so that your W&B instance can dispatch alerts and notifications to a Slack workspace your team already uses. This page walks W&B Server administrators through creating a Slack application, configuring its OAuth scopes and redirect URL, and registering the application with W&B.

--- a/platform/hosting/privacy-settings.mdx
+++ b/platform/hosting/privacy-settings.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure privacy settings
 description: "Configure and enforce privacy settings for team visibility, project access, and code saving defaults in W&B."
+keywords: ["code saving", "team visibility", "report sharing", "invitation controls"]
 ---
 
 This page describes how organization and team admins can configure privacy settings in W&B to control team visibility, project access, invitations, report sharing, and default code saving. Use these settings to standardize privacy across an organization or to tune controls for a single team.

--- a/platform/hosting/self-managed/disable-automatic-app-version-updates.mdx
+++ b/platform/hosting/self-managed/disable-automatic-app-version-updates.mdx
@@ -1,6 +1,7 @@
 ---
 title: Disable automatic updates for W&B Server
 description: Learn how to disable automatic updates for W&B Server.
+keywords: ["pin version", "freeze upgrade", "version lock", "manual upgrade"]
 ---
 
 This page shows administrators of Self-Managed W&B deployments how to disable automatic version upgrades for W&B Server and pin its version to a specific release. Pinning a version gives you control over when upgrades happen. This control is useful when you need to coordinate upgrades with internal change management processes or validate a release in a staging environment before you roll it out. These instructions work only for deployments managed by the [W&B Kubernetes Operator](/platform/hosting/self-managed/operator).

--- a/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
+++ b/platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped.mdx
@@ -1,6 +1,7 @@
 ---
 description: Deploy W&B Platform in air-gapped and disconnected Kubernetes environments
 title: Deploy on Air-Gapped Kubernetes
+keywords: ["air gap install", "offline deployment", "disconnected cluster", "private registry", "OpenShift"]
 ---
 
 import SelfManagedVersionRequirements from "/snippets/_includes/self-managed-version-requirements.mdx";

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -1,6 +1,7 @@
 ---
 description: Deploy W&B Platform with Kubernetes Operator on cloud or on-premises
 title: Deploy W&B with Kubernetes Operator
+keywords: ["W&B operator", "Helm chart", "Kubernetes CR", "operator install", "custom resource"]
 ---
 
 import SelfManagedMysqlRequirements from "/snippets/_includes/self-managed-mysql-requirements.mdx";

--- a/platform/hosting/self-managed/rate-limits.mdx
+++ b/platform/hosting/self-managed/rate-limits.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rate limits
 description: Optional rate limits on Self-Managed instances for stability
+keywords: ["API throttling", "rate limiting", "request limits", "server stability", "429 rate limit"]
 ---
 import RateLimitsDefaultsAndNotification from "/snippets/_includes/rate-limits-defaults-and-notification.mdx";
 

--- a/platform/hosting/self-managed/ref-arch.mdx
+++ b/platform/hosting/self-managed/ref-arch.mdx
@@ -1,6 +1,7 @@
 ---
 title: Reference architecture
 description: "Review the reference architecture for self-managed W&B deployments covering Kubernetes, MySQL, object storage, and networking."
+keywords: ["infrastructure sizing", "MySQL requirements", "Redis setup", "production architecture", "hardware specs"]
 ---
 
 import SelfManagedVersionRequirements from "/snippets/_includes/self-managed-version-requirements.mdx";

--- a/platform/hosting/self-managed/requirements.mdx
+++ b/platform/hosting/self-managed/requirements.mdx
@@ -1,6 +1,7 @@
 ---
 title: Self-Managed infrastructure requirements
 description: Infrastructure and software requirements for W&B Self-Managed deployments
+keywords: ["hardware requirements", "Kubernetes version", "MySQL version", "CPU memory requirements", "Redis requirements"]
 ---
 
 import SelfManagedVersionRequirements from "/snippets/_includes/self-managed-version-requirements.mdx";

--- a/platform/hosting/server-upgrade-process.mdx
+++ b/platform/hosting/server-upgrade-process.mdx
@@ -1,6 +1,7 @@
 ---
 description: Guide for updating W&B version and license across different installation methods.
 title: Update W&B license and version
+keywords: ["server upgrade", "license renewal", "Helm upgrade", "Terraform update", "version migration"]
 ---
 
 This guide shows W&B Server administrators how to update the W&B Server version and license key for an existing self-managed deployment. Keeping your server and license current ensures access to the latest features, fixes, and continued entitlement to use W&B Server.

--- a/platform/hosting/smtp.mdx
+++ b/platform/hosting/smtp.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure SMTP
 description: "Configure an internal SMTP server to send email invitations from a self-managed W&B Server instance."
+keywords: ["email server", "outbound email", "SMTP relay", "email invitations", "TLS email"]
 ---
 
 In W&B Server, adding users to the instance or a team triggers an email invitation. By default, W&B sends these invitations through a third-party mail server. If your organization restricts outbound traffic from the corporate network, these invitations might not reach the end user. To work around this, administrators of a self-managed W&B Server can route invitation emails through an internal SMTP server.

--- a/platform/launch/add-job-to-queue.mdx
+++ b/platform/launch/add-job-to-queue.mdx
@@ -1,6 +1,7 @@
 ---
 title: Add job to queue
 description: "Add launch jobs to a W&B Launch queue using the App UI or CLI to schedule ML workloads on target resources."
+keywords: ["enqueue job", "submit job", "launch CLI", "priority queue", "job priority"]
 ---
 This page describes how to add launch jobs to a launch queue. Adding a job to a queue submits it to run on the queue's target resource. You can schedule ML workloads against the compute environment your team configured.
 

--- a/platform/launch/create-launch-job.mdx
+++ b/platform/launch/create-launch-job.mdx
@@ -1,6 +1,7 @@
 ---
 title: Create a launch job
 description: "Create W&B Launch jobs from Git repositories, code artifacts, or Docker images using the wandb launch command."
+keywords: ["wandb job create", "git job", "code artifact job", "image job", "job blueprint"]
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/drive/1wX0OSVxZJDHRsZaOaOEDx-lLUrO1hHgP" icon="python"/>
 

--- a/platform/launch/job-inputs.mdx
+++ b/platform/launch/job-inputs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Manage job inputs
 description: "Programmatically manage and configure job inputs such as hyperparameters and file-based configs for W&B Launch jobs."
+keywords: ["job configuration", "hyperparameter overrides", "config file input", "JSON schema", "Pydantic schema"]
 ---
 The core experience of Launch is experimenting with different job inputs such as hyperparameters and datasets, and routing these jobs to appropriate hardware. After you create a job, users beyond the original author can adjust these inputs through the W&B UI or CLI. For information about how to set job inputs when launching from the CLI or UI, see the [Enqueue jobs](./add-job-to-queue) guide.
 

--- a/platform/launch/launch-faq/best_practices_launch_effectively.mdx
+++ b/platform/launch/launch-faq/best_practices_launch_effectively.mdx
@@ -1,5 +1,6 @@
 ---
 title: Are there best practices for using Launch effectively?
+keywords: ["launch tips", "service account launch", "queue best practices", "agent configuration"]
 ---
 
 Follow these practices to avoid common setup errors and keep your Launch workflows maintainable:

--- a/platform/launch/launch-faq/build_container_launch.mdx
+++ b/platform/launch/launch-faq/build_container_launch.mdx
@@ -1,5 +1,6 @@
 ---
 title: I don't want W&B to build a container for me, can I still use Launch?
+keywords: ["prebuilt image", "skip build", "custom container", "no container build"]
 ---
 
 To launch a pre-built Docker image, replace the `<>` placeholders with your values and run:

--- a/platform/launch/launch-faq/clicking_launch_without_going_ui.mdx
+++ b/platform/launch/launch-faq/clicking_launch_without_going_ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: I don't like clicking, can I use Launch without going through the UI?
+keywords: ["launch CLI", "wandb launch command", "programmatic launch", "headless launch"]
 ---
 
 Yes. The `wandb` CLI includes a `launch` subcommand for launching jobs. To see usage details, run:

--- a/platform/launch/launch-faq/control_push_queue.mdx
+++ b/platform/launch/launch-faq/control_push_queue.mdx
@@ -1,5 +1,6 @@
 ---
 title: How do I control who can push to a queue?
+keywords: ["queue permissions", "restrict queue access", "team queue", "push to queue"]
 ---
 
 Queues are specific to a user team. Define the owning entity when you create the queue. To restrict access, modify team membership.

--- a/platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact.mdx
+++ b/platform/launch/launch-faq/docker_queues_run_multiple_jobs_download_same_artifact_useartifact.mdx
@@ -1,6 +1,7 @@
 ---
 title: When multiple jobs in a Docker queue download the same artifact, is any caching
   used, or is it re-downloaded every run?
+keywords: ["artifact caching", "Docker cache", "artifact download", "artifact mount"]
 ---
 
 Launch jobs share no cache. Each launch job runs independently. To share a cache, configure the queue or agent to mount one with Docker arguments in the queue configuration.

--- a/platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me.mdx
+++ b/platform/launch/launch-faq/dockerfile_let_wb_build_docker_image_me.mdx
@@ -1,5 +1,6 @@
 ---
 title: Can I specify a Dockerfile and let W&B build a Docker image for me?
+keywords: ["custom Dockerfile", "Docker build", "bring own Dockerfile", "build from Dockerfile"]
 ---
 Yes. You can provide your own Dockerfile and have W&B Launch build the image for your run. This lets you control the build environment while still using Launch to queue and run jobs. This approach works well for projects with stable requirements but changing codebases.
 

--- a/platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment.mdx
+++ b/platform/launch/launch-faq/launch_automatically_provision_spin_compute_resources_target_environment.mdx
@@ -1,6 +1,7 @@
 ---
 title: Can Launch automatically provision (and spin down) compute resources for me
   in the target environment?
+keywords: ["autoscaling", "auto provisioning", "spot instances", "node autoscaler", "compute scaling"]
 ---
 
 Whether Launch automatically provisions and scales compute resources depends on the target environment:

--- a/platform/launch/launch-faq/launch_build_images.mdx
+++ b/platform/launch/launch-faq/launch_build_images.mdx
@@ -1,5 +1,6 @@
 ---
 title: How W&B Launch builds images
+keywords: ["image build process", "base image selection", "build steps", "container build process"]
 ---
 
 This page explains how W&B Launch builds container images for your jobs, so you can predict which build actions Launch performs and configure your queue or job accordingly.

--- a/platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker.mdx
+++ b/platform/launch/launch-faq/launch_d_wandb_job_create_image_uploading_whole_docker.mdx
@@ -1,6 +1,7 @@
 ---
 title: Is `wandb launch -d` or `wandb job create image` uploading a whole Docker artifact
   and not pulling from a registry?
+keywords: ["wandb launch -d", "Docker registry", "image upload", "push to registry"]
 ---
 
 No, the `wandb launch -d` command doesn't upload images to a registry. Upload images to a registry separately. Follow these steps:

--- a/platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job.mdx
+++ b/platform/launch/launch-faq/launch_support_parallelization_limit_resources_consumed_job.mdx
@@ -1,6 +1,7 @@
 ---
 title: Does Launch support parallelization? How can I limit the resources consumed
   by a job?
+keywords: ["multi-GPU", "distributed training", "resource limits", "max_jobs", "CPU GPU limits"]
 ---
 
 Launch supports scaling jobs across multiple GPUs and nodes. For details, see the [Volcano integration guide](/models/integrations).

--- a/platform/launch/launch-faq/launch_tensorflow_gpu.mdx
+++ b/platform/launch/launch-faq/launch_tensorflow_gpu.mdx
@@ -1,5 +1,6 @@
 ---
 title: How to make W&B Launch work with TensorFlow on GPU
+keywords: ["TensorFlow GPU", "CUDA launch", "GPU container", "accelerator image"]
 ---
 
 To run TensorFlow jobs on GPUs with W&B Launch, specify a custom base image for the container build. This lets the resulting container access the GPU. Add an image tag under the `builder.accelerator.base_image` key in the resource configuration. For example:

--- a/platform/launch/launch-faq/launcherror_permission_denied.mdx
+++ b/platform/launch/launch-faq/launcherror_permission_denied.mdx
@@ -1,5 +1,6 @@
 ---
 title: How do I fix a "permission denied" error in Launch?
+keywords: ["permission denied error", "launch error", "access error", "troubleshoot launch"]
 ---
 
 If you see the error `Launch Error: Permission denied`, you don't have permission to log to the project. Review the following causes and resolutions:

--- a/platform/launch/launch-faq/permissions_agent_require_kubernetes.mdx
+++ b/platform/launch/launch-faq/permissions_agent_require_kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: What permissions does the agent require in Kubernetes?
+keywords: ["RBAC agent", "Kubernetes RBAC", "agent permissions", "ClusterRole"]
 ---
 
 This page describes the Kubernetes permissions that the W&B Launch agent requires to run jobs in your cluster. Use this information to configure role-based access control (RBAC) for the agent before you deploy it.

--- a/platform/launch/launch-faq/requirements_accelerator_base_image.mdx
+++ b/platform/launch/launch-faq/requirements_accelerator_base_image.mdx
@@ -1,5 +1,6 @@
 ---
 title: What requirements does the accelerator base image have?
+keywords: ["GPU base image", "CUDA version", "accelerator requirements", "GPU driver"]
 ---
 
 For W&B Launch jobs that use an accelerator, provide a base image that includes the necessary accelerator components. This ensures that your job has the required GPU drivers, runtime libraries, and other hardware-specific dependencies to execute. The accelerator image must meet the following requirements:

--- a/platform/launch/launch-faq/restrict_access_modify_example.mdx
+++ b/platform/launch/launch-faq/restrict_access_modify_example.mdx
@@ -1,5 +1,6 @@
 ---
 title: How can admins restrict which users have modify access?
+keywords: ["queue access control", "restrict queue edit", "admin-only fields", "user permissions"]
 ---
 
 Control access to certain queue fields for users who aren't team administrators through [queue config templates](/platform/launch/setup-queue-advanced/). Team administrators define which fields non-admin users can view, and set the editing limits. Only team administrators can create or edit queues.

--- a/platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx
+++ b/platform/launch/launch-faq/secrets_jobsautomations_instance_api_key_wish_directly_visible.mdx
@@ -1,6 +1,7 @@
 ---
 title: Can you specify secrets for jobs or automations? For instance, an API key which
   you do not wish to be directly visible to users?
+keywords: ["Kubernetes secret", "kubectl secret", "hidden API key", "secret injection", "credential injection"]
 ---
 
 Yes. Follow these steps:

--- a/platform/launch/launch-queue-observability.mdx
+++ b/platform/launch/launch-queue-observability.mdx
@@ -1,6 +1,7 @@
 ---
 title: Monitor launch queue
 description: "Monitor launch queue workloads with an interactive dashboard to spot inefficient jobs and analyze resource usage."
+keywords: ["queue dashboard", "GPU utilization", "resource monitoring", "job metrics", "Datadog integration"]
 ---
 
 Use the interactive **Queue monitoring dashboard** to view when a launch queue is in heavy use or idle, visualize workloads that are running, and spot inefficient jobs. The launch queue dashboard helps you decide whether you're effectively using your compute hardware or cloud resources.

--- a/platform/launch/launch-terminology.mdx
+++ b/platform/launch/launch-terminology.mdx
@@ -1,6 +1,7 @@
 ---
 title: Launch terms and concepts
 description: "Learn key W&B Launch concepts including jobs, queues, target resources, agents, and agent environments."
+keywords: ["launch glossary", "launch concepts", "queue definition", "agent concepts", "target resource"]
 ---
 
 This page defines the core terms and concepts used throughout the W&B Launch documentation. Use it as a reference when you encounter unfamiliar terms in setup guides, tutorials, or the W&B App.

--- a/platform/launch/launch-view-jobs.mdx
+++ b/platform/launch/launch-view-jobs.mdx
@@ -1,6 +1,7 @@
 ---
 title: View launch jobs
 description: "View launch job details, list available jobs, and check job statuses in the W&B App and CLI."
+keywords: ["job status", "list jobs", "inspect job", "CLI job list"]
 ---
 
 This page describes how to view information about launch jobs in queues. You can inspect job details in the W&B App, list jobs from the CLI, and interpret the status of a queued run.

--- a/platform/launch/set-up-launch.mdx
+++ b/platform/launch/set-up-launch.mdx
@@ -1,6 +1,7 @@
 ---
 title: Set up Launch
 description: "Set up W&B Launch by configuring a queue and deploying an agent to submit jobs to your compute infrastructure."
+keywords: ["create queue", "deploy agent", "launch configuration", "FIFO queue"]
 ---
 This page describes the high-level steps required to set up W&B Launch so that you can submit machine learning jobs to your own compute infrastructure (such as Kubernetes, Amazon SageMaker, or Vertex AI) directly from W&B. Setting up Launch enables your team to share compute resources, queue jobs, and reproduce runs across environments.
 

--- a/platform/launch/setup-agent-advanced.mdx
+++ b/platform/launch/setup-agent-advanced.mdx
@@ -1,6 +1,7 @@
 ---
 title: Set up launch agent
 description: "Configure advanced agent options for W&B Launch including Docker and Kaniko builders and container registry settings."
+keywords: ["Kaniko builder", "ECR push", "GCR registry", "agent builder", "image registry"]
 ---
 # Advanced agent setup
 

--- a/platform/launch/setup-launch-docker.mdx
+++ b/platform/launch/setup-launch-docker.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tutorial: Set up W&B Launch with Docker'
 description: "Set up W&B Launch to run ML jobs using Docker on a local machine as both the agent environment and compute target."
+keywords: ["Docker queue", "local Docker", "Docker agent", "local machine launch"]
 ---
 This tutorial describes how to configure W&B Launch to use Docker on a local machine for both the launch agent environment and for the queue's target resource. By the end, you have a working Docker-based launch queue and a local launch agent ready to run ML jobs.
 

--- a/platform/launch/setup-launch-kubernetes.mdx
+++ b/platform/launch/setup-launch-kubernetes.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tutorial: Set up W&B Launch on Kubernetes'
 description: "Set up W&B Launch on a Kubernetes cluster using Helm charts, Kaniko image building, and Kubernetes job specs."
+keywords: ["Kubernetes launch", "EKS launch", "GKE launch", "K8s workloads"]
 ---
 This tutorial walks cluster administrators through setting up W&B Launch on a Kubernetes cluster so ML engineers can submit and manage training workloads directly from W&B. You can use W&B Launch to push ML workloads to a Kubernetes cluster, giving ML engineers an interface right in W&B to use the resources you already manage with Kubernetes.
 

--- a/platform/launch/setup-launch-sagemaker.mdx
+++ b/platform/launch/setup-launch-sagemaker.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tutorial: Set up W&B Launch on SageMaker'
 description: "Configure W&B Launch to submit training jobs to Amazon SageMaker with ECR, S3, and IAM setup instructions."
+keywords: ["SageMaker training", "CreateTrainingJob", "AWS launch", "ECR registry", "SageMaker queue"]
 ---
 This tutorial shows ML engineers and platform administrators how to configure W&B Launch to submit training jobs to Amazon SageMaker. By the end, you'll have the AWS resources, IAM roles, queue configuration, and Launch agent required to run SageMaker training jobs from W&B.
 

--- a/platform/launch/setup-queue-advanced.mdx
+++ b/platform/launch/setup-queue-advanced.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure launch queue
 description: "Configure advanced launch queue options including queue config templates with defaults, minimums, and maximums."
+keywords: ["queue template", "resource guardrails", "dynamic macros", "min max resources"]
 ---
 
 This page describes how to configure advanced launch queue options, including queue config templates, dynamic macros, and accelerator base images. These options help administrators enforce guardrails and tailor queues to specific compute environments.

--- a/platform/launch/setup-vertex.mdx
+++ b/platform/launch/setup-vertex.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tutorial: Set up W&B Launch on Vertex AI'
 description: "Set up W&B Launch on Google Cloud Vertex AI using CustomJob specs and Artifact Registry for ML workloads."
+keywords: ["Vertex AI training", "CustomJob", "Google Cloud launch", "GCP launch", "Artifact Registry"]
 ---
 
 This tutorial walks you through configuring W&B Launch to submit jobs for execution as Vertex AI training jobs, so you can offload training workloads to Google Cloud's managed infrastructure. With Vertex AI training jobs, you can train machine learning models using either provided or custom algorithms on the Vertex AI platform. After you start a launch job, Vertex AI manages the underlying infrastructure, scaling, and orchestration. This guide is for ML engineers and platform administrators who already use W&B Launch and want to run jobs on Google Cloud Vertex AI.

--- a/platform/launch/sweeps-on-launch.mdx
+++ b/platform/launch/sweeps-on-launch.mdx
@@ -1,6 +1,7 @@
 ---
 description: Discover how to automate hyperparamter sweeps on launch.
 title: Create sweeps with W&B Launch
+keywords: ["sweep scheduler", "hyperparameter tuning", "distributed sweep", "sweep automation"]
 ---
 <Card title="Try in Colab" href="https://colab.research.google.com/drive/1WxLKaJlltThgZyhc7dcZhDQ6cjVQDfil#scrollTo=AFEzIxA6foC7" icon="python"/>
 

--- a/platform/launch/walkthrough.mdx
+++ b/platform/launch/walkthrough.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Follow this getting started tutorial for W&B Launch covering jobs, queues, agents, and running ML workloads."
 title: 'Tutorial: W&B Launch basics'
+keywords: ["launch quickstart", "launch walkthrough", "wandb launch example", "end-to-end launch"]
 ---
 ## What is Launch
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use the W&B MCP Server
 description: "Connect your IDE or AI agent to the W&B Model Context Protocol (MCP) server to query and analyze your W&B data and documentation in natural language."
+keywords: ["MCP tool", "Cursor MCP", "Claude MCP", "AI assistant integration", "natural language queries"]
 ---
 
 Model Context Protocol (MCP) is an open standard that lets AI agents call external tools. The W&B MCP Server gives your IDE, coding assistant, or chat agent direct access to your W&B data and documentation. With this access, your agent can answer questions about your runs, traces, evaluations, and artifacts without copy-paste. For a full list of what you can do with the server, see the [W&B MCP Server capabilities](#w&b-mcp-server-capabilities) section.

--- a/platform/secrets.mdx
+++ b/platform/secrets.mdx
@@ -1,6 +1,7 @@
 ---
 description: Overview of W&B secrets, how they work, and how to get started using them.
 title: Manage secrets
+keywords: ["API key storage", "secret manager", "webhook secrets", "bearer token", "credential management"]
 ---
 
 W&B Secret Manager lets you securely and centrally store, manage, and inject _secrets_, which are sensitive strings such as access tokens, bearer tokens, API keys, or passwords. W&B features can read team secret values, which removes the need to paste them or store them in code, training scripts, or plain-text automation configuration. This page is for W&B Admins who need to create, rotate, delete, or manage access to team secrets used by webhook automations, Weave Playground, sandboxes, and LLM evaluation jobs.

--- a/platform/wb-skills.mdx
+++ b/platform/wb-skills.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use W&B Skills
 description: Install W&B Skills to teach your coding agent how to train models, build agents, and analyze experiments using W&B's AI development platform.
+keywords: ["Claude Code skills", "Codex skills", "agent instructions", "coding agent", "skill installation"]
 ---
 
 W&B Skills are reusable instruction sets that teach coding agents how to use W&B effectively. Instead of manually guiding your agent through W&B APIs and best practices, install Skills so that the agent can work with experiment tracking, tracing, evaluations, and monitoring on its own.


### PR DESCRIPTION
## Summary

- Adds `keywords` frontmatter to all 83 `platform/` pages touched by the style-guide pass in PR #2674.
- Applies the keyword guidance introduced in `docs-skills` commit [732f738](https://github.com/coreweave/docs-skills/commit/732f738152c6bcac7aba596a9867f07ca1e57df2) (`feat(skills): add frontmatter keyword guidance to author-docs and style-guide`).
- Each page gets 3–7 keywords following the published rules: acronyms/alternate names not in the title, specific technology names not in the title or description, and action phrases for task-oriented pages. Phrases are preferred over single words.

## Keyword strategy by section

| Section | Keyword focus |
|---------|---------------|
| Settings pages | Action phrases (account settings, create team), specific integrations (Auth0, GitHub) |
| Hosting / deployment | Technology names (CMEK, PrivateLink, Helm chart), acronyms (BYOB, SaaS) |
| Data security | Provider-specific terms (PrivateLink, VPC endpoint, SAS tokens, KMS) |
| IAM | Protocols and providers (SCIM 2.0, RFC 7523, Keycloak, Entra ID, LDAP bind) |
| Self-managed | Infrastructure terms (air gap install, Kaniko, OpenShift, operator install) |
| Launch | CLI commands (wandb job create, wandb launch -d), platform targets (SageMaker, Vertex AI, EKS) |
| MCP / Skills | Tool names (Cursor MCP, Claude MCP, Claude Code skills) |

## Files changed

All 83 files from PR #2674, now with `keywords:` added. No other content changes.

## Test plan

- [ ] Verify a sample of pages render correctly in a local Mintlify build (`mint dev`)
- [ ] Confirm keywords appear in Mintlify search results for terms like "CMEK", "PrivateLink", "Kaniko", "SCIM 2.0"