### PR TITLE
DOCS-2690: Remove outdated MCP notice

### DIFF
--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -33,10 +33,6 @@ The W&B MCP Server is available in two deployment options. Use the hosted server
   </Card>
 </CardGroup>
 
-<Tip>
-If you run W&B on Dedicated Cloud or Self-Managed and the hosted MCP server isn't yet enabled on your instance, contact [W&B support](mailto:support@wandb.com) or your W&B account team to request it.
-</Tip>
-
 ## Prerequisites
 
 Before you configure any client, make sure you have the following in place:


### PR DESCRIPTION
## Description
Removes outdated language from MCP doc. I confirmed this with A. Shah.
