### PR TITLE
docs: Update Monitors add-signal steps to current UI

### DIFF
--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -72,7 +72,6 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 1. In the Weave project sidebar, select **Monitors**.
 1. To add a signal to a project with no Monitors enabled, click on its card to activate its checkbox, then click **Setup monitors**.
 1. To add signals to an existing Monitor, select **Browse signals** at the top-right on the **Monitors** page. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
-1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 
 After you add signals, Weave automatically scores incoming traces.
 

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -70,7 +70,7 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
 1. In the Weave project sidebar, select **Monitors**.
-1. To add a single signal, hover over its card and select the **Add signal** button. The signal starts scoring new traces immediately.
+1. To add a signal, click on its card to activate its checkbox, then click **Setup monitors**.
 1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
 1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -71,7 +71,7 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
 1. In the Weave project sidebar, select **Monitors**.
 1. To add a signal to a project with no Monitors enabled, click on its card to activate its checkbox, then click **Setup monitors**.
-1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
+1. To add signals to an existing Monitor, select **Browse signals** at the top-right on the **Monitors** page. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
 1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 
 After you add signals, Weave automatically scores incoming traces.

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -71,7 +71,7 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
 1. In the Weave project sidebar, select **Monitors**.
 1. To add a signal to a project with no Monitors enabled, click on its card to activate its checkbox, then click **Setup monitors**.
-1. To add signals to an existing Monitor, select **Browse signals** at the top-right on the **Monitors** page. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
+1. To add signals to an existing Monitor, select **Browse signals** at the top-right on the **Monitors** page. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**. Then select **Add signals** at the bottom of the drawer. 
 
 After you add signals, Weave automatically scores incoming traces.
 

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -70,7 +70,6 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
 1. In the Weave project sidebar, select **Monitors**.
-1. At the top of the Monitors page, find the **Recommended signals** section. Each card shows the signal name and a description.
 1. To add a single signal, hover over its card and select the **Add signal** button. The signal starts scoring new traces immediately.
 1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
 1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -70,7 +70,7 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
 1. In the Weave project sidebar, select **Monitors**.
-1. To add a signal, click on its card to activate its checkbox, then click **Setup monitors**.
+1. To add a signal to a project with no Monitors enabled, click on its card to activate its checkbox, then click **Setup monitors**.
 1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
 1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -72,7 +72,7 @@ Adding a signal turns on automated scoring so that Weave evaluates new productio
 1. In the Weave project sidebar, select **Monitors**.
 1. At the top of the Monitors page, find the **Recommended signals** section. Each card shows the signal name and a description.
 1. To add a single signal, hover over its card and select the **Add signal** button. The signal starts scoring new traces immediately.
-1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category, such as Quality and Error, each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
+1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category (such as Quality classifiers and Error classifiers), each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
 1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 
 After you add signals, Weave automatically scores incoming traces.

--- a/weave/guides/evaluation/monitors.mdx
+++ b/weave/guides/evaluation/monitors.mdx
@@ -69,11 +69,11 @@ When multiple signals from the same group (Quality or Error) are active, Weave b
 Adding a signal turns on automated scoring so that Weave evaluates new production traces against that signal's criteria. To enable signals:
 
 1. Navigate to [wandb.ai](https://wandb.ai/) and then open your Weave project.
-2. In the Weave project sidebar, select **Monitors**.
-3. At the top of the Monitors page, a row of suggested signal cards appears. Each card shows the signal name, a description, and an **+ Add signal** button.
-4. To add a signal, select the **Add signal** button on the signal card. The signal starts scoring new traces immediately.
-5. To add multiple signals at once, select the **[X] more signals** button. This opens a drawer that lists all available signals grouped by category.
-6. Select the signals you want to turn on, then select **Add signals**.
+1. In the Weave project sidebar, select **Monitors**.
+1. At the top of the Monitors page, find the **Recommended signals** section. Each card shows the signal name and a description.
+1. To add a single signal, hover over its card and select the **Add signal** button. The signal starts scoring new traces immediately.
+1. To add several signals at once, select **Browse signals** in the **Recommended signals** header. This opens the **Add signals** drawer, which lists available signals grouped by category, such as Quality and Error, each with a checkbox. You can select individual signals, use **Enable all** for a group, or select **Create custom signal**.
+1. Select the signals you want to turn on, then select **Add signals** in the drawer footer to enable them.
 
 After you add signals, Weave automatically scores incoming traces.
 


### PR DESCRIPTION
## Summary

The Weave Monitors UI changed. The "Add a signal from the Monitors page" section on `/weave/guides/evaluation/monitors` still referenced UI elements that no longer exist. This updates the steps to match the current UI.

## Changes

- Renamed the top-of-page section reference from "suggested signal cards" to the current **Recommended signals** section.
- Documented that each recommended signal card shows the name and description, with an **Add signal** button that appears on hover.
- Replaced the removed **[X] more signals** button with the current **Browse signals** button, which opens the **Add signals** drawer (signals grouped by category such as Quality and Error, each with a checkbox, plus **Enable all** per group and a **Create custom signal** option).
- Clarified that the drawer footer button reads **Add signals**.

The "Manage active signals" section is unchanged: its "Manage signals" gear button and "Remove signal" still match the current UI.

## Testing

- `mint validate` passes (exit 0).
- `mint broken-links` reports no broken links (exit 0).

Closes #2799

🤖 Generated with [Claude Code](https://claude.com/claude-code)