### PR TITLE
Update server releases notes with automation feature

### DIFF
--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -27,6 +27,7 @@ W&B 0.82.0 brings richer artifact insights with editable collection overviews an
     <Frame>
     ![Runs table with pinned runs from another project](/images/runs/compare_runs_ui_element.png)
     </Frame>
+- Configure automations based on a change in a run's status or a change in a run's metric value. See [Run events](/models/automations/automation-events#run-events). Available in Dedicated Cloud v0.81+. Not yet available in Self-Managed.
 - The W&B UI now shows the latest available W&B SDK version, so you can tell when a newer release is available.
 - Workspace browser tabs now include the active view name in the page title, making it easier to differentiate saved views across browser tabs.
 


### PR DESCRIPTION
Added a note about configuring automations based on run status or metric changes, available in Dedicated Cloud v0.81+.
