### PR TITLE
style: apply /style-guide pass to models/automations

### DIFF
--- a/models/automations/api.mdx
+++ b/models/automations/api.mdx
@@ -7,7 +7,7 @@ keywords: ["Python API", "programmatic automation", "wandb.Api", "automation scr
 Manage W&B automations programmatically with the `wandb` Python API when you script automation workflows instead of using the W&B App.
 
 <Note>
-Programmatic **create** and **update** for automations through `wandb.Api().create_automation()` and related helpers can fail on some `wandb` Python client versions because of a client-side feature check (for example, run-state automations). Until a fixed SDK ships, use the [W&B App](/models/automations/create-automations) to create and edit automations. The `list`, `get`, and `delete` methods might still work for your version. If you encounter errors, use the W&B App. Internal tracking: WB-34263.
+Programmatic **create** and **update** for automations through `wandb.Api().create_automation()` and related helpers can fail on some `wandb` Python client versions because of a client-side feature check (for example, run-state automations). Until a fixed SDK ships, use the [W&B App](/models/automations/create-automations) to create and edit automations. The `list`, `get`, and `delete` methods aren't affected. Internal tracking: WB-34263.
 </Note>
 
 ## Next steps

--- a/models/automations/api.mdx
+++ b/models/automations/api.mdx
@@ -1,12 +1,7 @@
 ---
 title: Manage automations with the API
 description: Programmatic automation management with the Python API. Create and update may be affected on some client versions. Prefer the W&B App until the SDK fix ships.
-keywords:
-  - Python API
-  - programmatic automation
-  - wandb.Api
-  - automation scripting
-  - SDK
+keywords: ["Python API", "programmatic automation", "wandb.Api", "automation scripting", "SDK"]
 ---
 
 Manage W&B automations programmatically with the `wandb` Python API when you script automation workflows instead of using the W&B App.

--- a/models/automations/api.mdx
+++ b/models/automations/api.mdx
@@ -1,13 +1,23 @@
 ---
 title: Manage automations with the API
-description: Programmatic automation management with the Python API (create and update may be affected on some client versions; prefer the W&B App until the SDK fix ships).
+description: Programmatic automation management with the Python API. Create and update may be affected on some client versions. Prefer the W&B App until the SDK fix ships.
+keywords:
+  - Python API
+  - programmatic automation
+  - wandb.Api
+  - automation scripting
+  - SDK
 ---
 
+Manage W&B automations programmatically with the `wandb` Python API when you script automation workflows instead of using the W&B App.
+
 <Note>
-Programmatic **create** and **update** for automations through `wandb.Api().create_automation()` and related helpers can fail on recent `wandb` Python clients because of a client-side feature check (for example, run-state automations). Use the [W&B App](/models/automations/create-automations) to create and edit automations until a fixed SDK ships. List, get, and delete may still work for your version; if you hit errors, rely on the App. Internal tracking: WB-34263.
+Programmatic **create** and **update** for automations through `wandb.Api().create_automation()` and related helpers can fail on some `wandb` Python client versions because of a client-side feature check (for example, run-state automations). Until a fixed SDK ships, use the [W&B App](/models/automations/create-automations) to create and edit automations. The `list`, `get`, and `delete` methods might still work for your version. If you encounter errors, use the W&B App. Internal tracking: WB-34263.
 </Note>
 
 ## Next steps
+
+Refer to the following resources to manage automations and learn more about how they work:
 
 - [Automations overview](/models/automations)
 - [Create an automation](/models/automations/create-automations) (W&B App)

--- a/models/automations/automation-events.mdx
+++ b/models/automations/automation-events.mdx
@@ -1,6 +1,12 @@
 ---
 title: Automation events and scopes
 description: "Learn about events and scopes that trigger W&B Automations, including artifact changes, run status, and metric conditions."
+keywords:
+  - automation triggers
+  - artifact alias
+  - run status
+  - metric threshold
+  - z-score
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 import MultiTenantCloudOnly from "/snippets/_includes/multi-tenant-cloud-only.mdx";
@@ -9,41 +15,48 @@ import MultiTenantCloudOnly from "/snippets/_includes/multi-tenant-cloud-only.md
 <EnterpriseCloudOnly/>
 </Info>
 
-An automation can start when a specific event occurs within a project or registry. This page describes the events that can trigger an automation within each scope. Learn more about automations in the [Automations overview](/models/automations) or [Create an automation](/models/automations/create-automations).
+An automation can start when a specific event occurs within a project or registry. This page describes the events that can trigger an automation within each scope, so you can choose the right trigger when you configure an automation. Learn more about automations in the [Automations overview](/models/automations) or [Create an automation](/models/automations/create-automations).
 
 ## Registry
-This section describes the scopes and events for an automation in a [Registry](/models/registry).
+
+The following sections describe the scopes and events for an automation in a [Registry](/models/registry).
 
 ### Scopes
+
 A [Registry](/models/registry) automation watches for the event taking place on any collection within a specific registry, including collections added in the future.
 
 ### Events <a id="registry-events" aria-label="Registry events"></a>
+
 A Registry automation can watch for these events:
-- **A new version is linked to a collection**: Test and validate new models or datasets when they are added to a registry.
+- **A new version is linked to a collection**: Test and validate new models or datasets when they're added to a registry.
 - **An artifact alias is added**: Trigger a specific step of your workflow when a new artifact version has a specific alias applied. For example, deploy a model when it has the `production` alias applied.
 
 When the automation calls a webhook, it can access the same team-level webhook configurations and [team secrets](/platform/secrets) as project-scoped automations.
 
 ## Project
-This section describes the scopes and events for an automation in a [project](/models/track/project-page).
+
+The following sections describe the scopes and events for an automation in a [project](/models/track/project-page).
 
 ### Scopes
+
 A project-level automation watches for the event taking place on any collection in the project. Depending on the event you specify, you can further limit the scope of the automation.
 
 ### Artifact events
+
 This section describes the events related to an artifact that can trigger an automation.
 
 - **A new version is added to an artifact**: Apply recurring actions to each version of an artifact. For example, start a training job when a new dataset artifact version is created.
-- **An artifact alias is added**: Trigger a specific step of your workflow when a new artifact version in a project has an alias applied that matches the **Alias regex** you specify. For example, run a series of downstream processing steps when an artifact has the `test-set-quality-check` alias applied, or run a workflow each time a new artifact version has the `latest` alias. Only one artifact version can have a given alias at a point in time.
-- **An artifact tag is added**: Trigger a specific step of your workflow when an artifact version in a project has a tag applied that matches the **Tag regex** you specify. For example, specify `^europe.*` to trigger a geo-specific workflow when a tag beginning with the string `europe` is added to an artifact version. Artifact tags are used for grouping and filtering, and a given tag can be assigned to multiple artifact versions simultaneously.
+- **An artifact alias is added**: Trigger a specific step of your workflow when a new artifact version in a project has an alias applied that matches the **Alias regex** you specify. For example, run a series of downstream processing steps when an artifact has the `test-set-quality-check` alias applied, or run a workflow each time a new artifact version has the `latest` alias. Only one artifact version can have a given alias at a time.
+- **An artifact tag is added**: Trigger a specific step of your workflow when an artifact version in a project has a tag applied that matches the **Tag regex** you specify. For example, specify `^europe.*` to trigger a geo-specific workflow when a tag beginning with the string `europe` is added to an artifact version. Use artifact tags for grouping and filtering. You can assign a given tag to multiple artifact versions simultaneously.
 
 ### Run events
-An automation can be triggered by a change in a [run's status](/models/runs/run-states) or a change in a [metric value](/models/track/log#what-data-is-logged-with-specific-wb-api-calls).
+
+The following sections describe the events related to runs that can trigger an automation. A change in a [run's status](/models/runs/run-states) or a change in a [metric value](/models/track/log#what-data-is-logged-with-specific-wb-api-calls) can trigger an automation.
 
 #### Run status change
 <Note>
 - <MultiTenantCloudOnly/>
-- A run with **Killed** status cannot trigger an automation. This status indicates that the run was stopped forcibly by an admin user.
+- A run with **Killed** status can't trigger an automation. This status indicates that an admin user forcibly stopped the run.
 </Note>
 
 Trigger a workflow when a run changes its [status](/models/runs/run-states) to **Running**, **Finished**, or **Failed**. Optionally, you can further limit the runs that can trigger an automation by specifying a user or run name filter.
@@ -63,12 +76,13 @@ Trigger a workflow based on a logged value for a metric, either a metric in a ru
 
 You can create a run metrics automation from the project's **Automations** tab or directly from a line plot panel in a workspace.
 
-To set up a run metric automation, you configure how to compare the metric's value with the threshold you specify. Your choices depend on the event type and on any filters you specify.
+To set up a run metric automation, configure how to compare the metric's value with the threshold you specify. Your choices depend on the event type and on any filters you specify.
 
 Optionally, you can further limit the runs that can trigger an automation by specifying a user or run name filter.
 
 ##### Threshold
-For **Run metrics threshold met** events, you configure:
+
+Use a threshold event to start an automation when a metric crosses a fixed value. For **Run metrics threshold met** events, configure:
 1. The window of most recently logged values to consider (defaults to 5).
 1. Whether to evaluate the **Average**, **Min**, or **Max** value within the window.
 1. The comparison to make:
@@ -79,21 +93,22 @@ For **Run metrics threshold met** events, you configure:
       - Not equal to
       - Equal to
 
-For example, trigger an automation when average `accuracy` is above `.6`.
+For example, trigger an automation when average `accuracy` is above `0.6`.
 
 <Frame>
 ![Screenshot showing a run metrics threshold automation](/images/automations/run_metrics_threshold_automation.png)
 </Frame>
 
 ##### Change threshold
-For **Run metrics change threshold met** events, the automation uses two "windows" of values to check whether to start:
+
+Use a change threshold event to start an automation when a metric shifts between two recent windows of values. For **Run metrics change threshold met** events, the automation uses two "windows" of values to check whether to start:
 
 - The _current window_ of recently logged values to consider (defaults to 10).
 - The _prior window_ of recently logged values to consider (defaults to 50).
 
-The current and prior windows are consecutive and do not overlap.
+The current and prior windows are consecutive and don't overlap.
 
-To create the automation, you configure:
+To create the automation, configure:
 1. The current window of logged values (defaults to 10).
 1. The prior window of logged values (defaults to 50).
 1. Whether to evaluate the values as relative or absolute (defaults to **Relative**).
@@ -102,7 +117,7 @@ To create the automation, you configure:
       - Decreases by at least
       - Increases or decreases by at least
 
-For example, trigger an automation when average `loss` decreases by at least `.25`.
+For example, trigger an automation when average `loss` decreases by at least `0.25`.
 
 <Frame>
 ![Screenshot showing a run metrics change threshold automation](/images/automations/run_metrics_change_threshold_automation.png)
@@ -113,7 +128,7 @@ For example, trigger an automation when average `loss` decreases by at least `.2
 <MultiTenantCloudOnly/>
 </Note>
 
-W&B can trigger an automation when a metric’s z-score (standard score) exceeds a specified threshold. A z-score measures how many standard deviations the value is from the mean for that metric across a configurable window of runs in the project (defaults to 30 runs).
+W&B can trigger an automation when a metric's z-score (standard score) exceeds a specified threshold. A z-score measures how many standard deviations the value is from the mean for that metric across a configurable window of runs in the project (defaults to 30 runs).
 
 To use a z-score as an event trigger, select the **Run metrics z-score threshold met** event.
 
@@ -121,33 +136,35 @@ Automations based on z-score keep your team informed about unusual performance w
 
 You can create a run metrics z-score automation from the project's **Automations** tab or directly from a line plot panel in a workspace.
 
-To create a z-score automation, you configure:
+To create a z-score automation, configure:
 1. The target z-score threshold, expressed as a positive float value (for example, 2.0).
 1. The window of logged values that determine the mean value (defaults to 30).
 1. The comparison to make:
-   - Above (trigger when performance is unusually high)
-   - Below (trigger when performance is unusually low)
-   - Either above or below
+   - Above (triggers when performance is unusually high).
+   - Below (triggers when performance is unusually low).
+   - Either above or below.
 
-For example, trigger an automation when `accuracy` has a z-score above 2, which means the run is performing significantly better than other runs in the project.
+For example, trigger an automation when `accuracy` has a z-score above 2, which means the run is performing well above other runs in the project.
 
-**Understanding z-score values:**
+Z-score values have the following meanings:
+
 - A z-score of 0 means the metric is at the average.
 - A z-score of +2.0 means the metric is 2 standard deviations above average.
 - A z-score of -2.0 means the metric is 2 standard deviations below average.
 - Values beyond ±2 are often considered statistically significant outliers.
 
 #### Run filters
+
 This section describes how the automation selects runs to evaluate.
 
-- By default, any run in the project triggers the automation when the event occurs. You can limit which runs trigger an automation by configuring one of the following filters: 
+- By default, any run in the project triggers the automation when the event occurs. You can limit which runs trigger an automation by configuring one of the following filters:
   - **Filter to one user's runs**: Include only runs created by the specified user.
   - **Filter on run name**: Include only runs whose names match the given regular expression.
 
   For details, see [Create automations](/models/automations/create-automations).
 - Each run is considered individually and can potentially trigger the automation.
 - Each run's values are put into a separate window and compared to the threshold separately.
-- In a 24 hour period, a particular automation can fire at most once per run.
+- In a 24-hour period, a particular automation can fire at most once per run.
 
 ## Next steps
 - [Create a Slack automation](/models/automations/create-automations/slack)

--- a/models/automations/automation-events.mdx
+++ b/models/automations/automation-events.mdx
@@ -42,16 +42,16 @@ This section describes the events related to an artifact that can trigger an aut
 
 - **A new version is added to an artifact**: Apply recurring actions to each version of an artifact. For example, start a training job when a new dataset artifact version is created.
 - **An artifact alias is added**: Trigger a specific step of your workflow when a new artifact version in a project has an alias applied that matches the **Alias regex** you specify. For example, run a series of downstream processing steps when an artifact has the `test-set-quality-check` alias applied, or run a workflow each time a new artifact version has the `latest` alias. Only one artifact version can have a given alias at a time.
-- **An artifact tag is added**: Trigger a specific step of your workflow when an artifact version in a project has a tag applied that matches the **Tag regex** you specify. For example, specify `^europe.*` to trigger a geo-specific workflow when a tag beginning with the string `europe` is added to an artifact version. Use artifact tags for grouping and filtering. You can assign a given tag to multiple artifact versions simultaneously.
+- **An artifact tag is added**: Trigger a specific step of your workflow when an artifact version in a project has a tag applied that matches the **Tag regex** you specify. For example, specify `^europe.*` to trigger a geo-specific workflow when a tag beginning with the string `europe` is added to an artifact version. Use artifact tags for grouping and filtering. You can assign the same tag to multiple artifact versions.
 
 ### Run events
 
-The following sections describe the events related to runs that can trigger an automation. A change in a [run's status](/models/runs/run-states) or a change in a [metric value](/models/track/log#what-data-is-logged-with-specific-wb-api-calls) can trigger an automation.
+The following sections describe how to configure an automation that starts based on a change in a [run's status](/models/runs/run-states) or a change in a [run's metric value](/models/track/log#what-data-is-logged-with-specific-wb-api-calls).
 
 #### Run status change
 <Note>
 - <MultiTenantCloudOnly/>
-- A run with **Killed** status can't trigger an automation. This status indicates that an admin user forcibly stopped the run.
+- A run with **Killed** status can't trigger an automation. This status indicates that an admin forcibly stopped the run.
 </Note>
 
 Trigger a workflow when a run changes its [status](/models/runs/run-states) to **Running**, **Finished**, or **Failed**. Optionally, you can further limit the runs that can trigger an automation by specifying a user or run name filter.
@@ -152,14 +152,20 @@ Z-score values have the following meanings:
 
 This section describes how the automation selects runs to evaluate.
 
-- By default, any run in the project triggers the automation when the event occurs. You can limit which runs trigger an automation by configuring one of the following filters:
-  - **Filter to one user's runs**: Include only runs created by the specified user.
-  - **Filter on run name**: Include only runs whose names match the given regular expression.
+By default, any run in the project triggers the automation when the event occurs. You can limit which runs trigger an automation by configuring one of the following filters:
 
-  For details, see [Create automations](/models/automations/create-automations).
+| Filter | Description |
+|--------|-------------|
+| **Filter to one user's runs** | Include only runs created by the specified user. |
+| **Filter on run name** | Include only runs whose names match the given regular expression. |
+
+The automation evaluates each run as follows:
+
 - Each run is considered individually and can potentially trigger the automation.
 - Each run's values are put into a separate window and compared to the threshold separately.
 - In a 24-hour period, a particular automation can fire at most once per run.
+
+For details, see [Create automations](/models/automations/create-automations).
 
 ## Next steps
 - [Create a Slack automation](/models/automations/create-automations/slack)

--- a/models/automations/automation-events.mdx
+++ b/models/automations/automation-events.mdx
@@ -1,12 +1,7 @@
 ---
 title: Automation events and scopes
 description: "Learn about events and scopes that trigger W&B Automations, including artifact changes, run status, and metric conditions."
-keywords:
-  - automation triggers
-  - artifact alias
-  - run status
-  - metric threshold
-  - z-score
+keywords: ["automation triggers", "artifact alias", "run status", "metric threshold", "z-score"]
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 import MultiTenantCloudOnly from "/snippets/_includes/multi-tenant-cloud-only.mdx";

--- a/models/automations/create-automations.mdx
+++ b/models/automations/create-automations.mdx
@@ -1,12 +1,7 @@
 ---
 title: Overview
 description: Create and manage W&B automations to streamline your ML workflows
-keywords:
-  - automations
-  - Slack notifications
-  - webhooks
-  - registry events
-  - W&B secrets
+keywords: ["automations", "Slack notifications", "webhooks", "registry events", "W&B secrets"]
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 

--- a/models/automations/create-automations.mdx
+++ b/models/automations/create-automations.mdx
@@ -1,6 +1,12 @@
 ---
 title: Overview
 description: Create and manage W&B automations to streamline your ML workflows
+keywords:
+  - automations
+  - Slack notifications
+  - webhooks
+  - registry events
+  - W&B secrets
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 
@@ -8,33 +14,39 @@ import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 <EnterpriseCloudOnly/>
 </Info>
 
-This page gives an overview of creating and managing W&B [automations](/models/automations). For more detailed instructions, refer to [Create a Slack automation](/models/automations/create-automations/slack) or [Create a webhook automation](/models/automations/create-automations/webhook).
+This page gives an overview of how to create and manage W&B [automations](/models/automations), which let you trigger Slack notifications or webhooks in response to project and registry events. Use this overview to understand the prerequisites and high-level workflow before following the detailed instructions in [Create a Slack automation](/models/automations/create-automations/slack) or [Create a webhook automation](/models/automations/create-automations/webhook).
 
 <Note>
 Looking for companion tutorials for automations? 
-- [Learn to automatically trigger a Github Action for model evaluation and deployment](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw).
-- [Watch a video demonstrating automatically deploying a model to a Sagemaker endpoint](https://www.youtube.com/watch?v=s5CMj_w3DaQ).
+- [Learn to automatically trigger a GitHub Action for model evaluation and deployment](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw).
+- [Watch a video demonstrating automatically deploying a model to a SageMaker endpoint](https://www.youtube.com/watch?v=s5CMj_w3DaQ).
 - [Watch a video series introducing automations](https://youtube.com/playlist?list=PLD80i8An1OEGECFPgY-HPCNjXgGu-qGO6&feature=shared).
 </Note>
 
 ## Requirements
+
+The following requirements apply when creating automations:
+
 - A team admin can create and manage automations for the team's projects, as well as components of their automations, such as webhooks, secrets, and Slack integrations. Refer to [Team settings](/platform/app/settings-page/teams).
 - To create a registry automation, you must have access to the registry. Refer to [Configure Registry access](/models/registry/configure_registry/#registry-roles).
 - To create a Slack automation, you must have permission to post to the Slack instance and channel you select.
 
 ## Create an automation
+
 Create an automation from the project or registry's **Automations** tab. At a high level, to create an automation, follow these steps:
 
-1. If necessary, [create a W&B secret](/platform/secrets) for each sensitive string required by the automation, such as an access token, password, or SSH key. Secrets are defined in your **Team Settings**. Secrets are most commonly used in webhook automations.
-1. Configure team-level webhook or Slack integrations to authorize W&B to post to Slack or run the webhook on your behalf. A single webhook or Slack integration can be used by multiple automations. These actions are defined in your **Team Settings**. 
+1. If necessary, [create a W&B secret](/platform/secrets) for each sensitive string required by the automation, such as an access token, password, or SSH key. Storing these values as secrets keeps credentials out of automation configurations and lets you reuse them safely. Define secrets in your **Team Settings**. Webhook automations most commonly use secrets.
+1. Configure team-level webhook or Slack integrations to authorize W&B to post to Slack or run the webhook on your behalf. Multiple automations can use a single webhook or Slack integration. Define these actions in your **Team Settings**.
 1. In the project or registry, create the automation, which specifies the event to watch for and the action to take (such as posting to Slack or running a webhook). When you create a webhook automation, you configure the payload it sends.
 
-Or, from a line plot in the workspace, you can quickly create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows:
+After you complete these steps, the automation runs on your behalf whenever the specified event occurs in the project or registry.
+
+From a line plot in the workspace, you can also create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows:
 
 1. Hover over the panel, then click the bell icon at the top of the panel.
 
     <Frame>
-    <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location"  />
+    <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location" />
     </Frame>
 1. Configure the automation using the basic or advanced configuration controls. For example, apply a run filter to limit the scope of the automation, or configure an absolute threshold.
 
@@ -44,14 +56,18 @@ For details, refer to:
 - [Create a webhook automation](/models/automations/create-automations/webhook)
 
 ## View and manage automations
-View and manage automations from a project or registry's **Automations** tab.
+
+After you create an automation, view and manage it from a project or registry's **Automations** tab:
 
 - To view an automation's details, click its name.
-- To view an automation's execution history, click its name and select the **History** tab. See [View an automation's history](/models/automations/view-automation-history) for details.
+- To view an automation's execution history, click its name and select the **History** tab. For more information, see [View an automation's history](/models/automations/view-automation-history).
 - To edit an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit automation**.
 - To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**.
 
 ## Next steps
+
+For more information, see the following resources:
+
 - [Automations tutorials](/models/automations/tutorial): Build a [project run failure alert](/models/automations/project-automation-tutorial) or a [registry alias-to-webhook automation](/models/automations/registry-automation-tutorial) in the W&B App.
 - [Automation events and scopes](/models/automations/automation-events).
 - [Create a Slack automation](/models/automations/create-automations/slack).

--- a/models/automations/create-automations.mdx
+++ b/models/automations/create-automations.mdx
@@ -9,7 +9,7 @@ import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 <EnterpriseCloudOnly/>
 </Info>
 
-This page gives an overview of how to create and manage W&B [automations](/models/automations), which let you trigger Slack notifications or webhooks in response to project and registry events. Use this overview to understand the prerequisites and high-level workflow before following the detailed instructions in [Create a Slack automation](/models/automations/create-automations/slack) or [Create a webhook automation](/models/automations/create-automations/webhook).
+This page shows how to create and manage W&B [automations](/models/automations), which let you trigger Slack notifications or webhooks in response to project and registry events. Use this overview to understand the prerequisites and high-level workflow, then follow the detailed instructions in [Create a Slack automation](/models/automations/create-automations/slack) or [Create a webhook automation](/models/automations/create-automations/webhook).
 
 <Note>
 Looking for companion tutorials for automations? 
@@ -20,7 +20,7 @@ Looking for companion tutorials for automations?
 
 ## Requirements
 
-The following requirements apply when creating automations:
+When creating automations:
 
 - A team admin can create and manage automations for the team's projects, as well as components of their automations, such as webhooks, secrets, and Slack integrations. Refer to [Team settings](/platform/app/settings-page/teams).
 - To create a registry automation, you must have access to the registry. Refer to [Configure Registry access](/models/registry/configure_registry/#registry-roles).
@@ -28,13 +28,19 @@ The following requirements apply when creating automations:
 
 ## Create an automation
 
-Create an automation from the project or registry's **Automations** tab. At a high level, to create an automation, follow these steps:
+You can create an automation from the project or registry's **Automations** tab, or directly from a line plot panel in the workspace.
 
-1. If necessary, [create a W&B secret](/platform/secrets) for each sensitive string required by the automation, such as an access token, password, or SSH key. Storing these values as secrets keeps credentials out of automation configurations and lets you reuse them safely. Define secrets in your **Team Settings**. Webhook automations most commonly use secrets.
+### Create from the Automations tab
+
+At a high level, to create an automation from the **Automations** tab, follow these steps:
+
+1. If necessary, [create a W&B secret](/platform/secrets) for each sensitive string required by the automation, such as an access token, password, or SSH key. Secrets let you reuse sensitive strings safely and keep them out of automation configurations. Define secrets in your **Team Settings**. Webhook automations most commonly use secrets.
 1. Configure team-level webhook or Slack integrations to authorize W&B to post to Slack or run the webhook on your behalf. Multiple automations can use a single webhook or Slack integration. Define these actions in your **Team Settings**.
 1. In the project or registry, create the automation, which specifies the event to watch for and the action to take (such as posting to Slack or running a webhook). When you create a webhook automation, you configure the payload it sends.
 
-After you complete these steps, the automation runs on your behalf whenever the specified event occurs in the project or registry.
+After you complete these steps, the automation runs whenever the specified event occurs in the project or registry.
+
+### Create a run metric automation from a workspace panel
 
 From a line plot in the workspace, you can also create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows:
 
@@ -52,14 +58,14 @@ For details, refer to:
 
 ## View and manage automations
 
-After you create an automation, view and manage it from a project or registry's **Automations** tab:
+View and manage automations from a project or registry's **Automations** tab:
 
 - To view an automation's details, click its name.
-- To view an automation's execution history, click its name and select the **History** tab. For more information, see [View an automation's history](/models/automations/view-automation-history).
+- To view an automation's execution history (which actions ran and whether they succeeded), click its name and select the **History** tab. For more information, see [View an automation's history](/models/automations/view-automation-history).
 - To edit an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit automation**.
 - To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**.
 
-## Next steps
+## Go further
 
 For more information, see the following resources:
 

--- a/models/automations/create-automations/slack.mdx
+++ b/models/automations/create-automations/slack.mdx
@@ -58,7 +58,7 @@ A Registry admin can create automations in that registry.
 1. Provide a name for the automation. Optionally, provide a description.
 1. Click **Create automation**.
 
-   The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the registry.
+The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the registry.
 </Tab>
 <Tab title="Project">
 A W&B admin can create automations in a project.
@@ -66,7 +66,7 @@ A W&B admin can create automations in a project.
 1. Log in to W&B.
 1. Go to the project page and click the **Automations** tab, then click **Create automation**.
 
-    Or, from a line plot in the workspace, you can create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
+    Or, directly from a line plot in the workspace, you can create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
     <Frame>
     <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location"  />
     </Frame>
@@ -84,7 +84,7 @@ A W&B admin can create automations in a project.
 1. Provide a name for the automation. Optionally, provide a description.
 1. Click **Create automation**.
 
-   The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the project.
+The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the project.
 </Tab>
 </Tabs>
 

--- a/models/automations/create-automations/slack.mdx
+++ b/models/automations/create-automations/slack.mdx
@@ -1,12 +1,7 @@
 ---
 title: Create a Slack automation
 description: "Set up a Slack integration and create a W&B Automation that sends notifications to a Slack channel on specific events."
-keywords:
-  - Slack integration
-  - notifications
-  - automation events
-  - registry automation
-  - project automation
+keywords: ["Slack integration", "notifications", "automation events", "registry automation", "project automation"]
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 

--- a/models/automations/create-automations/slack.mdx
+++ b/models/automations/create-automations/slack.mdx
@@ -1,6 +1,12 @@
 ---
 title: Create a Slack automation
 description: "Set up a Slack integration and create a W&B Automation that sends notifications to a Slack channel on specific events."
+keywords:
+  - Slack integration
+  - notifications
+  - automation events
+  - registry automation
+  - project automation
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 
@@ -8,25 +14,28 @@ import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 <EnterpriseCloudOnly/>
 </Info>
 
-This page shows how to create a Slack [automation](/models/automations). To create a webhook automation, refer to [Create a webhook automation](/models/automations/create-automations/webhook) instead.
+This page shows how to create a Slack [automation](/models/automations) so that your team receives notifications in a Slack channel when specific events occur in W&B. Example events include a new model version or a run reaching a metric threshold. To create a webhook automation instead, refer to [Create a webhook automation](/models/automations/create-automations/webhook).
 
 At a high level, to create a Slack automation, you take these steps:
+
 1. [Add a Slack integration](#add-a-slack-integration), which authorizes W&B to post to the Slack instance and channel.
 1. [Create the automation](#create-an-automation), which defines the [event](/models/automations/automation-events) to watch for and the channel to notify.
 
 ## Add a Slack integration
+
 A team admin can add a Slack integration to the team.
 
 1. Log in to W&B and go to **Team Settings**.
 1. In the **Slack channel integrations** section, click **Connect Slack** to add a new Slack instance. To add a channel for an existing Slack instance, click **New integration**.
 
-    ![Screenshot showing two Slack integrations in a Team](/images/automations/slack_integrations.png)
+    ![Two Slack integrations in a Team](/images/automations/slack_integrations.png)
 1. If necessary, sign in to Slack in your browser. When prompted, grant W&B permission to post to the Slack channel you select. Read the page, then click **Search for a channel** and begin typing the channel name. Select the channel from the list, then click **Allow**.
-1. In Slack, go to the channel you selected. If you see a post like `[Your Slack handle] added an integration to this channel: Weights & Biases`, the integration is configured correctly.
+1. In Slack, go to the channel you selected. If you see a post like `[YOUR-SLACK-HANDLE] added an integration to this channel: Weights & Biases`, where `[YOUR-SLACK-HANDLE]` is your Slack username, the integration is configured correctly.
 
 Now you can [create an automation](#create-an-automation) that notifies the Slack channel you configured.
 
 ## View and manage Slack integrations
+
 A team admin can view and manage the team's Slack instances and channels.
 
 1. Log in to W&B and go to **Team Settings**.
@@ -34,14 +43,15 @@ A team admin can view and manage the team's Slack instances and channels.
 1. Delete a destination by clicking its trash icon.
 
 ## Create an automation
-After you [add a Slack integration](#add-a-slack-integration), select **Registry** or **Project**, then follow these steps to create an automation that notifies the Slack channel.
+
+After you [add a Slack integration](#add-a-slack-integration), you can create an automation that uses it to send notifications. Select **Registry** or **Project** based on the scope you want the automation to apply to. Then follow these steps to create an automation that notifies the Slack channel.
 
 <Tabs>
 <Tab title="Registry">
 A Registry admin can create automations in that registry.
 
 1. Log in to W&B.
-1. Click the name of a registry to view its details, 
+1. Click the name of a registry to view its details.
 1. To create an automation scoped to the registry, click the **Automations** tab, then click **Create automation**. An automation that is scoped to a registry is automatically applied to all of its collections (including those created in the future).
 1. Choose the [event](/models/automations/automation-events/#registry-events) to watch for.
 
@@ -52,14 +62,16 @@ A Registry admin can create automations in that registry.
 1. Set **Action type** to **Slack notification**. Select the Slack channel, then click **Next step**.
 1. Provide a name for the automation. Optionally, provide a description.
 1. Click **Create automation**.
+
+   The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the registry.
 </Tab>
 <Tab title="Project">
 A W&B admin can create automations in a project.
 
 1. Log in to W&B.
-1. Go the project page and click the **Automations** tab, then click **Create automation**.
+1. Go to the project page and click the **Automations** tab, then click **Create automation**.
 
-    Or, from a line plot in the workspace, you can quickly create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
+    Or, from a line plot in the workspace, you can create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
     <Frame>
     <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location"  />
     </Frame>
@@ -67,7 +79,7 @@ A W&B admin can create automations in a project.
 
     1. Fill in any additional fields that appear. For example, if you select **An artifact alias is added**, you must specify the **Alias regex**.
 
-        1. For automations triggered by a run, optionally specify one or more run filters.
+        1. For automations triggered by a run, optionally specify one or more run filters:
 
             - **Filter to one user's runs**: Include only runs created by the specified user. Click the toggle to turn on the filter, then specify a username.
             - **Filter on run name**: Include only runs whose names match the given regular expression. Click the toggle to turn on the filter, then specify a regular expression.
@@ -76,6 +88,8 @@ A W&B admin can create automations in a project.
 1. Set **Action type** to **Slack notification**. Select the Slack channel, then click **Next step**.
 1. Provide a name for the automation. Optionally, provide a description.
 1. Click **Create automation**.
+
+   The automation is now active and notifies the selected Slack channel whenever the chosen event occurs in the project.
 </Tab>
 </Tabs>
 
@@ -83,7 +97,8 @@ A W&B admin can create automations in a project.
 
 <Tabs>
 <Tab title="Registry">
-Manage the registry's automations from the registry's **Automations** tab.
+Manage the registry's automations from the registry's **Automations** tab:
+
 - To view an automation's details, click its name.
 - To edit an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit automation**.
 - To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**. Confirmation is required.

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -1,12 +1,7 @@
 ---
 title: Create a webhook automation
 description: "Create a webhook automation in W&B to send HTTP requests to external services when specific events occur."
-keywords:
-  - HTTP request
-  - GitHub Actions
-  - repository dispatch
-  - CI/CD pipeline
-  - webhook payload
+keywords: ["HTTP request", "GitHub Actions", "repository dispatch", "CI/CD pipeline", "webhook payload"]
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -1,6 +1,12 @@
 ---
 title: Create a webhook automation
 description: "Create a webhook automation in W&B to send HTTP requests to external services when specific events occur."
+keywords:
+  - HTTP request
+  - GitHub Actions
+  - repository dispatch
+  - CI/CD pipeline
+  - webhook payload
 ---
 import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 
@@ -8,50 +14,53 @@ import EnterpriseCloudOnly from "/snippets/_includes/enterprise-cloud-only.mdx";
 <EnterpriseCloudOnly/>
 </Info>
 
-This page shows how to create a webhook [automation](/models/automations). To create a Slack automation, refer to [Create a Slack automation](/models/automations/create-automations/slack) instead.
+This page shows how to create a webhook [automation](/models/automations), which sends an HTTP request to an external service when a specific event occurs in W&B. Use a webhook automation to integrate W&B with external systems such as CI/CD pipelines, notification services, or custom tooling. To create a Slack automation, refer to [Create a Slack automation](/models/automations/create-automations/slack) instead.
 
 At a high level, to create a webhook automation, you take these steps:
+
 1. If necessary, [create a W&B secret](/platform/secrets) for each sensitive string required by the automation, such as an access token, password, or SSH key. Secrets are defined in your **Team Settings**.
 1. [Create a webhook](#create-a-webhook) to define the endpoint and authorization details and grant the integration access to any secrets it needs.
-1. [Create the automation](#create-an-automation) to define the [event](/models/automations/automation-events) to watch for and the payload W&B will send. Grant the automation access to any secrets it needs for the payload.
+1. [Create the automation](#create-an-automation) to define the [event](/models/automations/automation-events) to watch for and the payload W&B sends. Grant the automation access to any secrets it needs for the payload.
 
 ## Create a webhook
-A team admin can add a webhook for the team.
+
+A team admin can add a webhook for the team. The webhook defines the endpoint W&B sends requests to and any credentials required to authenticate with it.
 
 <Note>
-If the webhook requires a Bearer token or its payload requires a sensitive string, [create a secret that contains it](/platform/secrets/#add-a-secret) before creating the webhook. You can configure at most one access token and one other secret for a webhook. Your webhook's authentication and authorization requirements are determined by the webhook's service.
+If the webhook requires a Bearer token or its payload requires a sensitive string, [create a secret that contains it](/platform/secrets/#add-a-secret) before creating the webhook. You can configure at most one access token and one other secret for a webhook. The webhook's service determines your webhook's authentication and authorization requirements.
 </Note>
 
-1. Log in to W&B and go to **Team Settings** page.
+1. Log in to W&B and go to the **Team Settings** page.
 1. In the **Webhooks** section, click **New webhook**.
-1. Provide a name for the webhook. 
-1. Provide the endpoint URL for the webhook.
-1. If the webhook requires a Bearer token, set **Access token** to the [secret](/platform/secrets) that contains it. When using the webhook automation, W&B sets the `Authorization: Bearer` HTTP header to the access token, and you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). Learn more about the structure of the `POST` request W&B sends to the webhook service in [Troubleshoot your webhook](#troubleshoot-your-webhook).
+1. Provide a name for the webhook.
+1. Provide the endpoint URL of the webhook.
+1. If the webhook requires a Bearer token, set **Access token** to the [secret](/platform/secrets) that contains it. When using the webhook automation, W&B sets the `Authorization: Bearer` HTTP header to the access token, and you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). For more information about the structure of the `POST` request W&B sends to the webhook service, see [Troubleshoot your webhook](#troubleshoot-your-webhook).
 1. If the webhook requires a password or other sensitive string in its payload, set **Secret** to the secret that contains it. When you configure the automation that uses the webhook, you can access the secret as a [payload variable](#payload-variables) by prefixing its name with `$`.
 
     If the webhook's access token is stored in a secret, you must _also_ complete the next step to specify the secret as the access token.
-1. To verify that the W&B can connect and authenticate to the endpoint:
-    1. Optionally, provide a payload to test. To refer to a secret the webhook has access to in the payload, prefix its name with `$`. This payload is only used for testing and is not saved. You configure an automation's payload when you [create the automation](#create-a-webhook-automation). See [Troubleshoot your webhook](#troubleshoot-your-webhook) to view where the secret and access token are specified in the `POST` request.
+1. To verify that W&B can connect and authenticate to the endpoint:
+    1. Optionally, provide a payload to test. To refer to a secret the webhook has access to in the payload, prefix its name with `$`. W&B uses this payload only for testing and doesn't save it. You configure an automation's payload when you [create the automation](#create-an-automation). For more information about where the secret and access token appear in the `POST` request, see [Troubleshoot your webhook](#troubleshoot-your-webhook).
     1. Click **Test**. W&B attempts to connect to the webhook's endpoint using the credentials you configured. If you provided a payload, W&B sends it.
 
-    If the test does not succeed, verify the webhook's configuration and try again. If necessary, refer to [Troubleshoot your webhook](#troubleshoot-your-webhook).
+    If the test doesn't succeed, verify the webhook's configuration and try again. If necessary, refer to [Troubleshoot your webhook](#troubleshoot-your-webhook).
 
 <Frame>
 ![Screenshot showing two webhooks in a Team](/images/automations/webhooks.png)
 </Frame>
 
-Now you can [create an automation](#create-a-webhook-automation) that uses the webhook.
+Now you can [create an automation](#create-an-automation) that uses the webhook.
 
 ## Create an automation
-After you [configure a webhook](#create-a-webhook), select **Registry** or **Project**, then follow these steps to create an automation that triggers the webhook.
+
+After you [configure a webhook](#create-a-webhook), create an automation that defines which W&B event triggers the webhook and what payload to send. Select **Registry** or **Project** depending on the scope you want, then follow these steps to create an automation that triggers the webhook.
 
 <Tabs>
 <Tab title="Registry">
-A Registry admin can create automations in that registry. Registry automations are applied to all collections in the registry, including those added in the future.
+A Registry admin can create automations in that registry. Registry automations apply to all collections in the registry, including those added in the future.
 
 1. Log in to W&B.
-1. Click the name of a registry to view its details, 
-1. To create an automation scoped to the registry, click the **Automations** tab, then click **Create automation**. 
+1. Click the name of a registry to view its details.
+1. To create an automation scoped to the registry, click the **Automations** tab, then click **Create automation**.
 
 1. Choose the [event](/models/automations/automation-events/#registry-events) to watch for.
 
@@ -60,7 +69,7 @@ A Registry admin can create automations in that registry. Registry automations a
     Click **Next step**.
 1. Select the team that owns the [webhook](#create-a-webhook).
 1. Set **Action type** to **Webhooks**. Then select the [webhook](#create-a-webhook) to use.
-1. If you configured an access token for the webhook, you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). If you configured a secret for the webhook, you can access it in the payload by prefixing its name with `$`. Your webhook's requirements are determined by the webhook's service.
+1. If you configured an access token for the webhook, you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). If you configured a secret for the webhook, you can access it in the payload by prefixing its name with `$`. The webhook's service determines your webhook's requirements.
 1. Click **Next step**.
 1. Provide a name for the automation. Optionally, provide a description. Click **Create automation**.
 </Tab>
@@ -72,7 +81,7 @@ A W&B admin can create automations in a project.
 
     Or, from a line plot in the workspace, you can quickly create a [run metric automation](/models/automations/automation-events/#run-events) for the metric it shows. Hover over the panel, then click the bell icon at the top of the panel.
     <Frame>
-    <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location"  />
+    <img src="/images/automations/run_metric_automation_from_panel.png" alt="Automation bell icon location" />
     </Frame>
 1. Choose the [event](/models/automations/automation-events/#project) to watch for, such as when an artifact alias is added or when a run metric meets a given threshold.
 
@@ -83,44 +92,51 @@ A W&B admin can create automations in a project.
             - **Filter to one user's runs**: Include only runs created by the specified user. Click the toggle to turn on the filter, then specify a username.
             - **Filter on run name**: Include only runs whose names match the given regular expression. Click the toggle to turn on the filter, then specify a regular expression.
 
-          The automation is applied to all collections in the project, including those added in the future.
+          The automation applies to all collections in the project, including those added in the future.
     1. Click **Next step**.
 1. Select the team that owns the [webhook](#create-a-webhook).
-1. Set **Action type** to **Webhooks**. Then select the [webhook](#create-a-webhook) to use. 
-1. If your webhook requires a payload, construct it and paste it into the **Payload** field. If you configured an access token for the webhook, you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). If you configured a secret for the webhook, you can access it in the payload by prefixing its name with `$`. Your webhook's requirements are determined by the webhook's service.
+1. Set **Action type** to **Webhooks**. Then select the [webhook](#create-a-webhook) to use.
+1. If your webhook requires a payload, construct it and paste it into the **Payload** field. If you configured an access token for the webhook, you can access the token in the `${ACCESS_TOKEN}` [payload variable](#payload-variables). If you configured a secret for the webhook, you can access it in the payload by prefixing its name with `$`. The webhook's service determines your webhook's requirements.
 1. Click **Next step**.
 1. Provide a name for the automation. Optionally, provide a description. Click **Create automation**.
 </Tab>
 </Tabs>
 
+After you complete these steps, the automation is active and triggers the webhook whenever the specified event occurs in the registry or project.
+
 ## View and manage automations
+
+After you create an automation, you can review, edit, or delete it from the **Automations** tab.
+
 <Tabs>
 <Tab title="Registry">
 Manage a registry's automations from the registry's **Automations** tab.
 
 - To view an automation's details, click its name.
 - To edit an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit automation**.
-- To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**. Confirmation is required.
+- To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**. W&B prompts you to confirm.
 </Tab>
 <Tab title="Project">
 A W&B admin can view and manage a project's automations from the project's **Automations** tab.
 
 - To view an automation's details, click its name.
 - To edit an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit automation**.
-- To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**. Confirmation is required.
+- To delete an automation, click its **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Delete automation**. W&B prompts you to confirm.
 </Tab>
 </Tabs>
 
 ## Payload reference
-Use these sections to construct your webhoook's payload. For details about testing your webhook and its payload, refer to [Troubleshoot your webhook](#troubleshoot-your-webhook).
+
+Use these sections to construct your webhook's payload. The following sections describe the variables available to your payload and show example payloads for common services. For details about testing your webhook and its payload, refer to [Troubleshoot your webhook](#troubleshoot-your-webhook).
 
 ### Payload variables
-This section describes the variables you can use to construct your webhook's payload.
+
+The following table describes the variables you can use to construct your webhook's payload.
 
 | Variable | Details |
 |----------|---------|
 | `${project_name}`             | The name of the project that owns the mutation that triggered the action. |
-| `${entity_name}`              | The name of the entity or team that owns the mutation that triggered the action.
+| `${entity_name}`              | The name of the entity or team that owns the mutation that triggered the action. |
 | `${event_type}`               | The type of event that triggered the action. |
 | `${event_author}`             | The user that triggered the action. |
 | `${alias}`                    | Contains an artifact's alias if the automation is triggered by the **An artifact alias is added** event. For other automations, this variable is blank. |
@@ -129,16 +145,17 @@ This section describes the variables you can use to construct your webhook's pay
 | `${artifact_metadata.<KEY>}`  | The value of an arbitrary top-level metadata key from the artifact version that triggered the action. Replace `<KEY>` with the name of a top-level metadata key. Only top-level metadata keys are available in the webhook's payload. |
 | `${artifact_version}`         | The [`Wandb.Artifact`](/models/ref/python/experiments/artifact) representation of the artifact version that triggered the action. |
 | `${artifact_version_string}` | The `string` representation of the artifact version that triggered the action. |
-| `${ACCESS_TOKEN}` | The value of the access token configured in the [webhook](#create-a-webhook), if an access token is configured. The access token is automatically passed in the `Authorization: Bearer` HTTP header. |
+| `${ACCESS_TOKEN}` | The value of the access token configured in the [webhook](#create-a-webhook), if you configured an access token. W&B automatically passes the access token in the `Authorization: Bearer` HTTP header. |
 | `${SECRET_NAME}` | If configured, the value of a secret configured in the [webhook](#create-a-webhook). Replace `SECRET_NAME` with the name of the secret. |
 
 ### Payload examples
-This section includes examples of webhook payloads for some common use cases. The examples demonstrate how to use [payload variables](#payload-variables).
+
+The following examples show webhook payloads for common use cases. The examples demonstrate how to use [payload variables](#payload-variables).
 
 <Tabs>
 <Tab title="GitHub repository dispatch">
 <Note>
-Verify that your access tokens have required set of permissions to trigger your GHA workflow. For more information, [see these GitHub Docs](https://docs.github.com/en/rest/repos/repos?#create-a-repository-dispatch-event).
+Verify that your access tokens have the required set of permissions to trigger your GitHub Actions workflow. For more information, see the [GitHub repository dispatch event documentation](https://docs.github.com/en/rest/repos/repos?#create-a-repository-dispatch-event).
 </Note>
 
 Send a repository dispatch from W&B to trigger a GitHub action. For example, suppose you have a GitHub workflow file that accepts a repository dispatch as a trigger for the `on` key:
@@ -154,7 +171,7 @@ The payload for the repository might look something like:
 ```json
 {
   "event_type": "BUILD_AND_DEPLOY",
-  "client_payload": 
+  "client_payload":
   {
     "event_author": "${event_author}",
     "artifact_version": "${artifact_version}",
@@ -170,12 +187,12 @@ The payload for the repository might look something like:
 The `event_type` key in the webhook payload must match the `types` field in the GitHub workflow YAML file.
 </Note>
 
-The contents and positioning of rendered template strings depends on the event or model version the automation is configured for. `${event_type}` will render as either `LINK_ARTIFACT` or `ADD_ARTIFACT_ALIAS`. See below for an example mapping:
+The contents and positioning of rendered template strings depend on the event or model version you configured the automation for. `${event_type}` renders as either `LINK_ARTIFACT` or `ADD_ARTIFACT_ALIAS`. The following shows an example mapping:
 
 ```text
 ${event_type} --> "LINK_ARTIFACT" or "ADD_ARTIFACT_ALIAS"
 ${event_author} --> "<wandb-user>"
-${artifact_version} --> "wandb-artifact://_id/QXJ0aWZhY3Q6NTE3ODg5ODg3""
+${artifact_version} --> "wandb-artifact://_id/QXJ0aWZhY3Q6NTE3ODg5ODg3"
 ${artifact_version_string} --> "<entity>/model-registry/<registered_model_name>:<alias>"
 ${artifact_collection_name} --> "<registered_model_name>"
 ${project_name} --> "model-registry"
@@ -184,16 +201,16 @@ ${entity_name} --> "<entity>"
 
 Use template strings to dynamically pass context from W&B to GitHub Actions and other tools. If those tools can call Python scripts, they can consume the registered model artifacts through the [W&B API](/models/artifacts/download-and-use-an-artifact).
 
+For more information about repository dispatch with W&B, see the following resources:
+
 - For more information about repository dispatch, see the [official documentation on the GitHub Marketplace](https://github.com/marketplace/actions/repository-dispatch).
-
-- Watch the videos [Webhook Automations for Model Evaluation](https://www.youtube.com/watch?v=7j-Mtbo-E74&ab_channel=Weights%26Biases) and [Webhook Automations for Model Deployment](https://www.youtube.com/watch?v=g5UiAFjM2nA&ab_channel=Weights%26Biases), which guide you to create automations for model evaluation and deployment. 
-
-- Review a W&B [report](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw), which illustrates how to use a Github Actions webhook automation for Model CI. Check out this [GitHub repository](https://github.com/hamelsmu/wandb-modal-webhook) to learn how to create model CI with a Modal Labs webhook.
+- Watch the videos [Webhook Automations for Model Evaluation](https://www.youtube.com/watch?v=7j-Mtbo-E74&ab_channel=Weights%26Biases) and [Webhook Automations for Model Deployment](https://www.youtube.com/watch?v=g5UiAFjM2nA&ab_channel=Weights%26Biases), which guide you to create automations for model evaluation and deployment.
+- Review the W&B report [Model CI/CD with W&B](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw), which illustrates how to use a GitHub Actions webhook automation for model CI. For an example of model CI with a Modal Labs webhook, see the [wandb-modal-webhook GitHub repository](https://github.com/hamelsmu/wandb-modal-webhook).
 </Tab>
 <Tab title="Microsoft Teams notification">
 This example payload shows how to notify your Teams channel using a webhook:
 
-```json 
+```json
 {
 "@type": "MessageCard",
 "@context": "http://schema.org/extensions",
@@ -218,14 +235,14 @@ This example payload shows how to notify your Teams channel using a webhook:
 }
 ```
 
-You can use template strings to inject W&B data into your payload at the time of execution (as shown in the Teams example above).
+You can use template strings to inject W&B data into your payload at the time of execution (as shown in the preceding Teams example).
 </Tab>
 <Tab title="Slack notifications">
 <Note>
-This section is provided for historical purposes. If you currently use a webhook to integrate with Slack, W&B recommends that you update your configuration to use the [new Slack integration](#create-a-slack-automation) instead.
+This section is provided for historical purposes. If you use a webhook to integrate with Slack, W&B recommends that you update your configuration to use the [Slack integration](/models/automations/create-automations/slack) instead.
 </Note>
 
-Set up your Slack app and add an incoming webhook integration with the instructions highlighted in the [Slack API documentation](https://api.slack.com/messaging/webhooks). Ensure that you have the secret specified under `Bot User OAuth Token` as your W&B webhook’s access token. 
+Set up your Slack app and add an incoming webhook integration by following the instructions in the [Slack API documentation](https://api.slack.com/messaging/webhooks). Ensure that you have the secret specified under `Bot User OAuth Token` as your W&B webhook's access token.
 
 The following is an example payload:
 
@@ -264,33 +281,34 @@ The following is an example payload:
 </Tabs>
 
 ## Troubleshoot your webhook
-Interactively troubleshoot your webhook with the W&B App UI or programmatically with a Bash script. You can troubleshoot a webhook when you create a new webhook or edit an existing webhook.
+
+If a webhook isn't behaving as expected, you can troubleshoot it interactively with the W&B App UI or programmatically with a Bash script. You can troubleshoot a webhook when you create a new webhook or edit an existing webhook.
 
 For details about the format W&B uses for the `POST` request, refer to the **Bash script** tab.
 
 <Tabs>
 <Tab title="W&B App UI">
-A team admin can test a webhook interactively with the W&B App UI. 
+A team admin can test a webhook interactively with the W&B App UI.
 
 1. Navigate to your W&B Team Settings page.
-2. Scroll to the **Webhooks** section.
-3. Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu next to the name of your webhook.
-4. Select **Test**.
-5. From the UI panel that appears, paste your POST request to the field that appears. 
+1. Scroll to the **Webhooks** section.
+1. Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu next to the name of your webhook.
+1. Select **Test**.
+1. From the UI panel that appears, paste your `POST` request into the field that appears.
     <Frame>
-    <img src="/images/models/webhook_ui.png" alt="Demo of testing a webhook payload"  />
+    <img src="/images/models/webhook_ui.png" alt="Demo of testing a webhook payload" />
     </Frame>
-6. Click on **Test webhook**. Within the W&B App UI, W&B posts the response from your endpoint.
+1. Click **Test webhook**. Within the W&B App UI, W&B posts the response from your endpoint.
     <Frame>
-    <img src="/images/models/webhook_ui_testing.gif" alt="Demo of testing a webhook"  />
+    <img src="/images/models/webhook_ui_testing.gif" alt="Demo of testing a webhook" />
     </Frame>
 
 Watch the video [Testing Webhooks in W&B](https://www.youtube.com/watch?v=bl44fDpMGJw&ab_channel=Weights%26Biases) for a demonstration.
 </Tab>
 <Tab title="Bash script">
-This shell script shows one method to generate a `POST` request similar to the request W&B sends to your webhook automation when it is triggered.
+This shell script shows one method to generate a `POST` request similar to the request W&B sends to your webhook automation when it's triggered.
 
-Copy and paste the code below into a shell script to troubleshoot your webhook. Specify your own values for:
+Copy and paste the following code into a shell script to troubleshoot your webhook. Specify your own values for:
 
 * `ACCESS_TOKEN`
 * `SECRET`

--- a/models/automations/create-automations/webhook.mdx
+++ b/models/automations/create-automations/webhook.mdx
@@ -97,11 +97,11 @@ A W&B admin can create automations in a project.
 </Tab>
 </Tabs>
 
-After you complete these steps, the automation is active and triggers the webhook whenever the specified event occurs in the registry or project.
+After you complete these steps, the automation is active and runs the webhook whenever the specified event occurs in the registry or project.
 
 ## View and manage automations
 
-After you create an automation, you can review, edit, or delete it from the **Automations** tab.
+Review, edit, or delete an automation from the **Automations** tab.
 
 <Tabs>
 <Tab title="Registry">
@@ -140,7 +140,7 @@ The following table describes the variables you can use to construct your webhoo
 | `${artifact_metadata.<KEY>}`  | The value of an arbitrary top-level metadata key from the artifact version that triggered the action. Replace `<KEY>` with the name of a top-level metadata key. Only top-level metadata keys are available in the webhook's payload. |
 | `${artifact_version}`         | The [`Wandb.Artifact`](/models/ref/python/experiments/artifact) representation of the artifact version that triggered the action. |
 | `${artifact_version_string}` | The `string` representation of the artifact version that triggered the action. |
-| `${ACCESS_TOKEN}` | The value of the access token configured in the [webhook](#create-a-webhook), if you configured an access token. W&B automatically passes the access token in the `Authorization: Bearer` HTTP header. |
+| `${ACCESS_TOKEN}` | The value of the access token configured in the [webhook](#create-a-webhook), if you configured an access token. W&B automatically passes it in the `Authorization: Bearer` HTTP header. |
 | `${SECRET_NAME}` | If configured, the value of a secret configured in the [webhook](#create-a-webhook). Replace `SECRET_NAME` with the name of the secret. |
 
 ### Payload examples
@@ -196,11 +196,12 @@ ${entity_name} --> "<entity>"
 
 Use template strings to dynamically pass context from W&B to GitHub Actions and other tools. If those tools can call Python scripts, they can consume the registered model artifacts through the [W&B API](/models/artifacts/download-and-use-an-artifact).
 
-For more information about repository dispatch with W&B, see the following resources:
+For more information, see the following resources:
 
 - For more information about repository dispatch, see the [official documentation on the GitHub Marketplace](https://github.com/marketplace/actions/repository-dispatch).
 - Watch the videos [Webhook Automations for Model Evaluation](https://www.youtube.com/watch?v=7j-Mtbo-E74&ab_channel=Weights%26Biases) and [Webhook Automations for Model Deployment](https://www.youtube.com/watch?v=g5UiAFjM2nA&ab_channel=Weights%26Biases), which guide you to create automations for model evaluation and deployment.
-- Review the W&B report [Model CI/CD with W&B](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw), which illustrates how to use a GitHub Actions webhook automation for model CI. For an example of model CI with a Modal Labs webhook, see the [wandb-modal-webhook GitHub repository](https://github.com/hamelsmu/wandb-modal-webhook).
+- Review the W&B report [Model CI/CD with W&B](https://wandb.ai/wandb/wandb-model-cicd/reports/Model-CI-CD-with-W-B--Vmlldzo0OTcwNDQw), which illustrates how to use a GitHub Actions webhook automation for model CI.
+- For an example of model CI with a Modal Labs webhook, see the [wandb-modal-webhook GitHub repository](https://github.com/hamelsmu/wandb-modal-webhook).
 </Tab>
 <Tab title="Microsoft Teams notification">
 This example payload shows how to notify your Teams channel using a webhook:
@@ -230,7 +231,7 @@ This example payload shows how to notify your Teams channel using a webhook:
 }
 ```
 
-You can use template strings to inject W&B data into your payload at the time of execution (as shown in the preceding Teams example).
+You can use template strings to inject W&B data into your payload at the time of execution. See the [Teams example](#microsoft-teams-notification).
 </Tab>
 <Tab title="Slack notifications">
 <Note>
@@ -277,15 +278,15 @@ The following is an example payload:
 
 ## Troubleshoot your webhook
 
-If a webhook isn't behaving as expected, you can troubleshoot it interactively with the W&B App UI or programmatically with a Bash script. You can troubleshoot a webhook when you create a new webhook or edit an existing webhook.
+If a webhook isn't working as expected, you can troubleshoot it interactively with the W&B App UI or programmatically with a shell script. You can troubleshoot a webhook during creation or afterward.
 
-For details about the format W&B uses for the `POST` request, refer to the **Bash script** tab.
+For details about the format W&B uses for the `POST` request, refer to the **Shell script** tab.
 
 <Tabs>
 <Tab title="W&B App UI">
 A team admin can test a webhook interactively with the W&B App UI.
 
-1. Navigate to your W&B Team Settings page.
+1. Go to your team page, then click **Settings**.
 1. Scroll to the **Webhooks** section.
 1. Click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu next to the name of your webhook.
 1. Select **Test**.
@@ -300,7 +301,7 @@ A team admin can test a webhook interactively with the W&B App UI.
 
 Watch the video [Testing Webhooks in W&B](https://www.youtube.com/watch?v=bl44fDpMGJw&ab_channel=Weights%26Biases) for a demonstration.
 </Tab>
-<Tab title="Bash script">
+<Tab title="Shell script">
 This shell script shows one method to generate a `POST` request similar to the request W&B sends to your webhook automation when it's triggered.
 
 Copy and paste the following code into a shell script to troubleshoot your webhook. Specify your own values for:

--- a/models/automations/project-automation-tutorial.mdx
+++ b/models/automations/project-automation-tutorial.mdx
@@ -1,12 +1,7 @@
 ---
 title: "Tutorial: Project run-failure alert automation"
 description: Build a run-failure alert that sends a Slack notification when a run in your project fails.
-keywords:
-  - run state change
-  - Slack notification
-  - failed run alert
-  - project-scoped automation
-  - OnRunState
+keywords: ["run state change", "Slack notification", "failed run alert", "project-scoped automation", "OnRunState"]
 ---
 import TutorialDiagramProject from "/snippets/en/_includes/automations/tutorial-diagram-project.mdx";
 import TutorialNotebook from "/snippets/en/_includes/automations/tutorial-notebook.mdx";

--- a/models/automations/project-automation-tutorial.mdx
+++ b/models/automations/project-automation-tutorial.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Tutorial: Project run-failure alert automation"
 description: Build a run-failure alert that sends a Slack notification when a run in your project fails.
+keywords:
+  - run state change
+  - Slack notification
+  - failed run alert
+  - project-scoped automation
+  - OnRunState
 ---
 import TutorialDiagramProject from "/snippets/en/_includes/automations/tutorial-diagram-project.mdx";
 import TutorialNotebook from "/snippets/en/_includes/automations/tutorial-notebook.mdx";
 import TutorialGoFurther from "/snippets/en/_includes/automations/tutorial-go-further.mdx";
 
-This tutorial walks you through building a **project** automation triggered by run status: when a run in your project transitions to **Failed**, W&B sends a Slack notification.
+This tutorial walks you through building a **project** automation triggered by run status: when a run in your project transitions to **Failed**, W&B sends a Slack notification. This automation lets your team learn about failed runs in real time, so you can investigate and remediate them instead of discovering failures later.
 
 <TutorialDiagramProject/>
 
@@ -19,7 +25,7 @@ This tutorial walks you through building a **project** automation triggered by r
 
 ## Create a project automation
 
-Follow these instructions to set up a project-scoped automation: When a run in the project transitions to **Failed**, W&B sends a Slack notification.
+Set up a project-scoped automation so that when a run in the project transitions to **Failed**, W&B sends a Slack notification.
 
 {/* W&B App vs Python tab temporarily hidden pending Python SDK fix for `create_automation` / run-state automations (internal WB-34263). Restore when the regression is shipped.
 
@@ -31,7 +37,7 @@ Follow these instructions to set up a project-scoped automation: When a run in t
 1. Click **Next step**. Set **Action type** to **Slack notification** and select the Slack channel.
 1. Click **Next step**. Give the automation a name (for example, "Run failure alert") and an optional description, then click **Create automation**.
 
-For more detail, see [Create a Slack automation](/models/automations/create-automations/slack#create-an-automation) (Project tab).
+Your project now has an active automation that posts to the Slack channel you selected when a run fails. For more detail, see [Create a Slack automation](/models/automations/create-automations/slack#create-an-automation) (Project tab).
 {/*
 </Tab>
 <Tab title="Python">
@@ -63,7 +69,8 @@ automation = api.create_automation(
 */}
 
 ## Test the automation
-Create a run and log it to the project, explicitly marking it as failed:
+
+To confirm the automation is configured correctly, trigger it with a deliberately failed run. Create a run and log it to the project, explicitly marking it as failed:
 
 ```python
 import wandb
@@ -73,7 +80,7 @@ with wandb.init(project="my-project") as run:
     run.finish(exit_code=1)
 ```
 
-Within a short time you should see a Slack message with the run link and status.
+Shortly after, you see a Slack message with the run link and status.
 
 <TutorialNotebook/>
 

--- a/models/automations/registry-automation-tutorial.mdx
+++ b/models/automations/registry-automation-tutorial.mdx
@@ -1,12 +1,7 @@
 ---
 title: "Tutorial: Registry artifact alias automation"
 description: Build an automation that runs a webhook when a Registry artifact gets a specific alias like "production".
-keywords:
-  - artifact alias
-  - model promotion
-  - MLOps webhook
-  - alias regex
-  - model lifecycle
+keywords: ["artifact alias", "model promotion", "MLOps webhook", "alias regex", "model lifecycle"]
 ---
 import TutorialDiagramRegistry from "/snippets/en/_includes/automations/tutorial-diagram-registry.mdx";
 import TutorialNotebook from "/snippets/en/_includes/automations/tutorial-notebook.mdx";

--- a/models/automations/registry-automation-tutorial.mdx
+++ b/models/automations/registry-automation-tutorial.mdx
@@ -7,7 +7,7 @@ import TutorialDiagramRegistry from "/snippets/en/_includes/automations/tutorial
 import TutorialNotebook from "/snippets/en/_includes/automations/tutorial-notebook.mdx";
 import TutorialGoFurther from "/snippets/en/_includes/automations/tutorial-go-further.mdx";
 
-This tutorial walks you through building a **registry** automation triggered by artifact metadata: when an artifact in your registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook. Use this pattern to notify downstream systems (such as a deployment pipeline, paging service, or notification channel) whenever you promote a model to a known stage. This tutorial is intended for ML engineers and MLOps practitioners who manage model lifecycles in W&B Registry.
+This tutorial walks you through building a **registry** automation triggered by artifact metadata: when an artifact in your registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook. Use this pattern to notify downstream systems like deployment pipelines, paging services, or notification channels, whenever you promote a model to a known stage. This tutorial is intended for ML engineers and MLOps practitioners who manage model lifecycles in W&B Registry.
 
 <TutorialDiagramRegistry/>
 
@@ -20,7 +20,7 @@ This tutorial walks you through building a **registry** automation triggered by 
 
 ## Create a registry automation
 
-Follow these instructions to set up a registry-scoped automation. When an artifact in any collection in that registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook.
+Set up a registry-scoped automation so that when an artifact in any collection in the registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook.
 
 {/* W&B App vs Python tab temporarily hidden pending Python SDK fix for `create_automation` (internal WB-34263). Restore when the regression is shipped.
 

--- a/models/automations/registry-automation-tutorial.mdx
+++ b/models/automations/registry-automation-tutorial.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Tutorial: Registry artifact alias automation"
 description: Build an automation that runs a webhook when a Registry artifact gets a specific alias like "production".
+keywords:
+  - artifact alias
+  - model promotion
+  - MLOps webhook
+  - alias regex
+  - model lifecycle
 ---
 import TutorialDiagramRegistry from "/snippets/en/_includes/automations/tutorial-diagram-registry.mdx";
 import TutorialNotebook from "/snippets/en/_includes/automations/tutorial-notebook.mdx";
 import TutorialGoFurther from "/snippets/en/_includes/automations/tutorial-go-further.mdx";
 
-This tutorial walks you through building a **registry** automation triggered by artifact metadata: when an artifact in your registry gets a specific alias (for example, **production**), W&B sends a POST request to your webhook.
+This tutorial walks you through building a **registry** automation triggered by artifact metadata: when an artifact in your registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook. Use this pattern to notify downstream systems (such as a deployment pipeline, paging service, or notification channel) whenever you promote a model to a known stage. This tutorial is intended for ML engineers and MLOps practitioners who manage model lifecycles in W&B Registry.
 
 <TutorialDiagramRegistry/>
 
@@ -19,7 +25,7 @@ This tutorial walks you through building a **registry** automation triggered by 
 
 ## Create a registry automation
 
-Follow these instructions to set up a registry-scoped automation: When an artifact in any collection in that registry gets a specific alias (for example, **production**), W&B sends a POST request to your webhook.
+Follow these instructions to set up a registry-scoped automation. When an artifact in any collection in that registry gets a specific alias (for example, **production**), W&B sends a `POST` request to your webhook.
 
 {/* W&B App vs Python tab temporarily hidden pending Python SDK fix for `create_automation` (internal WB-34263). Restore when the regression is shipped.
 
@@ -31,7 +37,7 @@ Follow these instructions to set up a registry-scoped automation: When an artifa
 1. Click **Next step**. Set **Action type** to **Webhooks** and select your webhook. If the webhook expects a payload, paste a JSON body and use [payload variables](/models/automations/create-automations/webhook#payload-variables) such as `${artifact_collection_name}` and `${artifact_version_string}`.
 1. Click **Next step**. Give the automation a name and optional description, then click **Create automation**.
 
-For more detail, see [Create a webhook automation](/models/automations/create-automations/webhook#create-an-automation) (Registry tab).
+For more information, see [Create a webhook automation](/models/automations/create-automations/webhook#create-an-automation) (Registry tab).
 {/*
 </Tab>
 <Tab title="Python">
@@ -71,7 +77,7 @@ automation = api.create_automation(
 
 ## Test the automation
 
-Add the alias (for example, **production**) to an artifact version in the registry, using the W&B App or the public API. For example:
+To confirm that the automation fires end-to-end, trigger the configured event by adding the alias to an artifact version. Add the alias (for example, **production**) to an artifact version in the registry, using the W&B App or the public API. For example:
 
 ```python
 import wandb
@@ -93,7 +99,7 @@ print("Added alias 'production' to", version.name)
 
 ```
 
-Within a short time your webhook endpoint should receive a POST with the payload you configured.
+Within a short time, your webhook endpoint receives a `POST` with the payload you configured. You now have a working registry automation that fires whenever a matching alias is applied to an artifact in this registry.
 
 <TutorialNotebook/>
 

--- a/models/automations/tutorial.mdx
+++ b/models/automations/tutorial.mdx
@@ -2,6 +2,12 @@
 title: Automation tutorial overview
 sidebarTitle: Overview
 description: Learn to build a project run-failure alert or a registry alias automation.
+keywords:
+  - tutorial
+  - project automation
+  - registry automation
+  - Slack alert
+  - webhook
 ---
 import AutomationsMentalModel from "/snippets/en/_includes/automations/mental-model.mdx";
 import TutorialDiagramProject from "/snippets/en/_includes/automations/tutorial-diagram-project.mdx";
@@ -9,7 +15,7 @@ import TutorialDiagramRegistry from "/snippets/en/_includes/automations/tutorial
 
 <AutomationsMentalModel/>
 
-Select a tutorial for detailed guidance.
+This page links to two end-to-end tutorials that show you how to create an automation in W&B. Each tutorial walks through a different scenario, so you can follow the one that matches what you want to build. For detailed guidance, select a tutorial.
 
 - **[Project automation tutorial](/models/automations/project-automation-tutorial)**: Alert when a run fails (Slack notification).
 - **[Registry automation tutorial](/models/automations/registry-automation-tutorial)**: Trigger a webhook when an alias (for example, `production`) is added to an artifact.

--- a/models/automations/tutorial.mdx
+++ b/models/automations/tutorial.mdx
@@ -2,12 +2,7 @@
 title: Automation tutorial overview
 sidebarTitle: Overview
 description: Learn to build a project run-failure alert or a registry alias automation.
-keywords:
-  - tutorial
-  - project automation
-  - registry automation
-  - Slack alert
-  - webhook
+keywords: ["tutorial", "project automation", "registry automation", "Slack alert", "webhook"]
 ---
 import AutomationsMentalModel from "/snippets/en/_includes/automations/mental-model.mdx";
 import TutorialDiagramProject from "/snippets/en/_includes/automations/tutorial-diagram-project.mdx";

--- a/models/automations/view-automation-history.mdx
+++ b/models/automations/view-automation-history.mdx
@@ -1,12 +1,7 @@
 ---
 title: View an automation's history
 description: "View the execution history of your W&B Automations to check status, triggering events, and action results."
-keywords:
-  - automation execution history
-  - automation troubleshooting
-  - automation audit log
-  - failed automation
-  - webhook execution status
+keywords: ["automation execution history", "automation troubleshooting", "automation audit log", "failed automation", "webhook execution status"]
 ---
 
 <Note>

--- a/models/automations/view-automation-history.mdx
+++ b/models/automations/view-automation-history.mdx
@@ -17,19 +17,20 @@ Each executed automation generates a record that includes:
 - **Action details**: Information about which action ran, such as notifying a Slack channel or running a webhook.
 - **Result details**: Additional information, if any, about the final outcome of the automation, including the error for a failed execution.
 
-Automation history is available for both registry-scoped and project-scoped automations. Select the **Registry** or **Project** tab for instructions on viewing automation history.
+Automation history is available for both registry-scoped and project-scoped automations. Select the **Registry** or **Project** tab for detailed instructions.
 
 <Tabs>
 <Tab title="Registry">
-1. Navigate to your registry by clicking **Registry** in the project sidebar.
+1. Click **Registry** in the project sidebar.
 1. Select your registry from the list.
-1. View the registry's automations in the **Automations** tab. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
+1. Navigate to the **Automations** tab, which lists the registry's automations. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
 1. View the registry's automation executions in reverse chronological order in the **Automations history** tab, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
 
 <Tip>If a collection has associated automation executions, the icon ![Collection automation execution symbol, a circle with a right-pointing arrow](/images/automations/collection-automation-execution-icon.png) displays, along with the number of associated executions.</Tip>
 </Tab>
 <Tab title="Project">
-1. Click the **Automations** tab in the project sidebar. The project's automations display. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
+1. Navigate to your project.
+1. Click the **Automations** tab in the project sidebar, which lists the project's automations. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
 1. In the **History** tab, view all executions of the project's automations in reverse chronological order. Each execution's metadata displays, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
 </Tab>
 </Tabs>

--- a/models/automations/view-automation-history.mdx
+++ b/models/automations/view-automation-history.mdx
@@ -1,64 +1,74 @@
 ---
 title: View an automation's history
 description: "View the execution history of your W&B Automations to check status, triggering events, and action results."
+keywords:
+  - automation execution history
+  - automation troubleshooting
+  - automation audit log
+  - failed automation
+  - webhook execution status
 ---
 
 <Note>
 Automation execution history is available on W&B Multi-tenant Cloud, W&B Dedicated Cloud, and W&B Self-Managed v0.75.0 and later.
 </Note>
 
-This page describes how to view and understand the execution history of your W&B [automations](/models/automations), including what triggered an automation, what actions were taken, and whether they succeeded or failed.
+This page describes how to view and understand the execution history of your W&B [automations](/models/automations). Execution history shows what triggered an automation, what actions ran, and whether they succeeded or failed. Reviewing automation history helps you confirm that automations run as expected, troubleshoot failures, and audit which events triggered downstream actions.
 
 Each executed automation generates a record that includes:
-- **Execution timestamp**: When the automation was triggered.
-- **Triggering event**: The specific event triggered the automation.
+- **Execution timestamp**: When the automation triggered.
+- **Triggering event**: The specific event that triggered the automation.
 - **Status**: The execution's status. See [Execution status](#execution-status).
-- **Action details**: Information about what action was performed, such as notifying a Slack channel or running a webhook.
-- **Result details**: Additional information, if any, about the final outcome of executing the automation, including the error for a failed execution.
+- **Action details**: Information about which action ran, such as notifying a Slack channel or running a webhook.
+- **Result details**: Additional information, if any, about the final outcome of the automation, including the error for a failed execution.
 
-Based on your use case, select the **Registry** or **Project** tab for detailed instructions for viewing automation history.
+Automation history is available for both registry-scoped and project-scoped automations. Select the **Registry** or **Project** tab for instructions on viewing automation history.
 
 <Tabs>
 <Tab title="Registry">
-1. Navigate to your registry by clicking on **Registry** in the project sidebar.
+1. Navigate to your registry by clicking **Registry** in the project sidebar.
 1. Select your registry from the list.
-1. View the registry's automations in the **Automations** tab. Click the **Last execution** timestamp to view the execution history details. You can use the search bar to filter by automation name, and you can sort by the last triggered date to find recently executed automations.
+1. View the registry's automations in the **Automations** tab. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
 1. View the registry's automation executions in reverse chronological order in the **Automations history** tab, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
 
 <Tip>If a collection has associated automation executions, the icon ![Collection automation execution symbol, a circle with a right-pointing arrow](/images/automations/collection-automation-execution-icon.png) displays, along with the number of associated executions.</Tip>
 </Tab>
 <Tab title="Project">
-1. Click the **Automations** tab in the project sidebar. The project's automations display. Click the **Last execution** timestamp to view the execution history details. You can use the search bar to filter by automation name, and you can sort by the last triggered date to find recently executed automations.
-1. In the **History** tab, view all executions of the project's automations in reverse chronological order, starting with the most recent execution. Each execution's metadata displays, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
+1. Click the **Automations** tab in the project sidebar. The project's automations display. Click the **Last execution** timestamp to view the execution history details. Use the search bar to filter by automation name, and sort by the last triggered date to find recently executed automations.
+1. In the **History** tab, view all executions of the project's automations in reverse chronological order. Each execution's metadata displays, including the event, action, and status. Click an execution timestamp to view details about a particular execution.
 </Tab>
 </Tabs>
 
-## Understanding execution details
+## Execution details
+
+After locating an execution in the history, use the following information to interpret its status and outcome.
+
+### Execution status
 
 Each automation execution has one of the following statuses:
 
 - **Finished**: The automation completed all actions successfully.
-- **Failed**: The automation encountered an error and terminated unsuccessfully.
+- **Failed**: The automation encountered an error and didn't complete.
 - **Pending**: The automation is queued for execution.
 
-Click on any execution in the history to view details:
+### Execution metadata
+
+Click any execution in the history to view the following details:
 
 - **Event details**: The specific event that triggered the automation, including:
-  - Event type (e.g., "New artifact version", "Run completed")
-  - Entity information (run ID, artifact name, etc.)
-  - User who triggered the event (if applicable)
-
-- **Action details**: Information about what the automation attempted to do:
-  - Action type (Slack notification or webhook)
-  - Target (Slack channel or webhook URL)
-  - Payload sent (for webhooks)
-
+  - Event type (for example, "New artifact version", "Run completed").
+  - Entity information, such as run ID or artifact name.
+  - User who triggered the event (if applicable).
+- **Action details**: Information about what the automation attempted:
+  - Action type (Slack notification or webhook).
+  - Target (Slack channel or webhook URL).
+  - Payload sent (for webhooks).
 - **Result information**:
-  - Response status (for webhooks)
-  - Any error messages or stack traces (for failed executions)
+  - Response status (for webhooks).
+  - Any error messages or stack traces (for failed executions).
 
 ## Next steps
 
 - [Create an automation](/models/automations/create-automations)
-- Learn about [Automation events and scopes](/models/automations/automation-events)
+- [Automation events and scopes](/models/automations/automation-events)
 - [Create a secret](/platform/secrets)


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to the `models/automations` section. The run was fully automated — no technical content changes were intended.

## Files edited

- `models/automations/api.mdx`
- `models/automations/automation-events.mdx`
- `models/automations/create-automations.mdx`
- `models/automations/create-automations/slack.mdx`
- `models/automations/create-automations/webhook.mdx`
- `models/automations/project-automation-tutorial.mdx`
- `models/automations/registry-automation-tutorial.mdx`
- `models/automations/tutorial.mdx`
- `models/automations/view-automation-history.mdx`

## Recommendations for technical review

### Prerequisites
- Consolidate implicit role and permissions prerequisites (team admin, Registry admin, W&B admin, IAM, Python tooling/`wandb login`) into explicit **Prerequisites** sections in `create-automations.mdx`, `create-automations/webhook.mdx`, `project-automation-tutorial.mdx`, `registry-automation-tutorial.mdx`, and `view-automation-history.mdx`.
- In `create-automations.mdx`, confirm the role-requirement asymmetry between the Registry tab (no admin restatement) and the Project tab ("W&B admin" restated) for view/manage flows.
- In `tutorial.mdx`, surface shared prerequisites (W&B account, project, Slack workspace, webhook endpoint) on the hub page instead of only inside each sub-tutorial.
- In `automation-events.mdx:34`, consider a prerequisite or cross-reference for readers landing directly on the Registry webhook section.
- In `create-automations/webhook.mdx`, consolidate the implicit prereqs (roles, an existing W&B secret, access to **Team Settings**) into a single block.
- In `tutorial.mdx`, surface the **Enterprise Cloud** tier requirement alongside the **Requirements** list rather than only in the `EnterpriseCloudOnly` callout.
- In `registry-automation-tutorial.mdx`, flag a minimum `wandb` Python SDK version for `api.artifact_collection`, `collection.versions()`, and `version.aliases.append`.
- In `view-automation-history.mdx:12`, verify the `W&B Self-Managed v0.75.0` minimum version is still accurate and consider moving it into a Prerequisites section; also document which roles can view automation history.

### Verification steps
- Add expected-outcome cues across procedures so readers can confirm success: where a new automation appears in the UI after **Create automation** (`create-automations.mdx`, `create-automations/webhook.mdx`, `tutorial.mdx`), what a successful webhook test looks like (`create-automations/webhook.mdx`), and what the test Slack message contains (sender, formatting, fields) in `project-automation-tutorial.mdx`.
- In `api.mdx`, the Note says `list`, `get`, and `delete` "might still work" — add a minimal example or link into the Python API reference so readers can attempt them.
- In `automation-events.mdx:165-167`, add an example or expected-behavior description for run-level evaluation (per-run windows, max once per 24 hours) so users can verify firing.
- In `create-automations.mdx`, verify the literal Slack handoff message (`[YOUR-SLACK-HANDLE] added an integration to this channel: Weights & Biases`) against actual Slack output.
- In `create-automations/webhook.mdx`, clarify what a successful vs. failed response from the W&B-posted response looks like in the troubleshooting flow.
- In `registry-automation-tutorial.mdx`, point readers to an in-product verification path (e.g., the **Automations** tab run history) and add brief troubleshooting guidance for common failure modes (alias regex mismatch, webhook auth failure, scope confusion).
- In `view-automation-history.mdx`, walk both Tab procedures (Registry and Project) in the UI to confirm click paths, tab names ("Automations history" vs. "History"), the **Last execution** column label, the `collection-automation-execution-icon.png` icon, and whether the Registry **Last execution** timestamp navigates to the **Automations history** tab or a separate detail view. Also confirm whether the single Project-tab step should be split.

### Technical accuracy
- In `api.mdx`, confirm the Note's framing (create/update fail due to client-side feature check) still matches engineering guidance, that `WB-34263` is the correct internal reference, and whether exposing that internal Jira ID publicly is acceptable.
- In `automation-events.mdx:57-60`, decide whether the `MultiTenantCloudOnly` availability notice and the **Killed** behavioral caveat belong in the same `<Note>` or should be split.
- In `automation-events.mdx:75`, confirm whether the "every 15 seconds" system metrics interval is configurable or version-dependent and consider linking the system metrics reference.
- In `automation-events.mdx:109`, consider a diagram or worked example showing how the current and prior windows align.
- In `create-automations.mdx`, confirm the side effects on dependent automations when a Slack destination is deleted, and document whether the run-filter username field accepts entity usernames vs. display names.
- In `create-automations/webhook.mdx`, validate the rewording of "the webhook's service determines your webhook's requirements"; confirm that nested artifact metadata is genuinely unsupported via `${artifact_metadata.<KEY>}`; decide between "GHA workflow" and the expanded "GitHub Actions workflow"; confirm **Bot User OAuth Token** is still the recommended secret type for the legacy Slack webhook flow and whether it should be bolded as a UI label; confirm whether the Bash shell script accurately mirrors W&B's actual `POST` or should be flagged as an approximation.
- In `project-automation-tutorial.mdx`, verify whether the commented-out Python tab (blocked by WB-34263) should be restored, removed, or updated, and confirm the regression is still open.
- In `registry-automation-tutorial.mdx`, confirm whether the **Alias regex** field accepts true regex or a literal/glob (the example `production` is ambiguous); confirm whether registry-wide scope is achievable via the Python SDK (vs. the commented `OnAddArtifactAlias(scope=collection, ...)`); verify that `next(collection.versions())` yields the newest version first; and confirm `run.wait()` is still the recommended pattern vs. `artifact.wait()` or context-manager finalization.
- In `tutorial.mdx`, decide whether the unused imports `TutorialDiagramProject` and `TutorialDiagramRegistry` should be rendered or removed.
- In `view-automation-history.mdx:21`, confirm the `#execution-status` anchor target is intended (vs. `#execution-details`); in line 51, confirm whether a **Failed** automation always halts entirely or may have partially completed actions; in lines 50–52, confirm Finished/Failed/Pending are the complete status set (no Running, Cancelled, Retrying); in line 59, verify event-type strings ("New artifact version", "Run completed") match exact UI labels.

### Missing content
- In `api.mdx`, add a one-sentence definition of "W&B automations" rather than relying on the overview link, and confirm the hidden HTML comment's restoration plan (list/get/create/update/delete examples + Automations tutorial notebook from `wandb/examples` PR 618) is still accurate; if the SDK fix is imminent, consider a temporary redirect to `/models/automations/create-automations`.
- In `automation-events.mdx`, document boundary behavior during the change-threshold warm-up before the prior window is fully populated (line 104), and confirm whether the z-score window has a minimum run count before evaluation begins (line 131).
- In `create-automations.mdx`, preview the nested numbered list in the Project tab (lines 80–86) to confirm Mintlify renders sub-steps correctly; if not, flatten to a single numbered list with embedded prose.
- In `create-automations/webhook.mdx`, re-validate the cross-reference in the Secret step that points to a "next step" about specifying the secret; confirm the Slack notifications "new Slack integration" link target `/models/automations/create-automations/slack`; reformat YAML (`on/repository_dispatch`) and JSON (`client_payload`) examples for consistent indentation; convert angle-bracket placeholders (`<wandb-user>`, `<entity>`, `<registered_model_name>`, `<alias>`) in the template-string output block to the `[ALL-CAPS-HYPHENATED]` convention; and flatten the four-level-deep nesting under "Choose the event to watch for."
- In `project-automation-tutorial.mdx`, add a brief link or note distinguishing "failed" runs from other terminal states (crashed, killed) since the filter depends on it.
- In `registry-automation-tutorial.mdx`, add **Clean up** or **Next steps** with teardown guidance (removing the test alias, disabling the automation); track restoring the commented Python tab once WB-34263 ships; confirm whether the existing payload-variables link is sufficient.
- In `tutorial.mdx`, verify that the `<AutomationsMentalModel/>` snippet provides sufficient framing; if not, add a brief "Who this is for" or "Before you begin" pointer on the hub.
- In `view-automation-history.mdx`, document conditions/typical duration for the **Pending** status (and what to do if stuck); clarify which event types include user attribution for the "User who triggered the event (if applicable)" line; add a parent description sentence for **Result information** for parallel structure; document the retention period for execution history; add guidance (link to troubleshooting or retry) for failed executions; and confirm or replace the **Next steps** link to "Create a secret," which is not clearly related to automation history.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
