### PR TITLE
docs(weave): add DaoXE provider integration (OpenAI-compatible base_url)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -689,7 +689,8 @@
                               "weave/guides/integrations/nvidia_nim",
                               "weave/guides/integrations/openai",
                               "weave/guides/integrations/openrouter",
-                              "weave/guides/integrations/together_ai"
+                              "weave/guides/integrations/together_ai",
+                              "weave/guides/integrations/daoxe"
                             ]
                           },
                           {

--- a/weave/guides/integrations.mdx
+++ b/weave/guides/integrations.mdx
@@ -40,6 +40,7 @@ LLM providers are the vendors that offer access to large language models to gene
 - **[OpenAI](/weave/guides/integrations/openai)**
 - **[OpenRouter](/weave/guides/integrations/openrouter)**
 - **[Together AI](/weave/guides/integrations/together_ai)**
+- **[DaoXE](/weave/guides/integrations/daoxe)**
 - **[Local Models](/weave/guides/integrations/local_models)** (for models running on your own infrastructure)
 
 ### Frameworks

--- a/weave/guides/integrations/daoxe.mdx
+++ b/weave/guides/integrations/daoxe.mdx
@@ -1,0 +1,54 @@
+---
+title: "DaoXE"
+description: "Trace DaoXE multi-model multi-protocol gateway calls with Weave using the OpenAI SDK and base_url https://daoxe.com/v1"
+keywords: ["DaoXE", "OpenAI SDK compatibility", "multi-protocol gateway", "multi-model API", "base_url"]
+---
+
+This guide shows you how to use Weave to automatically trace LLM calls routed through [DaoXE](https://daoxe.com), so you can monitor, debug, and evaluate model usage from a single dashboard.
+
+DaoXE is a multi-model, multi-protocol API gateway. It exposes OpenAI-compatible Chat Completions and Responses endpoints, Anthropic Messages (Claude protocol) paths, and image-compatible endpoints where available. Exact model IDs, pricing, and availability are account-scoped—use IDs from your DaoXE dashboard or catalog rather than a fixed public list.
+
+DaoXE is not available in mainland China.
+
+Because Weave detects the OpenAI SDK, you can reuse existing OpenAI client code for Chat Completions traffic by pointing the client at DaoXE. Set `base_url` to `https://daoxe.com/v1`, set `api_key` to your DaoXE API key, and set `model` to an exact model ID available on your account. When you call `weave.init()`, provide a project name for your traces. If you don't specify one, Weave uses your default entity. To find or update your default entity, refer to [User Settings](https://docs.wandb.ai/platform/app/settings-page/user-settings/#default-team) in the W&B Models documentation. After you run the following example, Weave captures your call to DaoXE as a trace in your Weave project.
+
+```python lines {5,10-13}
+import os
+import openai
+import weave
+
+weave.init("daoxe-weave")
+
+system_content = "You are a travel agent. Be descriptive and helpful."
+user_content = "Tell me about San Francisco"
+
+client = openai.OpenAI(
+    api_key=os.environ.get("DAOXE_API_KEY"),
+    base_url="https://daoxe.com/v1",
+)
+chat_completion = client.chat.completions.create(
+    model="YOUR_ACCOUNT_MODEL_ID",  # Exact model ID from your DaoXE account catalog
+    messages=[
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ],
+    temperature=0.7,
+    max_tokens=1024,
+)
+response = chat_completion.choices[0].message.content
+print("Model response:\n", response)
+```
+
+## Multi-protocol note
+
+This page traces DaoXE through the **OpenAI Chat Completions** path because that is what Weave's OpenAI integration instruments automatically.
+
+DaoXE also exposes other protocol surfaces for non-OpenAI clients—for example OpenAI Responses and Anthropic Messages (Claude protocol), plus image-compatible endpoints where enabled for your account. Those paths can still be observed in Weave by wrapping your own call sites with [`@weave.op`](/weave/guides/tracking/ops) or by following the [OpenAI](/weave/guides/integrations/openai#track-your-own-ops) guide for more complex apps.
+
+## Availability
+
+- Base URL (OpenAI-compatible): `https://daoxe.com/v1`
+- API keys and live model IDs: [daoxe.com](https://daoxe.com)
+- Examples repository: [seven7763/DaoXE-AI](https://github.com/seven7763/DaoXE-AI)
+
+While this is a basic example to get started, see the [OpenAI](/weave/guides/integrations/openai#track-your-own-ops) guide for more details on how to integrate Weave with your own functions for more complex use cases.


### PR DESCRIPTION
## Summary

Adds a Weave integration guide for [DaoXE](https://daoxe.com), a multi-model multi-protocol API gateway.

- New page: `weave/guides/integrations/daoxe.mdx`
- Links from `weave/guides/integrations.mdx` (LLM providers list)
- English nav entry in `docs.json` under LLM Providers

### What the guide documents

- OpenAI SDK path with `base_url="https://daoxe.com/v1"` and `DAOXE_API_KEY`
- Account-scoped model IDs (placeholders; no hardcoded public catalog)
- Multi-protocol note: Chat Completions is what Weave autopatch traces; DaoXE also exposes OpenAI Responses, Anthropic Messages (Claude protocol), and image-compatible endpoints where available
- Availability: not available in mainland China

Pattern matches existing OpenRouter / Together AI OpenAI-compatible provider pages.

## Test plan

- [ ] Preview renders `daoxe.mdx` under Weave Integrations LLM Providers
- [ ] Integrations overview list includes DaoXE link
- [ ] Code sample uses `https://daoxe.com/v1` and env-based API key
- [ ] No broken relative links to OpenAI / ops docs