### PR TITLE
Document securityContext for OpenShift upgrade hook jobs

### DIFF
--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -100,7 +100,7 @@ If needed, configure a custom security context for other components like `app` o
 
 #### Upgrade hook jobs
 
-The operator runs `pre-upgrade` and `post-upgrade` hook Jobs during upgrades (for example, the app-rename hook that also runs when you enable Weave). These hook pods default to UID 999 like the main components, so on OpenShift `restricted-v2` rejects them — which makes the Helm upgrade fail and can leave the custom resource stuck in `Loading`. Give the hook jobs the same UID-range security context:
+The operator runs `pre-upgrade` and `post-upgrade` hook jobs during upgrades (for example, the app-rename hook that also runs when you enable Weave). These hook pods default to UID 999 like the main components, so on OpenShift, `restricted-v2` rejects them. This rejection makes the Helm upgrade fail and can leave the custom resource stuck in `Loading`. Give the hook jobs the same UID-range security context:
 
 ```yaml
 appRenamePreHook:

--- a/platform/hosting/self-managed/operator.mdx
+++ b/platform/hosting/self-managed/operator.mdx
@@ -98,6 +98,23 @@ api:
 
 If needed, configure a custom security context for other components like `app` or `console`. For details, see [Custom security context](#custom-security-context).
 
+#### Upgrade hook jobs
+
+The operator runs `pre-upgrade` and `post-upgrade` hook Jobs during upgrades (for example, the app-rename hook that also runs when you enable Weave). These hook pods default to UID 999 like the main components, so on OpenShift `restricted-v2` rejects them — which makes the Helm upgrade fail and can leave the custom resource stuck in `Loading`. Give the hook jobs the same UID-range security context:
+
+```yaml
+appRenamePreHook:
+  podSecurityContext:
+    runAsUser: 1000810000      # a value within your project's UID range
+    runAsGroup: 0
+    fsGroup: 1000810000
+appRenamePostHook:
+  podSecurityContext:
+    runAsUser: 1000810000
+    runAsGroup: 0
+    fsGroup: 1000810000
+```
+
 ## Deploy W&B Server application
 
 <Note>


### PR DESCRIPTION
### What
Adds an "Upgrade hook jobs" note to the self-managed operator page's OpenShift section.

### Why
The operator runs `pre-upgrade`/`post-upgrade` hook Jobs during upgrades — for example the app-rename hook, which also runs when you enable Weave. Those hook pods default to UID 999 (inherited from `wandb-base`), so on OpenShift `restricted-v2` rejects them. The Helm upgrade then fails and the custom resource can get stuck in `Loading`, with nothing in the docs explaining why.

### Change
Documents setting `appRenamePreHook.podSecurityContext` and `appRenamePostHook.podSecurityContext` to the project's UID range — the same fix already used for the main components.

### Testing
Reproduced on OCP 4.21: enabling Weave triggered `pre-upgrade hooks failed: Job <release>-app-rename-pre-hook not ready`, and the Helm release went to `failed`. Validated the fix with `helm template` on `wandb-base` — setting the hook's `podSecurityContext` renders the Job pod with the given `runAsUser`/`fsGroup` (in-range) instead of the default 999.