### PR TITLE
fix(weave): restore broken otel docs page + correct OTLP endpoint guidance

### DIFF
--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -67,8 +67,7 @@ tracer_provider = trace_sdk.TracerProvider(resource=Resource({
     "wandb.project": PROJECT,
 }))
 ```
-```typescript twoslash TypeScript lines
-// @noErrors
+```typescript TypeScript lines
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { Resource } from "@opentelemetry/resources";
@@ -207,8 +206,7 @@ The TypeScript implementation of this example contains the following key differe
 
 Paste the following code into a TypeScript file such as `openinference_example.ts`:
 
-```typescript twoslash lines {11,12}
-// @noErrors
+```typescript lines {11,12}
 // IMPORTANT: Import OpenAI FIRST so instrumentation can patch it
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -379,8 +377,7 @@ python openllmetry_example.py
 
 Paste the following code into a TypeScript file such as `openllmetry_example.ts`. This uses the Traceloop OpenAI instrumentation package:
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
@@ -568,8 +565,7 @@ python opentelemetry_example.py
 
 Paste the following code into a TypeScript file such as `opentelemetry_example.ts`:
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import OpenAI from "openai";
 import { trace } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -760,8 +756,7 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-```typescript twoslash TypeScript lines
-// @noErrors
+```typescript TypeScript lines
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
@@ -867,8 +862,7 @@ tracer = trace.get_tracer(__name__)
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import { trace, context } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import {
@@ -965,8 +959,7 @@ if __name__ == "__main__":
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 function example_1_basic_thread_and_turn() {
   console.log("\n=== Example 1: Basic Thread and Turn ===");
 
@@ -1065,8 +1058,7 @@ if __name__ == "__main__":
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 function example_2_multiple_turns() {
   console.log("\n=== Example 2: Multiple Turns in Thread ===");
 
@@ -1180,8 +1172,7 @@ if __name__ == "__main__":
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 function example_3_complex_nested_structure() {
   console.log("\n=== Example 3: Complex Nested Structure ===");
 
@@ -1285,8 +1276,7 @@ if __name__ == "__main__":
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 function example_4_non_turn_operations() {
   console.log("\n=== Example 4: Non-Turn Thread Operations ===");
 

--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -20,6 +20,18 @@ This page covers the endpoint details, authentication, end-to-end examples in Py
 
 Replace `<your-subdomain>` with your organization's unique W&B domain, for example, `acme.wandb.io`.
 
+<Warning>
+**Setting the endpoint with an environment variable?** If you use zero-code instrumentation (`opentelemetry-instrument`) or otherwise rely on `OTEL_EXPORTER_OTLP_*` environment variables, use the **signal-specific** variable, which is sent verbatim with no path appended:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://trace.wandb.ai/otel/v1/traces"
+```
+
+Do **not** put that full URL in the generic `OTEL_EXPORTER_OTLP_ENDPOINT`. The OTel SDK treats that variable as a base and appends `/v1/traces` (producing `.../otel/v1/traces/v1/traces`, which returns 404); it also exports metrics and logs to Weave, which ingests traces only (those 404 as well). If you must use the generic variable, set it to the base (`https://trace.wandb.ai/otel`) and disable the metric and log exporters.
+
+The code examples below pass the URL straight to the exporter's `endpoint`/`url` argument, which is always used as-is, so they are unaffected.
+</Warning>
+
 ## Authentication and routing
 
 Weave uses the `wandb-api-key` header to authenticate requests and resource attributes on your `TracerProvider` to route spans to the correct entity and project. Pass your W&B API key in the `wandb-api-key` header, then specify the following keys as OpenTelemetry Resource attributes in your `TracerProvider` class:
@@ -40,13 +52,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_TRACES_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_TRACES_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -65,13 +77,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_TRACES_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_TRACES_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -141,13 +153,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_TRACES_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_TRACES_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -210,13 +222,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_TRACES_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_TRACES_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -318,13 +330,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_TRACES_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_TRACES_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -382,13 +394,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_TRACES_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_TRACES_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -496,14 +508,14 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_TRACES_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 # Configure the OTLP exporter
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_TRACES_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -570,13 +582,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_TRACES_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_TRACES_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -830,10 +842,10 @@ ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
-OTEL_EXPORTER_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces"
+WEAVE_TRACES_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces"
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_TRACES_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -878,10 +890,10 @@ if (!WANDB_API_KEY) {
 }
 
 // OTel Setup
-const OTEL_EXPORTER_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces";
+const WEAVE_TRACES_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces";
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_TRACES_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 


### PR DESCRIPTION
## Summary
Two fixes to `weave/guides/tracking/otel.mdx`:

- **Restore the broken page (urgent).** #2757 enabled `twoslash` here, and otel.mdx is the only weave page with twoslash TS blocks. The build now throws a Shiki error, `Language console not found` (raised while twoslash renders hover JSDoc), so the live page serves Mintlify's "🚧 A parsing error occured" boundary instead of content. Reverts the `twoslash` keyword and the `// @noErrors` lines #2757 added, restoring the pre-#2757 content. Verified rendering with `mint dev`.
- **Correct OTLP endpoint guidance.** Renames the example variable `OTEL_EXPORTER_OTLP_ENDPOINT` to `WEAVE_TRACES_ENDPOINT`: it was named identically to the real env var, so copying the value into the env var (or using `opentelemetry-instrument`) makes the OTel SDK append `/v1/traces` -> `.../otel/v1/traces/v1/traces` 404 (~273/day in prod). Adds a callout pointing env-var setups at signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.

## Testing
`mint dev` renders the page (it serves the parse-error boundary on `main`); `mint validate` passes. cc #2757 author re: the twoslash revert.