### PR TITLE
Adds Integrations section to end of sandboxes overview

### DIFF
--- a/sandboxes.mdx
+++ b/sandboxes.mdx
@@ -56,10 +56,14 @@ Follow these steps to create a sandbox and run a command inside it:
 
     The sandbox automatically stops when the context manager (the `with` block) exits. For more information on sandbox lifecycle and states, see [Lifecycle of sandboxes](/sandboxes/lifecycle).
 
-
 ## Serverless Sandboxes tutorials
 
 For more in-depth examples, see:
 
 * [Invoke an agent in a Serverless Sandbox tutorial](/sandboxes/invoke-agent-sandbox-tutorial)
 * [Train a PyTorch model in a Serverless Sandbox tutorial](/sandboxes/mltrain-in-sandbox-tutorial)
+
+## Integrations
+
+The following third-party frameworks support Serverless Sandboxes as a sandbox provider.
+- **[Harbor](https://github.com/harbor-framework/harbor)**

--- a/sandboxes.mdx
+++ b/sandboxes.mdx
@@ -66,4 +66,5 @@ For more in-depth examples, see:
 ## Integrations
 
 The following third-party frameworks support Serverless Sandboxes as a sandbox provider.
-- **[Harbor](https://github.com/harbor-framework/harbor)**
+
+- [Harbor](https://github.com/harbor-framework/harbor)


### PR DESCRIPTION
## Summary

- Adds the `## Integrations` section to after `## Serverless Sandboxes tutorials`, so all supplementary reference material is grouped at the bottom of the page.
- Fixes missing trailing newline.

## Test plan

- [ ] Verify page renders correctly locally with `mint dev`

Made with [Cursor](https://cursor.com)