### PR TITLE
ci: Fix DocEngine overlay matrix step for the descriptor API

### DIFF
--- a/.github/workflows/docengine-overlay.yml
+++ b/.github/workflows/docengine-overlay.yml
@@ -89,18 +89,22 @@ jobs:
         id: matrix
         # Slim-aware discovery: mirror `docengine overlay list`'s resolution. Emits
         # one row per discovered overlay as {api, output_path}; output_path =
-        # output_subpath + the overlay's output_spec_path. `tail -1` drops the
-        # resolver's note line.
+        # output_subpath + the overlay's output_spec_path. Python runs as its own
+        # command so a crash trips the shell's `-e` (GHA default) instead of being
+        # masked by the pipe in a command substitution; `tail -1` then drops the
+        # resolver's stdout note line.
         run: |
-          MATRIX=$(python -c "
+          python -c "
           import json
           from app.overlay_cli import _build_runner
           from app.cli_context import bootstrap_repo, resolve_default_site_context, resolve_site
           _, sm = bootstrap_repo()
           ctx = resolve_default_site_context(None, sm)
           resolved = resolve_site(ctx, sm)
+          if resolved is None:
+              raise SystemExit('resolve_site returned None')
           paths = resolved.paths
-          sub = (paths.site_entry.output_subpath or '').strip()
+          sub = (paths.descriptor.output_subpath or '').strip()
           runner = _build_runner(paths)
           rows = [
               {'api': r['name'],
@@ -108,7 +112,8 @@ jobs:
               for r in runner.list_overlays()
           ]
           print(json.dumps(rows))
-          " | tail -1)
+          " > "$RUNNER_TEMP/overlay-matrix.txt"
+          MATRIX=$(tail -1 "$RUNNER_TEMP/overlay-matrix.txt")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "Overlay matrix: $MATRIX"
 


### PR DESCRIPTION
## Problem

The "Build overlay matrix" step in `.github/workflows/docengine-overlay.yml` reads `paths.site_entry.output_subpath`, but DocEngine's `SitePaths` no longer has `site_entry` — the multi-site → single-site refactor moved `output_subpath` onto a nested `descriptor` object. Against the pinned submodule (`c06c2aa`, which already carries the `descriptor` API) this raises:

```
AttributeError: 'SitePaths' object has no attribute 'site_entry'
```

The break is currently latent here because the schedule is commented out and there are no overlays yet, but any `workflow_dispatch` run (or enabling the cron) would hit it.

**Secondary issue (masked failure).** The step runs `MATRIX=$(python ... | tail -1)`. A non-zero exit from `python` inside that command-substitution-in-assignment does not trip the runner's `-e`, so a crash would capture the resolver's stdout note (`Using wandb_docs from docengine-site/docengine.yaml`) as the matrix value and "succeed" — then fail `fromJson(...)` in the downstream `overlay` job.

## Fix

- Read `paths.descriptor.output_subpath` (the current DocEngine API).
- Run `python` as its own command writing to `$RUNNER_TEMP`, then extract the last line separately — so a future crash fails the step loudly instead of emitting a malformed matrix.
- Guard against `resolve_site` returning `None`.

The accurate "Hello World note" (no overlays yet → empty matrix → `overlay` job skipped) is kept as-is.

## Verification

Installed the pinned submodule (`pip install -e ./docengine` against `c06c2aa`) and ran the corrected snippet locally. It exits 0 and emits `[]` (no overlays defined yet), and `tail -1` correctly drops the resolver note line:

```
Using wandb_docs from docengine-site/docengine.yaml
[]
```

## Context

Mirrors the same fix in coreweave/docs#3238, where the identical step failed on a live scheduled run after the docengine submodule was bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)