### PR TITLE
Correcting style guide violations in golden selected docs

### DIFF
--- a/models/artifacts/construct-an-artifact.mdx
+++ b/models/artifacts/construct-an-artifact.mdx
@@ -13,7 +13,7 @@ Construct a [W&B Artifact](/models/ref/python/experiments/artifact) in three ste
 
 1. [Create an artifact Python object with `wandb.Artifact()`](/models/artifacts/construct-an-artifact#create-an-artifact-python-object-with-wandb-artifact)
 2. [Add one or more files to the artifact](/models/artifacts/construct-an-artifact#add-one-more-files-to-the-artifact)
-3. [Save your artifact to the W&B server](/models/artifacts/construct-an-artifact#save-your-artifact-to-the-wb-server)
+3. [Save your artifact to the W&B server](/models/artifacts/construct-an-artifact#save-your-artifact-to-the-w&b-server)
 
 ### Create an artifact Python object with `wandb.Artifact()`
 

--- a/models/artifacts/construct-an-artifact.mdx
+++ b/models/artifacts/construct-an-artifact.mdx
@@ -12,7 +12,7 @@ For information on how to track external files, such as files stored in Amazon S
 Construct a [W&B Artifact](/models/ref/python/experiments/artifact) in three steps:
 
 1. [Create an artifact Python object with `wandb.Artifact()`](/models/artifacts/construct-an-artifact#create-an-artifact-python-object-with-wandb-artifact)
-2. [Add one or more files to the artifact](/models/artifacts/construct-an-artifact#add-one-more-files-to-the-artifact)
+2. [Add one or more files to the artifact](/models/artifacts/construct-an-artifact#add-one-or-more-files-to-the-artifact)
 3. [Save your artifact to the W&B server](/models/artifacts/construct-an-artifact#save-your-artifact-to-the-w&b-server)
 
 ### Create an artifact Python object with `wandb.Artifact()`
@@ -43,7 +43,7 @@ import wandb
 artifact = wandb.Artifact(name="<name>", type="<type>")
 ```
 
-### Add one more files to the artifact
+### Add one or more files to the artifact
 
 [Add files, directories, external URI references (such as Amazon S3) and more](/models/artifacts/construct-an-artifact#add-files-to-an-artifact) to your artifact object.
 

--- a/models/artifacts/construct-an-artifact.mdx
+++ b/models/artifacts/construct-an-artifact.mdx
@@ -11,15 +11,15 @@ For information on how to track external files, such as files stored in Amazon S
 
 Construct a [W&B Artifact](/models/ref/python/experiments/artifact) in three steps:
 
-1. [Create an artifact Python object with `wandb.Artifact()`](/models/artifacts/construct-an-artifact#1-create-an-artifact-python-object-with-wandb-artifact)
-2. [Add one or more files to the artifact](/models/artifacts/construct-an-artifact#2-add-one-more-files-to-the-artifact)
-3. [Save your artifact to the W&B server](/models/artifacts/construct-an-artifact#3-save-your-artifact-to-the-w&b-server)
+1. [Create an artifact Python object with `wandb.Artifact()`](/models/artifacts/construct-an-artifact#create-an-artifact-python-object-with-wandb-artifact)
+2. [Add one or more files to the artifact](/models/artifacts/construct-an-artifact#add-one-more-files-to-the-artifact)
+3. [Save your artifact to the W&B server](/models/artifacts/construct-an-artifact#save-your-artifact-to-the-wb-server)
 
-### 1. Create an artifact Python object with `wandb.Artifact()`
+### Create an artifact Python object with `wandb.Artifact()`
 
 Initialize the [`wandb.Artifact()`](/models/ref/python/experiments/artifact) class to create an artifact object. Specify the following parameters:
 
-* **Name**: The name of your artifact. The name should be unique, descriptive, and easy to remember.
+* **Name**: The name of your artifact. The name should be unique, descriptive, and memorable.
 * **Type**: The type of artifact. The type should be simple, descriptive, and correspond to a single step of your machine learning pipeline. Common artifact types include `'dataset'` or `'model'`.
 
 
@@ -43,7 +43,7 @@ import wandb
 artifact = wandb.Artifact(name="<name>", type="<type>")
 ```
 
-### 2. Add one more files to the artifact
+### Add one more files to the artifact
 
 [Add files, directories, external URI references (such as Amazon S3) and more](/models/artifacts/construct-an-artifact#add-files-to-an-artifact) to your artifact object.
 
@@ -61,7 +61,7 @@ artifact.add_dir(local_path="path/to/directory", name="<name>")
 
 See the next section, [Add files to an artifact](/models/artifacts/construct-an-artifact#add-files-to-an-artifact), for more information on how to add different file types to an artifact.
 
-### 3. Save your artifact to the W&B server
+### Save your artifact to the W&B server
 
 Save your artifact to the W&B server. Use the run object's [`wandb.Run.log_artifact()`](/models/ref/python/experiments/run#log_artifact) method to save the artifact.
 
@@ -109,14 +109,14 @@ with wandb.init() as run:
         run.log_artifact(a)
 ```
 
-The artifact version **v0** is NOT guaranteed to have an index of 0 in its metadata because artifacts may be logged in an arbitrary order.
+The artifact version **v0** might not have an index of 0 in its metadata because artifacts may be logged in an arbitrary order.
 </Warning>
 
 ## Add files to an artifact
 
 The following sections demonstrate how to add different types of objects to an artifact. Assume you have a directory with the following structure as you read through the examples:
 
-```
+```text
 root-directory
 | - hello.txt
 | - images/
@@ -150,7 +150,7 @@ artifact.add_file("hello.txt")
 
 The artifact now has the following content:
 
-```
+```text
 hello.txt
 ```
 
@@ -165,7 +165,7 @@ artifact.add_file(
 
 The artifact is stored as:
 
-```
+```text
 new/path/hello_world.txt
 ```
 
@@ -203,7 +203,7 @@ The following table show how different API calls produce different artifact cont
 
 ### Add a URI reference
 
-Artifacts track checksums and other information for reproducibility if the URI has a scheme that W&B library knows how to handle.
+Artifacts track checksums and other information for reproducibility if the URI has a scheme that the W&B library supports.
 
 Add an external URI reference to an artifact with the [`wandb.Artifact.add_reference()`](/models/ref/python/experiments/artifact#method-artifact-add-reference) method. Replace the `'uri'` string with your own URI. Optionally pass the desired path within the artifact for the name parameter.
 
@@ -212,7 +212,7 @@ Add an external URI reference to an artifact with the [`wandb.Artifact.add_refer
 artifact.add_reference(uri="uri", name="optional-name")
 ```
 
-Artifacts currently support the following URI schemes:
+Artifacts support the following URI schemes:
 
 * `http(s)://`: A path to a file accessible over HTTP. The artifact will track checksums in the form of etags and size metadata if the HTTP server supports the `ETag` and `Content-Length` response headers.
 * `s3://`: A path to an object or object prefix in S3. The artifact will track checksums and versioning information (if the bucket has object versioning enabled) for the referenced objects. Object prefixes are expanded to include the objects under the prefix, up to a maximum of 10,000 objects.

--- a/models/sweeps/define-sweep-configuration.mdx
+++ b/models/sweeps/define-sweep-configuration.mdx
@@ -16,7 +16,7 @@ The following guide describes how to format your sweep configuration. See [Sweep
 
 ## Basic structure
 
-Both sweep configuration format options (YAML and Python dictionary) utilize key-value pairs and nested structures. 
+Both sweep configuration format options (YAML and Python dictionary) use key-value pairs and nested structures. 
 
 Use top-level keys within your sweep configuration to define qualities of your sweep search such as the name of the sweep ([`name`](./sweep-config-keys) key), the parameters to search through ([`parameters`](./sweep-config-keys#parameters) key), the methodology to search the parameter space ([`method`](./sweep-config-keys#method) key), and more. 
 

--- a/models/track/log/plots.mdx
+++ b/models/track/log/plots.mdx
@@ -149,7 +149,7 @@ For more information, see the [Custom Multi-Line Plots](https://wandb.ai/wandb/p
 
 ### Model evaluation charts
 
-These preset charts have built-in `wandb.plot()` methods that make it quick and easy to log charts directly from your script and see the exact information you're looking for in the UI.
+These preset charts have built-in `wandb.plot()` methods that make it quick to log charts directly from your script and see the exact information you're looking for in the UI.
 
 <Tabs>
 <Tab title="Precision-recall curves">
@@ -287,7 +287,7 @@ with wandb.init() as run:
     run.log({"chart": plt})
 ```
 
-Just pass a `matplotlib` plot or figure object to `wandb.Run.log()`. By default we'll convert the plot into a [Plotly](https://plot.ly/) plot. If you'd rather log the plot as an image, you can pass the plot into `wandb.Image`. We also accept Plotly charts directly.
+Pass a `matplotlib` plot or figure object to `wandb.Run.log()`. By default we'll convert the plot into a [Plotly](https://plot.ly/) plot. If you'd rather log the plot as an image, you can pass the plot into `wandb.Image`. We also accept Plotly charts directly.
 
 <Note>
 If you get an error like "You attempted to log an empty plot", store the figure separately from the plot with `fig = plt.figure()` and then log `fig` in your call to `wandb.Run.log()`.


### PR DESCRIPTION
(i manually reviewed these changes made by claude to correct legitimate style guide violations and they seem reasonable to me. Also verified the anchor links that were modified in the 1-3] list work).

Corrects style guide violations identified in the following golden selected docs:

`golden#wandb/docs:models/artifacts/construct-an-artifact.mdx@dcebe6970ccde4ac6407a435bfa43e5d948da1f6`
* score_pass2_structure — score 0.8 — 3 numbered heading(s) found (remove the numbers): ['1. Create an artifact Python object with', '2. Add one more files to the artifact', '3. Save your artifact to the W&B server']
* score_pass3_language — score 0.7 — anthropomorphic language found: ['library knows']; software doesn't want, think, or know things — describe what it does
* score_pass5_considerate — score 0.65 — condescending language: ['"easy" (1x)']; remove or rephrase — readers who don't find it easy will feel excluded
* score_pass6_formatting — score 0.8 — 3 fenced code block(s) missing a language tag; add bash, python, yaml, json, text, etc.
* score_pass7_polish — score 0.5
    * time-sensitive language found (1 type(s)): ['"currently": remove; present tense already implies current state']
    * unsubstantiated superlative(s): ['guaranteed']; remove or back with evidence

`golden#wandb/docs:models/sweeps/define-sweep-configuration.mdx@dcebe6970ccde4ac6407a435bfa43e5d948da1f6`
* score_pass4_terminology — score 0.88 — "utilize" found 1x → use "use"

`golden#wandb/docs:models/track/log/plots.mdx@dcebe6970ccde4ac6407a435bfa43e5d948da1f6`
* score_pass5_considerate — score 0.65 — condescending language: ['"easy" (1x)', '"just" as intensifier (1x)']; remove or rephrase — readers who don't find it easy will feel excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)