### PR TITLE
style: apply /style-guide pass to models/reports

### DIFF
--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -1,12 +1,7 @@
 ---
 description: "Export W&B Reports as PDF or LaTeX files, and clone reports using the App UI or the Report and Workspace API."
 title: Clone and export reports
-keywords:
-  - export report
-  - clone report
-  - PDF
-  - LaTeX
-  - Report and Workspace API
+keywords: ["export report", "clone report", "PDF", "LaTeX", "Report and Workspace API"]
 ---
 
 <Note>

--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -10,11 +10,11 @@ W&B Report and Workspace API is in Public Preview.
 
 This page describes how to export a W&B Report to a portable file format. It also describes how to clone an existing report to reuse its structure as a starting point for new work.
 
-## Export reports
+## Export a report
 
 Export a report as a PDF or LaTeX file to share its contents outside of W&B or to archive a static version of your analysis. In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Download** and select either PDF or LaTeX output format.
 
-## Clone reports
+## Clone a report
 
 Clone a report to reuse an existing project's template and formatting as the basis for a new report. You can clone reports in the W&B App UI or programmatically with the Report and Workspace API.
 
@@ -26,7 +26,7 @@ In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="so
     <img src="/images/reports/clone_reports.gif" alt="Cloning reports"  />
 </Frame>
 
-Cloned reports are visible to your team if you clone a report within the team's account. Reports cloned within an individual's account are visible only to that user.
+When you clone a report, you specify the destination. If you clone it to a team, all team members can view it. If you clone it to your personal account, only you can view it by default.
 </Tab>
 <Tab title="Report and Workspace API">
 Use the Report and Workspace API to load an existing report from its URL and reuse it as a template for a new report.

--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -1,30 +1,42 @@
 ---
 description: "Export W&B Reports as PDF or LaTeX files, and clone reports using the App UI or the Report and Workspace API."
 title: Clone and export reports
+keywords:
+  - export report
+  - clone report
+  - PDF
+  - LaTeX
+  - Report and Workspace API
 ---
 
 <Note>
 W&B Report and Workspace API is in Public Preview.
 </Note>
 
+This page describes how to export a W&B Report to a portable file format. It also describes how to clone an existing report to reuse its structure as a starting point for new work.
+
 ## Export reports
 
-Export a report as a PDF or LaTeX. Within your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu to expand the dropdown menu. Choose **Download and** select either PDF or LaTeX output format.
+Export a report as a PDF or LaTeX file to share its contents outside of W&B or to archive a static version of your analysis. In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Download** and select either PDF or LaTeX output format.
 
-## Cloning reports
+## Clone reports
+
+Clone a report to reuse an existing project's template and formatting as the basis for a new report. You can clone reports in the W&B App UI or programmatically with the Report and Workspace API.
 
 <Tabs>
 <Tab title="W&B App">
-Within your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu to expand the dropdown menu. Choose the **Clone this report** button. Pick a destination for your cloned report in the modal. Choose **Clone report**.
+In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Clone this report**. In the modal, pick a destination for your cloned report. Choose **Clone report**.
 
 <Frame>
     <img src="/images/reports/clone_reports.gif" alt="Cloning reports"  />
 </Frame>
 
-Clone a report to reuse a project's template and format. Cloned projects are visible to your team if you clone a project within the team's account. Projects cloned within an individual's account are only visible to that user.
+Cloned reports are visible to your team if you clone a report within the team's account. Reports cloned within an individual's account are visible only to that user.
 </Tab>
 <Tab title="Report and Workspace API">
-Load a Report from a URL to use it as a template.
+Use the Report and Workspace API to load an existing report from its URL and reuse it as a template for a new report.
+
+Load a report from a URL to use it as a template. Replace `PROJECT` with the name of your W&B project.
 
 ```python
 report = wr.Report(
@@ -34,7 +46,7 @@ report.save()  # Save
 new_report = wr.Report.from_url(report.url)  # Load
 ```
 
-Edit the content within `new_report.blocks`.
+After you load the report, edit the content in `new_report.blocks` to customize the cloned report, then save it. Replace `ENTITY` with your W&B entity name.
 
 ```python
 pg = wr.PanelGrid(

--- a/models/reports/collaborate-on-reports.mdx
+++ b/models/reports/collaborate-on-reports.mdx
@@ -6,7 +6,7 @@ keywords: ["share report", "report comments", "star report", "report collaborati
 
 This page describes ways to collaborate on reports with your team. Use these workflows to share results, gather feedback, and keep important reports accessible.
 
-The following sections describe how to share a report, edit it collaboratively, add comments, and star reports for quick access.
+You can share a report, edit it collaboratively, add comments, or star it for quick access.
 
 ## Share a report
 
@@ -31,7 +31,7 @@ If an edit conflict occurs, such as when two team members edit the report at onc
 
 To leave a comment on a report, click **Comment**.
 
-To comment directly on a panel, hover over the panel, then click the comment button, which looks like a speech bubble.
+To comment directly on a panel, hover over the panel, then click the comment button (<Icon icon="comment" iconType="regular"/>).
 
 <Frame>
     <img src="/images/reports/demo_comment_on_panels_in_reports.gif" alt="Adding a comment to a panel" />
@@ -39,6 +39,6 @@ To comment directly on a panel, hover over the panel, then click the comment but
 
 ## Star a report
 
-If your team has many reports, click **Star** at the top of a report to add it to your favorites. When viewing your team's list of reports, click the star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
+If your team has many reports, click the open star icon (<Icon icon="star" iconType="regular"/>) at the top of a report to add it to your favorites. To remove the star, click the closed star icon (<Icon icon="star" iconType="solid"/>). When viewing your team's list of reports, click the open star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
 
 From the list of reports, you can see how many members have starred each report to gauge its popularity.

--- a/models/reports/collaborate-on-reports.mdx
+++ b/models/reports/collaborate-on-reports.mdx
@@ -1,12 +1,7 @@
 ---
 description: Collaborate and share W&B Reports with peers, co-workers, and your team.
 title: Collaborate on reports
-keywords:
-  - share report
-  - report comments
-  - star report
-  - report collaboration
-  - edit conflict
+keywords: ["share report", "report comments", "star report", "report collaboration", "edit conflict"]
 ---
 
 This page describes ways to collaborate on reports with your team. Use these workflows to share results, gather feedback, and keep important reports accessible.

--- a/models/reports/collaborate-on-reports.mdx
+++ b/models/reports/collaborate-on-reports.mdx
@@ -1,36 +1,49 @@
 ---
 description: Collaborate and share W&B Reports with peers, co-workers, and your team.
 title: Collaborate on reports
+keywords:
+  - share report
+  - report comments
+  - star report
+  - report collaboration
+  - edit conflict
 ---
 
-This page describes various ways to collaborate on reports with your team.
+This page describes ways to collaborate on reports with your team. Use these workflows to share results, gather feedback, and keep important reports accessible.
+
+The following sections describe how to share a report, edit it collaboratively, add comments, and star reports for quick access.
 
 ## Share a report
-When viewing a report, click **Share**, then:
-- To share a link to the report with an email address or a username, click **Invite**. Enter an email address or username, select **Can view** or **Can edit**, then click **Invite**. If you share by email, the email address does not need to be a member of your organization or team.
+
+When viewing a report, click **Share**. You can share a report in one of the following ways:
+
+- To share a link to the report with an email address or a username, click **Invite**. Enter an email address or username, select **Can view** or **Can edit**, then click **Invite**. If you share by email, the email address doesn't need to be a member of your organization or team.
 - To generate a sharing link instead, click **Share**. Adjust the permissions for the link, then click **Copy report link**. Share the link with the member.
 
-When viewing the report, click a panel to open it in full-screen mode. If you copy the URL from the browser and share it with another user, when they access the link the panel will open directly in full-screen mode.
+When viewing the report, click a panel to open it in full-screen mode. If you copy the URL from the browser and share it with another user, the panel opens directly in full-screen mode when they access the link.
 
 ## Edit a report
-When any team member clicks the **Edit** button to begin editing the report, a draft is automatically saved. Select **Save to report** to publish your changes.
 
-If an edit conflict occurs, such as when two team members edit the report at once, a warning notification helps you to resolve any conflicts.
+Multiple team members can edit the same report and publish changes when they're ready. When any team member clicks the **Edit** button to begin editing the report, W&B automatically saves a draft. Select **Save to report** to publish your changes.
+
+If an edit conflict occurs, such as when two team members edit the report at once, a warning notification helps you resolve any conflicts.
 
 <Frame>
-    <img src="/images/reports/share-report.gif" alt="Report sharing modal for a report in a  'Public' project" max-width="90%"  />
+    <img src="/images/reports/share-report.gif" alt="Report sharing modal for a report in a 'Public' project" max-width="90%" />
 </Frame>
 
 ## Comment on reports
-Click **Comment** to leave a comment on a report.
+
+To leave a comment on a report, click **Comment**.
 
 To comment directly on a panel, hover over the panel, then click the comment button, which looks like a speech bubble.
 
 <Frame>
-    <img src="/images/reports/demo_comment_on_panels_in_reports.gif" alt="Adding a comment to a panel"  />
+    <img src="/images/reports/demo_comment_on_panels_in_reports.gif" alt="Adding a comment to a panel" />
 </Frame>
 
 ## Star a report
-If your team has a large number of reports, click **Star** at the top of a report to add it to your favorites. When viewing your team's list of reports, click the star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
 
-From the list of reports, you can see how many members have starred each report to gauge its relative popularity.
+If your team has many reports, click **Star** at the top of a report to add it to your favorites. When viewing your team's list of reports, click the star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
+
+From the list of reports, you can see how many members have starred each report to gauge its popularity.

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -28,7 +28,7 @@ For an example of how to programmatically create a report, see this [Google Cola
     <img src="/images/reports/create_a_report_modal.png" alt="Create report modal" />
     </Frame>
 
-4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. After you click **Create report**, a draft report is available in the report tab to continue working on.
+4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. A draft report is saved automatically. Access it in the **Reports** tab.
 </Tab>
 <Tab title="Report tab">
 1. Navigate to your project workspace in the W&B App.
@@ -46,7 +46,7 @@ Create a report programmatically:
     ```bash
     pip install wandb wandb-workspaces
     ```
-2. Import workspaces.
+2. Import the W&B Python SDK and the Report and Workspace API.
     ```python
     import wandb
     import wandb_workspaces.reports.v2 as wr
