### PR TITLE
Add wandb/examples as a shallow submodule under snippets/_includes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
 [submodule ".claude"]
 	path = .claude
 	url = https://github.com/coreweave/docs-skills.git
+[submodule "snippets/_includes/examples"]
+	path = snippets/_includes/examples
+	url = https://github.com/wandb/examples
+	branch = main
+	shallow = true

--- a/.mintignore
+++ b/.mintignore
@@ -8,6 +8,11 @@ runbooks/
 node_modules/
 .github/
 
+# wandb/examples submodule: example code kept current by Dependabot, not doc
+# pages. Excluded so Mintlify does not parse or publish its files. To surface
+# specific example content in the docs, narrow this pattern accordingly.
+snippets/_includes/examples/
+
 # Top-level config and assets (not doc pages)
 # Note: Do not exclude .js or .css. Mintlify loads
 # these automatically if present in the content root.


### PR DESCRIPTION
## Description

Adds [`wandb/examples`](https://github.com/wandb/examples) as a git submodule at `snippets/_includes/examples`, tracking the `main` branch, and ensures Dependabot keeps it current.

**What changed**
- New submodule `snippets/_includes/examples` → `https://github.com/wandb/examples`, pinned on `main`.
- `.gitmodules`: `branch = main` (the field Dependabot reads to track upstream) and `shallow = true` (depth-1 init).
- `.mintignore`: exclude the submodule so the Mintlify build doesn't parse or publish its files.

**Dependabot — no config change needed**
The existing `gitsubmodule` entry in `.github/dependabot.yml` (`directory: "/"`, `daily`) reads the root `.gitmodules` and monitors *every* submodule listed there. For `git_submodule`, Dependabot bumps to the latest commit on the branch named in `.gitmodules`, so it will open a PR (labeled `auto-generated`, prefixed `chore`) whenever `main` advances past the pinned commit.

**Clone footprint**
- A plain `git clone` pulls **only the gitlink pointer** — the ~736 MB of example content is *not* downloaded.
- `shallow = true` caps `git submodule update --init` at a **~240 MB depth-1 download** (vs. full history) for anyone who does initialize submodules. No CI workflow uses `submodules: true`, so CI checkouts are unaffected.

## Testing
- [x] Confirmed `wandb/examples` default branch is `main`.
- [x] Confirmed no workflow checks out submodules (`submodules: true`/`recursive`), so CI won't pull the content.
- [x] Verified `shallow = true` resolves correctly on GitHub even when the pinned SHA **lags** the branch tip (the normal state between Dependabot bumps) — via a fresh `git clone --recurse-submodules` end-to-end test against a commit 15 behind tip.
- [ ] `mint dev` / `mint broken-links` not run in this environment — relying on PR CI to validate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)