### PR TITLE
style: apply /style-guide pass to models/reports

### DIFF
--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -16,14 +16,14 @@ Export a report as a PDF or LaTeX file to share its contents outside of W&B or t
 
 ## Clone a report
 
-Clone a report to reuse an existing project's template and formatting as the basis for a new report. You can clone reports in the W&B App UI or programmatically with the Report and Workspace API.
+Clone a report to reuse an existing project's template and formatting as the basis for a new report. You can clone reports in the W&B App or programmatically with the Report and Workspace API.
 
 <Tabs>
 <Tab title="W&B App">
 In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Clone this report**. In the modal, select a destination for your cloned report. Choose **Clone report**.
 
 <Frame>
-    <img src="/images/reports/clone_reports.gif" alt="Cloning a report in the W&B App UI"  />
+    <img src="/images/reports/clone_reports.gif" alt="Cloning a report in the W&B App"  />
 </Frame>
 
 When you clone a report, you specify the destination. If you clone it to a team, all team members can view it. If you clone it to your personal account, only you can view it by default.
@@ -62,6 +62,6 @@ new_report.blocks = (
 new_report.save()
 ```
 
-After you save, your new report appears in your W&B project with the customized blocks.
+After you save, your new report appears in your W&B project.
 </Tab>
 </Tabs>

--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -1,7 +1,7 @@
 ---
 description: "Export W&B Reports as PDF or LaTeX files, and clone reports using the App UI or the Report and Workspace API."
 title: Clone and export reports
-keywords: ["export report", "clone report", "PDF", "LaTeX", "Report and Workspace API"]
+keywords: [PDF, LaTeX, Report and Workspace API, template, download]
 ---
 
 <Note>
@@ -20,10 +20,10 @@ Clone a report to reuse an existing project's template and formatting as the bas
 
 <Tabs>
 <Tab title="W&B App">
-In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Clone this report**. In the modal, pick a destination for your cloned report. Choose **Clone report**.
+In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Clone this report**. In the modal, select a destination for your cloned report. Choose **Clone report**.
 
 <Frame>
-    <img src="/images/reports/clone_reports.gif" alt="Cloning reports"  />
+    <img src="/images/reports/clone_reports.gif" alt="Cloning a report in the W&B App UI"  />
 </Frame>
 
 When you clone a report, you specify the destination. If you clone it to a team, all team members can view it. If you clone it to your personal account, only you can view it by default.
@@ -61,5 +61,7 @@ new_report.blocks = (
 )
 new_report.save()
 ```
+
+After you save, your new report appears in your W&B project with the customized blocks.
 </Tab>
 </Tabs>

--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -1,7 +1,7 @@
 ---
 description: "Export W&B Reports as PDF or LaTeX files, and clone reports using the App UI or the Report and Workspace API."
 title: Clone and export reports
-keywords: [PDF, LaTeX, Report and Workspace API, template, download]
+keywords: ["export report", "clone report", "PDF", "LaTeX", "Report and Workspace API"]
 ---
 
 <Note>

--- a/models/reports/collaborate-on-reports.mdx
+++ b/models/reports/collaborate-on-reports.mdx
@@ -4,32 +4,30 @@ title: Collaborate on reports
 keywords: ["share report", "report comments", "star report", "report collaboration", "edit conflict"]
 ---
 
-This page describes ways to collaborate on reports with your team. Use these workflows to share results, gather feedback, and keep important reports accessible.
-
-You can share a report, edit it collaboratively, add comments, or star it for quick access.
+This page describes ways to collaborate on W&B Reports with your team so you can share results, gather feedback, and keep important reports accessible. You can share a report, edit it collaboratively, add comments, or star it for quick access.
 
 ## Share a report
 
-When viewing a report, click **Share**. You can share a report in one of the following ways:
+Share a report when you want to give peers, co-workers, or teammates access to view or edit its contents. When viewing a report, click **Share**. You can share a report in one of the following ways:
 
 - To share a link to the report with an email address or a username, click **Invite**. Enter an email address or username, select **Can view** or **Can edit**, then click **Invite**. If you share by email, the email address doesn't need to be a member of your organization or team.
 - To generate a sharing link instead, click **Share**. Adjust the permissions for the link, then click **Copy report link**. Share the link with the member.
 
-When viewing the report, click a panel to open it in full-screen mode. If you copy the URL from the browser and share it with another user, the panel opens directly in full-screen mode when they access the link.
-
-## Edit a report
-
-Multiple team members can edit the same report and publish changes when they're ready. When any team member clicks the **Edit** button to begin editing the report, W&B automatically saves a draft. Select **Save to report** to publish your changes.
-
-If an edit conflict occurs, such as when two team members edit the report at once, a warning notification helps you resolve any conflicts.
+When viewing the report, click a panel to open it in full-screen mode. If you copy the URL from the browser and share it with another user, the panel opens in full-screen mode when they access the link.
 
 <Frame>
     <img src="/images/reports/share-report.gif" alt="Report sharing modal for a report in a 'Public' project" max-width="90%" />
 </Frame>
 
-## Comment on reports
+## Edit a report
 
-To leave a comment on a report, click **Comment**.
+Reports support collaborative editing so that team members can contribute updates without overwriting each other's work. Multiple team members can edit the same report and publish changes when they're ready. When any team member clicks **Edit** to begin editing the report, W&B automatically saves a draft. Select **Save to report** to publish your changes.
+
+If an edit conflict occurs, such as when two team members edit the report at once, a warning notification helps you resolve any conflicts.
+
+## Comment on a report
+
+Use comments to give feedback or ask questions about a report or one of its panels without modifying its contents. To leave a comment on a report, click **Comment**.
 
 To comment directly on a panel, hover over the panel, then click the comment button (<Icon icon="comment" iconType="regular"/>).
 
@@ -39,6 +37,6 @@ To comment directly on a panel, hover over the panel, then click the comment but
 
 ## Star a report
 
-If your team has many reports, click the open star icon (<Icon icon="star" iconType="regular"/>) at the top of a report to add it to your favorites. To remove the star, click the closed star icon (<Icon icon="star" iconType="solid"/>). When viewing your team's list of reports, click the open star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
+Star a report to mark it as a favorite and make it easier to find later. Click the open star icon (<Icon icon="star" iconType="regular"/>) at the top of a report to add it to your favorites. To remove the star, click the filled star icon (<Icon icon="star" iconType="solid"/>). When viewing your team's list of reports, click the open star in a report's row to add it to your favorites. Starred reports appear at the top of the list.
 
 From the list of reports, you can see how many members have starred each report to gauge its popularity.

--- a/models/reports/collaborate-on-reports.mdx
+++ b/models/reports/collaborate-on-reports.mdx
@@ -1,5 +1,5 @@
 ---
-description: Collaborate and share W&B Reports with peers, co-workers, and your team.
+description: Collaborate and share W&B Reports with peers, coworkers, and your team.
 title: Collaborate on reports
 keywords: ["share report", "report comments", "star report", "report collaboration", "edit conflict"]
 ---
@@ -8,7 +8,7 @@ This page describes ways to collaborate on W&B Reports with your team so you can
 
 ## Share a report
 
-Share a report when you want to give peers, co-workers, or teammates access to view or edit its contents. When viewing a report, click **Share**. You can share a report in one of the following ways:
+Share a report when you want to give peers, coworkers, or teammates access to view or edit its contents. When viewing a report, click **Share**. You can share a report in one of the following ways:
 
 - To share a link to the report with an email address or a username, click **Invite**. Enter an email address or username, select **Can view** or **Can edit**, then click **Invite**. If you share by email, the email address doesn't need to be a member of your organization or team.
 - To generate a sharing link instead, click **Share**. Adjust the permissions for the link, then click **Copy report link**. Share the link with the member.

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -1,7 +1,7 @@
 ---
 description: Create a W&B Report with the W&B App or programmatically.
 title: Create a report
-keywords: ["wandb-workspaces", "Report API", "programmatic reports"]
+keywords: ["create report", "wandb-workspaces", "Report API", "programmatic reports"]
 ---
 
 <Note>

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -1,17 +1,16 @@
 ---
 description: Create a W&B Report with the W&B App or programmatically.
 title: Create a report
-keywords: ["create report", "wandb-workspaces", "Report API", "programmatic reports"]
+keywords: ["wandb-workspaces", "Report API", "programmatic reports"]
 ---
 
 <Note>
 W&B Report and Workspace API is in Public Preview.
 </Note>
 
-Select a tab to learn how to create a report in the W&B App or programmatically with the Report and Workspace API.
+W&B Reports let you share findings, results, and visualizations from your runs with collaborators. Create a report from a project workspace, from the **Reports** tab, or programmatically with the Report and Workspace API. Select a tab to get started.
 
-For an example of how to programmatically create a report, see this [Google Colab](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb).
-
+For a programmatic example, see the [Report API Quickstart Google Colab](https://colab.research.google.com/github/wandb/examples/blob/master/colabs/intro/Report_API_Quickstart.ipynb).
 
 <Tabs>
 <Tab title="W&B App">
@@ -22,13 +21,13 @@ For an example of how to programmatically create a report, see this [Google Cola
     <img src="/images/reports/create_a_report_button.png" alt="Create report button" />
     </Frame>
 
-3. A modal appears. Select the charts you want to start with. You can add or delete charts later from the report interface.
+3. A modal appears. Select the charts you want to start with. You can add or remove charts later from the report interface.
 
     <Frame>
-    <img src="/images/reports/create_a_report_modal.png" alt="Create report modal" />
+    <img src="/images/reports/create_a_report_modal.png" alt="Create report modal with chart selection options" />
     </Frame>
 
-4. Select the **Filter run sets** option to prevent new runs from being added to your report. You can toggle this option on or off. A draft report is saved automatically. Access it in the **Reports** tab.
+4. To prevent W&B from adding more runs to your report, select the **Filter run sets** option. W&B saves a draft report automatically. Access it in the **Reports** tab.
 </Tab>
 <Tab title="Report tab">
 1. Navigate to your project workspace in the W&B App.
@@ -42,21 +41,21 @@ For an example of how to programmatically create a report, see this [Google Cola
 <Tab title="Report and Workspace API">
 Create a report programmatically:
 
-1. Install W&B SDK (`wandb`) and Report and Workspace API (`wandb-workspaces`):
+1. Install the W&B SDK (`wandb`) and the Report and Workspace API (`wandb-workspaces`):
     ```bash
     pip install wandb wandb-workspaces
     ```
-2. Import the W&B Python SDK and the Report and Workspace API.
+2. Import the W&B Python SDK and the Report and Workspace API:
     ```python
     import wandb
     import wandb_workspaces.reports.v2 as wr
     ```
-3. Create a report with `wandb_workspaces.reports.v2.Report`. Create a report instance with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify a name for the project.
+3. Create a report instance with `wandb_workspaces.reports.v2.Report` or with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify a project name so W&B associates the report with the correct project:
     ```python
     report = wr.Report(project="report_standard")
     ```
 
-4. Save the report. Reports aren't uploaded to W&B until you call the `.save()` method:
+4. Save the report. W&B doesn't upload reports until you call the `.save()` method:
     ```python
     report.save()
     ```

--- a/models/reports/create-a-report.mdx
+++ b/models/reports/create-a-report.mdx
@@ -27,7 +27,7 @@ For a programmatic example, see the [Report API Quickstart Google Colab](https:/
     <img src="/images/reports/create_a_report_modal.png" alt="Create report modal with chart selection options" />
     </Frame>
 
-4. To prevent W&B from adding more runs to your report, select the **Filter run sets** option. W&B saves a draft report automatically. Access it in the **Reports** tab.
+4. To prevent W&B from adding more runs to your report, select **Filter run sets**. W&B saves a draft report automatically. Access it in the **Reports** tab.
 </Tab>
 <Tab title="Report tab">
 1. Navigate to your project workspace in the W&B App.
@@ -45,12 +45,14 @@ Create a report programmatically:
     ```bash
     pip install wandb wandb-workspaces
     ```
+
 2. Import the W&B Python SDK and the Report and Workspace API:
     ```python
     import wandb
     import wandb_workspaces.reports.v2 as wr
     ```
-3. Create a report instance with `wandb_workspaces.reports.v2.Report` or with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify a project name so W&B associates the report with the correct project:
+
+3. Create a report instance with `wandb_workspaces.reports.v2.Report` or with the Report Class Public API ([`wandb.apis.reports`](/models/ref/python/public-api/api#reports)). Specify the project to associate with the report:
     ```python
     report = wr.Report(project="report_standard")
     ```

--- a/models/reports/cross-project-reports.mdx
+++ b/models/reports/cross-project-reports.mdx
@@ -8,7 +8,9 @@ Watch a [video demonstrating comparing runs across projects](https://www.youtube
 </Note>
 
 
-Cross-project reports let you compare runs from two different projects side by side, which is useful when you want to evaluate experiments tracked under separate W&B projects without duplicating data. Use the project selector in the run set table to pick a project.
+Cross-project reports let you compare runs from two different projects side by side. This is useful when you want to evaluate experiments tracked under separate W&B projects without duplicating data. This page describes how to pull runs from another project into a report and how to share that report with collaborators who don't have W&B accounts.
+
+To compare runs across projects, use the project selector in the run set table to pick a project.
 
 <Frame>
     <img src="/images/reports/howto_pick_a_different_project_to_draw_runs_from.gif" alt="Compare runs across different projects"  />
@@ -22,20 +24,20 @@ If you need to compare runs from two projects and the columns aren't working, ad
 
 ## View-only report links
 
-When you need to share a report with someone outside your project (such as a stakeholder who doesn't have a W&B account), use a view-only link. Share a view-only link to a report that is in a private project or team project.
+After you've built a cross-project report, you might want to share it with collaborators who don't have access to the underlying projects. When you need to share a report with someone outside your project (such as a stakeholder who doesn't have a W&B account), use a view-only link. Share a view-only link to a report that is in a private project or team project.
 
 <Frame>
     <img src="/images/reports/magic-links.gif" alt="View-only report links"  />
 </Frame>
 
-View-only report links add a secret access token to the URL, so anyone who opens the link can view the page. Anyone can use the magic link to view the report without logging in first. For customers on [W&B Local](/platform/hosting/) private cloud installations, these links remain behind your firewall, so only members of your team with access to your private instance _and_ access to the view-only link can view the report.
+View-only report links add a secret access token to the URL, so anyone who opens the link can view the page. Anyone can use the magic link to view the report without logging in first. For customers on [W&B Local](/platform/hosting/) private cloud installations, these links remain behind your firewall. Only team members who have both access to your private instance and access to the view-only link can view the report.
 
-In **view-only mode**, someone who isn't logged in can see the charts and mouse over to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. When in view mode, they can't create new charts or new table queries to explore the data. View-only visitors to the report link can't click a run to get to the run page. Also, view-only visitors can't see the share modal. Instead, they see a tooltip on hover that says: `Sharing not available for view only access`.
+In view-only mode, someone who isn't logged in can see the charts and hover over them to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. They can't create new charts or new table queries to explore the data. View-only visitors can't click a run to get to the run page, and they can't see the share modal. Instead, they see a tooltip on hover that says **Sharing not available for view only access**.
 
 <Info>
-The magic links are only available for "Private" and "Team" projects. For "Public" (anyone can view) or "Open" (anyone can view and contribute runs) projects, you can't turn the links on or off because the project is public, meaning it's already available to anyone with the link.
+The magic links are only available for Private and Team projects. For Public projects (anyone can view) or Open projects (anyone can view and contribute runs), you can't turn the links on or off. The project is already public, so the report is already available to anyone with the link.
 </Info>
 
 ## Send a graph to a report
 
-If you want to preserve a chart from a workspace alongside related analysis, you can send it directly to a report. Send a graph from your workspace to a report to keep track of your progress. Click the dropdown menu on the chart or panel you'd like to copy to a report and click **Add to report** to select the destination report.
+You can also populate a report with charts you've already built in a workspace, rather than recreating them. To preserve a chart from a workspace alongside related analysis, send it directly to a report. Click the dropdown menu on the chart or panel you want to copy, then click **Add to report** to select the destination report.

--- a/models/reports/cross-project-reports.mdx
+++ b/models/reports/cross-project-reports.mdx
@@ -24,7 +24,7 @@ If you need to compare runs from two projects and the columns aren't working, ad
 
 ## View-only report links
 
-After you've built a cross-project report, you might want to share it with collaborators who don't have access to the underlying projects. When you need to share a report with someone outside your project (such as a stakeholder who doesn't have a W&B account), use a view-only link. Share a view-only link to a report that is in a private project or team project.
+When you need to share a report with someone outside your project (such as a stakeholder who doesn't have a W&B account), use a view-only link. Share a view-only link to a report that is in a private project or team project.
 
 <Frame>
     <img src="/images/reports/magic-links.gif" alt="View-only report links"  />

--- a/models/reports/cross-project-reports.mdx
+++ b/models/reports/cross-project-reports.mdx
@@ -32,7 +32,7 @@ After you've built a cross-project report, you might want to share it with colla
 
 View-only report links add a secret access token to the URL, so anyone who opens the link can view the page. Anyone can use the magic link to view the report without logging in first. For customers on [W&B Local](/platform/hosting/) private cloud installations, these links remain behind your firewall. Only team members who have both access to your private instance and access to the view-only link can view the report.
 
-In view-only mode, someone who isn't logged in can see the charts and hover over them to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. They can't create new charts or new table queries to explore the data. View-only visitors can't click a run to get to the run page, and they can't see the share modal. Instead, they see a tooltip on hover that says **Sharing not available for view only access**.
+In view-only mode, someone who isn't logged in can see the charts and hover over them to see tooltips of values, zoom in and out on charts, and scroll through columns in the table. They can't create new charts or new table queries to explore the data. View-only visitors can't click a run to get to the run page, and they can't see the share modal. Instead, they see a tooltip on hover that says `Sharing not available for view only access`.
 
 <Info>
 The magic links are only available for Private and Team projects. For Public projects (anyone can view) or Open projects (anyone can view and contribute runs), you can't turn the links on or off. The project is already public, so the report is already available to anyone with the link.

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -82,7 +82,7 @@ Add run sets from projects interactively with the App UI or the W&B SDK.
 <Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Panel Grid**. W&B automatically imports the run set from the project the report was created from.
 
-If you import a panel into a report, run names inherit from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The rename applies only to the individual panel. If you clone the panel in the same report, the cloned panel also reflects the new name.
+If you import a panel into a report, the report inherits the run names from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The rename applies only to the individual panel. If you clone the panel in the same report, the cloned panel also reflects the new name.
 
 1. In the report, click the pencil icon to open the report editor.
 2. In the run set, find the run to rename. Hover over the run name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -85,7 +85,7 @@ Enter a forward slash (`/`) in the report to display a dropdown menu. From the d
 If you import a panel into a report, run names inherit from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The rename applies only to the individual panel. If you clone the panel in the same report, the cloned panel also reflects the new name.
 
 1. In the report, click the pencil icon to open the report editor.
-2. In the run set, find the run to rename. Hover over the report name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
+2. In the run set, find the run to rename. Hover over the run name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
 
     - **Rename run for project**: Rename the run across the entire project. To generate a new random name, leave the field blank.
     - **Rename run for panel grid**: Rename the run only in the report, preserving the existing name in other contexts. You can't generate a new random name with this option.
@@ -566,7 +566,7 @@ Add markdown to format narrative text, headings, and inline emphasis in your rep
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Markdown**.
 </Tab>
 <Tab title="Report and Workspace API">
-Use the `wandb.apis.reports.MarkdownBlock` class to create a markdown block programmatically. Pass a string to the `text` parameter:
+Use the `wr.MarkdownBlock` class to create a markdown block programmatically. Pass a string to the `text` parameter:
 
 ```python
 import wandb
@@ -597,7 +597,7 @@ Add HTML elements such as headings and lists to structure your report. You can a
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, select a type of text block. For example, to create an H2 heading block, select the `Heading 2` option.
 </Tab>
 <Tab title="Report and Workspace API">
-Pass a list of one or more HTML elements to `wandb.apis.reports.blocks` attribute. The following example demonstrates how to create an H1, H2, and an unordered list:
+Pass a list of one or more HTML elements to the report's `blocks` attribute. The following example demonstrates how to create an H1, H2, and an unordered list:
 
 ```python
 import wandb
@@ -656,7 +656,7 @@ Copy and paste a SoundCloud link to embed an audio file into a report.
 </Frame>
 </Tab>
 <Tab title="Report and Workspace API">
-Pass a list of one or more embedded media objects to the `wandb.apis.reports.blocks` attribute. The following example demonstrates how to embed video and Twitter media into a report:
+Pass a list of one or more embedded media objects to the report's `blocks` attribute. The following example demonstrates how to embed video and Twitter media into a report:
 
 ```python
 import wandb

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -9,7 +9,7 @@ keywords: ["wandb-workspaces", "PanelGrid", "RunSet", "report blocks", "report f
 W&B Report and Workspace API is in Public Preview.
 </Note>
 
-This page describes how to edit a report interactively with the App UI or programmatically with the W&B SDK. It covers adding plots, run sets, code blocks, markdown, HTML elements, and rich media, as well as filtering and grouping run sets, organizing report layout, and visualizing multi-dimensional relationships.
+This page describes how to edit a report interactively with the App UI or programmatically with the W&B SDK. It covers adding plots, run sets, code blocks, markdown, HTML elements, and rich media. It also covers filtering and grouping run sets, organizing report layout, and visualizing multi-dimensional relationships.
 
 A report's body consists of _blocks_. Blocks contain text, images, embedded visualizations, plots from experiments and runs, and panel grids.
 
@@ -30,10 +30,10 @@ pip install wandb wandb-workspaces
 
 ## Add plots
 
-Plots let you visualize run data inside a report. Each panel grid has a set of run sets and a set of panels. The run sets at the bottom of the section control what data appears on the panels in the grid. Create a new panel grid if you want to add charts that pull data from a different set of runs.
+Plots let you visualize run data inside a report. Each panel grid has a set of run sets and a set of panels. The run sets in the panel grid control what data appears on the panels in the grid. Create a new panel grid if you want to add charts that pull data from a different set of runs.
 
 <Tabs>
-<Tab title="W&B App">
+<Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. Select **Add panel** to add a panel. You can add any panel that W&B supports, including a line plot, scatter plot, or parallel coordinates chart.
 
 <Frame>
@@ -41,7 +41,7 @@ Enter a forward slash (`/`) in the report to display a dropdown menu. Select **A
 </Frame>
 </Tab>
 <Tab title="Report and Workspace API">
-Add plots to a report programmatically with the SDK. Pass a list of one or more plot or chart objects to the `panels` parameter in the `PanelGrid` Public API Class. Create a plot or chart object with its associated Python Class.
+Add plots to a report programmatically with the SDK. Pass a list of one or more plot or chart objects to the `panels` parameter in the `PanelGrid` Public API class. Create a plot or chart object with its associated Python class.
 
 
 The following examples demonstrate how to create a line plot and scatter plot.
@@ -79,24 +79,24 @@ For more information about available plots and charts you can add to a report pr
 Add run sets from projects interactively with the App UI or the W&B SDK.
 
 <Tabs>
-<Tab title="W&B App">
+<Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Panel Grid**. W&B automatically imports the run set from the project the report was created from.
 
-If you import a panel into a report, run names are inherited from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The run is renamed only in the individual panel. If you clone the panel in the same report, the run is also renamed in the cloned panel.
+If you import a panel into a report, run names inherit from the project. In the report, you can optionally [rename a run](/models/runs/#rename-a-run) to give the reader more context. The rename applies only to the individual panel. If you clone the panel in the same report, the cloned panel also reflects the new name.
 
 1. In the report, click the pencil icon to open the report editor.
-1. In the run set, find the run to rename. Hover over the report name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
+2. In the run set, find the run to rename. Hover over the report name and click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Select one of the following choices, then submit the form.
 
     - **Rename run for project**: Rename the run across the entire project. To generate a new random name, leave the field blank.
-    - **Rename run for panel grid**: Rename the run only in the report, preserving the existing name in other contexts. Generating a new random name is not supported.
+    - **Rename run for panel grid**: Rename the run only in the report, preserving the existing name in other contexts. You can't generate a new random name with this option.
 
-1. Click **Publish report**.
+3. Click **Publish report**.
 </Tab>
 <Tab title="Report and Workspace API">
-Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` Classes. To add a runset, follow these steps:
+Add run sets from projects with the `wr.Runset()` and `wr.PanelGrid` classes. To add a run set, follow these steps:
 
 1. Create a `wr.Runset()` object instance. Provide the name of the project that contains the run sets for the project parameter and the entity that owns the project for the entity parameter.
-2. Create a `wr.PanelGrid()` object instance. Pass a list of one or more runset objects to the `run sets` parameter.
+2. Create a `wr.PanelGrid()` object instance. Pass a list of one or more run set objects to the `runsets` parameter.
 3. Store one or more `wr.PanelGrid()` object instances in a list.
 4. Update the report instance blocks attribute with the list of panel grid instances.
 
@@ -186,7 +186,7 @@ report.save()
 
 ## Freeze a run set
 
-A report automatically updates run sets to show the latest data from the project. Freeze a run set when you want to preserve its state in a report at a point in time, so that later runs don't change what the report displays.
+A report automatically updates run sets to show the latest data from the project. Freeze a run set to preserve its state in a report at a specific time, so that later runs don't change what the report displays.
 
 To freeze a run set when viewing a report, click the snowflake icon in its panel grid near the **Filter** button.
 
@@ -196,7 +196,7 @@ To freeze a run set when viewing a report, click the snowflake icon in its panel
 
 ## Group a run set programmatically
 
-Group runs in a run set programmatically with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports). Grouping organizes related runs together in panels, which makes it easier to compare configurations and results.
+Group runs in a run set programmatically with the [Workspace and Reports API](/models/ref/wandb_workspaces/reports). Grouping organizes related runs together in panels, which makes comparing configurations and results easier.
 
 You can group runs in a run set by config values, run metadata, or summary metrics. The following table lists the available grouping methods along with the available keys for each grouping method:
 
@@ -265,7 +265,7 @@ report.save()
 
 ### Group runs by run metadata
 
-Group runs by a run's name (`Name`), state (`State`), or job type (`JobType`).
+Group runs by metadata to organize them based on intrinsic run properties rather than logged values. You can group by a run's name (`Name`), state (`State`), or job type (`JobType`).
 
 Continuing from the previous example, you can group your runs by their name with the following code snippet:
 
@@ -339,13 +339,13 @@ In this expression, `[KEY]` is the name of the filter, `operation` is a comparis
 |`Tags('[KEY]')` | Filter by tags | Tag values that you add to your run (programmatically or with the W&B App). |
 |`Metric('[KEY]')` | Filter by run properties | `tags`, `state`, `displayName`, `jobType` |
 
-After you define your filters, you can create a report and pass the filtered run sets to `wr.PanelGrid(runsets=)`. See the **Report and Workspace API** tabs throughout this page for more information about how to add various elements to a report programmatically.
+After you define your filters, you can create a report and pass the filtered run sets to `wr.PanelGrid(runsets=)`. See the **Report and Workspace API** tabs throughout this page for more information about how to add different elements to a report programmatically.
 
 The following examples demonstrate how to filter run sets in a report. Replace values enclosed in brackets (for example, `[ENTITY]` and `[PROJECT]`) with your own values.
 
 ### Config filters
 
-Filter a runset by one or more config values. Config values are parameters you specify in your run configuration (`wandb.init(config=)`).
+Filter a run set by one or more config values. Config values are parameters you specify in your run configuration (`wandb.init(config=)`).
 
 For example, the following code snippet first initializes a run with a config value for `learning_rate` and `batch_size`, then filters runs in a report based on the `learning_rate` config value.
 
@@ -384,7 +384,7 @@ runset = wr.Runset(
 )
 ```
 
-Continuing from the previous example, you can create a report with the filtered runset as follows:
+Continuing from the previous example, you can create a report with the filtered run set as follows:
 
 ```python
 report = wr.Report(
@@ -446,7 +446,7 @@ runset = wr.Runset(
 You can find the name of the run in the **Overview** page of a run in the W&B App or programmatically with `Api.runs().run.name`.
 </Note>
 
-The following examples demonstrate how to filter a runset by the run's state (`finished`, `crashed`, or `running`):
+The following examples demonstrate how to filter a run set by the run's state (`finished`, `crashed`, or `running`):
 
 ```python
 runset = wr.Runset(
@@ -467,7 +467,7 @@ runset = wr.Runset(
 
 ### SummaryMetric filters
 
-The following examples demonstrate how to filter a run set by summary metrics. Summary metrics are the values you log to a run with `wandb.Run.log()`. After you log a run, you can find the names of your summary metrics in the W&B App under the **Summary** section of a run's **Overview** page.
+Filter a run set by summary metrics to focus on runs that meet specific outcome thresholds, such as accuracy or loss values. Summary metrics are the values you log to a run with `wandb.Run.log()`. After you log a run, you can find the names of your summary metrics in the W&B App under the **Summary** section of a run's **Overview** page.
 
 ```python
 runset = wr.Runset(
@@ -487,7 +487,7 @@ runset = wr.Runset(
 
 ### Tags filters
 
-The following code snippet shows how to filter a runs set by its tags. Tags are values you add to a run (programmatically or with the W&B App).
+Filter a run set by tags to show only runs that you've labeled with a particular tag. Tags are values you add to a run (programmatically or with the W&B App).
 
 ```python
 runset = wr.Runset(
@@ -499,16 +499,16 @@ runset = wr.Runset(
 
 ## Add code blocks
 
-Add code blocks to your report interactively with the App UI or with the W&B SDK.
+Add code blocks to share configuration, examples, or snippets alongside your results. You can add them interactively with the App UI or programmatically with the W&B SDK.
 
 <Tabs>
 <Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Code**.
 
-Select the name of the programming language on the right side of the code block to expand a dropdown. From the dropdown, select your programming language syntax. You can choose from JavaScript, Python, CSS, JSON, HTML, Markdown, and YAML.
+Select the name of the programming language in the code block to expand a dropdown. From the dropdown, select your programming language syntax. You can choose from JavaScript, Python, CSS, JSON, HTML, Markdown, and YAML.
 </Tab>
 <Tab title="Report and Workspace API">
-Use the `wr.CodeBlock` Class to create a code block programmatically. Provide the name of the language and the code you want to display for the language and code parameters, respectively.
+Use the `wr.CodeBlock` class to create a code block programmatically. Provide the name of the language and the code you want to display for the language and code parameters, respectively.
 
 The following example demonstrates a list in a YAML file:
 
@@ -559,14 +559,14 @@ Hello, World!
 
 ## Add markdown
 
-Add markdown to your report interactively with the App UI or with the W&B SDK.
+Add markdown to format narrative text, headings, and inline emphasis in your report. You can add markdown interactively with the App UI or programmatically with the W&B SDK.
 
 <Tabs>
 <Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, choose **Markdown**.
 </Tab>
 <Tab title="Report and Workspace API">
-Use the `wandb.apis.reports.MarkdownBlock` Class to create a markdown block programmatically. Pass a string to the `text` parameter:
+Use the `wandb.apis.reports.MarkdownBlock` class to create a markdown block programmatically. Pass a string to the `text` parameter:
 
 ```python
 import wandb
@@ -590,7 +590,7 @@ This renders a markdown block similar to:
 
 ## Add HTML elements
 
-Add HTML elements to your report interactively with the App UI or with the W&B SDK.
+Add HTML elements such as headings and lists to structure your report. You can add them interactively with the App UI or programmatically with the W&B SDK.
 
 <Tabs>
 <Tab title="App UI">
@@ -625,7 +625,7 @@ This renders the HTML elements to the following:
 
 ## Embed rich media links
 
-Embed rich media within the report with the App UI or with the W&B SDK.
+Embed rich media such as tweets, videos, and audio to enrich your report with external context. You can embed rich media with the App UI or with the W&B SDK.
 
 <Tabs>
 <Tab title="App UI">
@@ -639,7 +639,7 @@ Copy and paste a Tweet link URL into a report to view the Tweet within the repor
     <img src="/images/reports/twitter.gif" alt="Embedding Twitter content"  />
 </Frame>
 
-### Youtube
+### YouTube
 
 Copy and paste a YouTube video URL link to embed a video in the report.
 
@@ -687,7 +687,7 @@ Highlight a whole panel grid section by selecting the drag handle in the upper r
 
 ## Delete panel grids
 
-Select a panel grid and press `delete` on your keyboard to delete a panel grid.
+Delete a panel grid when you no longer need its layout or content in the report. Select a panel grid and press `delete` on your keyboard to delete a panel grid.
 
 <Frame>
     <img src="/images/reports/delete_panel_grid.gif" alt="Deleting panel grids"  />
@@ -695,16 +695,16 @@ Select a panel grid and press `delete` on your keyboard to delete a panel grid.
 
 ## Collapse headers to organize reports
 
-Collapse headers in a report to hide content within a text block. When the report loads, only expanded headers show content. Collapsing headers in reports helps organize your content and prevents excessive data loading. The following gif demonstrates the process.
+Collapse headers in a report to hide content within a text block. When the report loads, only expanded headers show content. Collapsing headers in reports helps organize your content and prevents loading more data than you need. The following animation demonstrates the process.
 
 <Frame>
-    <img src="/images/reports/collapse_headers.gif" alt="Collapsing headers in a report."  />
+    <img src="/images/reports/collapse_headers.gif" alt="Collapsing headers in a report"  />
 </Frame>
 
 ## Visualize relationships across multiple dimensions
 
-To compare more variables than a 2D plot can show, you can use a color gradient as an additional dimension. Using a color gradient to represent one of the variables can make patterns easier to interpret.
+When you want to surface relationships between three or more variables in a single chart, a standard 2D plot can be limiting. To compare more variables than a 2D plot can show, you can use a color gradient as an additional dimension. Using a color gradient to represent one of the variables can make patterns easier to interpret.
 
-1. Choose a variable to represent with a color gradient, like penalty scores or learning rates. This provides a clearer understanding of how penalty (color) interacts with reward/side effects (y-axis) over training time (x-axis).
+1. Choose a variable to represent with a color gradient, like penalty scores or learning rates. This provides a clearer understanding of how penalty (color) interacts with reward or side effects (y-axis) over training time (x-axis).
 2. Highlight key trends. Hover over a specific group of runs to highlight them in the visualization.
 

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -13,7 +13,7 @@ Use an HTML `iframe` element to embed a report on any web page that accepts cust
 In the upper right of a report, select the **Share** button to open a dialog, then select **Copy embed code**. The copied snippet is an `iframe` HTML element that you can paste into any page that accepts custom HTML.
 
 <Note>
-You can only embed *public* reports.
+Only *public* reports are viewable when embedded.
 </Note>
 
 <Frame>

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -1,7 +1,7 @@
 ---
 description: Embed W&B reports directly into Notion or with an HTML `iframe` element.
 title: Embed a report
-keywords: [Confluence, Gradio, Hugging Face Spaces, embed code, share report]
+keywords: ["iframe", "Confluence", "Notion", "Gradio", "Hugging Face Spaces"]
 ---
 
 Embed a W&B report in an external page or tool so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and use it in HTML, Confluence, Notion, or Gradio.

--- a/models/reports/embed-reports.mdx
+++ b/models/reports/embed-reports.mdx
@@ -1,7 +1,7 @@
 ---
 description: Embed W&B reports directly into Notion or with an HTML `iframe` element.
 title: Embed a report
-keywords: ["iframe", "Confluence", "Notion", "Gradio", "Hugging Face Spaces"]
+keywords: [Confluence, Gradio, Hugging Face Spaces, embed code, share report]
 ---
 
 Embed a W&B report in an external page or tool so that your team can view live experiment results alongside other documentation. This page describes how to generate an embed code from a report and use it in HTML, Confluence, Notion, or Gradio.
@@ -10,10 +10,10 @@ Embed a W&B report in an external page or tool so that your team can view live e
 
 Use an HTML `iframe` element to embed a report on any web page that accepts custom HTML. W&B provides a prebuilt embed code that you can copy directly from the report.
 
-Select the **Share** button in the upper right of a report to open a dialog, then select **Copy embed code**. The copied snippet is an `iframe` HTML element that you can paste into any page that accepts custom HTML.
+In the upper right of a report, select the **Share** button to open a dialog, then select **Copy embed code**. The copied snippet is an `iframe` HTML element that you can paste into any page that accepts custom HTML.
 
 <Note>
-Only *public* reports are viewable when embedded.
+You can only embed *public* reports.
 </Note>
 
 <Frame>
@@ -22,7 +22,7 @@ Only *public* reports are viewable when embedded.
 
 ## Confluence
 
-The following animation demonstrates how to insert the direct link to the report within an `iframe` cell in Confluence.
+Confluence supports embedded reports through its built-in `iframe` macro. The following animation demonstrates how to insert the direct link to the report within an `iframe` cell in Confluence.
 
 <Frame>
     <img src="/images/reports/embed_iframe_confluence.gif" alt="Embedding in Confluence"  />
@@ -30,7 +30,7 @@ The following animation demonstrates how to insert the direct link to the report
 
 ## Notion
 
-The following animation demonstrates how to insert a report into a Notion document using an **Embed** block in Notion and the report's embed code.
+Notion's **Embed** block accepts the same embed code that W&B provides. The following animation demonstrates how to insert a report into a Notion document using an **Embed** block in Notion and the report's embed code.
 
 <Frame>
     <img src="/images/reports/embed_iframe_notion.gif" alt="Embedding in Notion"  />

--- a/models/reports/reports-gallery.mdx
+++ b/models/reports/reports-gallery.mdx
@@ -1,20 +1,20 @@
 ---
 description: "Explore example W&B Reports showcasing use cases like experiment summaries, team collaboration, and sharing findings."
 title: Example reports
-keywords: ["report examples", "report gallery", "experiment notes", "collaboration", "work log"]
+keywords: [report gallery, experiment notes, collaboration, work log]
 ---
 
 This page showcases example W&B Reports that demonstrate common use cases, including capturing experiment notes, collaborating with colleagues, and tracking project work logs. Use these examples as inspiration for structuring your own reports.
 
-The following sections describe common report patterns and link to example reports for each.
+The following sections describe common report patterns and link to example reports for each. Browse the patterns that match how you want to communicate your work, then open the linked reports to see how others have applied them.
 
-## Notes: Add a visualization with a quick summary
+## Notes: add a visualization with a quick summary
 
 Capture an important observation, an idea for future work, or a milestone reached in the development of a project. All experiment runs in your report link to their parameters, metrics, logs, and code, so you can save the full context of your work.
 
 Jot down some text and pull in relevant charts to illustrate your insight.
 
-See the [What To Do When Inception-ResNet-V2 Is Too Slow](https://wandb.ai/stacey/estuary/reports/When-Inception-ResNet-V2-is-too-slow--Vmlldzo3MDcxMA) report for an example of how you can share comparisons of training time.
+See the [What To Do When Inception-ResNet-V2 Is Too Slow](https://wandb.ai/stacey/estuary/reports/When-Inception-ResNet-V2-is-too-slow--Vmlldzo3MDcxMA) report for an example of how to share comparisons of training time.
 
 <Frame>
     <img src="/images/reports/notes_add_quick_summary.png" alt="Quick summary notes" max-width="90%"  />
@@ -26,7 +26,7 @@ Save the best examples from a complex code base for quick reference and future i
     <img src="/images/reports/notes_add_quick_summary_save_best_examples.png" alt="Save best examples" max-width="90%"  />
 </Frame>
 
-## Collaboration: Share findings with your colleagues
+## Collaboration: share findings with your colleagues
 
 Explain how to get started with a project, share what you've observed so far, and synthesize the latest findings. Your colleagues can make suggestions or discuss details using comments on any panel or at the end of the report.
 
@@ -52,15 +52,15 @@ Use sliders and configurable media panels to showcase a model's results or train
     <img src="/images/reports/intro_collaborate4.png" alt="Interactive media panels"  />
 </Frame>
 
-## Work log: Track what you've tried and plan next steps
+## Work log: track what you've tried and plan next steps
 
-Write down your thoughts on experiments, your findings, and any gotchas and next steps as you work through a project, and keep everything organized in one place. This lets you "document" all the important pieces beyond your scripts. See the [Who Is Them? Text Disambiguation With Transformers](https://wandb.ai/stacey/winograd/reports/Who-is-Them-Text-Disambiguation-with-Transformers--VmlldzoxMDU1NTc) report for an example of how you can report your findings.
+As you work through a project, write down your thoughts on experiments, your findings, and any pitfalls and next steps. Keep everything organized in one place to document all the important pieces beyond your scripts. See the [Who Is Them? Text Disambiguation With Transformers](https://wandb.ai/stacey/winograd/reports/Who-is-Them-Text-Disambiguation-with-Transformers--VmlldzoxMDU1NTc) report for an example of how to report your findings.
 
 <Frame>
     <img src="/images/reports/intro_work_log_1.png" alt="Text disambiguation report"  />
 </Frame>
 
-Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) report for how you can report your findings.
+Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See the [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) report for an example of how to report your findings.
 
 <Frame>
     <img src="/images/reports/intro_work_log_2.png" alt="Driver's seat project report"  />

--- a/models/reports/reports-gallery.mdx
+++ b/models/reports/reports-gallery.mdx
@@ -60,7 +60,7 @@ As you work through a project, write down your thoughts on experiments, your fin
     <img src="/images/reports/intro_work_log_1.png" alt="Text disambiguation report"  />
 </Frame>
 
-Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See the [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) report for an example of how to report your findings.
+Tell the story of a project, which you and others can reference later to understand how and why a model was developed. See [The View from the Driver's Seat](https://wandb.ai/stacey/deep-drive/reports/The-View-from-the-Driver-s-Seat--Vmlldzo1MTg5NQ) report for an example of how to report your findings.
 
 <Frame>
     <img src="/images/reports/intro_work_log_2.png" alt="Driver's seat project report"  />

--- a/models/reports/reports-gallery.mdx
+++ b/models/reports/reports-gallery.mdx
@@ -1,7 +1,7 @@
 ---
 description: "Explore example W&B Reports showcasing use cases like experiment summaries, team collaboration, and sharing findings."
 title: Example reports
-keywords: [report gallery, experiment notes, collaboration, work log]
+keywords: ["report examples", "report gallery", "experiment notes", "collaboration", "work log"]
 ---
 
 This page showcases example W&B Reports that demonstrate common use cases, including capturing experiment notes, collaborating with colleagues, and tracking project work logs. Use these examples as inspiration for structuring your own reports.


### PR DESCRIPTION
## Summary

This PR applies the `/style-guide` skill (Google Developer Style Guide + CoreWeave conventions) to the Reports section under `models/reports`. The run was automated; no technical content was intentionally changed.

## Files edited

- `models/reports/clone-and-export-reports.mdx`
- `models/reports/collaborate-on-reports.mdx`
- `models/reports/create-a-report.mdx`
- `models/reports/cross-project-reports.mdx`
- `models/reports/edit-a-report.mdx`
- `models/reports/embed-reports.mdx`
- `models/reports/reports-gallery.mdx`

## Recommendations for technical review

**Prerequisites**
- Report and Workspace API examples reference `wr` without showing or linking the import (e.g., `import wandb_workspaces.reports.v2 as wr`) — confirm whether to add or link this prerequisite (`clone-and-export-reports.mdx`).
- `PROJECT` and `ENTITY` placeholders are introduced inline; consider linking to the entities/projects concept pages, and note CoreWeave convention prefers `[ALL-CAPS-HYPHENATED]` placeholders — converting requires touching code samples (`clone-and-export-reports.mdx`).
- `create-a-report.mdx` (API tab) has no prerequisites section; consider whether to require an authenticated W&B environment, a supported Python version, or a `wandb login` step.
- `collaborate-on-reports.mdx` lists no prerequisites (team/project/org membership, role or permission level required to share, edit, comment, or star) — consider adding one.
- `embed-reports.mdx` lacks a brief prerequisites section (e.g., a published report URL or specific sharing permissions).
- `cross-project-reports.mdx` does not define "run set" or link to run set documentation, references "private/team/public/open project" without linking project-visibility docs, and uses "magic link" and "view-only link" interchangeably without defining them together.

**Verification steps**
- Neither flow in `clone-and-export-reports.mdx` (UI export, UI clone, API clone) has a "you should see..." statement after the procedure.
- `collaborate-on-reports.mdx`: after **Save to report**, the doc does not describe how a reader confirms changes were saved (status indicator, draft location if not published); and after **Invite** or sharing link, no way to verify the recipient has access or to revoke it.
- `create-a-report.mdx` (Report tab) ends at "Click **Create report**" without describing the resulting screen; the W&B App tab step 4 outcome ("A draft report is saved automatically") could cross-link to the publish/edit workflow.
- `cross-project-reports.mdx`: no way to confirm a cross-project pull worked (e.g., expected run set table state), and no way to confirm a view-only link works or to revoke/rotate the secret token.
- `edit-a-report.mdx`: **Visualize relationships across multiple dimensions** ends without a screenshot, sample output, or rendered example.
- `embed-reports.mdx`: the HTML `iframe` procedure does not describe what the embedded report should look like once pasted.

**Technical accuracy**
- `clone-and-export-reports.mdx`: confirm the **action menu > Download > PDF/LaTeX** click path is current; confirm `wr.Report.from_url(report.url)` is still the recommended clone-via-API workflow; the top-level `<Note>` about Public Preview applies only to the API tab and may need to be scoped.
- `collaborate-on-reports.mdx`: the "edit conflict" warning is mentioned but the resolution UI and user options aren't described; confirm the **Invite** and **Share** button labels still match the current UI; consider whether full-screen panel URL-sharing belongs under "Share a report" or in a panels/embedding section.
- `create-a-report.mdx`: confirm whether `Report` should be styled as a class name (`Report` class) or remain prose (line 53); confirm "select the **Filter run sets** option" sufficiently conveys reversibility after the redundant toggle phrasing was removed.
- `cross-project-reports.mdx`: the statement that history data on time series lines is supported but summary metrics across projects aren't could use a concrete example or workaround link; the "add a tag and move runs" workaround has no link to instructions for moving runs between projects.
- `edit-a-report.mdx`: step 2 in **Visualize relationships across multiple dimensions** ("Highlight key trends. Hover over a specific group of runs to highlight them in the visualization") reads more like a tip than a sequential step; the audit pass changed `` `run sets` `` to `` `runsets` `` (line 99) to match the `runsets=` parameter — confirm; the audit pass unified the Tabs title to `App UI` across all Tabs sections (previously two used "W&B App") — confirm which label is canonical.
- `embed-reports.mdx`: verify only fully public reports embed correctly versus reports shared via magic links or team visibility (line 16); reconcile Confluence guidance — prose says "insert the direct link... within an `iframe` cell," but the HTML section instructs copying a full `<iframe>` embed code (line 25); verify Confluence has a built-in `iframe` macro versus requiring an add-on (line 25); confirm Notion's `Embed` block accepts the full embed code, not just a report URL (line 33); verify the Gradio f-string `<iframe>` (no closing tag) renders correctly in `gr.HTML` (line 48); confirm the **Share** button is still in the upper right of a report (line 13).
- `reports-gallery.mdx`: verify external link liveness — all example report links point to public `wandb.ai/stacey/...` URLs plus a `bit.ly/wandb-learning-dexterity` shortlink, which can rot.

**Missing content**
- `clone-and-export-reports.mdx`: no troubleshooting guidance for failed exports or clones (e.g., team permissions when cloning).
- `collaborate-on-reports.mdx`: no coverage of how to stop sharing, remove a collaborator, or change permissions; who can see comments, whether comments support mentions/notifications, or how to resolve/delete them; whether starred reports are visible only to the current user or to the team (the closing sentence implies the latter); and no links to related concepts (Reports overview, project/team permissions, panels).
- `create-a-report.mdx` (API tab): no `wandb.login()` or authentication step is shown before `report.save()` — confirm whether intentional.
- `cross-project-reports.mdx`: no procedure for generating or toggling a view-only link in the UI (only what view-only mode is); no mention of where in the UI to find the project selector beyond "in the run set table"; no guidance on choosing a destination report for **Add to report** (new vs. existing).
- `edit-a-report.mdx`: introduction lists no prerequisites beyond the `pip install` Note; the **Group runs by config values** code example (lines 250–264) has uneven indentation in the `report.blocks` literal.
- `embed-reports.mdx`: the Gradio example URL is hardcoded to `_scott/pytorch-sweeps-demo/...` (an individual user's report) — consider a placeholder or a canonical W&B-owned sample.
- `reports-gallery.mdx`: intro doesn't explicitly name the audience (first-time authors vs. experienced users looking for templates); the **Notes** section bundles two distinct example patterns under one H2 — consider splitting; all three H2 headings use a `Label: action` colon pattern unusual for the style guide — consider refactoring as H2 label + H3 subtitle or dropping the labels.

## How to review

- Each file's changes are style edits only. Compare side-by-side and flag any that change technical meaning.
- Approve and merge to accept the edits, or close to reject them.
