### PR TITLE
docs: Link individual line plot expressions to the reference examples

### DIFF
--- a/models/app/features/panels/line-plot.mdx
+++ b/models/app/features/panels/line-plot.mdx
@@ -111,7 +111,7 @@ Line plot settings are organized into tabs:
 * **Grouping**: Configure whether and how to group and aggregate runs in the plot.
 * **Chart**: Specify titles for the panel and axes, and configure legend visibility and position.
 * **Legend**: Customize the appearance and content of the panel's legend.
-* **Expressions**: Add custom calculated expressions for the axes.
+* **Expressions**: Add custom calculated expressions for the axes. For the full list of operators and example expressions, including arithmetic such as multiplication, see [Expressions](/models/app/features/panels/line-plot/reference#expressions).
 
 For detailed information about each setting, see the [Line plot reference](/models/app/features/panels/line-plot/reference).
 


### PR DESCRIPTION
## Summary

The individual line plot settings section in `models/app/features/panels/line-plot.mdx` lists the **Expressions** tab but does not link to the comprehensive expression docs that already exist in the line plot reference. As a result, users who want guidance and examples for axis expressions (such as multiplication) do not find them.

This PR adds a single cross-link from the **Expressions** tab bullet to the [Expressions](/models/app/features/panels/line-plot/reference#expressions) section of the reference, which contains the operators table (`+ - * / % **`) and worked example expressions.

## Before

> **Expressions**: Add custom calculated expressions for the axes.

## After

> **Expressions**: Add custom calculated expressions for the axes. For the full list of operators and example expressions, including arithmetic such as multiplication, see [Expressions](/models/app/features/panels/line-plot/reference#expressions).

## Testing

- `mint validate` passes (exit 0).
- `mint broken-links` reports no broken links, confirming the new internal link and `#expressions` anchor resolve.

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)