### PR TITLE
Platform: Customer feedback on Viewer seat option

### DIFF
--- a/platform/hosting/iam/access-management/manage-organization.mdx
+++ b/platform/hosting/iam/access-management/manage-organization.mdx
@@ -51,7 +51,7 @@ The following table summarizes how seats work for Models and Weave:
 
 | Product | Seats | Cost based on |
 | ----- | ----- | ----- |
-| Models | Pay per seat | The number of Models paid seats you have and the usage you’ve accrued determine your overall subscription cost. Each user can be assigned one of three available seat types: Full, Viewer, or No access. |
+| Models | Pay per seat | The number of Models paid seats you have and the usage you’ve accrued determine your overall subscription cost. Each user can be assigned one of three available seat types: Full, Viewer (Enterprise-only feature), or No access. |
 | Weave | Free | Usage based |
 
 ### Invite a user


### PR DESCRIPTION
## Description

Customer feedback from ARIA session about. Models Viewer seat missing "Enterprise-only" qualifier, causing customer confusion

See JIRA ticket for full details and session where convo was derived from.

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-2848