@@ -56,11 +56,11 @@ Create a report programmatically:
     report = wr.Report(project="report_standard")
     ```
 
-4. Save the report. Reports aren't uploaded to the W&B server until you call the `.save()` method:
+4. Save the report. Reports aren't uploaded to W&B until you call the `.save()` method:
     ```python
     report.save()
     ```
 
-For more information about how to edit a report interactively with the App UI or programmatically, see [Edit a report](/models/reports/edit-a-report/).
+For more information, see [Edit a report](/models/reports/edit-a-report).
 </Tab>
 </Tabs>

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -1,41 +1,46 @@
 ---
 description: Create a W&B Report with the W&B App or programmatically.
 title: Create a report
+keywords:
+  - create report
+  - wandb-workspaces
+  - Report API
+  - programmatic reports
 ---
 
 <Note>
 W&B Report and Workspace API is in Public Preview.
 </Note>
 
-Select a tab below to learn how to create a report in the W&B App or programmatically with the W&B Report and Workspace API.
+Select a tab to learn how to create a report in the W&B App or programmatically with the Report and Workspace API.
 
-See this [Google Colab](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb) for an example on how to programmatically create a report.
+For an example of how to programmatically create a report, see this [Google Colab](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb).
 
 
 <Tabs>
 <Tab title="W&B App">
 1. Navigate to your project workspace in the W&B App.
-2. Click **Create report** in the upper right corner of your workspace.
+2. In the upper-right corner of your workspace, click **Create report**.
 
     <Frame>
-    <img src="/images/reports/create_a_report_button.png" alt="Create report button"  />
+    <img src="/images/reports/create_a_report_button.png" alt="Create report button" />
     </Frame>
 
-3. A modal will appear. Select the charts you would like to start with. You can add or delete charts later from the report interface.
+3. A modal appears. Select the charts you want to start with. You can add or delete charts later from the report interface.
 
     <Frame>
-    <img src="/images/reports/create_a_report_modal.png" alt="Create report modal"  />
+    <img src="/images/reports/create_a_report_modal.png" alt="Create report modal" />
     </Frame>
 
-4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. Once you click **Create report,** a draft report will be available in the report tab to continue working on.
+4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. After you click **Create report**, a draft report is available in the report tab to continue working on.
 </Tab>
 <Tab title="Report tab">
 1. Navigate to your project workspace in the W&B App.
-2. Select to the **Reports** tab (clipboard image) in your project.
-3. Select the **Create Report** button on the report page. 
+2. Select the **Reports** tab in your project.
+3. Click **Create report**.
 
     <Frame>
-    <img src="/images/reports/create_report_button.png" alt="Create report button"  />
+    <img src="/images/reports/create_report_button.png" alt="Create report button" />
     </Frame>
 </Tab>
 <Tab title="Report and Workspace API">
@@ -45,21 +50,21 @@ Create a report programmatically:
     ```bash
     pip install wandb wandb-workspaces
     ```
-2. Next, import workspaces
+2. Import workspaces.
     ```python
     import wandb
     import wandb_workspaces.reports.v2 as wr
