### PR TITLE
fix(weave-ts-sdk): strip TypeDoc kind prefixes from nav titles

### DIFF
--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -198,6 +198,14 @@ def convert_to_mintlify_format(docs_dir):
         
         # Fix escaped angle brackets in title (TypeDoc escapes them as \< and \>)
         title_fixed = title.replace('\\<', '<').replace('\\>', '>')
+
+        # Strip TypeDoc's reflection-kind prefix ("Class: LLM" → "LLM") so the
+        # left nav shows bare symbol names; the nav group already conveys the kind.
+        title_fixed = re.sub(
+            r'^(?:Class|Interface|Function|Type alias|Enumeration|Namespace|Variable|Module):\s+',
+            '',
+            title_fixed,
+        )
         
         # Add Mintlify frontmatter
         frontmatter = f"""---

--- a/weave/reference/typescript-sdk/classes/conversation.mdx
+++ b/weave/reference/typescript-sdk/classes/conversation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: Conversation"
+title: "Conversation"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/dataset.mdx
+++ b/weave/reference/typescript-sdk/classes/dataset.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: Dataset<R>"
+title: "Dataset<R>"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/evaluation.mdx
+++ b/weave/reference/typescript-sdk/classes/evaluation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: Evaluation<R, E, M>"
+title: "Evaluation<R, E, M>"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/evaluationlogger.mdx
+++ b/weave/reference/typescript-sdk/classes/evaluationlogger.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: EvaluationLogger"
+title: "EvaluationLogger"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/llm.mdx
+++ b/weave/reference/typescript-sdk/classes/llm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: LLM"
+title: "LLM"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/messagesprompt.mdx
+++ b/weave/reference/typescript-sdk/classes/messagesprompt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: MessagesPrompt"
+title: "MessagesPrompt"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/objectref.mdx
+++ b/weave/reference/typescript-sdk/classes/objectref.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: ObjectRef"
+title: "ObjectRef"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/scorelogger.mdx
+++ b/weave/reference/typescript-sdk/classes/scorelogger.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: ScoreLogger"
+title: "ScoreLogger"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/stringprompt.mdx
+++ b/weave/reference/typescript-sdk/classes/stringprompt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: StringPrompt"
+title: "StringPrompt"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/subagent.mdx
+++ b/weave/reference/typescript-sdk/classes/subagent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: SubAgent"
+title: "SubAgent"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/tool.mdx
+++ b/weave/reference/typescript-sdk/classes/tool.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: Tool"
+title: "Tool"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/turn.mdx
+++ b/weave/reference/typescript-sdk/classes/turn.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: Turn"
+title: "Turn"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/weaveadkplugin.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveadkplugin.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: WeaveAdkPlugin"
+title: "WeaveAdkPlugin"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/weaveclient.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveclient.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: WeaveClient"
+title: "WeaveClient"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/classes/weaveobject.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveobject.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Class: WeaveObject"
+title: "WeaveObject"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/callschema.mdx
+++ b/weave/reference/typescript-sdk/interfaces/callschema.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: CallSchema"
+title: "CallSchema"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/callsfilter.mdx
+++ b/weave/reference/typescript-sdk/interfaces/callsfilter.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: CallsFilter"
+title: "CallsFilter"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/conversationinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/conversationinit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: ConversationInit"
+title: "ConversationInit"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getagentsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentsoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetAgentsOptions"
+title: "GetAgentsOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getagentspansoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentspansoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetAgentSpansOptions"
+title: "GetAgentSpansOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getagentturnoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentturnoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetAgentTurnOptions"
+title: "GetAgentTurnOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getagentturnsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentturnsoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetAgentTurnsOptions"
+title: "GetAgentTurnsOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getagentversionsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentversionsoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetAgentVersionsOptions"
+title: "GetAgentVersionsOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/getcallsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getcallsoptions.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: GetCallsOptions"
+title: "GetCallsOptions"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/httpresponse.mdx
+++ b/weave/reference/typescript-sdk/interfaces/httpresponse.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: HttpResponse<D, E>"
+title: "HttpResponse<D, E>"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/httpvalidationerror.mdx
+++ b/weave/reference/typescript-sdk/interfaces/httpvalidationerror.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: HTTPValidationError"
+title: "HTTPValidationError"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/llminit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/llminit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: LLMInit"
+title: "LLMInit"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/message.mdx
+++ b/weave/reference/typescript-sdk/interfaces/message.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: Message"
+title: "Message"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/query.mdx
+++ b/weave/reference/typescript-sdk/interfaces/query.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: Query"
+title: "Query"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/reasoning.mdx
+++ b/weave/reference/typescript-sdk/interfaces/reasoning.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: Reasoning"
+title: "Reasoning"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/sortby.mdx
+++ b/weave/reference/typescript-sdk/interfaces/sortby.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: SortBy"
+title: "SortBy"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/subagentinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/subagentinit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: SubAgentInit"
+title: "SubAgentInit"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/toolinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/toolinit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: ToolInit"
+title: "ToolInit"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/turninit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/turninit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: TurnInit"
+title: "TurnInit"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/usage.mdx
+++ b/weave/reference/typescript-sdk/interfaces/usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: Usage"
+title: "Usage"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/weaveaudio.mdx
+++ b/weave/reference/typescript-sdk/interfaces/weaveaudio.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: WeaveAudio"
+title: "WeaveAudio"
 description: "TypeScript SDK reference"
 ---
 

--- a/weave/reference/typescript-sdk/interfaces/weaveimage.mdx
+++ b/weave/reference/typescript-sdk/interfaces/weaveimage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface: WeaveImage"
+title: "WeaveImage"
 description: "TypeScript SDK reference"
 ---
 


### PR DESCRIPTION
## Description

The Weave TypeScript SDK reference pages render in the left nav with redundant kind prefixes — `Class: LLM`, `Interface: CallSchema`, and so on. This PR fixes that.

Root cause: `typedoc-plugin-markdown` (v3.17.1) titles every generated page with its reflection kind, and `scripts/reference-generation/weave/generate_typescript_sdk_docs.py` copies that H1 verbatim into the Mintlify frontmatter `title`, which is what the nav displays (`docs.json` lists these pages by path only). The plugin has no option to drop the prefix until v4, so the generator post-processing is the right place to fix it.

BIG NOTE: The link checker is wrong here and the warning comment can be ignored. 