### PR TITLE
docs: Add servers base URL to serverless-training OpenAPI spec

### DIFF
--- a/serverless-training/api-reference/openapi.json
+++ b/serverless-training/api-reference/openapi.json
@@ -4,6 +4,9 @@
     "title": "Serverless Training",
     "version": "1.0.0"
   },
+  "servers": [
+    { "url": "https://api.training.wandb.ai" }
+  ],
   "paths": {
     "/v1/chat/completions/": {
       "post": {


### PR DESCRIPTION
## Summary

The serverless-training API reference "Try It" panel showed the placeholder base URL `https://api.example.com/`, so users could not test the API. The root cause is that `serverless-training/api-reference/openapi.json` has no top-level `servers` field, so Mintlify falls back to the placeholder host.

This PR adds a top-level `servers` array (immediately after `info`) pointing at the real host.

## Why the bare host (no `/v1`)

The server URL uses the **bare host** `https://api.training.wandb.ai` with **no** `/v1` suffix. Every path key in this spec already begins with `/v1` (for example `/v1/preview/models`, the create-model endpoint). If the server URL included `/v1`, Mintlify's "Try It" would build a doubled path `/v1/v1/preview/models` and return 404.

The human-readable base URL shown in `serverless-training/api-reference.mdx` (`https://api.training.wandb.ai/v1`) is intentionally left unchanged.

## Testing

- `python -m json.tool` confirms the JSON stays valid.
- `mint validate` exits 0.
- `mint broken-links` reports no broken links.

Closes #2657

🤖 Generated with [Claude Code](https://claude.com/claude-code)