### PR TITLE
fix: Resolve MDX render error on Weave inference quickstart (preserve process.env example)

### DIFF
--- a/weave/quickstart-inference.mdx
+++ b/weave/quickstart-inference.mdx
@@ -72,8 +72,7 @@ print(result)
 ```
 </Tab>
 <Tab title="TypeScript">
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import * as weave from 'weave';
 import OpenAI from 'openai';
 
@@ -177,8 +176,7 @@ print("\nSummary:", result["summary"])
 ```
 </Tab>
 <Tab title="TypeScript">
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import * as weave from 'weave';
 import OpenAI from 'openai';
 
@@ -288,8 +286,7 @@ print(deepseek_model.predict(test_question))
 ```
 </Tab>
 <Tab title="TypeScript">
-```typescript twoslash lines
-// @noErrors
+```typescript lines
 import * as weave from 'weave';
 import OpenAI from 'openai';
 


### PR DESCRIPTION
## Problem

Readers reported a Mintlify parsing error on **/weave/quickstart-inference** (issues #2827 and #2804). The page fails to render in `mint dev` with:

```
[next-mdx-remote-client] error compiling MDX:
Language `console` not found, you may need to load it first
```

This reproduces on `main` (@247abd21): `mint validate` passes, but a cold `mint dev` load of the page throws the error 2x per render, so the page does not render.

## Root cause

Three `typescript twoslash` code blocks reference `process.env.WANDB_API_KEY`:

```ts
apiKey: process.env.WANDB_API_KEY || 'YOUR_WANDB_API_KEY',
```

Shiki's `twoslash` transformer type-checks the block. Resolving `process.env.WANDB_API_KEY` (typed `string | undefined` via `@types/node`) against the OpenAI client's `apiKey: string` argument produces a type popup that Shiki then tries to highlight with an unregistered `console` language, aborting the MDX compile for the whole page. Isolation confirmed the three blocks containing `process.env` fail while the fourth twoslash block (no `process.env`) renders fine.

## Fix — Approach B (drop `twoslash`, preserve `process.env`)

Per reviewer feedback, the `process.env.WANDB_API_KEY` environment-variable example must stay. Splitting the expression so `process.env.X` is on its own line (Approach A) did **not** fix the render — verified by cold render, twoslash still resolves `process.env.X` against `apiKey: string` and emits the same popup.

The working fix, matching PR #2840 for the sibling `querying-calls` page, is to drop the `twoslash` meta and the `// @noErrors` line from the three affected TypeScript fences:

```diff
-```typescript twoslash lines
-// @noErrors
+```typescript lines
```

This keeps the code verbatim, so the `process.env.WANDB_API_KEY` example and its explanatory comment are fully preserved in all three blocks. The fourth block (no `process.env`) keeps `twoslash`. Python blocks are untouched.

## Verification

- Cold `mint dev` load of `/weave/quickstart-inference` → HTTP 200, **0** parse/console-language errors (was 2 before the fix)
- `mint validate` → `success build validation passed`
- `mint broken-links` → `success no broken links found`
- `process.env.WANDB_API_KEY || 'YOUR_WANDB_API_KEY'` still present in all 3 TypeScript blocks

Closes #2827
Closes #2804

🤖 Generated with [Claude Code](https://claude.com/claude-code)