### PR TITLE
style: apply /style-guide pass to models/launch

### DIFF
--- a/models/launch/evaluate-hosted-model.mdx
+++ b/models/launch/evaluate-hosted-model.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Evaluate a hosted API model using infrastructure managed by CoreWeave"
 title: "Evaluate a hosted API model"
+keywords: ["LLM evaluation jobs", "hosted model benchmarks", "leaderboard", "OpenAI-compatible API", "Inspect AI"]
 ---
 import ReviewEvaluationResults from "/snippets/_includes/llm-eval-jobs/review-evaluation-results.mdx";
 import RerunEvaluation from "/snippets/_includes/llm-eval-jobs/rerun-evaluation.mdx";
@@ -9,33 +10,37 @@ import PreviewLink from '/snippets/_includes/llm-eval-jobs/preview.mdx';
 
 <PreviewLink />
 
-This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a hosted API model at a publicly-accessible URL, using infrastructure managed by CoreWeave. To evaluate a model checkpoint saved as an artifact in W&B Models, see [Evaluate a model checkpoint](/models/launch/evaluate-model-checkpoint) instead.
+This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a hosted API model at a publicly accessible URL, using infrastructure managed by CoreWeave. Running these benchmarks helps you compare model performance, validate model quality, and publish results to a shared leaderboard without managing your own evaluation infrastructure. To evaluate a model checkpoint saved as an artifact in W&B Models, see [Evaluate a model checkpoint](/models/launch/evaluate-model-checkpoint) instead.
 
 ## Prerequisites
