### PR TITLE
docs: Fix bar plot box/violin instructions and grouping prerequisite

### DIFF
--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -18,7 +18,7 @@ Use chart settings to limit the maximum number of runs shown, group runs by any 
 
 ## Customize bar plots
 
-You can also create **Box Plot** or **Violin** plots to combine many summary statistics into one chart type. These styles appear only when runs are grouped, so group your runs before you look for the **Box Plot** or **Violin** option.
+You can also create **Box Plot** or **Violin** plots to combine many summary statistics into one chart type. Group or aggregate your runs before you choose **Box Plot** or **Violin**, because these styles show distributions across multiple values.
 
 To create a box or violin plot:
 

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -18,7 +18,7 @@ Use chart settings to limit the maximum number of runs shown, group runs by any 
 
 ## Customize bar plots
 
-You can also create **Box Plot** or **Violin** plots to combine many summary statistics into one chart type. Group or aggregate your runs before you choose **Box Plot** or **Violin**, because these styles show distributions across multiple values.
+You can also create **Box Plot** or **Violin** plots to combine many summary statistics into one chart type, if you group your runs.
 
 To create a box or violin plot:
 

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -22,7 +22,7 @@ You can also create **Box Plot** or **Violin** plots to combine many summary sta
 
 To create a box or violin plot:
 
-1. Group your runs. [Group runs in the runs table](/models/runs/grouping), or enable grouping in the panel.
+1. [Group your runs in the runs table](/models/runs/grouping), or enable grouping in the panel.
 1. In the workspace, click **Add panel**, then choose **Bar Chart**.
 1. On the **Data** tab, use the **Metric** selector to choose your summary metric.
 1. On the **Grouping** tab, in the **Style** control, choose **Box Plot** or **Violin**.

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -22,7 +22,7 @@ You can also create **Box Plot** or **Violin** plots to combine many summary sta
 
 To create a box or violin plot:
 
-1. Group your runs. Group runs in the runs table, or enable grouping in the panel.
+1. Group your runs. [Group runs in the runs table](/models/runs/grouping), or enable grouping in the panel.
 1. In the workspace, click **Add panel**, then choose **Bar Chart**.
 1. On the **Data** tab, use the **Metric** selector to choose your summary metric.
 1. On the **Grouping** tab, in the **Style** control, choose **Box Plot** or **Violin**.

--- a/models/app/features/panels/bar-plot.mdx
+++ b/models/app/features/panels/bar-plot.mdx
@@ -18,14 +18,16 @@ Use chart settings to limit the maximum number of runs shown, group runs by any 
 
 ## Customize bar plots
 
-You can also create **Box** or **Violin** plots to combine many summary statistics into one chart type.
+You can also create **Box Plot** or **Violin** plots to combine many summary statistics into one chart type. These styles appear only when runs are grouped, so group your runs before you look for the **Box Plot** or **Violin** option.
 
 To create a box or violin plot:
 
-1. Group runs through the runs table.
-2. In the workspace, click **Add panel**.
-3. Add a standard **Bar Chart** and select the metric to plot.
-4. Under the **Grouping** tab, pick **Box** or **Violin** to plot either of these styles.
+1. Group your runs. Group runs in the runs table, or enable grouping in the panel.
+1. In the workspace, click **Add panel**, then choose **Bar Chart**.
+1. On the **Data** tab, use the **Metric** selector to choose your summary metric.
+1. On the **Grouping** tab, in the **Style** control, choose **Box Plot** or **Violin**.
+
+If you do not see the **Style** control or the **Box Plot** and **Violin** options, your runs are not grouped. Group your runs and the options appear.
 
 <Frame>
     <img src="/images/app_ui/bar_plots.gif" alt="Customizing a bar plot with grouping options"  />


### PR DESCRIPTION
## Summary

Fixes the "Customize bar plots" section on `/guides/app/features/panels/bar-plot`, which a user reported as incomplete and partly wrong when trying to create a box plot for a summary metric.

### What was wrong

- The style control was labeled **Box** in the doc. In the app it is **Box Plot**.
- The doc did not mention that the **Box Plot** and **Violin** styles only appear when runs are grouped. This is the root cause of "it does not work": without grouping, the option is not shown at all.
- The instructions conflated the tabs. The summary metric is chosen on the **Data** tab, and the **Style** (Bar / Box Plot / Violin) is on the **Grouping** tab.

### What changed

- State up front that Box Plot and Violin styles appear only when runs are grouped, and instruct the user to group runs first.
- Add the panel and choose **Bar Chart**.
- On the **Data** tab, use the **Metric** selector to choose the summary metric.
- On the **Grouping** tab, in the **Style** control, choose **Box Plot** or **Violin** (corrects the old "Box" label).
- Add a short troubleshooting note: if the Style / Box Plot / Violin option is missing, the runs are not grouped.

Text fixes only. Existing image references are unchanged.

### Testing

- `mint validate` passes (exit 0).
- `mint broken-links` reports no broken links.

Closes #1471