### PR TITLE
Correcting style guide violations in golden selected docs

### DIFF
--- a/weave/guides/evaluation/builtin_scorers.mdx
+++ b/weave/guides/evaluation/builtin_scorers.mdx
@@ -22,7 +22,7 @@ pip install weave[scorers]
 
 **LLM-evaluators**
 
-The predefined scorers that use LLMs integrate with litellm automatically. You don't need to pass an LLM client; set the `model_id` instead. See the [supported models](https://docs.litellm.ai/docs/providers).
+The predefined scorers that use LLMs integrate with litellm automatically. You don't need to pass an LLM client. Set the `model_id` instead. See the [supported models](https://docs.litellm.ai/docs/providers).
 
 ## `HallucinationFreeScorer`
 

--- a/weave/guides/tools/attributes.mdx
+++ b/weave/guides/tools/attributes.mdx
@@ -6,7 +6,7 @@ keywords: ["weave.attributes", "global_attributes", "trace metadata", "get_curre
 
 Attributes in Weave let you attach custom metadata to your traces and evaluations. This metadata can include information like environment names, model versions, experiment IDs, user IDs, or other contextual information to help you organize, filter, and analyze your Weave data.
 
-Attributes are especially helpful when you need to group or filter traces by:
+Attributes are especially helpful for grouping or filtering traces by:
 * Deployments
 * Tenants
 * Experiments
@@ -258,7 +258,7 @@ main().catch(console.error);
 
 ## Get attributes during execution
 
-At runtime, you can inspect the attributes currently in effect for a Call. This is useful when you want to debug which metadata Weave attaches, or when your code needs to branch on contextual information set by an outer caller.
+At runtime, you can inspect the attributes in effect for a Call. This is useful when you want to debug which metadata Weave attaches, or when your code needs to branch on contextual information set by an outer caller.
 
 <Tabs>
 <Tab title="Python">

--- a/weave/guides/tracking/feedback.mdx
+++ b/weave/guides/tracking/feedback.mdx
@@ -164,7 +164,7 @@ The maximum number of characters in a feedback note is 1024. If a note exceeds t
 
 #### Retrieve the Call UUID
 
-For scenarios where you need to add feedback immediately after a Call, you can retrieve the Call UUID programmatically during or after the Call execution.
+For scenarios where you must add feedback immediately after a Call, you can retrieve the Call UUID programmatically during or after the Call execution.
 
 ##### During Call execution
 
@@ -379,7 +379,7 @@ Expanding on [creating a human annotation scorer using the API](#create-a-human-
 
 ### Use a human annotation scorer using the API
 
-The feedback API allows you to use a human annotation scorer by specifying a specially constructed name and an `annotation_ref` field. You can obtain the `annotation_spec_ref` from the UI by selecting the appropriate tab, or during the creation of the `AnnotationSpec`.
+The feedback API lets you use a human annotation scorer by specifying a specially constructed name and an `annotation_ref` field. You can obtain the `annotation_spec_ref` from the UI by selecting the appropriate tab, or during the creation of the `AnnotationSpec`.
 
 <Tabs>
   <Tab title="Python">

--- a/weave/guides/tracking/threads.mdx
+++ b/weave/guides/tracking/threads.mdx
@@ -355,9 +355,9 @@ if __name__ == "__main__":
 
 ### Resume a previous session
 
-Sometimes you need to resume a previously started session and continue adding Calls to the same thread. In other cases, you may not be able to resume an existing session and must start a new thread instead.
+Sometimes you must resume a previously started session and continue adding Calls to the same thread. In other cases, you may not be able to resume an existing session and must start a new thread instead.
 
-When implementing optional thread resumption, never leave the `thread_id` parameter as `None`, as this disables thread grouping. Instead, always provide a valid thread ID. If you need to create a new thread, generate a unique identifier using a function like `generate_id()`.
+When implementing optional thread resumption, never leave the `thread_id` parameter as `None`, as this disables thread grouping. Instead, always provide a valid thread ID. To create a new thread, generate a unique identifier using a function like `generate_id()`.
 
 When no `thread_id` is specified, Weave's internal implementation automatically generates a random UUID v7. You can replicate this behavior in your own `generate_id()` function or use any unique string value you prefer.
 


### PR DESCRIPTION
Corrects style guide violations identified in the following golden selected docs.

`golden#wandb/docs:weave/guides/evaluation/builtin_scorers.mdx@e62b5f2cea1ed832a53102b97a2013c4b431ace2`
* score_pass6_formatting — 1 semicolon in prose; split into two sentences instead

`golden#wandb/docs:weave/guides/tools/attributes.mdx@e62b5f2cea1ed832a53102b97a2013c4b431ace2`
* score_pass1_context — weak "you need to" phrasing; reworded for prescriptive framing
* score_pass7_polish — time-sensitive language: '"currently": remove; present tense already implies current state'

`golden#wandb/docs:weave/guides/tracking/feedback.mdx@e62b5f2cea1ed832a53102b97a2013c4b431ace2`
* score_pass1_context — weak "you need to" phrasing → "you must" for the required-action scenario
* score_pass4_terminology — "allows you to" found 1x → use "lets you"

`golden#wandb/docs:weave/guides/tracking/threads.mdx@e62b5f2cea1ed832a53102b97a2013c4b431ace2`
* score_pass1_context — weak "you need to" phrasing found 2x; reworded for prescriptive framing

---

### Items intentionally not changed

- **feedback.mdx — emoji in prose (pass7_polish):** false positive. That page documents using emojis as feedback, so the emoji is intentional subject matter, not decorative prose.
- **threads.mdx — "recently" (pass7_polish):** false positive. The phrase is "the 50 most recently updated threads" — a description of sort order (by recency), not a temporal claim about a feature. "recently" is essential to the meaning, so it can't be removed or tied to a date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)