-    ```       
-3. Create a report with `wandb_workspaces.reports.v2.Report`. Create a report instance with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify a name for the project.   
+    ```
+3. Create a report with `wandb_workspaces.reports.v2.Report`. Create a report instance with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify a name for the project.
     ```python
     report = wr.Report(project="report_standard")
-    ```  
+    ```
 
-4. Save the report. Reports are not uploaded to the W&B server until you call the .`save()` method:
+4. Save the report. Reports aren't uploaded to the W&B server until you call the `.save()` method:
     ```python
     report.save()
     ```
 
-For information on how to edit a report interactively with the App UI or programmatically, see [Edit a report](/models/reports/edit-a-report/).
+For more information about how to edit a report interactively with the App UI or programmatically, see [Edit a report](/models/reports/edit-a-report/).
 </Tab>
 </Tabs>

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -1,11 +1,7 @@
 ---
 description: Create a W&B Report with the W&B App or programmatically.
 title: Create a report
-keywords:
-  - create report
-  - wandb-workspaces
-  - Report API
-  - programmatic reports
+keywords: ["create report", "wandb-workspaces", "Report API", "programmatic reports"]
 ---
 
 <Note>

--- a/models/reports/cross-project-reports.mdx
+++ b/models/reports/cross-project-reports.mdx
@@ -1,27 +1,33 @@
 ---
 description: Compare runs from two different projects with cross-project reports.
 title: Compare runs across projects
+keywords:
+  - magic link
+  - view-only report
+  - run set
+  - share report
+  - project selector
 ---
 <Note>
 Watch a [video demonstrating comparing runs across projects](https://www.youtube.com/watch?v=uD4if_nGrs4) (2 min).
 </Note>
 
 
-Compare runs from two different projects with cross-project reports. Use the project selector in the run set table to pick a project.
+Cross-project reports let you compare runs from two different projects side by side, which is useful when you want to evaluate experiments tracked under separate W&B projects without duplicating data. Use the project selector in the run set table to pick a project.
 
 <Frame>
     <img src="/images/reports/howto_pick_a_different_project_to_draw_runs_from.gif" alt="Compare runs across different projects"  />
 </Frame>
 
-The visualizations in the section pull columns from the first active runset. Make sure that the first run set checked in the section has that column available if you do not see the metric you are looking for in the line plot.
+The visualizations in the section pull columns from the first active run set. If you don't see the metric you're looking for in the line plot, make sure that the first run set checked in the section has that column available.
 
-This feature supports history data on time series lines, but we don't support pulling different summary metrics from different projects. In other words, you can not create a scatter plot from columns that are only logged in another project.
+This feature supports history data on time series lines, but doesn't support pulling different summary metrics from different projects. In other words, you can't create a scatter plot from columns that are only logged in another project.
 
-If you need to compare runs from two projects and the columns are not working, add a tag to the runs in one project and then move those runs to the other project. You can still filter only the runs from each project, but the report includes all the columns for both sets of runs.
+If you need to compare runs from two projects and the columns aren't working, add a tag to the runs in one project and then move those runs to the other project. You can still filter only the runs from each project, but the report includes all the columns for both sets of runs.
 
 ## View-only report links
 
-Share a view-only link to a report that is in a private project or team project.
+When you need to share a report with someone outside your project (such as a stakeholder who doesn't have a W&B account), use a view-only link. Share a view-only link to a report that is in a private project or team project.
 
 <Frame>
     <img src="/images/reports/magic-links.gif" alt="View-only report links"  />
@@ -29,12 +35,12 @@ Share a view-only link to a report that is in a private project or team project.
 
 View-only report links add a secret access token to the URL, so anyone who opens the link can view the page. Anyone can use the magic link to view the report without logging in first. For customers on [W&B Local](/platform/hosting/) private cloud installations, these links remain behind your firewall, so only members of your team with access to your private instance _and_ access to the view-only link can view the report.
 
-In **view-only mode**, someone who is not logged in can see the charts and mouse over to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. When in view mode, they cannot create new charts or new table queries to explore the data. View-only visitors to the report link won't be able to click a run to get to the run page. Also, the view-only visitors would not be able to see the share modal but instead would see a tooltip on hover which says: `Sharing not available for view only access`.
+In **view-only mode**, someone who isn't logged in can see the charts and mouse over to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. When in view mode, they can't create new charts or new table queries to explore the data. View-only visitors to the report link can't click a run to get to the run page. Also, view-only visitors can't see the share modal. Instead, they see a tooltip on hover that says: `Sharing not available for view only access`.
 
 <Info>
-The magic links are only available for “Private” and “Team” projects. For “Public” (anyone can view) or “Open” (anyone can view and contribute runs) projects, the links can't turn on/off because this project is public implying that it is already available to anyone with the link.
+The magic links are only available for "Private" and "Team" projects. For "Public" (anyone can view) or "Open" (anyone can view and contribute runs) projects, you can't turn the links on or off because the project is public, meaning it's already available to anyone with the link.
 </Info>
 
 ## Send a graph to a report
 
-Send a graph from your workspace to a report to keep track of your progress. Click the dropdown menu on the chart or panel you'd like to copy to a report and click **Add to report** to select the destination report.
+If you want to preserve a chart from a workspace alongside related analysis, you can send it directly to a report. Send a graph from your workspace to a report to keep track of your progress. Click the dropdown menu on the chart or panel you'd like to copy to a report and click **Add to report** to select the destination report.

--- a/models/reports/cross-project-reports.mdx
+++ b/models/reports/cross-project-reports.mdx
@@ -1,12 +1,7 @@
 ---
 description: Compare runs from two different projects with cross-project reports.
 title: Compare runs across projects
-keywords:
-  - magic link
-  - view-only report
-  - run set
-  - share report
-  - project selector
+keywords: ["magic link", "view-only report", "run set", "share report", "project selector"]
 ---
 <Note>
 Watch a [video demonstrating comparing runs across projects](https://www.youtube.com/watch?v=uD4if_nGrs4) (2 min).

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -11,13 +11,13 @@ W&B Report and Workspace API is in Public Preview.
 
 This page describes how to edit a report interactively with the App UI or programmatically with the W&B SDK. It covers adding plots, run sets, code blocks, markdown, HTML elements, and rich media, as well as filtering and grouping run sets, organizing report layout, and visualizing multi-dimensional relationships.
 
-Reports consist of _blocks_. Blocks make up the body of a report. Within these blocks you can add text, images, embedded visualizations, plots from experiments and runs, and panel grids.
+A report's body consists of _blocks_. Blocks contain text, images, embedded visualizations, plots from experiments and runs, and panel grids.
 
 _Panel grids_ are a specific type of block that hold panels and _run sets_. Run sets are a collection of runs logged to a project in W&B. Panels are visualizations of run set data.
 
 
 <Note>
-See the [Programmatic workspaces notebook](https://colab.research.google.com/github/wandb/wandb-workspaces/blob/Update-wandb-workspaces-tuturial/Workspace_tutorial.ipynb) for a step-by-step example of how to create and customize a saved workspace view.
+Run the [Programmatic workspaces notebook](https://colab.research.google.com/github/wandb/wandb-workspaces/blob/Update-wandb-workspaces-tuturial/Workspace_tutorial.ipynb) for an end-to-end tutorial of creating a customized saved workspace view.
 </Note>
 
 <Note>
@@ -327,17 +327,17 @@ Programmatically filter run sets and add them to a report with the [Workspace an
 The general syntax for a filter expression is:
 
 ```text
-Filter('KEY') operation [VALUE]
+Filter('[KEY]') operation [VALUE]
 ```
 
-In this expression, `KEY` is the name of the filter, `operation` is a comparison operator (for example, `>`, `<`, `==`, `in`, `not in`, `or`, and `and`), and `[VALUE]` is the value to compare against. `Filter` is a placeholder for the type of filter you want to apply. The following table lists the available filters and their descriptions:
+In this expression, `[KEY]` is the name of the filter, `operation` is a comparison operator (for example, `>`, `<`, `==`, `in`, `not in`, `or`, and `and`), and `[VALUE]` is the value to compare against. `Filter` is a placeholder for the type of filter you want to apply. The following table lists the available filters and their descriptions:
 
 | Filter | Description | Available keys |
 | ---|---| --- |
-|`Config('KEY')` | Filter by config values | Values specified in `config` parameter in `wandb.init(config=)`. |
-|`SummaryMetric('KEY')` | Filter by summary metrics | Values you log to a run with `wandb.Run.log()`. |
-|`Tags('KEY')` | Filter by tags | Tag values that you add to your run (programmatically or with the W&B App). |
-|`Metric('KEY')` | Filter by run properties | `tags`, `state`, `displayName`, `jobType` |
+|`Config('[KEY]')` | Filter by config values | Values specified in `config` parameter in `wandb.init(config=)`. |
+|`SummaryMetric('[KEY]')` | Filter by summary metrics | Values you log to a run with `wandb.Run.log()`. |
+|`Tags('[KEY]')` | Filter by tags | Tag values that you add to your run (programmatically or with the W&B App). |
+|`Metric('[KEY]')` | Filter by run properties | `tags`, `state`, `displayName`, `jobType` |
 
 After you define your filters, you can create a report and pass the filtered run sets to `wr.PanelGrid(runsets=)`. See the **Report and Workspace API** tabs throughout this page for more information about how to add various elements to a report programmatically.
 
@@ -416,7 +416,7 @@ Filter run sets based on a run's tag (`tags`), run state (`state`), run name (`d
 `Metric` filters use a different syntax than other filters. You must pass values as a list.
 
 ```text
-Metric('KEY') operation [VALUE]
+Metric('[KEY]') operation [VALUE]
 ```
 </Note>
 
@@ -510,7 +510,7 @@ Select the name of the programming language on the right side of the code block 
 <Tab title="Report and Workspace API">
 Use the `wr.CodeBlock` Class to create a code block programmatically. Provide the name of the language and the code you want to display for the language and code parameters, respectively.
 
