### PR TITLE
Fix agents quickstart Colab link

### DIFF
--- a/weave/agents-quickstart.mdx
+++ b/weave/agents-quickstart.mdx
@@ -7,7 +7,7 @@ import AgentsPreview from '/snippets/_includes/agents-public-preview.mdx';
 
 <AgentsPreview />
 
-[Try in Colab](https://colab.research.google.com/github/wandb/weave/blob/master/docs/weave/cookbooks/source/agents-quickstart.ipynb) · [GitHub source](https://github.com/wandb/weave/blob/master/docs/weave/cookbooks/source/agents-quickstart.ipynb)
+[Try in Colab](https://colab.research.google.com/github/wandb/docs/blob/main/weave/cookbooks/source/agents-quickstart.ipynb) · [GitHub source](https://github.com/wandb/docs/blob/main/weave/cookbooks/source/agents-quickstart.ipynb)
 
 The Weave SDK allows you to trace agents built with popular SDKs or custom harnesses. This quickstart guides you through how to manually integrate Weave into a custom-built multi-turn agent to emit and capture OpenTelemetry spans. For conceptual understanding on Weave for agents, see [Trace your agents](/weave/guides/tracking/trace-agents).
 


### PR DESCRIPTION
## Summary
- Updates the Colab and GitHub source links on `weave/agents-quickstart.mdx` to point at `wandb/docs` on `main` instead of a nonexistent path in `wandb/weave`.
- Aligns with other weave cookbook pages (for example, `ocr-pipeline.mdx`).

## Test plan
- [ ] Open the updated Colab link and confirm the notebook loads without a GitHub API 404.
- [ ] Confirm the GitHub source link opens `weave/cookbooks/source/agents-quickstart.ipynb` in `wandb/docs`.


Made with [Cursor](https://cursor.com)