### PR TITLE
Fix Mintlify tabs on trace-agents pages

### DIFF
--- a/weave/guides/tracking/trace-agents-batch.mdx
+++ b/weave/guides/tracking/trace-agents-batch.mdx
@@ -18,7 +18,7 @@ If you are building your own agent loop, use the real-time instrumentation APIs 
 `weave.log_turn` accepts a fully-formed turn, including all LLM and tool spans.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines highlight="1,3,28"
 weave.init("[YOUR-TEAM]/[YOUR-PROJECT]")
@@ -59,14 +59,14 @@ weave.log_turn(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```plaintext
 This feature is not available in the TypeScript SDK yet.
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 `log_turn` returns a `LogResult` containing the trace IDs of the emitted spans.
@@ -78,7 +78,7 @@ An optional `model` parameter on `log_turn` sets the model on the turn's own spa
 To bulk-import a complete, multi-turn session at once, use `weave.log_session`. The `turns` parameter accepts a list of `Turn` objects, each constructed the same way as the `log_turn` example above.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 weave.log_session(
@@ -88,12 +88,12 @@ weave.log_session(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```plaintext
 This feature is not available in the TypeScript SDK yet.
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>

--- a/weave/guides/tracking/trace-agents.mdx
+++ b/weave/guides/tracking/trace-agents.mdx
@@ -20,7 +20,7 @@ To get started, install the `weave` package and initialize your project. This ma
 Install Weave and initialize your project:
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```bash lines
 pip install weave
@@ -36,8 +36,8 @@ weave.init("[YOUR-TEAM]/[YOUR-PROJECT]")
 
 Call `weave.init()` before any `start_session()`, `start_turn()`, `start_llm()`, or `start_tool()` call. All agent tracing functions no-op silently when tracing is disabled or the init call is absent, so you can leave instrumentation in production code and control it through configuration.
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```bash lines
 npm install weave
@@ -53,7 +53,7 @@ await weave.init('[YOUR-TEAM]/[YOUR-PROJECT]');
 
 Call `weave.init()` before any `startSession()`, `startTurn()`, `startLLM()`, or `startTool()` call. All agent tracing functions no-op silently when tracing is disabled or the init call is absent, so you can leave instrumentation in production code and control it through configuration.
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 ## The agent data model
@@ -122,7 +122,7 @@ Weave exposes the following top-level functions. Each function returns an object
 The active session is stored in context (a Python `ContextVar` or Node.js `AsyncLocalStorage`), so any code running in the same async context can retrieve it with `weave.get_current_session()` / `weave.getCurrentSession()` without passing the session object explicitly.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 session = weave.start_session(
@@ -135,8 +135,8 @@ session = weave.start_session(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const session = weave.startSession({
@@ -146,7 +146,7 @@ const session = weave.startSession({
 });
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 
@@ -157,7 +157,7 @@ const session = weave.startSession({
 When called as a top-level function, it resolves the active session from context and inherits its conversation ID. If no session is active, the turn is created without a `conversation_id` and won't be grouped with other turns.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 turn = weave.start_turn(
@@ -167,8 +167,8 @@ turn = weave.start_turn(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const turn = weave.startTurn({
@@ -177,7 +177,7 @@ const turn = weave.startTurn({
 });
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 
@@ -187,7 +187,7 @@ const turn = weave.startTurn({
 `start_llm()` / `startLLM()` creates a `chat` span nested under the current turn. Weave uses this span to display token usage, model name, input and output messages, and reasoning in the Agents view.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 llm = weave.start_llm(
@@ -197,8 +197,8 @@ llm = weave.start_llm(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const llm = weave.startLLM({
@@ -207,7 +207,7 @@ const llm = weave.startLLM({
 });
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 
@@ -215,7 +215,7 @@ const llm = weave.startLLM({
 After the LLM call completes, assign the response data to the `llm` object before it closes:
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 with weave.start_llm(model="gpt-4o", provider_name="openai") as llm:
@@ -228,8 +228,8 @@ with weave.start_llm(model="gpt-4o", provider_name="openai") as llm:
     )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const llm = weave.startLLM({ model: 'gpt-4o', providerName: 'openai' });
@@ -246,7 +246,7 @@ try {
 }
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 Pass `provider_name` / `providerName` explicitly. Weave doesn't infer it from the model string.
@@ -256,7 +256,7 @@ Pass `provider_name` / `providerName` explicitly. Weave doesn't infer it from th
 `start_tool()` / `startTool()` creates an `execute_tool` span. The span becomes a child of whatever OTel span is active in context (typically the `chat` span of the LLM call that produced the tool call).
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 tool = weave.start_tool(
@@ -266,8 +266,8 @@ tool = weave.start_tool(
 )
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const tool = weave.startTool({
@@ -277,13 +277,13 @@ const tool = weave.startTool({
 });
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 Assign the tool result before closing:
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines
 with weave.start_tool(name="get_weather", arguments='{"city": "Tokyo"}') as tool:
@@ -291,8 +291,8 @@ with weave.start_tool(name="get_weather", arguments='{"city": "Tokyo"}') as tool
     tool.result = result  # Accepts dict, list, or string. JSON-encoded automatically.
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines
 const tool = weave.startTool({ name: 'get_weather', args: '{"city": "Tokyo"}' });
@@ -303,7 +303,7 @@ try {
 }
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 ## Usage patterns for agent tracing
@@ -324,7 +324,7 @@ The recommended approach for most agents is using a context manager pattern in P
 Weave stores the active session, turn, and LLM call in context, so any function called within a block can call `start_llm()` / `startLLM()` or `start_tool()` / `startTool()` without holding an explicit reference to the parent. This works across module boundaries as long as the code runs in the same async context. To retrieve the active objects from anywhere in the call stack, use `weave.get_current_session()` / `weave.getCurrentSession()`, `weave.get_current_turn()` / `weave.getCurrentTurn()`, and `weave.get_current_llm()` / `weave.getCurrentLLM()`.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines highlight="13,14,17,25,29"
 import weave
@@ -361,8 +361,8 @@ with weave.start_session(agent_name="weather-bot") as session:
             llm.usage = Usage(input_tokens=150, output_tokens=30)
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines highlight="11,13,16,24,35"
 import * as weave from 'weave';
@@ -415,7 +415,7 @@ try {
 }
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 ### Manual start and end pattern
@@ -423,7 +423,7 @@ try {
 Use `.end()` explicitly when you can't use `with` blocks or `try/finally`. For example, when spans are opened and closed in different function calls, or when managing async lifecycle outside a coroutine.
 
 <Tabs>
-  <TabItem value="python" label="Python">
+<Tab title="Python">
 
 ```python lines highlight="1,2,4,9,15"
 session = weave.start_session(agent_name="weather-bot")
@@ -449,8 +449,8 @@ turn.end()
 session.end()
 ```
 
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
+</Tab>
+<Tab title="TypeScript">
 
 ```typescript lines highlight="1,2,4,9,15"
 const session = weave.startSession({ agentName: 'weather-bot' });
@@ -476,7 +476,7 @@ turn.end();
 session.end();
 ```
 
-  </TabItem>
+</Tab>
 </Tabs>
 
 ## Semantic conventions


### PR DESCRIPTION
## Summary

- Replaces `<TabItem>` with Mintlify's `<Tab title="...">` on `trace-agents.mdx` and `trace-agents-batch.mdx`.
- Code examples in tabbed sections were not rendering in the live docs because `TabItem` is not a supported Mintlify component.

## Test plan

- [ ] Run `mint dev` and open the trace-agents and trace-agents-batch pages.
- [ ] Confirm Python and TypeScript tabs show code blocks in each tabbed section.


Made with [Cursor](https://cursor.com)