-For example, the following example demonstrates a list in a YAML file:
+The following example demonstrates a list in a YAML file:
 
 ```python
 import wandb
@@ -675,15 +675,17 @@ report.save()
 </Tab>
 </Tabs>
 
-## Duplicate and delete panel grids
+## Duplicate panel grids
 
-Duplicating and deleting panel grids helps you reuse layouts and remove content you no longer need. If you have a layout that you want to reuse, select a panel grid and copy-paste it to duplicate it in the same report or paste it into a different report.
+Duplicate a panel grid to reuse its layout in the same report or in a different report. Select a panel grid and copy-paste it to duplicate it in the same report or paste it into a different report.
 
 Highlight a whole panel grid section by selecting the drag handle in the upper right corner. Click and drag to highlight and select a region in a report such as panel grids, text, and headings.
 
 <Frame>
     <img src="/images/reports/demo_copy_and_paste_a_panel_grid_section.gif" alt="Copying panel grids"  />
 </Frame>
+
+## Delete panel grids
 
 Select a panel grid and press `delete` on your keyboard to delete a panel grid.
 
@@ -701,8 +703,8 @@ Collapse headers in a report to hide content within a text block. When the repor
 
 ## Visualize relationships across multiple dimensions
 
-When you want to compare more variables than a 2D plot can show, you can use a color gradient as an additional dimension. W&B recommends using a color gradient to represent one of the variables, which enhances clarity and makes patterns easier to interpret.
+To compare more variables than a 2D plot can show, you can use a color gradient as an additional dimension. Using a color gradient to represent one of the variables can make patterns easier to interpret.
 
-1. Choose a variable to represent with a color gradient (for example, penalty scores or learning rates). This provides a clearer understanding of how penalty (color) interacts with reward/side effects (y-axis) over training time (x-axis).
+1. Choose a variable to represent with a color gradient, like penalty scores or learning rates. This provides a clearer understanding of how penalty (color) interacts with reward/side effects (y-axis) over training time (x-axis).
 2. Highlight key trends. Hover over a specific group of runs to highlight them in the visualization.
 

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -2,38 +2,44 @@
 description: Edit a report interactively with the App UI or programmatically with
   the W&B SDK.
 title: Edit a report
+keywords:
+  - wandb-workspaces
+  - PanelGrid
+  - RunSet
+  - report blocks
+  - report filters
 ---
 
 <Note>
 W&B Report and Workspace API is in Public Preview.
 </Note>
 
-Edit a report interactively with the App UI or programmatically with the W&B SDK.
+This page describes how to edit a report interactively with the App UI or programmatically with the W&B SDK. It covers adding plots, run sets, code blocks, markdown, HTML elements, and rich media, as well as filtering and grouping run sets, organizing report layout, and visualizing multi-dimensional relationships.
 
-Reports consist of _blocks_. Blocks make up the body of a report. Within these blocks you can add text, images, embedded visualizations, plots from experiments and run, and panels grids.
+Reports consist of _blocks_. Blocks make up the body of a report. Within these blocks you can add text, images, embedded visualizations, plots from experiments and runs, and panel grids.
 
 _Panel grids_ are a specific type of block that hold panels and _run sets_. Run sets are a collection of runs logged to a project in W&B. Panels are visualizations of run set data.
 
 
 <Note>
-Check out the [Programmatic workspaces notebook](https://colab.research.google.com/github/wandb/wandb-workspaces/blob/Update-wandb-workspaces-tuturial/Workspace_tutorial.ipynb) for a step by step example on how create and customize a saved workspace view.
+See the [Programmatic workspaces notebook](https://colab.research.google.com/github/wandb/wandb-workspaces/blob/Update-wandb-workspaces-tuturial/Workspace_tutorial.ipynb) for a step-by-step example of how to create and customize a saved workspace view.
 </Note>
 
 <Note>
-Verify that you have the W&B Report and Workspace API `wandb-workspaces` installed in addition to the W&B Python SDK if you want to programmatically edit a report:
+To programmatically edit a report, you must have the W&B Report and Workspace API (`wandb-workspaces`) installed along with the W&B Python SDK:
 
-```pip
+```bash
 pip install wandb wandb-workspaces
 ```
 </Note>
 
 ## Add plots
 
-Each panel grid has a set of run sets and a set of panels. The run sets at the bottom of the section control what data shows up on the panels in the grid. Create a new panel grid if you want to add charts that pull data from a different set of runs.
+Plots let you visualize run data inside a report. Each panel grid has a set of run sets and a set of panels. The run sets at the bottom of the section control what data appears on the panels in the grid. Create a new panel grid if you want to add charts that pull data from a different set of runs.
 
 <Tabs>
 <Tab title="W&B App">
-Enter a forward slash (`/`) in the report to display a dropdown menu. Select **Add panel** to add a panel. You can add any panel that is supported by W&B, including a line plot, scatter plot or parallel coordinates chart.
+Enter a forward slash (`/`) in the report to display a dropdown menu. Select **Add panel** to add a panel. You can add any panel that W&B supports, including a line plot, scatter plot, or parallel coordinates chart.
 
 <Frame>
     <img src="/images/reports/demo_report_add_panel_grid.gif" alt="Add charts to a report"  />
