### PR TITLE
docs(weave): enable Twoslash on TS SDK reference code blocks

### DIFF
--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -214,7 +214,16 @@ description: "TypeScript SDK reference"
         
         # Fix parameter tables
         content = re.sub(r'\|\s*:--\s*\|', '| --- |', content)
-        
+
+        # Enable Mintlify Twoslash on TS code blocks for IDE-style hover types.
+        # `// @noErrors` suppresses type errors from non-self-contained snippets.
+        content = re.sub(
+            r'^```(ts|typescript)([^\n]*)$',
+            r'```\1\2 twoslash\n// @noErrors',
+            content,
+            flags=re.MULTILINE,
+        )
+
         # Fix internal links to use relative paths with lowercase filenames
         # TypeDoc generates links like ../classes/WeaveObject.md which need fixing
         


### PR DESCRIPTION
## Description

Extends `scripts/reference-generation/weave/generate_typescript_sdk_docs.py` so the generated Weave TypeScript SDK reference docs get the same Mintlify Twoslash treatment that #2757 applied to guides, tutorials, concepts, and quickstarts.

## Related

- Follow-up to #2757 ("Reference docs are intentionally excluded and will be handled in a separate PR")