### PR TITLE
Remove twoslash from problematic Weave code block

### DIFF
--- a/weave/guides/tracking/querying-calls.mdx
+++ b/weave/guides/tracking/querying-calls.mdx
@@ -138,6 +138,7 @@ The endpoint provides several filtering options so you can target Calls made wit
 The following example demonstrates how to retrieve Calls generated from an Op named `web_app` over two days. Replace `[YOUR-TEAM-NAME/YOUR-PROJECT-NAME]` with your team and project names:
 
 <CodeGroup>
+
 ```python Python lines {10-11,16-24}
 import requests
 import json
@@ -173,8 +174,7 @@ response = requests.post(url, json=payload, auth=("api", API_KEY))
 print(json.dumps(response.json(), indent=2))
 ```
 
-```typescript twoslash TypeScript lines {6-7,13-20}
-// @noErrors
+```typescript TypeScript lines {6-7,13-20}
 const url = "https://trace.wandb.ai/calls/stats";
 
 const payload = {
@@ -212,6 +212,7 @@ const response = await fetch(url, {
 const data = await response.json();
 console.log(JSON.stringify(data, null, 2));
 ```
+
 </CodeGroup>
 
 The request also specifies how to aggregate the metrics. You can aggregate metrics by `sum`, `count`, `avg`, `min`, `max`, and `count`.


### PR DESCRIPTION
## Description
Fixes a Weave page that is not rendering by removing twoslash, the TypeScript syntax-highlighting and contextualization tool that Mintlify offers.