@@ -51,8 +57,8 @@ import wandb_workspaces.reports.v2 as wr
 
 report = wr.Report(
     project="report-editing",
-    title="An amazing title",
-    description="A descriptive description.",
+    title="Report title",
+    description="Report description.",
 )
 
 blocks = [
@@ -79,25 +85,27 @@ Add run sets from projects interactively with the App UI or the W&B SDK.
 
 <Tabs>
 <Tab title="W&B App">
-Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Panel Grid**. This will automatically import the run set from the project the report was created from.
+Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Panel Grid**. W&B automatically imports the run set from the project the report was created from.
 
 If you import a panel into a report, run names are inherited from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The run is renamed only in the individual panel. If you clone the panel in the same report, the run is also renamed in the cloned panel.
 
 1. In the report, click the pencil icon to open the report editor.
-1. In the run set, find the run to rename. Hover over the report name, click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
+1. In the run set, find the run to rename. Hover over the report name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
 
-    - **Rename run for project**: rename the run across the entire project. To generate a new random name, leave the field blank.
-    - **Rename run for panel grid** rename the run only in the report, preserving the existing name in other contexts. Generating a new random name is not supported.
+    - **Rename run for project**: Rename the run across the entire project. To generate a new random name, leave the field blank.
+    - **Rename run for panel grid**: Rename the run only in the report, preserving the existing name in other contexts. Generating a new random name is not supported.
 
 1. Click **Publish report**.
 </Tab>
 <Tab title="Report and Workspace API">
-Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. The following procedure describes how to add a runset:
+Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. To add a runset, follow these steps:
 
 1. Create a `wr.Runset()` object instance. Provide the name of the project that contains the run sets for the project parameter and the entity that owns the project for the entity parameter.
 2. Create a `wr.PanelGrid()` object instance. Pass a list of one or more runset objects to the `run sets` parameter.
 3. Store one or more `wr.PanelGrid()` object instances in a list.
 4. Update the report instance blocks attribute with the list of panel grid instances.
+
+Replace `[PROJECT-NAME]` with your W&B project name and `[ENTITY-NAME]` with your W&B entity name in the following example:
 
 ```python
 import wandb
@@ -105,12 +113,12 @@ import wandb_workspaces.reports.v2 as wr
 
 report = wr.Report(
     project="report-editing",
-    title="An amazing title",
-    description="A descriptive description.",
+    title="Report title",
+    description="Report description.",
 )
 
 panel_grids = wr.PanelGrid(
-    runsets=[wr.RunSet(project="<project-name>", entity="<entity-name>")]
+    runsets=[wr.RunSet(project="[PROJECT-NAME]", entity="[ENTITY-NAME]")]
 )
 
 report.blocks = [panel_grids]
@@ -124,8 +132,8 @@ import wandb
 
 report = wr.Report(
     project="report-editing",
-    title="An amazing title",
-    description="A descriptive description.",
+    title="Report title",
+    description="Report description.",
 )
 
 panel_grids = wr.PanelGrid(
@@ -170,7 +178,7 @@ panel_grids = wr.PanelGrid(
             regression=True,
         ),
     ],
-    runsets=[wr.RunSet(project="<project-name>", entity="<entity-name>")],
+    runsets=[wr.RunSet(project="[PROJECT-NAME]", entity="[ENTITY-NAME]")],
 )
 
 
@@ -183,7 +191,7 @@ report.save()
 
 ## Freeze a run set
 
-A report automatically updates run sets to show the latest data from the project. You can preserve the run set in a report by *freezing* that run set. When you freeze a run set, you preserve the state of the run set in a report at a point in time.
+A report automatically updates run sets to show the latest data from the project. Freeze a run set when you want to preserve its state in a report at a point in time, so that later runs don't change what the report displays.
 
 To freeze a run set when viewing a report, click the snowflake icon in its panel grid near the **Filter** button.
 
@@ -193,11 +201,11 @@ To freeze a run set when viewing a report, click the snowflake icon in its panel
 
 ## Group a run set programmatically
 
-Group runs in a run set programmatically with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports).
+Group runs in a run set programmatically with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports). Grouping organizes related runs together in panels, which makes it easier to compare configurations and results.
 
-You can group runs in a run set by config values, run metadata or summary metrics. The following table lists the available grouping methods along with the available keys for that grouping method:
+You can group runs in a run set by config values, run metadata, or summary metrics. The following table lists the available grouping methods along with the available keys for each grouping method:
 
-| Grouping Method | Description |Available keys |
+| Grouping method | Description | Available keys |
 | ---|------| --- |
 | Config values| Group runs by config values | Values specified in config parameter in `wandb.init(config=)` |
 | Run metadata| Group runs by run metadata | `State`, `Name`, `JobType` |
@@ -210,16 +218,16 @@ You can group runs in a run set by config values, run metadata or summary metric
 
 ### Group runs by config values
 
-Group runs by config values to compare runs with similar configurations. Config values are parameters you specify in your run configuration `(wandb.init(config=))`. To group runs by config values, use the `config.<key>` syntax, where `<key>` is the name of the config value you want to group by. 
+Group runs by config values to compare runs with similar configurations. Config values are parameters you specify in your run configuration `(wandb.init(config=))`. To group runs by config values, use the `config.[KEY]` syntax, where `[KEY]` is the name of the config value you want to group by.
 
-For example, the following code snippet first initializes a run with a config value for `group`, then groups runs in a report based on the `group` config value. Replace values for `<entity>` and `<project>` with your W&B entity and project names.
+For example, the following code snippet first initializes a run with a config value for `group`, then groups runs in a report based on the `group` config value. Replace `[ENTITY]` and `[PROJECT]` with your W&B entity and project names.
 
 ```python
 import wandb
 import wandb_workspaces.reports.v2 as wr
 
-entity = "<entity>"
-project = "<project>"
+entity = "[ENTITY]"
+project = "[PROJECT]"
 
 for group in ["control", "experiment_a", "experiment_b"]:
     for i in range(3):
@@ -262,7 +270,7 @@ report.save()
 
 ### Group runs by run metadata
 
-Group runs by a run's name (`Name`), state (`State`), or job type (`JobType`). 
+Group runs by a run's name (`Name`), state (`State`), or job type (`JobType`).
 
 Continuing from the previous example, you can group your runs by their name with the following code snippet:
 
@@ -275,7 +283,7 @@ runset = wr.Runset(
 ```
 
 <Note>
-The name of the run is the name you specify in the `wandb.init(name=)` parameter. If you do not specify a name, W&B generates a random name for the run.
+The name of the run is the name you specify in the `wandb.init(name=)` parameter. If you don't specify a name, W&B generates a random name for the run.
 
 You can find the name of the run in the **Overview** page of a run in the W&B App or programmatically with `Api.runs().run.name`.
 </Note>
@@ -284,16 +292,16 @@ You can find the name of the run in the **Overview** page of a run in the W&B Ap
 
 The following examples demonstrate how to group runs by summary metrics. Summary metrics are the values you log to a run with `wandb.Run.log()`. After you log a run, you can find the names of your summary metrics in the W&B App under the **Summary** section of a run's **Overview** page.
 
-The syntax for grouping runs by summary metrics is `summary.<key>`, where `<key>` is the name of the summary metric you want to group by. 
+The syntax for grouping runs by summary metrics is `summary.[KEY]`, where `[KEY]` is the name of the summary metric you want to group by.
 
-For example, suppose you log a summary metric called `acc`:
+For example, suppose you log a summary metric called `acc`. Replace `[ENTITY]` and `[PROJECT]` with your W&B entity and project names:
 
 ```python
 import wandb
 import wandb_workspaces.reports.v2 as wr
 
-entity = "<entity>"
-project = "<project>"
+entity = "[ENTITY]"
+project = "[PROJECT]"
 
 for group in ["control", "experiment_a", "experiment_b"]:
     for i in range(3):
@@ -313,32 +321,32 @@ You can then group runs by the `summary.acc` summary metric:
 runset = wr.Runset(
   project=project,
   entity=entity,
-  groupby=["summary.acc"]  # Group by summary values 
+  groupby=["summary.acc"]  # Group by summary values
 )
 ```
 
 ## Filter a run set programmatically
 
-Programmatically filter run sets and add them to a report with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports).
+Programmatically filter run sets and add them to a report with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports). Filtering narrows a run set to the specific runs you want to display, based on config values, metrics, tags, or run properties.
 
 The general syntax for a filter expression is:
 
 ```text
-Filter('key') operation <value>
+Filter('KEY') operation [VALUE]
 ```
 
-Where `key` is the name of the filter, `operation` is a comparison operator (e.g., `>`, `<`, `==`, `in`, `not in`, `or`, and `and`), and `<value>` is the value to compare against. `Filter` is a placeholder for the type of filter you want to apply. The following table lists the available filters and their descriptions:
+In this expression, `KEY` is the name of the filter, `operation` is a comparison operator (for example, `>`, `<`, `==`, `in`, `not in`, `or`, and `and`), and `[VALUE]` is the value to compare against. `Filter` is a placeholder for the type of filter you want to apply. The following table lists the available filters and their descriptions:
 
 | Filter | Description | Available keys |
 | ---|---| --- |
-|`Config('key')` | Filter by config values | Values specified in `config` parameter in `wandb.init(config=)`. |
-|`SummaryMetric('key')` | Filter by summary metrics | Values you log to a run with `wandb.Run.log()`. |
-|`Tags('key')` | Filter by tags | Tag values that you add to your run (programmatically or with the W&B App). |
-|`Metric('key')` | Filter by run properties | `tags`, `state`, `displayName`, `jobType` |
+|`Config('KEY')` | Filter by config values | Values specified in `config` parameter in `wandb.init(config=)`. |
+|`SummaryMetric('KEY')` | Filter by summary metrics | Values you log to a run with `wandb.Run.log()`. |
+|`Tags('KEY')` | Filter by tags | Tag values that you add to your run (programmatically or with the W&B App). |
+|`Metric('KEY')` | Filter by run properties | `tags`, `state`, `displayName`, `jobType` |
 
-Once you have defined your filters, you can create a report and pass the filtered run sets to `wr.PanelGrid(runsets=)`. See the **Report and Workspace API** tabs throughout this page for more information on how to add various elements to a report programmatically.
+After you define your filters, you can create a report and pass the filtered run sets to `wr.PanelGrid(runsets=)`. See the **Report and Workspace API** tabs throughout this page for more information about how to add various elements to a report programmatically.
 
-The following examples demonstrate how to filter run sets in a report. Replace values enclosed in `<>` with your own values.
+The following examples demonstrate how to filter run sets in a report. Replace values enclosed in brackets (for example, `[ENTITY]` and `[PROJECT]`) with your own values.
 
 ### Config filters
 
@@ -354,7 +362,7 @@ config = {
     "batch_size": 32,
 }
 
-with wandb.init(project="<project>", entity="<entity>", config=config) as run:
+with wandb.init(project="[PROJECT]", entity="[ENTITY]", config=config) as run:
     # Your training code here
     pass
 ```
@@ -365,18 +373,18 @@ Within your Python script or notebook, you can then programmatically filter runs
 import wandb_workspaces.reports.v2 as wr
 
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Config('learning_rate') > 0.01"
 )
 ```
 
 You can also filter by multiple config values with the `and` operator:
- 
+
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Config('learning_rate') > 0.01 and Config('batch_size') == 32"
 )
 ```
@@ -385,8 +393,8 @@ Continuing from the previous example, you can create a report with the filtered 
 
 ```python
 report = wr.Report(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   title="My Report"
 )
 
@@ -407,13 +415,13 @@ report.save()
 
 ### Metric filters
 
-Filter run sets based on a run's: tag (`tags`), run state (`state`), run name (`displayName`), or job type (`jobType`).
+Filter run sets based on a run's tag (`tags`), run state (`state`), run name (`displayName`), or job type (`jobType`).
 
 <Note>
-`Metric` filters posses a different syntax. Pass a list of values as a list.
+`Metric` filters use a different syntax than other filters. You must pass values as a list.
 
 ```text
-Metric('key') operation [<value>]
+Metric('KEY') operation [VALUE]
 ```
 </Note>
 
@@ -422,7 +430,7 @@ For example, consider the following Python snippet that creates three runs and a
 ```python
 import wandb
 
-with wandb.init(project="<project>", entity="<entity>") as run:
+with wandb.init(project="[PROJECT]", entity="[ENTITY]") as run:
     for i in range(3):
         run.name = f"run{i+1}"
         # Your training code here
@@ -433,8 +441,8 @@ When you create your report, you can filter runs by their display name. For exam
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Metric('displayName') in ['run1', 'run2', 'run3']"
 )
 ```
@@ -447,16 +455,16 @@ The following examples demonstrate how to filter a runset by the run's state (`f
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Metric('state') in ['finished']"
 )
 ```
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Metric('state') not in ['crashed']"
 )
 ```
@@ -468,16 +476,16 @@ The following examples demonstrate how to filter a run set by summary metrics. S
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="SummaryMetric('accuracy') > 0.9"
 )
 ```
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Metric('state') in ['finished'] and SummaryMetric('train/train_loss') < 0.5"
 )
 ```
