### PR TITLE
docs(weave): cover the agents data model in the ingest sampling guide

### DIFF
--- a/weave/guides/platform/ingest-sampling.mdx
+++ b/weave/guides/platform/ingest-sampling.mdx
@@ -9,7 +9,7 @@ Ingest sampling lets you control the share of traces that arrive at a [self-mana
 This guide walks you through how to enable the feature on your self-managed Weave instance.
 
 <Note>
-Ingest sampling requires a Weave server version that includes the sampler. Sampling of `@weave.op` calls also requires the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. Agent traces have no SDK requirement. For details, see [Requirements and limitations](#requirements-and-limitations).
+Ingest sampling requires a Weave server version that includes the sampler. Sampling of `@weave.op` calls also requires the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. Agent spans have no SDK requirement. For details, see [Requirements and limitations](#requirements-and-limitations).
 </Note>
 
 Ingest sampling is independent of client-side sampling. The `tracing_sample_rate` parameter in the `@weave.op` decorator still lets an individual traced function sample its own calls, but only a server-side rate applies across the whole deployment and can't be changed or ignored by individual clients. For more information, see [Control sampling rate](/weave/guides/tracking/ops#control-sampling-rate).
@@ -22,30 +22,24 @@ You define the ingest sampling rate by setting a number between `0` and `1`:
 
 - `1.0` keeps all traces and sampling is off (default).
 - `0.1` keeps 10% of traces and drops the rest.
-- `0.0` drops all traces, except for evaluations. See [Evaluations are always kept](#evaluations-are-always-kept).
+- `0.0` drops all traces, except for evaluations.
 
 ## What ingest sampling applies to
 
-Ingest sampling covers both Weave data models, and a single rate applies to both:
+Ingest sampling applies to two kinds of traffic, and one rate covers both:
 
 - Calls from the `@weave.op` decorator, which appear in the **Traces** tab.
 - Agent spans sent to the agent tracing endpoint (`/agents/otel/v1/traces`), which appear in the **Agents** tab. For more information, see [Trace your agents](/weave/guides/tracking/trace-agents).
 
 The following traffic is never sampled and is always kept in full:
 
-- Evaluations. See [Evaluations are always kept](#evaluations-are-always-kept).
-- Traces sent with your own OpenTelemetry tooling to the OTel endpoint (`/otel/v1/traces`). That traffic carries no evaluation marker, so sampling it could silently drop evaluations. For more information, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).
+- Evaluations. Weave keeps all evaluations because they are deliberate quality measurements, and their scores would be wrong if computed over partial data.
+- Traces sent with your own OpenTelemetry tooling to the raw OTel endpoint (`/otel/v1/traces`). Raw OpenTelemetry traffic carries no evaluation marker, so sampling it could silently drop evaluations. For more information, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).
 - Calls from Weave SDK versions earlier than the supported versions. See [Requirements and limitations](#requirements-and-limitations).
-
-## Evaluations are always kept
-
-Weave keeps every evaluation regardless of the sample rate. Evaluations are deliberate quality measurements rather than production traffic, and their scores would be wrong if computed over a partial set of results. For this reason, a rate of `0.0` drops all traces except evaluations.
-
-The Weave SDK marks evaluation calls and evaluation agent spans as they're sent, and the server keeps the whole trace when it sees that marker. The server makes its decision as each trace arrives and doesn't buffer traffic, so the carve-out is reliable for traffic from a supported Weave SDK and best-effort otherwise. Traffic that carries no marker, such as spans sent to the agent tracing endpoint by other OpenTelemetry tooling, is sampled like any other traffic even when it records an evaluation.
 
 ## How it works
 
-The server uses the trace's ID and [deterministic hash-based sampling](https://opentelemetry.io/docs/concepts/sampling/) to decide which traces to drop and keep. If a trace contains several calls that have the same `trace_id`, the server's verdict to keep or drop a trace extends to any nested calls that share the same trace ID. A trace is kept whole or dropped whole, never stored partway. Both data models use the same rate and the same hash.
+The server uses the trace's ID and [deterministic hash-based sampling](https://opentelemetry.io/docs/concepts/sampling/) to decide which traces to drop and keep. If a trace contains several calls that have the same `trace_id`, the server's verdict to keep or drop a trace extends to any nested calls or spans that share the same trace ID. A trace is kept whole or dropped whole, never stored partway.
 
 <Warning>
 The verdict is stable only while the rate is fixed. A trace that's in flight when the rate changes can be split across the change. Change the sample rate during a low-traffic window.
@@ -68,43 +62,35 @@ You can preview the effect of a sample rate before dropping anything using a dry
 
 If you do collect the metrics, run with `WEAVE_INGEST_SAMPLE_RATE=0.1` and `WEAVE_INGEST_SAMPLE_DRY_RUN=true` for a period that covers representative peak traffic, such as one full day, to see how much traffic the server would drop and how much traffic isn't eligible for sampling. Then set `WEAVE_INGEST_SAMPLE_DRY_RUN=false` to begin dropping traces.
 
-Each data model reports its own counters. Every counter carries a `route` tag that identifies the endpoint, and the two `dropped` counters also carry a `dry_run` tag that separates a real drop from a dry-run one.
+Calls and agent spans report separate counters. Each counter carries a `route` tag that identifies the endpoint. The counters count individual call records or spans, not whole traces, so ratios between them reflect message volume rather than trace counts.
 
-The counters for calls count individual call records rather than whole traces:
+The following counters cover calls:
 
 | Metric | What it counts |
 | --- | --- |
 | `ingest_sampling.seen.otel` | Call records the sampler evaluated. |
-| `ingest_sampling.evals_kept.otel` | Evaluation call records kept. |
-| `ingest_sampling.dropped.otel` | Call records dropped. |
-| `ingest_sampling.dropped_bytes.otel` | Bytes dropped. |
-| `ingest_sampling.unsupported.otel` | Call records from clients too old to be sampled. |
-| `ingest_sampling.parse_failures.otel` | Call records received without a usable trace ID. |
+| `ingest_sampling.evals_kept.otel` | Evaluation calls kept. |
+| `ingest_sampling.dropped.otel` | Records dropped. Carries a `dry_run` tag. |
+| `ingest_sampling.dropped_bytes.otel` | Bytes dropped. Carries a `dry_run` tag. |
+| `ingest_sampling.unsupported.otel` | Traffic from clients too old to be sampled. |
+| `ingest_sampling.parse_failures.otel` | Messages received without a usable trace id. |
 
-The counters for agents count individual spans:
+The following counters cover agent spans:
 
 | Metric | What it counts |
 | --- | --- |
 | `weave_trace_server.ingest_sampling.spans.seen` | Spans the sampler evaluated. |
 | `weave_trace_server.ingest_sampling.spans.evals_kept` | Evaluation spans kept. |
-| `weave_trace_server.ingest_sampling.spans.dropped` | Spans dropped. |
-| `weave_trace_server.ingest_sampling.spans.dropped_bytes` | Bytes dropped. |
-| `weave_trace_server.ingest_sampling.spans.parse_failures` | Spans received without a usable trace ID. |
-
-Because one family counts call records and the other counts spans, compare each family against itself rather than adding the two together.
-
-## Recover original volumes from sampled data
-
-When the server keeps a trace by the hash, it records the rate it applied on the data it stores, under the `weave.ingest_sample_rate` attribute. To estimate the volume that arrived before sampling, weight each record that carries a rate by `1 / rate`. For example, a call kept at a rate of `0.1` stands for 10 calls.
-
-Traffic that the server keeps whole carries no rate and counts as itself. This includes evaluations, traffic that isn't eligible for sampling, and everything kept during a dry run.
+| `weave_trace_server.ingest_sampling.spans.dropped` | Spans dropped. Carries a `dry_run` tag. |
+| `weave_trace_server.ingest_sampling.spans.dropped_bytes` | Bytes dropped. Carries a `dry_run` tag. |
+| `weave_trace_server.ingest_sampling.spans.parse_failures` | Spans received without a usable trace id. |
 
 ## Requirements and limitations
 
-Before you enable ingest sampling, review the following requirements, limitations, and behaviors:
+Before you enable ingest sampling, review the following limitations and behaviors:
 
-- **Server version**: Ingest sampling requires a Weave server version that includes the sampler. Support for agent spans was added after support for calls, so a server that predates it samples calls only. If you already set a rate below `1.0`, upgrading to a server version that samples agent spans starts sampling your agent traffic at that same rate.
-- **SDK version requirements for calls**: The server samples calls only from the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. These versions add the signals the server uses to group a trace's call records and recognize evaluation calls. Calls from older SDKs aren't sampled and aren't rejected, so until your apps upgrade, the rate has no effect on their traffic. Agent spans carry a trace ID as part of the OpenTelemetry protocol, so sampling them has no SDK requirement.
-- **Savings depend on your client mix**: Traffic that isn't sampled, such as calls from older SDKs and traces sent to the OTel endpoint, doesn't reduce cost. If much of your traffic comes from those sources, savings are smaller than the rate implies. A dry run is the best way to measure this first.
+- **SDK version requirements**: The server samples calls only from the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. These versions add the signals the server uses to group a trace's messages and recognize evaluation calls. Calls from older SDKs aren't sampled and aren't rejected, so until your apps upgrade, the rate has no effect on their traffic. Agent spans carry a trace ID as part of the OpenTelemetry protocol, so sampling them has no SDK requirement.
+- **Server version**: Support for agent spans was added after support for calls. If you already set a rate below `1.0`, upgrading to a server version that samples agent spans starts sampling your agent traffic at the same rate.
+- **Savings depend on your client mix**: Traffic that isn't sampled, such as traffic from older SDKs and raw OpenTelemetry, doesn't reduce cost. If much of your traffic comes from those sources, savings are smaller than the rate implies. A dry run is the best way to measure this first.
 - **Monitors and scoring**: A dropped trace is neither stored nor scored. If you rely on monitors covering 100% of traffic, account for this before you enable sampling.
 - **No drop signal to the client**: A dropped trace receives a normal success response. The client isn't notified that its trace was dropped.

--- a/weave/guides/platform/ingest-sampling.mdx
+++ b/weave/guides/platform/ingest-sampling.mdx
@@ -33,7 +33,7 @@ Ingest sampling applies to two kinds of traffic, and one rate covers both:
 
 The following traffic is never sampled and is always kept in full:
 
-- Evaluations. Weave keeps all evaluations because they are deliberate quality measurements, and their scores would be wrong if computed over partial data.
+- Evaluations from the Weave SDK. Weave keeps these because they are deliberate quality measurements, and their scores would be wrong if computed over partial data.
 - Traces sent with your own OpenTelemetry tooling to the raw OTel endpoint (`/otel/v1/traces`). Raw OpenTelemetry traffic carries no evaluation marker, so sampling it could silently drop evaluations. For more information, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).
 - Calls from Weave SDK versions earlier than the supported versions. See [Requirements and limitations](#requirements-and-limitations).
 
@@ -58,11 +58,11 @@ Set `WEAVE_INGEST_SAMPLE_RATE` to the share of traces that you want to keep, for
 
 ### Optional: Preview with a dry run
 
-You can preview the effect of a sample rate before dropping anything using a dry run. Its only output is the server's sampling metrics, emitted as counters that your metrics pipeline collects, for example Datadog. If your deployment doesn't collect those metrics, a dry run has no visible effect, and you can skip it and set the rate directly.
+You can preview the effect of a sample rate before dropping anything using a dry run. Its only output is the server's sampling metrics, emitted as counters to a metrics backend such as Datadog. If your deployment doesn't collect those metrics, a dry run has no visible effect, and you can skip it and set the rate directly.
 
 If you do collect the metrics, run with `WEAVE_INGEST_SAMPLE_RATE=0.1` and `WEAVE_INGEST_SAMPLE_DRY_RUN=true` for a period that covers representative peak traffic, such as one full day, to see how much traffic the server would drop and how much traffic isn't eligible for sampling. Then set `WEAVE_INGEST_SAMPLE_DRY_RUN=false` to begin dropping traces.
 
-Calls and agent spans report separate counters. Each counter carries a `route` tag that identifies the endpoint. The counters count individual call records or spans, not whole traces, so ratios between them reflect message volume rather than trace counts.
+Calls and agent spans report separate counters, and the two sets count different things, so don't combine them. Each counter carries a `route` tag that identifies the endpoint. The call counters count call records and the agent counters count spans, not whole traces, so ratios within a set reflect record volume rather than trace counts.
 
 The following counters cover calls:
 

--- a/weave/guides/platform/ingest-sampling.mdx
+++ b/weave/guides/platform/ingest-sampling.mdx
@@ -62,7 +62,7 @@ You can preview the effect of a sample rate before dropping anything using a dry
 
 If you do collect the metrics, run with `WEAVE_INGEST_SAMPLE_RATE=0.1` and `WEAVE_INGEST_SAMPLE_DRY_RUN=true` for a period that covers representative peak traffic, such as one full day, to see how much traffic the server would drop and how much traffic isn't eligible for sampling. Then set `WEAVE_INGEST_SAMPLE_DRY_RUN=false` to begin dropping traces.
 
-Calls and agent spans report separate counters, and the two sets count different things, so don't combine them. Each counter carries a `route` tag that identifies the endpoint. The call counters count call records and the agent counters count spans, not whole traces, so ratios within a set reflect record volume rather than trace counts.
+Calls and agent spans report separate counters, and the two sets count different things, so don't combine them. Each counter carries a `route` tag that identifies the endpoint. The call counters count call records and the agent counters count spans, not whole traces, so ratios within a set reflect message volume rather than trace counts.
 
 The following counters cover calls:
 
@@ -87,7 +87,7 @@ The following counters cover agent spans:
 
 ## Requirements and limitations
 
-Before you enable ingest sampling, review the following limitations and behaviors:
+Before you enable ingest sampling, review the following requirements, limitations, and behaviors:
 
 - **SDK version requirements**: The server samples calls only from the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. These versions add the signals the server uses to group a trace's messages and recognize evaluation calls. Calls from older SDKs aren't sampled and aren't rejected, so until your apps upgrade, the rate has no effect on their traffic. Agent spans carry a trace ID as part of the OpenTelemetry protocol, so sampling them has no SDK requirement.
 - **Server version**: Support for agent spans was added after support for calls. If you already set a rate below `1.0`, upgrading to a server version that samples agent spans starts sampling your agent traffic at the same rate.

--- a/weave/guides/platform/ingest-sampling.mdx
+++ b/weave/guides/platform/ingest-sampling.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configure ingest sampling for self-managed Weave"
 description: "Keep only a share of incoming traces to control storage and LLM scoring costs on a self-managed Weave instance"
-keywords: ["ingest sampling", "sample rate", "self-managed", "trace server", "WEAVE_INGEST_SAMPLE_RATE", "dry run", "DogStatsD"]
+keywords: ["ingest sampling", "sample rate", "self-managed", "trace server", "WEAVE_INGEST_SAMPLE_RATE", "dry run", "agents"]
 ---
 
 Ingest sampling lets you control the share of traces that arrive at a [self-managed Weave instance](/weave/guides/platform/weave-self-managed) and drop the rest. This can help alleviate storage and processing costs for high-volume clusters by only keeping a specified percentage of traces.
@@ -9,7 +9,7 @@ Ingest sampling lets you control the share of traces that arrive at a [self-mana
 This guide walks you through how to enable the feature on your self-managed Weave instance.
 
 <Note>
-Ingest sampling requires a Weave server version that includes the sampler, and it applies only to traffic from applications using the Weave Python SDK 0.53.0 or later. For details, see [Requirements and limitations](#requirements-and-limitations).
+Ingest sampling requires a Weave server version that includes the sampler. Sampling of `@weave.op` calls also requires the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. Agent traces have no SDK requirement. For details, see [Requirements and limitations](#requirements-and-limitations).
 </Note>
 
 Ingest sampling is independent of client-side sampling. The `tracing_sample_rate` parameter in the `@weave.op` decorator still lets an individual traced function sample its own calls, but only a server-side rate applies across the whole deployment and can't be changed or ignored by individual clients. For more information, see [Control sampling rate](/weave/guides/tracking/ops#control-sampling-rate).
@@ -26,16 +26,26 @@ You define the ingest sampling rate by setting a number between `0` and `1`:
 
 ## What ingest sampling applies to
 
-Ingest sampling applies only to traces emitted from the `@weave.op` decorator in your applications. These are the same traces that appear in the **Traces** tab of the Weave UI. The following traffic is never sampled and is always kept in full:
+Ingest sampling covers both Weave data models, and a single rate applies to both:
 
-- Evaluations. Weave keeps all evaluations because they are deliberate quality measurements, and their scores would be wrong if computed over partial data.
-- Spans from agent tracing, which appear in the **Agents** tab.
-- Traces sent with your own OpenTelemetry tooling to the raw OTel endpoint (`/otel/v1/traces`). Raw OpenTelemetry traffic carries no evaluation marker, so sampling it could silently drop evaluations. For more information, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).
-- Traffic from Weave SDK versions earlier than the supported versions. See [Requirements and limitations](#requirements-and-limitations).
+- Calls from the `@weave.op` decorator, which appear in the **Traces** tab.
+- Agent spans sent to the agent tracing endpoint (`/agents/otel/v1/traces`), which appear in the **Agents** tab. For more information, see [Trace your agents](/weave/guides/tracking/trace-agents).
+
+The following traffic is never sampled and is always kept in full:
+
+- Evaluations. See [Evaluations are always kept](#evaluations-are-always-kept).
+- Traces sent with your own OpenTelemetry tooling to the OTel endpoint (`/otel/v1/traces`). That traffic carries no evaluation marker, so sampling it could silently drop evaluations. For more information, see [Send OpenTelemetry traces to Weave](/weave/guides/tracking/otel).
+- Calls from Weave SDK versions earlier than the supported versions. See [Requirements and limitations](#requirements-and-limitations).
+
+## Evaluations are always kept
+
+Weave keeps every evaluation regardless of the sample rate. Evaluations are deliberate quality measurements rather than production traffic, and their scores would be wrong if computed over a partial set of results. For this reason, a rate of `0.0` drops all traces except evaluations.
+
+The Weave SDK marks evaluation calls and evaluation agent spans as they're sent, and the server keeps the whole trace when it sees that marker. The server makes its decision as each trace arrives and doesn't buffer traffic, so the carve-out is reliable for traffic from a supported Weave SDK and best-effort otherwise. Traffic that carries no marker, such as spans sent to the agent tracing endpoint by other OpenTelemetry tooling, is sampled like any other traffic even when it records an evaluation.
 
 ## How it works
 
-The server uses the trace's ID and [deterministic hash-based sampling](https://opentelemetry.io/docs/concepts/sampling/) to decide which traces to drop and keep. If a trace contains several calls that have the same `trace_id`, the server's verdict to keep or drop a trace extends to any nested calls that share the same trace ID. A trace is kept whole or dropped whole, never stored partway. 
+The server uses the trace's ID and [deterministic hash-based sampling](https://opentelemetry.io/docs/concepts/sampling/) to decide which traces to drop and keep. If a trace contains several calls that have the same `trace_id`, the server's verdict to keep or drop a trace extends to any nested calls that share the same trace ID. A trace is kept whole or dropped whole, never stored partway. Both data models use the same rate and the same hash.
 
 <Warning>
 The verdict is stable only while the rate is fixed. A trace that's in flight when the rate changes can be split across the change. Change the sample rate during a low-traffic window.
@@ -54,26 +64,47 @@ Set `WEAVE_INGEST_SAMPLE_RATE` to the share of traces that you want to keep, for
 
 ### Optional: Preview with a dry run
 
-You can preview the effect of a sample rate before dropping anything using a dry run. Its only output is the server's sampling metrics, emitted as DogStatsD counters, for example to Datadog. If your deployment doesn't collect those metrics, a dry run has no visible effect, and you can skip it and set the rate directly.
+You can preview the effect of a sample rate before dropping anything using a dry run. Its only output is the server's sampling metrics, emitted as counters that your metrics pipeline collects, for example Datadog. If your deployment doesn't collect those metrics, a dry run has no visible effect, and you can skip it and set the rate directly.
 
 If you do collect the metrics, run with `WEAVE_INGEST_SAMPLE_RATE=0.1` and `WEAVE_INGEST_SAMPLE_DRY_RUN=true` for a period that covers representative peak traffic, such as one full day, to see how much traffic the server would drop and how much traffic isn't eligible for sampling. Then set `WEAVE_INGEST_SAMPLE_DRY_RUN=false` to begin dropping traces.
 
-Each counter carries a `route` tag that identifies the endpoint. The counters count individual call records, not whole traces, so ratios between them reflect message volume rather than trace counts.
+Each data model reports its own counters. Every counter carries a `route` tag that identifies the endpoint, and the two `dropped` counters also carry a `dry_run` tag that separates a real drop from a dry-run one.
+
+The counters for calls count individual call records rather than whole traces:
 
 | Metric | What it counts |
 | --- | --- |
-| `ingest_sampling.seen` | Call records the sampler evaluated. |
-| `ingest_sampling.evals_kept` | Evaluation calls kept. |
-| `ingest_sampling.dropped` | Records dropped. Carries a `dry_run` tag. |
-| `ingest_sampling.dropped_bytes` | Bytes dropped. Carries a `dry_run` tag. |
-| `ingest_sampling.unsupported` | Traffic from clients too old to be sampled. |
-| `ingest_sampling.parse_failures` | Messages received without a usable trace id. |
+| `ingest_sampling.seen.otel` | Call records the sampler evaluated. |
+| `ingest_sampling.evals_kept.otel` | Evaluation call records kept. |
+| `ingest_sampling.dropped.otel` | Call records dropped. |
+| `ingest_sampling.dropped_bytes.otel` | Bytes dropped. |
+| `ingest_sampling.unsupported.otel` | Call records from clients too old to be sampled. |
+| `ingest_sampling.parse_failures.otel` | Call records received without a usable trace ID. |
 
-## Limitations and expected behaviors
+The counters for agents count individual spans:
 
-Before you enable ingest sampling, review the following limitations and behaviors:
+| Metric | What it counts |
+| --- | --- |
+| `weave_trace_server.ingest_sampling.spans.seen` | Spans the sampler evaluated. |
+| `weave_trace_server.ingest_sampling.spans.evals_kept` | Evaluation spans kept. |
+| `weave_trace_server.ingest_sampling.spans.dropped` | Spans dropped. |
+| `weave_trace_server.ingest_sampling.spans.dropped_bytes` | Bytes dropped. |
+| `weave_trace_server.ingest_sampling.spans.parse_failures` | Spans received without a usable trace ID. |
 
-- **SDK version requirements**: The server samples only traffic from the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.1 or later. These versions add the signals the server uses to group a trace's messages and recognize evaluation calls. Traffic from older SDKs isn't sampled and isn't rejected, so until your apps upgrade, the rate has no effect on their traffic.
-- **Savings depend on your client mix**: Traffic that isn't sampled, such as traffic from older SDKs, agent tracing, and raw OpenTelemetry, doesn't reduce cost. If much of your traffic comes from those sources, savings are smaller than the rate implies. A dry run is the best way to measure this first.
+Because one family counts call records and the other counts spans, compare each family against itself rather than adding the two together.
+
+## Recover original volumes from sampled data
+
+When the server keeps a trace by the hash, it records the rate it applied on the data it stores, under the `weave.ingest_sample_rate` attribute. To estimate the volume that arrived before sampling, weight each record that carries a rate by `1 / rate`. For example, a call kept at a rate of `0.1` stands for 10 calls.
+
+Traffic that the server keeps whole carries no rate and counts as itself. This includes evaluations, traffic that isn't eligible for sampling, and everything kept during a dry run.
+
+## Requirements and limitations
+
+Before you enable ingest sampling, review the following requirements, limitations, and behaviors:
+
+- **Server version**: Ingest sampling requires a Weave server version that includes the sampler. Support for agent spans was added after support for calls, so a server that predates it samples calls only. If you already set a rate below `1.0`, upgrading to a server version that samples agent spans starts sampling your agent traffic at that same rate.
+- **SDK version requirements for calls**: The server samples calls only from the Weave Python SDK 0.53.0 or later, or the Weave TypeScript SDK 0.16.0 or later. These versions add the signals the server uses to group a trace's call records and recognize evaluation calls. Calls from older SDKs aren't sampled and aren't rejected, so until your apps upgrade, the rate has no effect on their traffic. Agent spans carry a trace ID as part of the OpenTelemetry protocol, so sampling them has no SDK requirement.
+- **Savings depend on your client mix**: Traffic that isn't sampled, such as calls from older SDKs and traces sent to the OTel endpoint, doesn't reduce cost. If much of your traffic comes from those sources, savings are smaller than the rate implies. A dry run is the best way to measure this first.
 - **Monitors and scoring**: A dropped trace is neither stored nor scored. If you rely on monitors covering 100% of traffic, account for this before you enable sampling.
 - **No drop signal to the client**: A dropped trace receives a normal success response. The client isn't notified that its trace was dropped.


### PR DESCRIPTION
## Description

This targets `weave/ingest-sampling-docs` (the branch behind #2882) rather than `main`, so the diff reads as "what to change in that page" and you can pull it into your PR with one merge instead of resolving a conflicting copy of the same file.

The page says agent spans are never sampled. That is no longer true. The agent-spans sampler shipped in wandb/weave#7531 (WB-36877) on July 10 and it reads the same `WEAVE_INGEST_SAMPLE_RATE`, with no separate switch, so one rate now covers both calls and agent spans. An operator who follows the page as written would set a rate believing their agent traffic is untouched, and it would be dropped at that rate. Worse, a deployment that already has a rate below `1.0` starts sampling agent traffic on upgrade without any config change, so that gets its own line under requirements.

That change pulls one more thing with it. The page said Weave keeps all evaluations, full stop. The server recognizes an evaluation from a signal the Weave SDK puts on it, so an evaluation recorded by other OpenTelemetry tooling on the agent endpoint is now sampled like anything else. The bullet says "evaluations from the Weave SDK" instead.

I re-checked the rest of the page against the merged server code while I was in there, and three smaller things were off. The published counter names are missing the `.otel` suffix the calls counters actually carry, and the agent counters were absent, so a dry run measured against this page reports nothing. Relatedly, the counters are no longer described as DogStatsD: the calls counters moved to the server's OpenTelemetry metrics exporter in wandb/core#47206, so the DogStatsD wording was already wrong for them, and the page now stays transport-neutral. The TypeScript SDK minimum is 0.16.0, not 0.16.1: 0.16.0 is the first published version that sends the capability header, 0.15.1 does not. And the SDK version gate applies to calls only, because an agent span carries its trace ID as part of the OpenTelemetry protocol and needs nothing from the SDK. (The Python 0.53.0 number in the page is right. The 0.52.44 in the old ticket was the in-development version at the time of the commit and was never released.)

Two in-page links pointed at headings that don't exist: `#requirements-and-limitations`, where the heading read "Limitations and expected behaviors", and `#evaluations-are-always-kept`, where there is no such section. The heading is renamed to match the first link, and the second link is dropped, since the bullet right above it already says evaluations are kept. The link checker doesn't validate anchor fragments, so neither showed up in CI on #2882.

I kept the edit deliberately small and did not add anything the staleness didn't force, so no new sections and no restyling of your prose. Two things I left out on purpose, happy to add either if you want them: the server now records the applied rate on the data it keeps, which is what lets an operator reweight volumes after they start dropping traffic, and custom OpenTelemetry tooling can protect an evaluation from sampling by setting the `weave.eval.*` attributes on its spans. The first is a pre-existing gap rather than part of this change, and the second is an attribute contract I'd rather not publish without product sign-off.

## Testing

- [x] `mint validate` passes with no errors or warnings.
- [x] `mint broken-links` passes.
- [x] Every claim checked against the merged code: the calls sampler and counters in `wandb/core`, the agent sampler and counters in `wandb/weave`, and the SDK minimums against the published PyPI and npm packages.

## Related issues

- WB-37133
