### PR TITLE
WEAVE: Reframes Weave Self-Managed to be a component of the W&B Self-Managed

### DIFF
--- a/weave/guides/platform.mdx
+++ b/weave/guides/platform.mdx
@@ -12,7 +12,7 @@ Weave is available on the following deployment options:
 
 - **[W&B Multi-tenant Cloud](https://docs.wandb.ai/platform/hosting/hosting-options/multi_tenant_cloud):** A multi-tenant, fully managed platform deployed in W&B's Google Cloud Platform (Google Cloud) account in a North America region.
 - **[W&B Dedicated Cloud](https://docs.wandb.ai/platform/hosting/hosting-options/dedicated-cloud):** Generally available on AWS, Google Cloud, and Azure.
-- **[Self-Managed instances](/weave/guides/platform/weave-self-managed):** Set up a W&B Self-Managed instance and enable Weave in your own infrastructure. This is for teams that prefer to host Weave independently, your W&B team provides guidance to evaluate deployment options.
+- **[Self-Managed instances](/weave/guides/platform/weave-self-managed):** Set up a W&B Self-Managed instance and enable Weave on your own infrastructure. This is for teams that prefer to host Weave independently, your W&B team provides guidance to evaluate deployment options.
 
 ## Identity and access management
 

--- a/weave/guides/platform.mdx
+++ b/weave/guides/platform.mdx
@@ -12,7 +12,7 @@ Weave is available on the following deployment options:
 
 - **[W&B Multi-tenant Cloud](https://docs.wandb.ai/platform/hosting/hosting-options/multi_tenant_cloud):** A multi-tenant, fully managed platform deployed in W&B's Google Cloud Platform (Google Cloud) account in a North America region.
 - **[W&B Dedicated Cloud](https://docs.wandb.ai/platform/hosting/hosting-options/dedicated-cloud):** Generally available on AWS, Google Cloud, and Azure.
-- **[Self-Managed instances](/weave/guides/platform/weave-self-managed):** For teams that prefer to host Weave independently, your W&B team provides guidance to evaluate deployment options.
+- **[Self-Managed instances](/weave/guides/platform/weave-self-managed):** Set up a W&B Self-Managed instance and enable Weave in your own infrastructure. This is for teams that prefer to host Weave independently, your W&B team provides guidance to evaluate deployment options.
 
 ## Identity and access management
 

--- a/weave/guides/platform/weave-self-managed.mdx
+++ b/weave/guides/platform/weave-self-managed.mdx
@@ -4,7 +4,9 @@ description: "Deploy and manage Weave on your own infrastructure"
 keywords: ["self-hosted", "ClickHouse", "Altinity", "Keeper", "Kubernetes"]
 ---
 
-Self-hosting W&B Weave gives you more control over its environment and configuration. This can help you create a more isolated environment and meet additional security compliance. This document guides you through how to deploy the components required to run W&B Weave in a self-managed environment using the Altinity ClickHouse Operator. By the end, you'll have a production-grade Weave instance running on your own Kubernetes cluster, backed by a replicated ClickHouse database and S3-compatible object storage. This guide is for Kubernetes administrators and platform engineers who are responsible for deploying and operating W&B in their organization.
+Self-hosting W&B Weave gives you more control over its environment and configuration. This can help you create a more isolated environment and meet additional security compliance. 
+
+This document guides you through how to deploy the components required to run W&B Weave in a [W&B Self-Managed](/platform/hosting/hosting-options/self-managed) deployment using the Altinity ClickHouse Operator. By the end, you'll have a production-grade Weave instance running on your own Kubernetes cluster, backed by a replicated ClickHouse database and S3-compatible object storage. This guide is for Kubernetes administrators and platform engineers who are responsible for deploying and operating W&B in their organization.
 
 Self-managed Weave deployments rely on [ClickHouseDB](https://clickhouse.com/) to manage its backend. This deployment uses:
 


### PR DESCRIPTION
Resolves DOCS-2764. Updates intros of a couple docs to properly define the relationship of Self-Managed Weave to W&B Self-Managed. Right now, the docs kinda make it sound like Weave SM is its own thing. It's not, it's a part of W&B Self-Managed.