@@ -488,8 +496,8 @@ The following code snippet shows how to filter a runs set by its tags. Tags are 
 
 ```python
 runset = wr.Runset(
-  entity="<entity>",
-  project="<project>",
+  entity="[ENTITY]",
+  project="[PROJECT]",
   filters="Tags('training') == 'training'"
 )
 ```
@@ -500,14 +508,14 @@ Add code blocks to your report interactively with the App UI or with the W&B SDK
 
 <Tabs>
 <Tab title="App UI">
-Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown choose **Code**.
+Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Code**.
 
-Select the name of the programming language on the right hand of the code block. This will expand a dropdown. From the dropdown, select your programming language syntax. You can choose from Javascript, Python, CSS, JSON, HTML, Markdown, and YAML.
+Select the name of the programming language on the right side of the code block to expand a dropdown. From the dropdown, select your programming language syntax. You can choose from JavaScript, Python, CSS, JSON, HTML, Markdown, and YAML.
 </Tab>
 <Tab title="Report and Workspace API">
 Use the `wr.CodeBlock` Class to create a code block programmatically. Provide the name of the language and the code you want to display for the language and code parameters, respectively.
 
-For example the following example demonstrates a list in YAML file:
+For example, the following example demonstrates a list in a YAML file:
 
 ```python
 import wandb
@@ -524,7 +532,7 @@ report.blocks = [
 report.save()
 ```
 
-This will render a code block similar to:
+This renders a code block similar to:
 
 ```yaml
 this:
@@ -546,7 +554,7 @@ report.blocks = [wr.CodeBlock(code=["Hello, World!"], language="python")]
 report.save()
 ```
 
-This will render a code block similar to:
+This renders a code block similar to:
 
 ```md
 Hello, World!
@@ -560,7 +568,7 @@ Add markdown to your report interactively with the App UI or with the W&B SDK.
 
 <Tabs>
 <Tab title="App UI">
-Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown choose **Markdown**.
+Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Markdown**.
 </Tab>
 <Tab title="Report and Workspace API">
 Use the `wandb.apis.reports.MarkdownBlock` Class to create a markdown block programmatically. Pass a string to the `text` parameter:
@@ -576,7 +584,7 @@ report.blocks = [
 ]
 ```
 
-This will render a markdown block similar to:
+This renders a markdown block similar to:
 
 <Frame>
     <img src="/images/reports/markdown.png" alt="Rendered markdown block"  />
@@ -591,7 +599,7 @@ Add HTML elements to your report interactively with the App UI or with the W&B S
 
 <Tabs>
 <Tab title="App UI">
-Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown select a type of text block. For example, to create an H2 heading block, select the `Heading 2` option.
+Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, select a type of text block. For example, to create an H2 heading block, select the `Heading 2` option.
 </Tab>
 <Tab title="Report and Workspace API">
 Pass a list of one or more HTML elements to `wandb.apis.reports.blocks` attribute. The following example demonstrates how to create an H1, H2, and an unordered list:
