### PR TITLE
chore(security): move GitHub Actions updates to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ registries:
     username: x-access-token
     password: ${{secrets.DOCENGINE_TOKEN}}
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     registries:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}


### PR DESCRIPTION
## Summary

This migrates GitHub Actions dependency management from Dependabot to the centralized WandB Renovate setup.

- Adds `.github/renovate.json5` extending `github>wandb/renovate-config`
- Removes only the Dependabot `github-actions` ecosystem block
- Keeps Dependabot managing the existing `gitsubmodule` ecosystem

## Why

Dependabot updates GitHub Actions versions, but it does not perform the initial migration from tag refs to 40-character commit SHA refs. The shared Renovate config enables SHA pinning for GitHub Actions and keeps future GitHub Actions updates under one owner to avoid duplicate PRs.

## Expected follow-up

After this merges and the centralized WandB Renovate workflow runs, Renovate should open a follow-up PR that pins this repo's GitHub Actions `uses:` references to commit SHAs.
