### PR TITLE
ci(docengine): only comment orphan report when there's something to report

### DIFF
--- a/.github/workflows/docengine-build.yml
+++ b/.github/workflows/docengine-build.yml
@@ -96,8 +96,17 @@ jobs:
         run: docengine build --orphan-report-file "${RUNNER_TEMP}/orphan-report.md"
 
       - name: Orphan report → job summary
+        # The engine writes the report file only when there is something to report
+        # (orphans, or escapes the host has not declared in allowed_escapes). A clean
+        # build leaves no file — say so rather than failing on a missing cat.
         if: success()
-        run: cat "${RUNNER_TEMP}/orphan-report.md" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          f="${RUNNER_TEMP}/orphan-report.md"
+          if [ -s "$f" ]; then
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "DocEngine: no orphans or escapes to report." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Commit generated output back to the branch
         # Never commit back to main (e.g. a workflow_dispatch run targeting main);
@@ -123,11 +132,35 @@ jobs:
           num=$(gh pr list --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number // empty')
           echo "number=${num}" >> "$GITHUB_OUTPUT"
 
+      - name: Detect orphan report
+        # File presence is the signal: written only when there is something to report.
+        id: orphanfile
+        if: success()
+        run: |
+          if [ -s "${RUNNER_TEMP}/orphan-report.md" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upsert orphan-report PR comment
-        if: ${{ success() && github.actor != 'dependabot[bot]' && github.ref_name != 'main' && steps.findpr.outputs.number != '' }}
+        # Only when there is something to report; a clean build is silent.
+        if: ${{ success() && github.actor != 'dependabot[bot]' && github.ref_name != 'main' && steps.findpr.outputs.number != '' && steps.orphanfile.outputs.present == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           pr-number: ${{ steps.findpr.outputs.number }}
           comment-tag: docengine-orphans
           file-path: ${{ runner.temp }}/orphan-report.md
+          github-token: ${{ steps.app_token.outputs.token }}
+
+      - name: Clear stale orphan-report PR comment
+        # A previous build may have posted orphans that are now resolved — delete that
+        # comment so the PR does not carry a stale warning. No-ops when none exists.
+        if: ${{ success() && github.actor != 'dependabot[bot]' && github.ref_name != 'main' && steps.findpr.outputs.number != '' && steps.orphanfile.outputs.present == 'false' }}
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          pr-number: ${{ steps.findpr.outputs.number }}
+          comment-tag: docengine-orphans
+          mode: delete
+          create-if-not-exists: false
           github-token: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
## What

Stops the DocEngine atomic-output workflow from posting the *"orphan report: none…"* comment on every clean build. The comment now appears only when there is something actionable, and clears itself when a later build comes back clean.

In `.github/workflows/docengine-build.yml`:
- **Guard the job-summary `cat`** — the engine now writes the report file only when there's something to report, so `cat` of a missing file would fail; emit a "no orphans or escapes" line instead.
- **Detect step** — sets `present` from `[ -s orphan-report.md ]`.
- **Gate the upsert** on `present == 'true'` (keeps the existing `github.ref_name != 'main'` guard).
- **Clear-stale step** — `thollander/actions-comment-pull-request@v3` with `mode: delete` + `comment-tag: docengine-orphans` when `present == 'false'`, deleting a previously-posted comment (no-ops when none exists).

## Rollout

Backward-compatible with the **current** engine (always writes the file → `present=true` → upsert; the delete branch never fires). **Merge this before** the `docengine` submodule is bumped to the engine version (coreweave/docengine#181) that stops writing the file on clean builds — the old workflow's unguarded `cat` of the now-absent file would fail CI.

wandb/docs produces no escapes today, so no `allowed_escapes` descriptor entry is needed; add one only if future generators emit fixed-name assets outside the owned subtree (verify from a real build's advisory).

Pairs with coreweave/docengine#181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)