### PR TITLE
Remove docs survey banner

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,10 +3,6 @@
   "background": {
     "decoration": "gradient"
   },
-  "banner": {
-    "content": "Help us improve these docs. [Take our quick survey.](https://forms.gle/a843ZFZu8oKqXYVDA)",
-    "dismissible": true
-  },
   "baseUrl": "https://docs.wandb.ai",
   "colors": {
     "dark": "#FCBC32",


### PR DESCRIPTION
## Summary
- Removes the top-of-site banner in `docs.json` that pointed readers to the docs survey (`Help us improve these docs. Take our quick survey.`)

## Test plan
- [x] Confirmed `docs.json` remains valid JSON after removal