### PR TITLE
fix: correct broken code samples in models/integrations docs

### DIFF
--- a/models/integrations/accelerate.mdx
+++ b/models/integrations/accelerate.mdx
@@ -20,7 +20,7 @@ accelerator = Accelerator(log_with="wandb")
 # Initialise your wandb run, passing wandb parameters and any config information
 accelerator.init_trackers(
     project_name="my_project", 
-    config={"dropout": 0.1, "learning_rate": 1e-2}
+    config={"dropout": 0.1, "learning_rate": 1e-2},
     init_kwargs={"wandb": {"entity": "my-wandb-team"}}
     )
 

--- a/models/integrations/huggingface_transformers.mdx
+++ b/models/integrations/huggingface_transformers.mdx
@@ -282,7 +282,7 @@ with wandb.init(
 ) as run:
     # Connect an Artifact to the run
     my_checkpoint_name = f"checkpoint-{last_run_id}:latest"
-    my_checkpoint_artifact = run.use_artifact(my_model_name)
+    my_checkpoint_artifact = run.use_artifact(my_checkpoint_name)
 
     # Download checkpoint to a folder and return the path
     checkpoint_dir = my_checkpoint_artifact.download()

--- a/models/integrations/keras.mdx
+++ b/models/integrations/keras.mdx
@@ -140,7 +140,7 @@ While checkpointing on TPUs you might encounter `UnimplementedError: File system
 checkpoint_options = tf.saved_model.SaveOptions(experimental_io_device="/job:localhost")
 
 WandbModelCheckpoint(
-    filepath="models/,
+    filepath="models/",
     options=checkpoint_options,
 )
 ```

--- a/models/integrations/lightning.mdx
+++ b/models/integrations/lightning.mdx
@@ -442,7 +442,7 @@ my_data = [
 ]
 
 # log the Table
-wandb_logger.log_table(key="my_samples", columns=columns, data=data)
+wandb_logger.log_table(key="my_samples", columns=columns, data=my_data)
 ```
 </Tab>
 </Tabs>

--- a/models/integrations/metaflow.mdx
+++ b/models/integrations/metaflow.mdx
@@ -86,7 +86,7 @@ class WandbExampleFlow(FlowSpec):
     @wandb_log(datasets=True, models=True, settings=wandb.Settings(...))
     @step
     def start(self):
-        self.raw_df = pd.read_csv(...).    # pd.DataFrame -> upload as dataset
+        self.raw_df = pd.read_csv(...)    # pd.DataFrame -> upload as dataset
         self.model_file = torch.load(...)  # nn.Module    -> upload as model
         self.next(self.transform)
 ```
@@ -103,7 +103,7 @@ from wandb.integration.metaflow import wandb_log
 class WandbExampleFlow(FlowSpec):
     @step
     def start(self):
-        self.raw_df = pd.read_csv(...).    # pd.DataFrame -> upload as dataset
+        self.raw_df = pd.read_csv(...)    # pd.DataFrame -> upload as dataset
         self.model_file = torch.load(...)  # nn.Module    -> upload as model
         self.next(self.transform)
 ```
@@ -124,14 +124,14 @@ class WandbExampleFlow(FlowSpec):
   # this step will log datasets and models
   @step
   def start(self):
-    self.raw_df = pd.read_csv(...).    # pd.DataFrame -> upload as dataset
+    self.raw_df = pd.read_csv(...)    # pd.DataFrame -> upload as dataset
     self.model_file = torch.load(...)  # nn.Module    -> upload as model
     self.next(self.mid)
 
   # this step will also log datasets and models
   @step
   def mid(self):
-    self.raw_df = pd.read_csv(...).    # pd.DataFrame -> upload as dataset
+    self.raw_df = pd.read_csv(...)    # pd.DataFrame -> upload as dataset
     self.model_file = torch.load(...)  # nn.Module    -> upload as model
     self.next(self.end)
 
@@ -139,7 +139,7 @@ class WandbExampleFlow(FlowSpec):
   @wandb_log(datasets=False, models=False)
   @step
   def end(self):
-    self.raw_df = pd.read_csv(...).    
+    self.raw_df = pd.read_csv(...)    
     self.model_file = torch.load(...)
 ```
 </Tab>

--- a/models/integrations/pytorch.mdx
+++ b/models/integrations/pytorch.mdx
@@ -41,9 +41,9 @@ with wandb.init(project="new-sota-model", config=config) as run:
     run.watch(model)
 
     for batch in dataloader:
-    metrics = model.training_step()
-    # log metrics inside your training loop to visualize model performance
-    run.log(metrics)
+        metrics = model.training_step()
+        # log metrics inside your training loop to visualize model performance
+        run.log(metrics)
 
     # optional: save model at the end
     model.to_onnx()

