### PR TITLE
chore: install node modules with `--legacy-peer-deps`

### DIFF
--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -118,12 +118,12 @@ def setup_typescript_project(weave_source):
     try:
         # Install dependencies
         print("  Installing dependencies...")
-        subprocess.run(["npm", "install"], check=True)
-        
+        subprocess.run(["npm", "install", "--legacy-peer-deps"], check=True)
+
         # Install typedoc and markdown plugin with compatible versions
         print("  Installing typedoc...")
         subprocess.run([
-            "npm", "install", "--save-dev",
+            "npm", "install", "--save-dev", "--legacy-peer-deps",
             "typedoc@0.25.13",
             "typedoc-plugin-markdown@3.17.1"
         ], check=True)


### PR DESCRIPTION
## Description

The `generate-weave-reference-docs` GH workflow currently fails on the pinned version of `typedoc` we're installing here:

```ts
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: weave@0.16.1
npm error Found: typescript@5.9.3
npm error node_modules/typescript
npm error   dev typescript@"^5.9.3" from the root project
npm error
npm error Could not resolve dependency:
npm error peer typescript@"4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x" from typedoc@0.25.13
npm error node_modules/typedoc
npm error   dev typedoc@"0.25.13" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/runner/.npm/_logs/2026-06-30T14_12_58_483Z-eresolve-report.txt
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-06-30T14_12_58_483Z-debug-0.log
✗ Failed to install dependencies: Command '['npm', 'install', '--save-dev', 'typedoc@0.25.13', 'typedoc-plugin-markdown@3.17.1']' returned non-zero exit status 1.
```

* This change adds a flag when installing node modules to get past that peer dependency error.

* Note: we can eventually upgrade `typedoc`, but there are some breaking changes that might not play nicely with some of the steps we take after generating these docs at the moment. PR for that exploration here (https://github.com/wandb/docs/pull/2835)