### PR TITLE
Fix callout in Sandboxes secrets page

### DIFF
--- a/sandboxes/secrets.mdx
+++ b/sandboxes/secrets.mdx
@@ -12,9 +12,9 @@ Use the [W&B Secrets Manager](/platform/secrets) with the W&B Python SDK to acce
 
 To use a secret in a sandbox, first add it to your team's Secrets Manager. Then reference that secret by name when you create the sandbox.
 
-<Caution>
+<Warning>
 Don't include the secret's value directly in your code or in the sandbox configuration. Reference secrets by name only.
-</Caution>
+</Warning>
 
 W&B injects each requested secret into the sandbox as an environment variable. By default, the environment variable name matches the secret name. You can customize the environment variable name with the `env_var` parameter.
 


### PR DESCRIPTION
## Description

Mintlify supports `<Warning>` but not `<Caution>`. [source](https://www.mintlify.com/docs/components/callouts) So this text on the page was not rendering.

[Internal discussion](https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1783571359916789)

Before:
<img width="890" height="141" alt="Screenshot 2026-07-09 at 4 04 31 PM" src="https://github.com/user-attachments/assets/0da6a448-3b49-420b-b847-7898a38dc2f6" />

After:
<img width="707" height="267" alt="Screenshot 2026-07-09 at 4 04 36 PM" src="https://github.com/user-attachments/assets/8f3a8e1f-2d4e-4fb4-bed4-abf089f032de" />


## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