--- a/models/integrations/ray-tune.mdx
+++ b/models/integrations/ray-tune.mdx
@@ -71,6 +71,7 @@ from ray.air.integrations.wandb import setup_wandb
 This utility function helps initialize Wandb for use with Ray Tune. For basic usage, call `setup_wandb()` in your training function:
 
 ```python
+from ray import tune
 from ray.air.integrations.wandb import setup_wandb
 
 

--- a/models/integrations/scikit.mdx
+++ b/models/integrations/scikit.mdx
@@ -64,7 +64,7 @@ wandb.login()
 ```python
 import wandb
 
-wandb.init(project="visualize-sklearn") as run:
+with wandb.init(project="visualize-sklearn") as run:
 
   y_pred = clf.predict(X_test)
   accuracy = sklearn.metrics.accuracy_score(y_true, y_pred)

--- a/models/integrations/skorch.mdx
+++ b/models/integrations/skorch.mdx
@@ -22,10 +22,11 @@ We've created a few examples for you to see how the integration works:
 * [Colab](https://colab.research.google.com/drive/1Bo8SqN1wNPMKv5Bn9NjwGecBxzFlaNZn?usp=sharing): A simple demo to try the integration
 * [A step by step guide](https://app.wandb.ai/cayush/uncategorized/reports/Automate-Kaggle-model-training-with-Skorch-and-W%26B--Vmlldzo4NTQ1NQ): to tracking your Skorch model performance
 
-```python
-# Install wandb
-... pip install wandb
+```bash
+pip install wandb
+```
 
+```python
 import wandb
 from skorch.callbacks import WandbLogger
 

--- a/models/integrations/tensorboard.mdx
+++ b/models/integrations/tensorboard.mdx
@@ -22,9 +22,9 @@ Upload your TensorBoard logs to the cloud, quickly share your results among coll
 import wandb
 
 # Start a wandb run with `sync_tensorboard=True`
-wandb.init(project="my-project", sync_tensorboard=True) as run:
-  # Your training code using TensorBoard
-  ...
+with wandb.init(project="my-project", sync_tensorboard=True) as run:
+    # Your training code using TensorBoard
+    ...
 
 ```
 

--- a/models/integrations/tensorflow.mdx
+++ b/models/integrations/tensorflow.mdx
@@ -62,7 +62,7 @@ With TensorFlow 2, the recommended way of training a model with a custom loop is
         loss = loss_func(labels, predictions)
 
     # Log your metrics
-    run.log("loss": loss.numpy())
+    run.log({"loss": loss.numpy()})
     # Get the gradients
     gradients = tape.gradient(loss, model.trainable_variables)
     # Update the weights


### PR DESCRIPTION
## Summary

Fixes copy-paste-breaking defects in `models/integrations` code samples. These bugs pre-date and are **independent of** the `/style-guide` pass in #2673, so they're split out here to keep that PR strictly style-only (as requested). Each snippet below now runs as written.

Surfaced by an adversarially-verified per-page audit of the integration docs; every fix was confirmed against the current `main`.

## Fixes

| File | Bug | Fix |
|------|-----|-----|
| `accelerate.mdx` | missing comma after `config={...}` in `init_trackers` → `SyntaxError` | add comma |
| `huggingface_transformers.mdx` | resume-from-checkpoint calls `use_artifact(my_model_name)`, which is undefined in that block → `NameError` | use `my_checkpoint_name` |
| `keras.mdx` | unterminated string `filepath="models/,` → `SyntaxError` | `filepath="models/",` |
| `lightning.mdx` | Log Tables example passes undefined `data` → `NameError` | `data=my_data` |
| `metaflow.mdx` | stray trailing `.` after `pd.read_csv(...)` (5 places) | remove `.` |
| `pytorch.mdx` | opening snippet's `for` loop body not indented → `IndentationError`; stray em space in a comment | indent body; normalize space |
| `ray-tune.mdx` | `setup_wandb` snippet calls `tune.report` without importing `tune` → `NameError` | add `from ray import tune` |
| `scikit.mdx` | `wandb.init(...) as run:` missing `with` → `SyntaxError` | add `with` |
| `tensorboard.mdx` | `wandb.init(...) as run:` missing `with` → `SyntaxError` | add `with` |
| `skorch.mdx` | shell `pip install` inside a ` ```python ` block | split into a ` ```bash ` block |
| `tensorflow.mdx` | `run.log("loss": loss.numpy())` → `SyntaxError` | wrap arg in a dict |

## Testing

- `mint validate` passes (strict).

## Notes

- The `lightning.mdx` "Log images and predictions as a Table" (Option 2) example also contains a malformed list comprehension. It's syntactically valid (no crash), so it's left out of this crash-fix PR — worth a follow-up.
- The description of #2673 lists further lower-confidence technical items (version currency, deprecated APIs, link hygiene) that could be a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)