### PR TITLE
WEAVE: Remove problematic twoslash implementations on OTEL page

### DIFF
--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -1379,3 +1379,7 @@ Weave supports attribute conventions from the following observability frameworks
 | `wandb.is_turn`                   | `is_turn`                     | Marks span as conversation turn.            | Boolean                     | `true`                                         |
 | `langfuse.startTime`              | `start_time` (override)       | Override span start timestamp.              | Timestamp (ISO8601/unix ns) | `"2024-01-01T12:00:00Z"`                       |
 | `langfuse.endTime`                | `end_time` (override)         | Override span end timestamp.                | Timestamp (ISO8601/unix ns) | `"2024-01-01T12:00:01Z"`                       |
+
+## Limitations
+
+The Weave UI does not support rendering OTel trace tool calls in the Chat view. They appear as raw JSON instead.

--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -10,10 +10,10 @@ This page covers the endpoint details, authentication, end-to-end examples in Py
 
 ## Endpoint details
 
-**Path**: `/otel/v1/traces`
-**Method**: `POST`
-**Content-Type**: `application/x-protobuf`
-**Base URL**: The base URL for the OTel trace endpoint depends on your W&B deployment type:
+* **Path**: `/otel/v1/traces`
+* **Method**: `POST`
+* **Content-Type**: `application/x-protobuf`
+* **Base URL**: The base URL for the OTel trace endpoint depends on your W&B deployment type:
 
 - Multi-tenant Cloud: `https://trace.wandb.ai/otel/v1/traces`.
 - Dedicated Cloud and Self-Managed instances: `https://<your-subdomain>.wandb.io/traces/otel/v1/traces`.
@@ -55,8 +55,7 @@ tracer_provider = trace_sdk.TracerProvider(resource=Resource({
     "wandb.project": PROJECT,
 }))
 ```
-```typescript twoslash TypeScript lines
-// @noErrors
+```typescript TypeScript lines
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { Resource } from "@opentelemetry/resources";
@@ -195,8 +194,7 @@ The TypeScript implementation of this example contains the following key differe
 
 Paste the following code into a TypeScript file such as `openinference_example.ts`:
 
-```typescript twoslash lines {11,12}
-// @noErrors
+```typescript lines {11,12}
 // IMPORTANT: Import OpenAI FIRST so instrumentation can patch it
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -367,8 +365,7 @@ python openllmetry_example.py
 
 Paste the following code into a TypeScript file such as `openllmetry_example.ts`. This uses the Traceloop OpenAI instrumentation package:
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
@@ -556,8 +553,7 @@ python opentelemetry_example.py
 
 Paste the following code into a TypeScript file such as `opentelemetry_example.ts`:
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import OpenAI from "openai";
 import { trace } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -748,8 +744,7 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-```typescript twoslash TypeScript lines
-// @noErrors
+```typescript TypeScript lines
 import OpenAI from "openai";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
@@ -855,8 +850,7 @@ tracer = trace.get_tracer(__name__)
 </Tab>
 <Tab title="TypeScript">
 
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import { trace, context } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import {
@@ -1385,8 +1379,3 @@ Weave supports attribute conventions from the following observability frameworks
 | `wandb.is_turn`                   | `is_turn`                     | Marks span as conversation turn.            | Boolean                     | `true`                                         |
 | `langfuse.startTime`              | `start_time` (override)       | Override span start timestamp.              | Timestamp (ISO8601/unix ns) | `"2024-01-01T12:00:00Z"`                       |
 | `langfuse.endTime`                | `end_time` (override)         | Override span end timestamp.                | Timestamp (ISO8601/unix ns) | `"2024-01-01T12:00:01Z"`                       |
-
-
-## Limitations
-
-The Weave UI does not support rendering OTel trace tool calls in the Chat view. They appear as raw JSON instead.


### PR DESCRIPTION
## Description
Removes twoslash from a few code blocks that were causing the Weave OTEL documentation page to not parse.