### PR TITLE
docs: add missing Colab button in tables walkthrough

### DIFF
--- a/models/tables/tables-walkthrough.mdx
+++ b/models/tables/tables-walkthrough.mdx
@@ -3,9 +3,13 @@ description: Explore how to use W&B Tables with this 5 minute Quickstart.
 title: 'Tutorial: Log tables, visualize and query data'
 ---
 
+import { ColabLink } from '/snippets/_includes/colab-link.mdx';
+
 The following Quickstart demonstrates how to log data tables, visualize data, and query data.
 
-Select the button below to try a PyTorch Quickstart example project on MNIST data. 
+Select the button below to try a PyTorch Quickstart example project on MNIST data.
+
+<ColabLink url="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/datasets-predictions/W%26B_Tables_Quickstart.ipynb" />
 
 ## 1. Log a table
 Log a table with W&B. You can either construct a new table or pass a Pandas Dataframe.


### PR DESCRIPTION
## Summary

`models/tables/tables-walkthrough.mdx` told readers to "Select the button below to try a PyTorch Quickstart example project on MNIST data" — but no button ever followed it. The sentence has pointed at nothing since the original Mintlify import ([#1727](https://github.com/wandb/docs/pull/1727)).

This supplies the missing button using the existing **`<ColabLink>`** snippet component (`/snippets/_includes/colab-link.mdx`) — the same one used in the Weave quickstarts and integration guides — rather than inventing a new component. It points at the **W&B Tables Quickstart** Colab in `wandb/examples`, which is the PyTorch-on-MNIST notebook the text describes (its own title: "View & analyze model predictions during training … using PyTorch on MNIST data"). Verified the notebook resolves; the same notebook is already linked from `models/tables/visualize-tables.mdx`.

## Change

```mdx
import { ColabLink } from /snippets/_includes/colab-link.mdx;

...

Select the button below to try a PyTorch Quickstart example project on MNIST data.

<ColabLink url="https://colab.research.google.com/github/wandb/examples/blob/master/colabs/datasets-predictions/W%26B_Tables_Quickstart.ipynb" />
```

Scoped to this one file.

## Note for reviewers

[#2725](https://github.com/wandb/docs/pull/2725) (the `models/tables` style pass) also touches this same line (it trims a trailing space), so expect a trivial merge conflict between the two — resolve in favor of this change. Merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)