### PR TITLE
docs: Correct report copy menu label to "Make a copy"

### DIFF
--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -20,7 +20,13 @@ Clone a report to reuse an existing project's template and formatting as the bas
 
 <Tabs>
 <Tab title="W&B App">
-In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Make a copy**. In the modal, select a destination for your cloned report. Choose **Clone report**. The destination dropdown defaults to the current project and lists projects across the teams you belong to, so to copy the report into a different project or team, open the dropdown and select it.
+In your report:
+
+1. Select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu, then choose **Make a copy**.
+1. In the modal, select a destination for your cloned report.
+1. Choose **Clone report**.
+
+    The destination dropdown defaults to the current project and lists projects across the teams you belong to. To copy the report into a different project or team, open the dropdown and select it.
 
 <Frame>
     <img src="/images/reports/clone_reports.gif" alt="Cloning a report in the W&B App"  />

--- a/models/reports/clone-and-export-reports.mdx
+++ b/models/reports/clone-and-export-reports.mdx
@@ -20,7 +20,7 @@ Clone a report to reuse an existing project's template and formatting as the bas
 
 <Tabs>
 <Tab title="W&B App">
-In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Clone this report**. In the modal, select a destination for your cloned report. Choose **Clone report**.
+In your report, select the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu. Choose **Make a copy**. In the modal, select a destination for your cloned report. Choose **Clone report**. The destination dropdown defaults to the current project and lists projects across the teams you belong to, so to copy the report into a different project or team, open the dropdown and select it.
 
 <Frame>
     <img src="/images/reports/clone_reports.gif" alt="Cloning a report in the W&B App"  />


### PR DESCRIPTION
## Summary

On [/models/reports/clone-and-export-reports](https://docs.wandb.ai/models/reports/clone-and-export-reports), the "Clone a report" section (W&B App tab) told users to choose **Clone this report**, but the current W&B app menu item is **Make a copy**. The string "Clone this report" no longer exists in the app.

## Changes

- Update the menu label from **Clone this report** to **Make a copy** in `models/reports/clone-and-export-reports.mdx`.
- Add a short clarifying sentence: the destination dropdown defaults to the current project and lists projects across the teams you belong to, so you can copy a report into a different project or team by selecting it from the dropdown. (Cross-project copying does work; the reporter was looking for the old label.)

The remaining steps ("select a destination for your cloned report", confirm button **Clone report**) still match the current UI and are unchanged.

## Testing

- `mint validate` passes (exit 0).
- `mint broken-links` reports no broken links.

Closes #2026