@@ -611,7 +619,7 @@ report.blocks = [
 report.save()
 ```
 
-This will render the HTML elements to the following:
+This renders the HTML elements to the following:
 
 
 <Frame>
@@ -674,7 +682,7 @@ report.save()
 
 ## Duplicate and delete panel grids
 
-If you have a layout that you would like to reuse, you can select a panel grid and copy-paste it to duplicate it in the same report or even paste it into a different report.
+Duplicating and deleting panel grids helps you reuse layouts and remove content you no longer need. If you have a layout that you want to reuse, select a panel grid and copy-paste it to duplicate it in the same report or paste it into a different report.
 
 Highlight a whole panel grid section by selecting the drag handle in the upper right corner. Click and drag to highlight and select a region in a report such as panel grids, text, and headings.
 
@@ -688,9 +696,9 @@ Select a panel grid and press `delete` on your keyboard to delete a panel grid.
     <img src="/images/reports/delete_panel_grid.gif" alt="Deleting panel grids"  />
 </Frame>
 
-## Collapse headers to organize Reports
+## Collapse headers to organize reports
 
-Collapse headers in a Report to hide content within a text block. When the report is loaded, only headers that are expanded will show content. Collapsing headers in reports can help organize your content and prevent excessive data loading. The following gif demonstrates the process.
+Collapse headers in a report to hide content within a text block. When the report loads, only expanded headers show content. Collapsing headers in reports helps organize your content and prevents excessive data loading. The following gif demonstrates the process.
 
 <Frame>
     <img src="/images/reports/collapse_headers.gif" alt="Collapsing headers in a report."  />
@@ -698,8 +706,8 @@ Collapse headers in a Report to hide content within a text block. When the repor
 
 ## Visualize relationships across multiple dimensions
 
-To effectively visualize relationships across multiple dimensions, use a color gradient to represent one of the variables. This enhances clarity and makes patterns easier to interpret.
+When you want to compare more variables than a 2D plot can show, you can use a color gradient as an additional dimension. W&B recommends using a color gradient to represent one of the variables, which enhances clarity and makes patterns easier to interpret.
 
-1. Choose a variable to represent with a color gradient (e.g., penalty scores, learning rates, etc.). This allows for a clearer understanding of how penalty (color) interacts with reward/side effects (y-axis) over training time (x-axis).
-2. Highlight key trends. Hovering over a specific group of runs highlights them in the visualization.
+1. Choose a variable to represent with a color gradient (for example, penalty scores or learning rates). This provides a clearer understanding of how penalty (color) interacts with reward/side effects (y-axis) over training time (x-axis).
+2. Highlight key trends. Hover over a specific group of runs to highlight them in the visualization.
 

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -2,12 +2,7 @@
 description: Edit a report interactively with the App UI or programmatically with
   the W&B SDK.
 title: Edit a report
-keywords:
-  - wandb-workspaces
-  - PanelGrid
-  - RunSet
-  - report blocks
-  - report filters
+keywords: ["wandb-workspaces", "PanelGrid", "RunSet", "report blocks", "report filters"]
 ---
 
 <Note>

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -1,12 +1,7 @@
 ---
 description: Embed W&B reports directly into Notion or with an HTML `iframe` element.
 title: Embed a report
-keywords:
-  - iframe
-  - Confluence
-  - Notion
-  - Gradio
-  - Hugging Face Spaces
+keywords: ["iframe", "Confluence", "Notion", "Gradio", "Hugging Face Spaces"]
 ---
 
 Embed W&B reports in external pages and tools so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and how to use it in HTML, Confluence, Notion, and Gradio.

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -4,7 +4,7 @@ title: Embed a report
 keywords: ["iframe", "Confluence", "Notion", "Gradio", "Hugging Face Spaces"]
 ---
 
-Embed W&B reports in external pages and tools so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and how to use it in HTML, Confluence, Notion, and Gradio.
+Embed a W&B report in an external page or tool so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and use it in HTML, Confluence, Notion, or Gradio.
 
 ## HTML `iframe` element
 
@@ -38,7 +38,7 @@ The following animation demonstrates how to insert a report into a Notion docume
 
 ## Gradio
 
-To embed a W&B report in a Gradio app, including apps hosted on Hugging Face Spaces, use Gradio's `gr.HTML` element to render an `iframe` that points to the report URL.
+To embed a W&B report in a Gradio app, including an app hosted on Hugging Face Spaces, use Gradio's `gr.HTML` element to render an `iframe` that points to the report URL.
 
 ```python
 import gradio as gr

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -1,14 +1,24 @@
 ---
-description: Embed W&B reports directly into Notion or with an HTML IFrame element.
+description: Embed W&B reports directly into Notion or with an HTML `iframe` element.
 title: Embed a report
+keywords:
+  - iframe
+  - Confluence
+  - Notion
+  - Gradio
+  - Hugging Face Spaces
 ---
 
-## HTML iframe element
+Embed W&B reports in external pages and tools so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and how to use it in HTML, Confluence, Notion, and Gradio.
 
-Select the **Share** button on the upper right hand corner within a report. A modal window will appear. Within the modal window, select **Copy embed code**. The copied code will render within an Inline Frame (IFrame)  HTML element. Paste the copied code into an iframe HTML element of your choice.
+## HTML `iframe` element
+
+Use an HTML `iframe` element to embed a report on any web page that accepts custom HTML. W&B provides a prebuilt embed code that you can copy directly from the report.
+
+Select the **Share** button in the upper right of a report to open a dialog, then select **Copy embed code**. The copied snippet is an `iframe` HTML element that you can paste into any page that accepts custom HTML.
 
 <Note>
-Only **public** reports are viewable when embedded.
+Only *public* reports are viewable when embedded.
 </Note>
 
 <Frame>
@@ -17,7 +27,7 @@ Only **public** reports are viewable when embedded.
 
 ## Confluence
 
-The following animation demonstrates how to insert the direct link to the report within an IFrame cell in Confluence.
+The following animation demonstrates how to insert the direct link to the report within an `iframe` cell in Confluence.
 
 <Frame>
     <img src="/images/reports/embed_iframe_confluence.gif" alt="Embedding in Confluence"  />
@@ -25,7 +35,7 @@ The following animation demonstrates how to insert the direct link to the report
 
 ## Notion
 
-The following animation demonstrates how to insert a report into a Notion document using an Embed block in Notion and the report's embedded code.
+The following animation demonstrates how to insert a report into a Notion document using an **Embed** block in Notion and the report's embed code.
 
 <Frame>
     <img src="/images/reports/embed_iframe_notion.gif" alt="Embedding in Notion"  />
@@ -33,7 +43,7 @@ The following animation demonstrates how to insert a report into a Notion docume
 
 ## Gradio
 
-You can use the `gr.HTML` element to embed W&B Reports within Gradio Apps and use them within Hugging Face Spaces.
+To embed a W&B report in a Gradio app, including apps hosted on Hugging Face Spaces, use Gradio's `gr.HTML` element to render an `iframe` that points to the report URL.
 
 ```python
 import gradio as gr
@@ -50,5 +60,3 @@ with gr.Blocks() as demo:
     )
 demo.launch()
 ```
-
-##

--- a/models/reports/reports-gallery.mdx
+++ b/models/reports/reports-gallery.mdx
@@ -1,21 +1,31 @@
 ---
 description: "Explore example W&B Reports showcasing use cases like experiment summaries, team collaboration, and sharing findings."
 title: Example reports
+keywords:
+  - report examples
+  - report gallery
+  - experiment notes
+  - collaboration
+  - work log
 ---
+
+This page showcases example W&B Reports that demonstrate common use cases, including capturing experiment notes, collaborating with colleagues, and tracking project work logs. Use these examples as inspiration for structuring your own reports.
+
+The following sections describe common report patterns and link to example reports for each.
 
 ## Notes: Add a visualization with a quick summary
 
-Capture an important observation, an idea for future work, or a milestone reached in the development of a project. All experiment runs in your report will link to their parameters, metrics, logs, and code, so you can save the full context of your work.
+Capture an important observation, an idea for future work, or a milestone reached in the development of a project. All experiment runs in your report link to their parameters, metrics, logs, and code, so you can save the full context of your work.
 
-Jot down some text and pull in relevant charts to illustrate your insight. 
+Jot down some text and pull in relevant charts to illustrate your insight.
 
-See the [What To Do When Inception-ResNet-V2 Is Too Slow](https://wandb.ai/stacey/estuary/reports/When-Inception-ResNet-V2-is-too-slow--Vmlldzo3MDcxMA) W&B Report for an example of how you can share comparisons of training time.
+See the [What To Do When Inception-ResNet-V2 Is Too Slow](https://wandb.ai/stacey/estuary/reports/When-Inception-ResNet-V2-is-too-slow--Vmlldzo3MDcxMA) report for an example of how you can share comparisons of training time.
 
 <Frame>
     <img src="/images/reports/notes_add_quick_summary.png" alt="Quick summary notes" max-width="90%"  />
 </Frame>
 
-Save the best examples from a complex code base for easy reference and future interaction. See the [LIDAR point clouds](https://wandb.ai/stacey/lyft/reports/LIDAR-Point-Clouds-of-Driving-Scenes--Vmlldzo2MzA5Mg) W&B Report for an example of how to visualize LIDAR point clouds from the Lyft dataset and annotate with 3D bounding boxes.
+Save the best examples from a complex code base for quick reference and future interaction. See the [LIDAR point clouds](https://wandb.ai/stacey/lyft/reports/LIDAR-Point-Clouds-of-Driving-Scenes--Vmlldzo2MzA5Mg) report for an example of how to visualize LIDAR point clouds from the Lyft dataset and annotate with 3D bounding boxes.
 
 <Frame>
     <img src="/images/reports/notes_add_quick_summary_save_best_examples.png" alt="Save best examples" max-width="90%"  />
@@ -25,9 +35,9 @@ Save the best examples from a complex code base for easy reference and future in
 
 Explain how to get started with a project, share what you've observed so far, and synthesize the latest findings. Your colleagues can make suggestions or discuss details using comments on any panel or at the end of the report.
 
-Include dynamic settings so that your colleagues can explore for themselves, get additional insights, and better plan their next steps. In this example, three types of experiments can be visualized independently, compared, or averaged. 
+Include dynamic settings so that your colleagues can explore for themselves, get additional insights, and better plan their next steps. In this example, you can visualize three types of experiments independently, compare them, or average them.
 
-See the [SafeLife benchmark experiments](https://wandb.ai/stacey/saferlife/reports/SafeLife-Benchmark-Experiments--Vmlldzo0NjE4MzM) W&B Report for an example of how to share first runs and observations of a benchmark.
+See the [SafeLife benchmark experiments](https://wandb.ai/stacey/saferlife/reports/SafeLife-Benchmark-Experiments--Vmlldzo0NjE4MzM) report for an example of how to share first runs and observations of a benchmark.
 
 <Frame>
     <img src="/images/reports/intro_collaborate1.png" alt="SafeLife benchmark report"  />
@@ -37,7 +47,7 @@ See the [SafeLife benchmark experiments](https://wandb.ai/stacey/saferlife/repor
     <img src="/images/reports/intro_collaborate2.png" alt="Experiment comparison view"  />
 </Frame>
 
-Use sliders and configurable media panels to showcase a model's results or training progress. View the [Cute Animals and Post-Modern Style Transfer: StarGAN v2 for Multi-Domain Image Synthesis](https://wandb.ai/stacey/stargan/reports/Cute-Animals-and-Post-Modern-Style-Transfer-StarGAN-v2-for-Multi-Domain-Image-Synthesis---VmlldzoxNzcwODQ) report for an example W&B Report with sliders.
+Use sliders and configurable media panels to showcase a model's results or training progress. View the [Cute Animals and Post-Modern Style Transfer: StarGAN v2 for Multi-Domain Image Synthesis](https://wandb.ai/stacey/stargan/reports/Cute-Animals-and-Post-Modern-Style-Transfer-StarGAN-v2-for-Multi-Domain-Image-Synthesis---VmlldzoxNzcwODQ) report for an example report with sliders.
 
 <Frame>
     <img src="/images/reports/intro_collaborate3.png" alt="StarGAN report with sliders"  />
@@ -49,16 +59,16 @@ Use sliders and configurable media panels to showcase a model's results or train
 
 ## Work log: Track what you've tried and plan next steps
 
-Write down your thoughts on experiments, your findings, and any gotchas and next steps as you work through a project, keeping everything organized in one place. This lets you "document" all the important pieces beyond your scripts. See the [Who Is Them? Text Disambiguation With Transformers](https://wandb.ai/stacey/winograd/reports/Who-is-Them-Text-Disambiguation-with-Transformers--VmlldzoxMDU1NTc) W&B Report for an example of how you can report your findings.
+Write down your thoughts on experiments, your findings, and any gotchas and next steps as you work through a project, and keep everything organized in one place. This lets you "document" all the important pieces beyond your scripts. See the [Who Is Them? Text Disambiguation With Transformers](https://wandb.ai/stacey/winograd/reports/Who-is-Them-Text-Disambiguation-with-Transformers--VmlldzoxMDU1NTc) report for an example of how you can report your findings.
 
 <Frame>
     <img src="/images/reports/intro_work_log_1.png" alt="Text disambiguation report"  />
 </Frame>
 
-Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) W&B Report for how you can report your findings.
+Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) report for how you can report your findings.
 
 <Frame>
     <img src="/images/reports/intro_work_log_2.png" alt="Driver's seat project report"  />
 </Frame>
 
-See the [Learning Dexterity End-to-End Using W&B Reports](https://bit.ly/wandb-learning-dexterity) for an example of how W&B Reports were used to explore how the OpenAI Robotics team used W&B Reports to run massive machine learning projects.
+See [Learning Dexterity End-to-End Using W&B Reports](https://bit.ly/wandb-learning-dexterity) for an example of how the OpenAI Robotics team uses Reports to run large-scale machine learning projects.

--- a/models/reports/reports-gallery.mdx
+++ b/models/reports/reports-gallery.mdx
@@ -1,12 +1,7 @@
 ---
 description: "Explore example W&B Reports showcasing use cases like experiment summaries, team collaboration, and sharing findings."
 title: Example reports
-keywords:
-  - report examples
-  - report gallery
-  - experiment notes
-  - collaboration
-  - work log
+keywords: ["report examples", "report gallery", "experiment notes", "collaboration", "work log"]
 ---
 
 This page showcases example W&B Reports that demonstrate common use cases, including capturing experiment notes, collaborating with colleagues, and tracking project work logs. Use these examples as inspiration for structuring your own reports.


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to documentation under `models/reports`. The run was automated and contains style-only edits across 7 files.

## Files edited

- `models/reports/clone-and-export-reports.mdx`
- `models/reports/collaborate-on-reports.mdx`
- `models/reports/create-a-report.mdx`
- `models/reports/cross-project-reports.mdx`
- `models/reports/edit-a-report.mdx`
- `models/reports/embed-reports.mdx`
- `models/reports/reports-gallery.mdx`

## Recommendations for technical review

### Prerequisites
- Add a Prerequisites section (or links) to most pages covering: W&B account/login (`wandb login`), `wandb` and `wandb-workspaces` package install, the canonical import statement (`import wandb_workspaces.reports.v2 as wr`), and required SDK versions for the Report and Workspace API (`clone-and-export-reports.mdx`, `create-a-report.mdx`, `edit-a-report.mdx`, `embed-reports.mdx`).
- Document the role/seat/permissions needed to clone a report into a team vs. individual account, edit a published report, and share with external (non-org) recipients (`clone-and-export-reports.mdx`, `collaborate-on-reports.mdx`, `edit-a-report.mdx`).
- Define or link out to W&B concepts referenced without context: W&B Local, project visibility types (Private/Team/Public/Open), run sets (`cross-project-reports.mdx`).
- Link to a "Create a report" prerequisite from `embed-reports.mdx` and `clone-and-export-reports.mdx` for readers who don't yet have a report.

### Verification steps
- Add success/confirmation cues after major procedures: where the saved/cloned report appears, how to find it, what `report.url` returns, and noting that `report.url` is populated only after `report.save()` (`clone-and-export-reports.mdx`, `create-a-report.mdx`, `edit-a-report.mdx`).
- Add guidance on confirming an export succeeded (where the PDF/LaTeX file lands, browser behavior) in `clone-and-export-reports.mdx`.
- Document the UI path for generating a view-only/magic link in `cross-project-reports.mdx`.
- Add brief "what success looks like" sentences to each embed flow (Confluence, Notion, HTML, Gradio) in `embed-reports.mdx`, and confirmation cues for share/invite/save actions in `collaborate-on-reports.mdx`.

### Technical accuracy
- Confirm the Public Preview status of the Report and Workspace API callout in `clone-and-export-reports.mdx`.
- Verify the current W&B App click paths and that referenced GIFs still match the UI: action menu → **Download** → PDF/LaTeX and action menu → **Clone this report** → **Clone report** (`clone-and-export-reports.mdx`); `share-report.gif` placement (`collaborate-on-reports.mdx`); collapse-header behavior (`edit-a-report.mdx`).
- Confirm UI labels are current and use consistent casing/bolding: **Create report** (sentence case), **Add to report**, **Share**/**Invite**, **view-only mode**, project visibility labels Private/Team/Public/Open (`create-a-report.mdx`, `cross-project-reports.mdx`, `collaborate-on-reports.mdx`).
- Verify the API surface in code samples (`wr.Report`, `wr.Report.from_url`, `wr.PanelGrid`, `wr.Runset` vs. `wr.RunSet` casing, `wr.LinePlot`, `wr.BarPlot`, `wr.MediaBrowser`, `wr.RunComparer`, `wr.H1`) and whether the older `wandb.apis.reports` Public API referenced alongside `wandb_workspaces.reports.v2.Report` is still recommended (`clone-and-export-reports.mdx`, `create-a-report.mdx`, `edit-a-report.mdx`).
- Confirm the exact "Add run sets" parameter name (`runsets` vs. "`run sets`") and `Tags` filter syntax (`Tags('training') == 'training'` vs. `Metric('tags') in [...]`) in `edit-a-report.mdx`.
- Verify the Colab notebook link in `edit-a-report.mdx` — URL contains `Update-wandb-workspaces-tuturial` (likely a typo).
- Confirm `PROJECT` and `ENTITY` should appear as bare identifiers vs. quoted strings in code snippets, and that "W&B entity" is the correct user-facing term (username vs. team) (`clone-and-export-reports.mdx`).
- Verify the active-voice rewrite "W&B automatically saves a draft" — confirm W&B (server-side) is the actor, not the browser/client (`collaborate-on-reports.mdx`).
- Confirm that the second **Share** bullet under "Share a report" requires clicking the outer **Share** button first, or whether labels have changed (`collaborate-on-reports.mdx`).
- Confirm that the W&B Local access-control sentence still accurately describes private-instance behavior with view-only links (`cross-project-reports.mdx`).
- Verify embed claims in `embed-reports.mdx`: **Share** button location (upper right), that **Copy embed code** returns a full `<iframe>` snippet, that "only public reports are viewable when embedded" remains absolute (no embed-token/signed-URL support), current Confluence macro name (`iframe cell` may be stale), current Notion **Embed** block label, that the Gradio sample URL still resolves, that `gr.HTML` is still current, and whether the unclosed `<iframe>` in the Gradio sample is intentional.
- Verify external/example links in `reports-gallery.mdx` still resolve and demonstrate the described capabilities: Inception-ResNet-V2, StarGAN v2, LIDAR, SafeLife, the `bit.ly/wandb-learning-dexterity` shortlink, and the OpenAI Robotics report. Confirm the published display title for "What To Do When Inception-ResNet-V2 Is Too Slow."

### Missing content
- Link to the Report and Workspace API reference for `wr.Report`, `wr.PanelGrid`, `wr.Runset`, panel constructors, and block types; briefly explain what `report.blocks` is and which block types are valid (`clone-and-export-reports.mdx`, `edit-a-report.mdx`).
- Document export limitations: size limits, whether interactive panels are flattened in PDF/LaTeX, image/asset handling, and PDF vs. LaTeX formatting caveats (`clone-and-export-reports.mdx`).
- Add a one-line conceptual anchor or link to a "What is a W&B Report?" page near the top of pages that reference Reports without defining them (`create-a-report.mdx`, `reports-gallery.mdx`).
- Note the next state after clicking **Create report** in the "Report tab" tab — particularly whether it opens the same chart-selection modal as the W&B App tab (`create-a-report.mdx`).
- Consider replacing the removed "(clipboard image)" parenthetical with a screenshot if a visual cue helps locate the **Reports** tab (`create-a-report.mdx`).
- Promote the history-data limitation to a `<Note>` or `<Warning>`, and the tag/move workaround to its own subheading (and verify the workaround is current) in `cross-project-reports.mdx`.
- Show how to attach a `runset` built via `Group runs by summary metrics`, `SummaryMetric filters`, and `Tags filters` to a report; document whether SoundCloud has an embed class to match the App UI tab; add a written procedure (not just a GIF) for collapsing headers (`edit-a-report.mdx`).
- Relocate the public-only embed `<Note>` to the page intro of `embed-reports.mdx` since it applies to all embed methods; add written procedural steps to accompany the Confluence and Notion GIFs; add a link explaining how to make a report public; add a comment in the Gradio sample indicating readers should substitute their own report URL.
- In `reports-gallery.mdx`, decide whether to keep the "Label: Description" H2 pattern or simplify, and harmonize line 68's link phrasing ("See [The View from the Driver's Seat] report for how you can report your findings.") with the parallel "See the [Title] report for an example of how..." pattern used elsewhere.
- Consider moving the inline `# Create`, `# Save`, `# Load` comments in `clone-and-export-reports.mdx` into surrounding prose if the goal is pedagogy rather than copy-pastable code.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
