### PR TITLE
Clarify Subject/sub field values per IdP for external service accounts (DOCS-2714)

### DIFF
--- a/platform/hosting/iam/identity_federation.mdx
+++ b/platform/hosting/iam/identity_federation.mdx
@@ -67,7 +67,7 @@ To configure an external service account, a team admin must:
 
 1. Navigate to the **Service Accounts** tab for your team.
 2. Click **New service account**.
-3. Provide a name for the service account, select **Federated Identity** as the **Authentication Method**, provide a **Subject**, and click **Create**.
+3. Provide a name for the service account, select **Federated Identity** as the **Authentication Method**, provide a **Subject** (see [Determine the Subject value for your identity provider](#determine-the-subject-value-for-your-identity-provider)), and click **Create**.
 
 After this step, the external service account is registered with the team and can use JWTs issued by the configured identity provider to access W&B. The `sub` claim in the external service account's JWT must equal the subject configured by the team admin in the team-level **Service Accounts** tab. W&B verifies that claim as part of [JWT validation](#jwt-validation). The `aud` claim requirement is similar to that for human user JWTs.
 
@@ -76,3 +76,20 @@ When [using an external service account's JWT to access W&B](#use-the-jwt-to-acc
 <Note>
 W&B recommends using a mix of built-in and external service accounts across your AI workloads with different levels of data sensitivity. This mix strikes a balance between flexibility and simplicity.
 </Note>
+
+### Determine the Subject value for your identity provider
+
+The value you enter for **Subject** must exactly match the `sub` (subject) claim in the JWTs that your identity provider issues for the service account. W&B verifies this as part of [JWT validation](#jwt-validation), using the same check for every identity provider. The match is exact, case-sensitive, and whitespace-sensitive, so even a trailing space or a difference in capitalization causes authentication to fail.
+
+The W&B UI accepts any non-empty **Subject** without validating its value, so an incorrect value isn't caught when you create the service account. Instead, authentication fails later, when the service account presents its JWT.
+
+The value to use depends on your identity provider, because each provider populates `sub` differently. The following values are typical. Always confirm them against an actual token from your provider:
+
+| Identity provider | Where to find the `sub` value |
+| ----- | ----- |
+| Microsoft Entra ID | The service principal's **Object ID**, found under **Enterprise Applications** in the [Microsoft Entra admin center](https://entra.microsoft.com). Use the **Enterprise Application** (service principal) Object ID, not the **App registration** Object ID. For app-only (client credentials) tokens, this is typically the value Entra ID places in `sub`. |
+| Google Cloud (GCP) | The `sub` value from the ID token that Google issues for the service account. |
+
+<Tip>
+To find the exact value for any provider, including one not listed above, read it from a real token. Obtain a sample JWT issued for the service account, base64url-decode its payload (the middle segment, between the two dots) locally, and copy the `sub` value verbatim into the **Subject** field. Don't paste JWTs into third-party online decoders, because a JWT is a credential.
+</Tip>

--- a/platform/hosting/iam/identity_federation.mdx
+++ b/platform/hosting/iam/identity_federation.mdx
@@ -67,7 +67,9 @@ To configure an external service account, a team admin must:
 
 1. Navigate to the **Service Accounts** tab for your team.
 2. Click **New service account**.
-3. Provide a name for the service account, select **Federated Identity** as the **Authentication Method**, provide a **Subject** (see [Determine the Subject value for your identity provider](#determine-the-subject-value-for-your-identity-provider)), and click **Create**.
+3. Provide a name for the service account.
+4. Select **Federated Identity** as the **Authentication Method**, then provide a **Subject**. See [Determine the Subject value for your identity provider](#determine-the-subject-value-for-your-identity-provider).
+5. Click **Create**.
 
 After this step, the external service account is registered with the team and can use JWTs issued by the configured identity provider to access W&B. The `sub` claim in the external service account's JWT must equal the subject configured by the team admin in the team-level **Service Accounts** tab. W&B verifies that claim as part of [JWT validation](#jwt-validation). The `aud` claim requirement is similar to that for human user JWTs.
 
@@ -79,17 +81,15 @@ W&B recommends using a mix of built-in and external service accounts across your
 
 ### Determine the Subject value for your identity provider
 
-The value you enter for **Subject** must exactly match the `sub` (subject) claim in the JWTs that your identity provider issues for the service account. W&B applies the same comparison for every identity provider. The match is exact, case-sensitive, and whitespace-sensitive, so even a trailing space or a difference in capitalization causes authentication to fail.
+The value you enter for **Subject** must exactly match the `sub` (subject) claim in JWTs issued by your IdP for the service account. W&B applies the same comparison for every identity provider. The match is exact, case-sensitive, and whitespace-sensitive, so even a trailing space or a difference in capitalization causes authentication to fail.
 
-The W&B UI accepts any non-empty **Subject** without validating its value, so an incorrect value isn't caught when you create the service account. Instead, authentication fails later, when the service account presents its JWT.
+The W&B App accepts any non-empty **Subject** without validating its value, since the value is entirely dependent on the IdP. W&B can't detect an incorrect value when you create the service account. Instead, authentication fails later, when the service account presents its JWT.
 
-The value to use depends on your identity provider, because each provider populates `sub` differently. The following values are typical. Always confirm them against an actual token from your provider:
+The most reliable way to determine the correct value is to read it from a real token. Obtain a sample JWT issued for the service account, base64url-decode its payload (the middle segment, between the two dots) locally, and copy the `sub` value verbatim into the **Subject** field. Don't paste JWTs into third-party online decoders, because a JWT is a credential.
+
+The value differs by provider. The following are typical, but always confirm them against an actual token:
 
 | Identity provider | Where to find the `sub` value |
 | ----- | ----- |
 | Microsoft Entra ID | The service principal's **Object ID**, found under **Enterprise Applications** in the [Microsoft Entra admin center](https://entra.microsoft.com). Use the **Enterprise Application** (service principal) Object ID, not the **App registration** Object ID. For app-only (client credentials) tokens, this is typically the value Entra ID places in `sub`. |
 | Google Cloud (GCP) | The `sub` value from the ID token that Google issues for the service account. |
-
-<Tip>
-To find the exact value for any provider, including one not listed above, read it from a real token. Obtain a sample JWT issued for the service account, base64url-decode its payload (the middle segment, between the two dots) locally, and copy the `sub` value verbatim into the **Subject** field. Don't paste JWTs into third-party online decoders, because a JWT is a credential.
-</Tip>

--- a/platform/hosting/iam/identity_federation.mdx
+++ b/platform/hosting/iam/identity_federation.mdx
@@ -79,7 +79,7 @@ W&B recommends using a mix of built-in and external service accounts across your
 
 ### Determine the Subject value for your identity provider
 
-The value you enter for **Subject** must exactly match the `sub` (subject) claim in the JWTs that your identity provider issues for the service account. W&B verifies this as part of [JWT validation](#jwt-validation), using the same check for every identity provider. The match is exact, case-sensitive, and whitespace-sensitive, so even a trailing space or a difference in capitalization causes authentication to fail.
+The value you enter for **Subject** must exactly match the `sub` (subject) claim in the JWTs that your identity provider issues for the service account. W&B applies the same comparison for every identity provider. The match is exact, case-sensitive, and whitespace-sensitive, so even a trailing space or a difference in capitalization causes authentication to fail.
 
 The W&B UI accepts any non-empty **Subject** without validating its value, so an incorrect value isn't caught when you create the service account. Instead, authentication fails later, when the service account presents its JWT.
 


### PR DESCRIPTION
## Description

Clarifies what value to enter in the **Subject** field when creating an external service account with federated identity.

**Problem:** Users were unsure what to put in the **Subject** field. The W&B UI accepts any non-empty string without validating its value, and the correct value differs per identity provider — so a wrong value isn't caught at creation time and authentication just fails later.

**Change:** Adds a *Determine the Subject value for your identity provider* subsection to the External service accounts section of `identity_federation.mdx`, plus a forward-link from the configuration steps. It:

- States that the Subject must exactly match the JWT `sub` claim, and that the comparison is **case- and whitespace-sensitive** and applied identically for every IdP. This directly explains the "the UI accepted my value but auth fails" symptom (a trailing space or wrong case is a real cause).
- Gives **typical per-IdP values** — Microsoft Entra ID (the Enterprise Application service principal's Object ID, *not* the App registration's) and Google Cloud (the `sub` from the issued ID token) — framed as "typical; confirm against a real token."
- Recommends the authoritative, **IdP-agnostic method**: decode a sample JWT's payload locally and copy the `sub` value verbatim (with a note not to paste credentials into third-party decoders).

**Verification:** The mechanism claims were adjudicated against the `wandb/core` OIDC validation code — the match is an exact, case- and whitespace-sensitive comparison with no per-IdP branching, and the Subject field is stored free-form with only a non-empty check — and corroborated by an internal engineering confirmation. The per-IdP specifics are field-validated guidance from the originating support escalation; the doc frames them as *typical* and points users to the decode method as the definitive check.

## Related issues

- Fixes DOCS-2714

🤖 Generated with [Claude Code](https://claude.com/claude-code)