### PR TITLE
Correct macOS path formatting in documentation

### DIFF
--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -83,7 +83,7 @@ You need [Node.js](https://nodejs.org/) installed on your system.
 
 Open your Claude Desktop config file in a text editor. You can find the config file at the following location for your OS:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **macOS**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
 Add the following to the JSON object in your config file, replacing `[YOUR-WANDB-API-KEY]` with your W&B API key:


### PR DESCRIPTION
## Description
Fix formatting for macOS config file path.

Fixes DOCS-2697

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
