### PR TITLE
fix: Add run id to resume="must" example

### DIFF
--- a/models/runs/resuming.mdx
+++ b/models/runs/resuming.mdx
@@ -34,7 +34,7 @@ If a run is stopped, crashes, or fails, you can resume it using the same run ID.
 The following code snippet shows how to accomplish this with the W&B Python SDK:
 
 ```python
-with wandb.init(entity="<entity>", project="<project>", resume="must") as run:
+with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="must") as run:
         # Your training code here
 ```
 


### PR DESCRIPTION
Fixes the `resume="must"` code snippet on `/models/runs/resuming`, which omitted the `id` argument even though the surrounding prose instructs the reader to "Provide the run ID of the run that stopped or crashed."

## Before

```python
with wandb.init(entity="<entity>", project="<project>", resume="must") as run:
        # Your training code here
```

## After

```python
with wandb.init(entity="<entity>", project="<project>", id="<run ID>", resume="must") as run:
        # Your training code here
```

The `id="<run ID>"` placeholder matches the style already used in the `resume="allow"` and `resume="auto"` examples in the same file. `resume="must"` requires an existing run ID, so the snippet must include it.

Verified with `mint validate` (exit 0) and `mint broken-links` (no broken links).

Closes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)