+
+Before you create an evaluation job, complete the following:
+
 1. Review the [requirements and limitations](/models/launch#more-details) for LLM Evaluation Jobs.
 1. To run certain benchmarks, a team admin must add the required API keys as team-scoped secrets. Any team member can specify the secret when configuring an evaluation job.
-    - An **OpenAPI API key**: Used by benchmarks that use OpenAI models for scoring. Required if the field **Scorer API key** appears after you select a benchmark. The secret must be named `OPENAI_API_KEY`.
-    - A **Hugging Face user access token**: Required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face Token** appears after selecting a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
-    - To evaluate a model provided by [Serverless Inference](/inference), an organization or team admin must create `WANDB_API_KEY` with any value. The secret is not actually used for authentication. 
+    - An **OpenAI API key**: Used by benchmarks that use OpenAI models for scoring. Required if the field **Scorer API key** appears after you select a benchmark. The secret must be named `OPENAI_API_KEY`.
+    - A **Hugging Face user access token**: Required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face Token** appears after you select a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
+    - To evaluate a model provided by [Serverless Inference](/inference), an organization or team admin must create `WANDB_API_KEY` with any value. The secret isn't used for authentication.
 1. The model to evaluate must be available at a publicly accessible URL. An organization or team admin must create a team-scoped secret with the API key for authentication.
 1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the project sidebar, click **Create new project**.
-1. Review the documentation for a given benchmark to understand how it works and learn about specific requirements. For convenience, the [Available evaluation benchmarks](/models/launch/evaluations) reference includes relevant links.
+1. Review the documentation for a given benchmark to understand how it works and learn about specific requirements. The [Available evaluation benchmarks](/models/launch/evaluations) reference includes relevant links.
 
 ## Evaluate your model
-Follow these steps to set up and launch an evaluation job:
+
+Follow these steps to set up and launch an evaluation job. When you finish, your benchmark runs are queued on CoreWeave-managed infrastructure and their results appear in the destination W&B project you specify.
 
 1. Log in to W&B, then click **Launch** in the project sidebar. The **LLM Evaluation Jobs** page displays.
 1. Click **Evaluate hosted API model** to set up the evaluation.
 1. Select a destination project to save the evaluation results to.
-1. In the **Model** section, specify the base URL and model name to evaluate, and select the API key to use for authentication. Provide the model name in OpenAI-compatible format defined by the [AI Security Institute](https://inspect.aisi.org.uk/providers.html#openai-api). For example, specify an OpenAI mode in the following syntax: `openai/<model-name>`. For a comprehensive list of hosted model providers and models, see [AI Security Institute's model provider reference](https://inspect.aisi.org.uk/providers.html).
-      - To evaluate a model provided by [Serverless Inference](/inference), set the base URL to `https://api.inference.wandb.ai/v1` and specify the model name in the following syntax: `openai-api/wandb/<model_id>`. Refer to the [Inference model catalog](/inference/models) for details.
-      - To use the [OpenRouter](https://inspect.aisi.org.uk/providers.html#openrouter) provider, prefix the model name with `openrouter` in the following syntax: `openrouter/<model-name>`.
-      - To evaluate a custom OpenAPI-compliant model, specify the model name in the following syntax: `openai-api/wandb/<model-name>`.
+1. In the **Model** section, specify the base URL and model name to evaluate, and select the API key to use for authentication. Provide the model name in OpenAI-compatible format defined by the [AI Security Institute](https://inspect.aisi.org.uk/providers.html#openai-api). For example, specify an OpenAI model in the following syntax, where `[MODEL-NAME]` is the name of the model: `openai/[MODEL-NAME]`. For a list of hosted model providers and models, see [AI Security Institute's model provider reference](https://inspect.aisi.org.uk/providers.html).
+      - To evaluate a model provided by [Serverless Inference](/inference), set the base URL to `https://api.inference.wandb.ai/v1` and specify the model name in the following syntax, where `[MODEL-ID]` is the model ID: `openai-api/wandb/[MODEL-ID]`. Refer to the [Inference model catalog](/inference/models) for details.
+      - To use the [OpenRouter](https://inspect.aisi.org.uk/providers.html#openrouter) provider, prefix the model name with `openrouter` in the following syntax, where `[MODEL-NAME]` is the name of the model: `openrouter/[MODEL-NAME]`.
+      - To evaluate a custom OpenAPI-compliant model, specify the model name in the following syntax, where `[MODEL-NAME]` is the name of the model: `openai-api/wandb/[MODEL-NAME]`.
 1. Click **Select evaluations**, then select up to four benchmarks to run.
-1. If you select benchmarks that use OpenAI models for scoring, the **Scorer API key** field displays. Click it, then select the `OPENAI_API_KEY` secret. For convenience, a team admin can create a secret from this drawer by clicking **Create secret**.
+1. If you select benchmarks that use OpenAI models for scoring, the **Scorer API key** field displays. Click it, then select the `OPENAI_API_KEY` secret. A team admin can create a secret from this drawer by clicking **Create secret**.
 1. If you select benchmarks that require access to gated datasets in Hugging Face, a **Hugging Face token** field displays. [Request access to the relevant dataset](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user), then select the secret that contains the Hugging Face user access token.
-1. Optionally, set **Sample limit** to a positive integer to limit the maximum number of benchmark samples to evaluate. Otherwise, all samples in the task are included.
-1. To create a leaderboard automatically, click **Publish results to leaderboard**. The leaderboard will display all evaluations together in a workspace panel, and you can also share it in a report.
+1. Optional: Set **Sample limit** to a positive integer to limit the maximum number of benchmark samples to evaluate. Otherwise, all samples in the task are included.
+1. To create a leaderboard automatically, click **Publish results to leaderboard**. The leaderboard displays all evaluations together in a workspace panel, and you can also share it in a report.
 1. Click **Launch** to launch the evaluation job.
 1. Click the circular arrow icon at the top of the page to open the recent run modal. Evaluation jobs appear with your other recent runs. Click the name of a finished run to open it in single-run view, or click the **Leaderboard** link to open the leaderboard directly. For details, see [View the results](#view-the-results).
 
@@ -45,7 +50,7 @@ This example job runs the `simpleqa` benchmark against the OpenAI model `o4-mini
 ![Example hosted model evaluation job](/images/models/llm-evaluation-jobs/hosted-model-job-example.png)
 </Frame>
 
-This example leaderboard visualizes the performance of several OpenAI models together:
+If you published results to a leaderboard, you can compare evaluations side by side. This example leaderboard visualizes the performance of several OpenAI models together:
 
 <Frame>
 ![Example leaderboard visualizing the performance of several hosted models](/images/models/llm-evaluation-jobs/hosted-model-leaderboard-example.png)

--- a/models/launch/evaluate-model-checkpoint.mdx
+++ b/models/launch/evaluate-model-checkpoint.mdx
@@ -1,6 +1,7 @@
 ---
 description: "Evaluate a VLLM-compatible model checkpoint using infrastructure managed by CoreWeave"
 title: "Evaluate a model checkpoint"
+keywords: ["LLM Evaluation Jobs", "VLLM", "benchmark", "leaderboard", "model checkpoint"]
 ---
 import ReviewEvaluationResults from "/snippets/_includes/llm-eval-jobs/review-evaluation-results.mdx";
 import RerunEvaluation from "/snippets/_includes/llm-eval-jobs/rerun-evaluation.mdx";
@@ -9,19 +10,23 @@ import PreviewLink from '/snippets/_includes/llm-eval-jobs/preview.mdx';
 
 <PreviewLink />
 
-This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a fine-tuned model in W&B Models, using infrastructure managed by CoreWeave. To evaluate a hosted API model served at a publicly-accessible URL, see [Evaluate an API-hosted model](/models/launch/evaluate-hosted-model) instead, or run a small benchmark against a public OpenAI model endpoint with a streamlined [Quickstart](/models/launch#quickstart).
+This page shows how to use [LLM Evaluation Jobs](/models/launch) to run a series of evaluation benchmarks on a fine-tuned model in W&B Models, using infrastructure managed by CoreWeave. To evaluate a hosted API model served at a publicly accessible URL, see [Evaluate an API-hosted model](/models/launch/evaluate-hosted-model) instead, or run a small benchmark against a public OpenAI model endpoint with a streamlined [Quickstart](/models/launch#quickstart).
 
 ## Prerequisites
+
+Before you evaluate a model checkpoint, complete the following:
+
 1. Review the [requirements and limitations](/models/launch#more-details) for LLM Evaluation Jobs.
 1. To run certain benchmarks, a team admin must add the required API keys as [team-scoped secrets](/platform/secrets#add-a-secret). Any team member can specify the secret when configuring an evaluation job. See [Evaluation model catalog](/models/launch/evaluations) for requirements.
-    - An **OpenAPI API key**: Used by benchmarks that use OpenAI models for scoring. Required if the field **Scorer API key** appears after you select a benchmark. The secret must be named `OPENAI_API_KEY`.
-    - A **Hugging Face user access token**: Required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face Token** appears after selecting a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
+    - An **OpenAPI API key**: used by benchmarks that use OpenAI models for scoring. Required if the field **Scorer API key** appears after you select a benchmark. The secret must be named `OPENAI_API_KEY`.
+    - A **Hugging Face user access token**: required for certain benchmarks like `lingoly` and `lingoly2` that require access to one or more gated Hugging Face datasets. Required if the field **Hugging Face token** appears after selecting a benchmark. The API key must have access to the relevant dataset. See the Hugging Face documentation for [User access tokens](https://huggingface.co/docs/hub/en/security-tokens) and [accessing gated datasets](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user).
 1. Create a new [W&B project](/models/track/project-page) for the evaluation results. From the project sidebar, click **Create new project**.
-1. Package the model in VLLM-compatible format and save it as an artifact in W&B Models. An attempt to benchmark any other type of artifact will fail. For one approach, see [Example: Prepare a model](#example-prepare-your-model) at the end of this page.
+1. Package the model in VLLM-compatible format and save it as an artifact in W&B Models. An attempt to benchmark any other type of artifact fails. For one approach, see the following [Example: Prepare a model](#example-prepare-a-model) section.
 1. Review the documentation for a given benchmark to understand how it works and learn about specific requirements. For convenience, the [Available evaluation benchmarks](/models/launch/evaluations) reference includes relevant links.
 
 ## Evaluate your model
-Follow these steps to set up and launch an evaluation job:
+
+After you complete the prerequisites, follow these steps to set up and launch an evaluation job:
 
 1. Log in to W&B, then click **Launch** in the project sidebar. The **LLM Evaluation Jobs** page displays.
 1. Click **Evaluate model checkpoint** to set up the evaluation job.
@@ -30,8 +35,8 @@ Follow these steps to set up and launch an evaluation job:
 1. Click **Evaluations**, then select up to four benchmarks.
 1. If you select benchmarks that use OpenAI models for scoring, the **Scorer API key** field displays. Click it, then select the `OPENAI_API_KEY` secret. For convenience, a team admin can create a secret from this drawer by clicking **Create secret**.
 1. If you select benchmarks that require access to gated datasets in Hugging Face, a **Hugging Face token** field displays. [Request access to the relevant dataset](https://huggingface.co/docs/hub/en/datasets-gated#access-gated-datasets-as-a-user), then select the secret that contains the Hugging Face user access token.
-1. Optionally, set **Sample limit** to a positive integer to limit the maximum number of benchmark samples to evaluate. Otherwise, all samples in the task are included.
-1. To create a leaderboard automatically, click **Publish results to leaderboard**. The leaderboard will display all evaluations together in a workspace panel, and you can also share it in a report.
+1. Optional: Set **Sample limit** to a positive integer to limit the maximum number of benchmark samples to evaluate. Otherwise, the job includes all samples in the task.
+1. To create a leaderboard automatically, click **Publish results to leaderboard**. The leaderboard displays all evaluations together in a workspace panel, and you can also share it in a report.
 1. Click **Launch** to launch the evaluation job.
 1. Click the circular arrow icon at the top of the page to open the recent run modal. Evaluation jobs appear with your other recent runs. Click the name of a finished run to open it in single-run view, or click the **Leaderboard** link to open the leaderboard directly. For details, see [View the results](#view-the-results).
 
@@ -58,7 +63,8 @@ This example leaderboard visualizes the performance of several models together:
 <ExportEvaluation />
 
 ## Example: Prepare a model
-To prepare your model, you load it in W&B Models, package the model weights in VLLM-compatible format, and save the result. This example shows one way to do this:
+
+Before you can evaluate a model checkpoint, you must package it in VLLM-compatible format and save it as an artifact in W&B Models. This example shows one way to do this:
 
 ```python lines
 import os

--- a/models/launch/evaluations.mdx
+++ b/models/launch/evaluations.mdx
@@ -2,12 +2,7 @@
 title: "Evaluation benchmark catalog"
 description: >
   Browse the evaluation benchmarks available through LLM Evaluation Jobs
-keywords:
-  - benchmark catalog
-  - task IDs
-  - Inspect Evals
-  - OpenAI scorer
-  - gated Hugging Face dataset
+keywords: ["benchmark catalog","task IDs","Inspect Evals","OpenAI scorer","gated Hugging Face dataset"]
 ---
 import PreviewLink from '/snippets/_includes/llm-eval-jobs/preview.mdx';
 

--- a/models/launch/evaluations.mdx
+++ b/models/launch/evaluations.mdx
@@ -2,7 +2,8 @@
 title: "Evaluation benchmark catalog"
 description: >
   Browse the evaluation benchmarks available through LLM Evaluation Jobs
-keywords: ["benchmark catalog","task IDs","Inspect Evals","OpenAI scorer","gated Hugging Face dataset"]
+mode: wide
+keywords: ["benchmark catalog", "task IDs", "Inspect Evals", "OpenAI scorer", "gated Hugging Face dataset"]
 ---
 import PreviewLink from '/snippets/_includes/llm-eval-jobs/preview.mdx';
 

--- a/models/launch/evaluations.mdx
+++ b/models/launch/evaluations.mdx
@@ -2,16 +2,23 @@
 title: "Evaluation benchmark catalog"
 description: >
   Browse the evaluation benchmarks available through LLM Evaluation Jobs
+keywords:
+  - benchmark catalog
+  - task IDs
+  - Inspect Evals
+  - OpenAI scorer
+  - gated Hugging Face dataset
 ---
 import PreviewLink from '/snippets/_includes/llm-eval-jobs/preview.mdx';
 
 <PreviewLink />
 
-This page lists the evaluation benchmarks [LLM Evaluation Jobs](/models/launch) provides by category.
+This page catalogs the evaluation benchmarks available through [LLM Evaluation Jobs](/models/launch), organized by category. Use it to discover which benchmarks you can run, identify their task IDs, and check whether a benchmark requires additional credentials.
 
-To run certain benchmarks, a team admin must add the required API keys as [team-scoped secrets](/platform/secrets#add-a-secret). Any team member can specify the secret when configuring an evaluation job.
-    - If a benchmark has `true` in the **OpenAI Model Scorer** column, the benchmark uses OpenAI models for scoring. An organization or team admin must add an OpenAI API key as a team secret. When you configure an evaluation job with a benchmark with this requirement, set the **Scorer API key** field to the secret.
-    - If a benchmark has a link in the **Gated Hugging Face Dataset** column, the benchmark requires access to a gated Hugging Face dataset. An organization or team admin must request access to the dataset in Hugging Face, create a Hugging Face user access token, and configure a team secret with the access key. When you configure a benchmark with this requirement, set the **Hugging Face Token** field to the secret.
+Some benchmarks require additional credentials. A team admin must add these credentials as [team-scoped secrets](/platform/secrets#add-a-secret) before any team member can use the benchmarks in an evaluation job:
+
+- If a benchmark has `Yes` in the **OpenAI Scorer** column, the benchmark uses OpenAI models for scoring. An organization or team admin must add an OpenAI API key as a team secret. When you configure an evaluation job with a benchmark that has this requirement, set the **Scorer API key** field to the secret.
+- If a benchmark has a link in the **Gated HF Dataset** column, the benchmark requires access to a gated Hugging Face dataset. An organization or team admin must request access to the dataset in Hugging Face. The admin then creates a Hugging Face user access token and configures a team secret with that token. When you configure a benchmark with this requirement, set the **Hugging Face Token** field to the secret.
 
 {/*
     Benchmark list: https://github.com/wandb/launch-jobs/blob/main/jobs/inspect_ai_evals/api_model/sample-schema.json 
@@ -20,9 +27,9 @@ To run certain benchmarks, a team admin must add the required API keys as [team-
 
 ## Knowledge
 
-Evaluate factual knowledge across various domains like science, language, and general reasoning.
+Evaluate factual knowledge across domains such as science, language, and general reasoning.
 
-| Evaluation | Task ID | <div className='!w-[100px]'>OpenAI Scorer</div> | Gated Hugging Face Dataset | Description |
+| Evaluation | Task ID | <div className='!w-[100px]'>OpenAI Scorer</div> | Gated HF Dataset | Description |
 |------------|---------|---------------|------------------|-------------|
 | [BoolQ](https://github.com/google-research-datasets/boolean-questions) | `boolq` | | | Boolean yes/no questions from natural language queries |
 | [GPQA Diamond](https://arxiv.org/abs/2311.12022) | `gpqa_diamond` | | | Graduate-level science questions (highest quality subset) |
@@ -65,7 +72,7 @@ Evaluate logical thinking, problem-solving, and common-sense reasoning capabilit
 
 ## Math
 
-Evaluate mathematical problem-solving at various difficulty levels, from grade school to competition-level problems.
+Evaluate mathematical problem-solving across difficulty levels, from grade school to competition-level problems.
 
 | Evaluation | Task ID | OpenAI Scorer | Gated HF Dataset | Description |
 |------------|---------|---------------|------------------|-------------|
@@ -81,7 +88,7 @@ Evaluate mathematical problem-solving at various difficulty levels, from grade s
 
 ## Code
 
-Evaluate programming and software development capabilities like debugging, code execution prediction, and function calling.
+Evaluate programming and software development capabilities such as debugging, code execution prediction, and function calling.
 
 | Evaluation | Task ID | OpenAI Scorer | Gated HF Dataset | Description |
 |------------|---------|---------------|------------------|-------------|
@@ -146,7 +153,7 @@ Evaluate alignment, bias detection, harmful content resistance, and truthfulness
 | [WMDP Cyber](https://www.wmdp.ai/) | `wmdp_cyber` | | | Tests hazardous knowledge in cybersecurity |
 | [XSTest](https://arxiv.org/abs/2308.01263) | `xstest` | Yes | | Exaggerated safety test for over-refusal detection |
 
-## Domain-Specific
+## Domain-specific
 
 Evaluate specialized knowledge in medicine, chemistry, law, biology, and other professional fields.
 


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to documentation under `models/launch`. The run was automated; no technical content was intentionally changed.

## Files edited

- `models/launch/evaluate-hosted-model.mdx`
- `models/launch/evaluate-model-checkpoint.mdx`
- `models/launch/evaluations.mdx`

## Recommendations for technical review

**Prerequisites**
- Confirm whether `WANDB_API_KEY` being required-but-unused for Serverless Inference (`evaluate-hosted-model.mdx` line 23) is still accurate, and whether a Note callout should explain this behavior.
- Prerequisite 3 of `evaluate-hosted-model.mdx` (line 24) mentions a team-scoped secret holding the model's API key but doesn't specify a required name/format or where it's selected in the flow. Add guidance if needed.
- In `evaluate-model-checkpoint.mdx`, the prerequisite item references "OpenAPI API key" but surrounding text and the secret name use OpenAI (`OPENAI_API_KEY`). Likely a typo — confirm and correct.
- Confirm whether a specific W&B role (beyond team-admin for secrets) is required to launch evaluation jobs. Add to prerequisites if so.
- In `evaluations.mdx`, the credentials section only links to the secrets doc. Consider also linking to role/permission documentation and to the "Evaluate a model checkpoint" / "Evaluate a hosted API model" pages from the credentials section (not only from "Next steps").

**Verification steps**
- After "Click **Launch**" in both `evaluate-hosted-model.mdx` (line 44) and `evaluate-model-checkpoint.mdx` (step 11), no confirmation cue (toast, queued status, log location) is described before directing the reader to the recent-run modal. Consider adding a confirmation description.
- `evaluate-model-checkpoint.mdx` doesn't describe expected outcome states for the evaluation job (running, succeeded, failed) or how the reader confirms successful completion.
- Neither launch page has troubleshooting guidance for failed benchmarks, missing secrets, unreachable model URLs, or runs that don't appear in the recent runs list.

**Technical accuracy**
- `evaluate-hosted-model.mdx` line 38: "custom **OpenAPI-compliant** model" — verify whether this should be "OpenAI-compatible" (matching the rest of the page) or whether "OpenAPI" is intentional.
- `evaluate-hosted-model.mdx` line 38: the custom-model syntax `openai-api/wandb/[MODEL-NAME]` appears identical to the Serverless Inference syntax on line 36. Confirm whether the custom case should use a different prefix.
- Confirm the "AI Security Institute" attribution in `evaluate-hosted-model.mdx` (line 35) is current and correct.
- In `evaluate-model-checkpoint.mdx`, "VLLM-compatible format" is used but not defined or linked. Add a definition or link.
- Confirm the `AutoModelForCausalLM.from_pretrained` / `save_pretrained` example in `evaluate-model-checkpoint.mdx` produces VLLM-compatible output for all supported architectures, or document when additional steps are required.
- `evaluate-model-checkpoint.mdx` step 5 mentions an "up to four benchmarks" limit without explanation or reference. Link or document the limit.
- In `evaluations.mdx`, confirm the OpenAI Scorer column shows `Yes` (not `true`) in the product UI — Pass 8 aligned the prose to match the table cells; verify both reflect what users see.
- Confirm the exact field labels `Scorer API key` and `Hugging Face Token` in `evaluations.mdx` match the strings in the product UI.
- The hidden HTML comment in `evaluations.mdx` (lines 23–26) points to source-of-truth files in other repos. Confirm those URLs are current and the catalog is in sync.

**Missing content**
- `evaluate-hosted-model.mdx` doesn't link to a secrets-management page on first mention of "team-scoped secret". Consider linking for self-containment.
- `evaluate-hosted-model.mdx` has no "Next steps" pointer beyond imported snippets. Optional editorial improvement.
- The `wandb.init` call in `evaluate-model-checkpoint.mdx` uses placeholder strings but doesn't clarify whether `entity` and `project` must already exist or are created on the fly.
- In `evaluations.mdx`, `SOSBench` in the Safety table is the only entry without a hyperlink on its name — likely an oversight.
- The "Next steps" list in `evaluations.mdx` mixes link-label items with one longer descriptive item. Consider rephrasing for parallel structure (e.g., "Browse all benchmarks at AISI Inspect Evals").
- Some benchmark descriptions in the `evaluations.mdx` tables don't fully expand their acronyms on first use within the cell. Confirm whether the table is self-explanatory or if a glossary link would help.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
