### PR TITLE
Python SDK-related: Removed page from top nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -504,7 +504,6 @@
                     "group": "Reference",
                     "pages": [
                       "models/ref-link-python",
-                      "models/ref-link-public-api",
                       "models/ref-link-cli",
                       "models/ref-link-query-panel",
                       "models/ref-link-workspaces"
@@ -1886,7 +1885,6 @@
                     "group": "Référence",
                     "pages": [
                       "fr/models/ref-link-python",
-                      "fr/models/ref-link-public-api",
                       "fr/models/ref-link-cli",
                       "fr/models/ref-link-query-panel",
                       "fr/models/ref-link-workspaces"
@@ -3268,7 +3266,6 @@
                     "group": "リファレンス",
                     "pages": [
                       "ja/models/ref-link-python",
-                      "ja/models/ref-link-public-api",
                       "ja/models/ref-link-cli",
                       "ja/models/ref-link-query-panel",
                       "ja/models/ref-link-workspaces"
@@ -4650,7 +4647,6 @@
                     "group": "레퍼런스",
                     "pages": [
                       "ko/models/ref-link-python",
-                      "ko/models/ref-link-public-api",
                       "ko/models/ref-link-cli",
                       "ko/models/ref-link-query-panel",
                       "ko/models/ref-link-workspaces"

--- a/models/ref-link-public-api.mdx
+++ b/models/ref-link-public-api.mdx
@@ -1,4 +1,0 @@
----
-title: "Public API"
-url: "/models/ref/python/public-api"
----


### PR DESCRIPTION
## Description

This page was vibe-coded in. It shouldn't exist. The Public API is part of the Python SDK.