### PR TITLE
Add kapa.ai chat widget

### DIFF
--- a/.github/workflows/linkcheck-pr.yml
+++ b/.github/workflows/linkcheck-pr.yml
@@ -107,6 +107,28 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('deploy_url', deployUrl);
 
+      - name: Resolve GitHub-style PR diff
+        id: pr-diff
+        if: |
+          (github.event_name == 'deployment_status' &&
+           steps.pr-context.outputs.pr_number != '') ||
+          (github.event_name == 'pull_request' &&
+           github.event.pull_request.head.repo.fork == true)
+        env:
+          TARGET_SHA: ${{ steps.pr-context.outputs.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ steps.pr-context.outputs.head_sha || github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if ! merge_base_sha=$(git merge-base "$TARGET_SHA" "$HEAD_SHA"); then
+            echo "::error::No merge base between target $TARGET_SHA and head $HEAD_SHA"
+            exit 1
+          fi
+
+          echo "merge_base_sha=$merge_base_sha" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "PR diff: $merge_base_sha...$HEAD_SHA (target tip: $TARGET_SHA)"
+
       - name: Get changed documentation files
         id: changed-files
         # Skip this for fork PRs with no doc changes (already checked above)
@@ -120,8 +142,8 @@ jobs:
           github.event_name == 'workflow_dispatch'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          base_sha: ${{ steps.pr-context.outputs.base_sha || github.event.pull_request.base.sha }}
-          sha: ${{ steps.pr-context.outputs.head_sha || github.event.pull_request.head.sha }}
+          base_sha: ${{ steps.pr-diff.outputs.merge_base_sha }}
+          sha: ${{ steps.pr-diff.outputs.head_sha }}
           files: |
             **/*.mdx
 
@@ -165,6 +187,39 @@ jobs:
             
             core.warning(`Unsupported event type: ${context.eventName}`);
             return null;
+
+      - name: Clear stale comment when no documentation changed
+        if: |
+          github.event_name == 'deployment_status' &&
+          steps.pr-context.outputs.pr_number != '' &&
+          steps.changed-files.outputs.any_changed != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const identifier = '<!-- lychee-link-checker-comment -->';
+            const prNumber = Number('${{ steps.pr-context.outputs.pr_number }}');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body?.includes(identifier) && comment.user?.login === 'github-actions[bot]'
+            );
+
+            if (!existingComment) {
+              core.info(`No existing link-check comment on PR #${prNumber}.`);
+              return;
+            }
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body: `${identifier}\n## 🔗 Link Checker Results\n\n✅ **No documentation links to check**\n\nThis PR does not change any \`.mdx\` files.`,
+            });
+            core.info(`Cleared stale link-check results on PR #${prNumber}.`);
 
       - name: Debug - Show lychee config being used
         if: |
@@ -215,8 +270,8 @@ jobs:
            github.event_name == 'workflow_dispatch')
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ steps.pr-context.outputs.base_sha || github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ steps.pr-context.outputs.head_sha || github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ steps.pr-diff.outputs.merge_base_sha }}
+          HEAD_SHA: ${{ steps.pr-diff.outputs.head_sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
@@ -267,14 +322,16 @@ jobs:
           format: markdown
           # GitHub token for API rate limiting
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Use deployment URL (from Mintlify preview) or fallback to production
-          # Same-repo PRs: Wait for deployment and use preview URL
-          # Fork PRs: Run immediately and check against production (no preview available)
+          # Check internal links against the repository tree. A single --base-url
+          # cannot preserve each changed page's directory when resolving relative links.
+          # Mintlify validation separately verifies the rendered route structure.
           # Inputs come from lychee-pr-inputs.txt (see "Write lychee input file list") so
           # we do not pass every path on the shell argv (ARG_MAX on large PRs).
           args: >-
             --config lychee.toml
-            --base-url ${{ steps.pr-context.outputs.deploy_url || 'https://docs.wandb.ai' }}
+            --root-dir ${{ github.workspace }}
+            --fallback-extensions mdx
+            --index-files index.mdx,.
             --files-from lychee-pr-inputs.txt
 
       - name: Skip comment for fork PR
@@ -308,22 +365,21 @@ jobs:
             
             const identifier = '<!-- lychee-link-checker-comment -->';
             let commentBody = identifier + '\n';
-            
-            const checkedAgainst = deployUrl || 'https://docs.wandb.ai';
+            const previewContext = deployUrl ? `\n_Preview: ${deployUrl}_\n` : '';
             
             if (exitCode === 0) {
               // Success - no broken links
               commentBody += '## 🔗 Link Checker Results\n\n';
               commentBody += '✅ **All links are valid!**\n\n';
               commentBody += 'No broken links were detected.\n';
-              commentBody += `\n_Checked against: ${checkedAgainst}_\n`;
+              commentBody += previewContext;
             } else {
               // Issues found
               try {
                 const report = fs.readFileSync('./lychee/out.md', 'utf8');
                 commentBody += '## 🔗 Link Checker Results\n\n';
                 commentBody += '⚠️ **Some issues were detected**\n\n';
-                commentBody += `_Checked against: ${checkedAgainst}_\n\n`;
+                commentBody += previewContext;
                 commentBody += '---\n\n';
                 commentBody += report;
               } catch (e) {

--- a/kapa-widget.js
+++ b/kapa-widget.js
@@ -1,0 +1,22 @@
+(function () {
+  var websiteId = '3c6baf90-a547-43ae-9431-03e31215bf6b';
+
+  if (document.querySelector('script[data-website-id="' + websiteId + '"]')) return;
+
+  var script = document.createElement('script');
+  script.src = 'https://widget.kapa.ai/kapa-widget.bundle.js';
+  script.async = true;
+  script.setAttribute('data-website-id', websiteId);
+  script.setAttribute('data-project-name', 'Weights & Biases');
+  script.setAttribute('data-project-color', '#FCBC32');
+  script.setAttribute(
+    'data-project-logo',
+    'https://site.wandb.ai/wp-content/uploads/2024/05/pictorial-mark-black-1.svg'
+  );
+  script.setAttribute('data-modal-image', 'https://docs.wandb.ai/icons/wandb-gold.svg');
+  script.setAttribute('data-color-scheme-selector', '.dark');
+  // Keep anonymous Kapa tracking off unless it is wired into the site's consent flow.
+  script.setAttribute('data-user-analytics-cookie-enabled', 'false');
+
+  document.head.appendChild(script);
+})();

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,9 +1,8 @@
 # Lychee link checker configuration
 # See https://lychee.cli.rs/guides/config/ for full documentation
 
-# Base URL for resolving relative links
-# This will be overridden at runtime by the workflows
-base_url = 'https://docs.wandb.ai'
+# PR checks resolve relative links from each source file's directory. The workflow
+# supplies the repository root and Mintlify's .mdx fallback extension at runtime.
 
 # Don't check heading anchors (fragments) - Mintlify generates these dynamically
 include_fragments = false
@@ -31,6 +30,7 @@ accept = [200, 403, 429]
 scheme = [
   "http",
   "https",
+  "file",
 ]
 
 # Logging verbosity


### PR DESCRIPTION
## Summary

- Load the kapa.ai website widget globally on the Mintlify documentation site.
- Configure W&B branding, including the official black pictorial mark on the gold launcher.
- Synchronize the widget with the site dark mode and preserve a readable gold modal mark.
- Disable Kapa anonymous analytics cookies until the widget is integrated with the site consent flow.
- Scope PR link checks from the Git merge base so main-only documentation changes are not attributed to the PR.
- Resolve relative documentation links from each source file directory instead of the site root.
- Clear stale link-check comments when a PR has no changed MDX files.

## Why

This gives documentation visitors an AI-assisted way to find answers. Using the black W&B mark fixes the low-contrast gold-on-gold launcher treatment.

The link-checker changes prevent unrelated upstream pages and valid nested relative links from producing large false-positive reports on preview deployments.

## Validation

- `node --check kapa-widget.js`
- `actionlint .github/workflows/linkcheck-pr.yml`
- `mint validate`
- `mint broken-links`
- Re-ran the original 701-link TypeScript SDK input set with Lychee 0.23.0: 0 errors instead of 363.
- Verified the merge-base diff selects 0 MDX files for the original PR #2908 topology.
- Verified the launcher and modal in local light and dark mode previews.
