### PR TITLE
Release notes: note ClickHouse 26.2+ requirement for Server v0.81.0+

### DIFF
--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -90,7 +90,7 @@ W&B 0.82.0 brings richer artifact insights with editable collection overviews an
 
 W&B Server 0.81.0 makes debugging and comparing runs easier with deeper, searchable run logs, a new diff patch viewer for run code, more flexible run filtering, improved artifact download, new triggers for automations, and more. Weave adds configurable trace retention, custom monitor signals with faster evaluation workflows. To keep your deployment secure and stable, this release includes security improvements and mitigations, expanded SCIM support for Okta and Microsoft Entra, and reliability fixes across artifacts, workspaces, and reports.
 
-<Note>For deployments using the ClickHouse/OLAP features (Registry Search, Run Store Accelerator, or History), ClickHouse 26.2+ is required before upgrading to v0.81.0+. On older ClickHouse, the runs-accelerator schema migration fails on boot and the `api`/`glue` pods do not start.</Note>
+<Note>For deployments using the ClickHouse/OLAP features (Registry Search, Run Store Accelerator, or History), ClickHouse 26.2+ is required before upgrading to v0.81.0+. Self-managed deployments must upgrade **both** the ClickHouse server and ClickHouse Keeper images. On older ClickHouse, the runs-accelerator schema migration fails on boot and the `api`/`glue` pods do not start.</Note>
 
 ## Support and end of life
 

--- a/release-notes/server-releases.mdx
+++ b/release-notes/server-releases.mdx
@@ -90,6 +90,8 @@ W&B 0.82.0 brings richer artifact insights with editable collection overviews an
 
 W&B Server 0.81.0 makes debugging and comparing runs easier with deeper, searchable run logs, a new diff patch viewer for run code, more flexible run filtering, improved artifact download, new triggers for automations, and more. Weave adds configurable trace retention, custom monitor signals with faster evaluation workflows. To keep your deployment secure and stable, this release includes security improvements and mitigations, expanded SCIM support for Okta and Microsoft Entra, and reliability fixes across artifacts, workspaces, and reports.
 
+<Note>For deployments using the ClickHouse/OLAP features (Registry Search, Run Store Accelerator, or History), ClickHouse 26.2+ is required before upgrading to v0.81.0+. On older ClickHouse, the runs-accelerator schema migration fails on boot and the `api`/`glue` pods do not start.</Note>
+
 ## Support and end of life
 
 - W&B Server v0.69 has reached end of life.


### PR DESCRIPTION
## What
Adds an upgrade-prerequisite `<Note>` to the **v0.81.0** server release notes: deployments using the ClickHouse/OLAP features (Registry Search, Run Store Accelerator, or History) need **ClickHouse 26.2+** before upgrading to v0.81.0+.

## Why
W&B Server 0.81.0 introduced a runs-accelerator schema migration (`services/gorilla/clickhouse/migrations/runs/001_init.up.sql`) that uses a **ClickHouse-26.2-only** full-text index — `INDEX … TYPE text(tokenizer = array)`. On older ClickHouse (e.g. 25.x) the migration **fails on boot and the `api`/`glue` pods don't start**. 0.80 and earlier don't carry this migration. Dedicated/managed instances are already on 26.2; this is an on-prem / self-managed concern.

This came up with a self-managed customer and isn't currently documented. It mirrors the existing v0.78 Weave/ClickHouse upgrade note already on this page.

## Notes for reviewer
- Placed once on the **v0.81.0** block with "v0.81.0+" wording so it covers the 0.81.x line. Happy to also echo it onto the 0.81.1/.2/.3 patch blocks (as the v0.78 note was repeated) if you prefer that pattern.
- Wording/placement is yours to adjust — flagging the requirement is the goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)