### PR TITLE
fix(weave): rename shadowing OTLP endpoint var in otel tracing docs

### DIFF
--- a/weave/guides/integrations/agno.mdx
+++ b/weave/guides/integrations/agno.mdx
@@ -71,7 +71,7 @@ PROJECT_ID = os.environ.get("WANDB_PROJECT_ID")
 # Create a W&B API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ.get("WANDB_API_KEY")
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 AUTH = base64.b64encode(f"api:{WANDB_API_KEY}".encode()).decode()
 
 OTEL_EXPORTER_OTLP_HEADERS = {
@@ -81,7 +81,7 @@ OTEL_EXPORTER_OTLP_HEADERS = {
 
 # Create the OTLP span exporter with endpoint and headers
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers=OTEL_EXPORTER_OTLP_HEADERS,
 )
 

--- a/weave/guides/integrations/pydantic_ai.mdx
+++ b/weave/guides/integrations/pydantic_ai.mdx
@@ -50,7 +50,7 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 PROJECT_ID = os.environ.get("WANDB_PROJECT_ID")  # Your W&B entity/project name e.g. "myteam/myproject"
 WANDB_API_KEY = os.environ.get("WANDB_API_KEY")  # Your W&B API key
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 AUTH = base64.b64encode(f"api:{WANDB_API_KEY}".encode()).decode()
 
 OTEL_EXPORTER_OTLP_HEADERS = {
@@ -60,7 +60,7 @@ OTEL_EXPORTER_OTLP_HEADERS = {
 
 # Create the OTLP span exporter with endpoint and headers
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers=OTEL_EXPORTER_OTLP_HEADERS,
 )
 

--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -29,6 +29,10 @@ Weave uses the `wandb-api-key` header to authenticate requests and resource attr
 
 The following example shows how to configure authentication and project routing:
 
+<Warning>
+`WEAVE_OTLP_ENDPOINT` below is a local variable, not the OTel SDK's `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, and it's set to the full traces path (`.../otel/v1/traces`). It's passed explicitly to `endpoint=`/`url:` on the exporter, so the SDK sends requests to that URL verbatim. If you instead `export` a value as the real `OTEL_EXPORTER_OTLP_ENDPOINT` and construct the exporter with no arguments (for example, `OTLPSpanExporter()`), the SDK appends `/v1/traces` itself, so that variable must hold the base URL (`.../otel`) instead, or you get a doubled path (`.../otel/v1/traces/v1/traces`), a `404`, and silently dropped spans. The signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is also used verbatim, like the local variable here.
+</Warning>
+
 <CodeGroup>
 ```python Python lines {7,8}
 import os
@@ -40,13 +44,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -64,13 +68,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_OTLP_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -140,13 +144,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -208,13 +212,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_OTLP_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -316,13 +320,13 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -379,13 +383,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_OTLP_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -493,14 +497,14 @@ WANDB_BASE_URL = "https://trace.wandb.ai"
 ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 
-OTEL_EXPORTER_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = f"{WANDB_BASE_URL}/otel/v1/traces"
 
 # Create an API key at https://wandb.ai/settings
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
 # Configure the OTLP exporter
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -566,13 +570,13 @@ const WANDB_BASE_URL = "https://trace.wandb.ai";
 const ENTITY = "<your-team-name>";
 const PROJECT = "<your-project-name>";
 
-const OTEL_EXPORTER_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
+const WEAVE_OTLP_ENDPOINT = `${WANDB_BASE_URL}/otel/v1/traces`;
 
 // Create an API key at https://wandb.ai/settings
 const WANDB_API_KEY = process.env.WANDB_API_KEY!;
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_OTLP_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 
@@ -825,10 +829,10 @@ ENTITY = "<your-team-name>"
 PROJECT = "<your-project-name>"
 WANDB_API_KEY = os.environ["WANDB_API_KEY"]
 
-OTEL_EXPORTER_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces"
+WEAVE_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces"
 
 exporter = OTLPSpanExporter(
-    endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
+    endpoint=WEAVE_OTLP_ENDPOINT,
     headers={"wandb-api-key": WANDB_API_KEY},
 )
 
@@ -872,10 +876,10 @@ if (!WANDB_API_KEY) {
 }
 
 // OTel Setup
-const OTEL_EXPORTER_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces";
+const WEAVE_OTLP_ENDPOINT = "https://trace.wandb.ai/otel/v1/traces";
 
 const exporter = new OTLPTraceExporter({
-  url: OTEL_EXPORTER_OTLP_ENDPOINT,
+  url: WEAVE_OTLP_ENDPOINT,
   headers: { "wandb-api-key": WANDB_API_KEY },
 });
 

--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -30,7 +30,7 @@ Weave uses the `wandb-api-key` header to authenticate requests and resource attr
 The following example shows how to configure authentication and project routing:
 
 <Warning>
-`WEAVE_OTLP_ENDPOINT` below is a local variable, not the OTel SDK's `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, and it's set to the full traces path (`.../otel/v1/traces`). It's passed explicitly to `endpoint=`/`url:` on the exporter, so the SDK sends requests to that URL verbatim. If you instead `export` a value as the real `OTEL_EXPORTER_OTLP_ENDPOINT` and construct the exporter with no arguments (for example, `OTLPSpanExporter()`), the SDK appends `/v1/traces` itself, so that variable must hold the base URL (`.../otel`) instead, or you get a doubled path (`.../otel/v1/traces/v1/traces`), a `404`, and silently dropped spans. The signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is also used verbatim, like the local variable here.
+`WEAVE_OTLP_ENDPOINT` below is a local variable, not the OTel SDK's `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable, and it's set to the full traces path (`.../otel/v1/traces`). It's passed explicitly to `endpoint=`/`url:` on the exporter, so the SDK sends requests to that URL verbatim. If you instead `export` a value as the real `OTEL_EXPORTER_OTLP_ENDPOINT` and construct the exporter with no arguments (for example, `OTLPSpanExporter()`), the SDK appends `/v1/traces` itself, so that variable must hold the base URL (`.../otel`) instead, or you get a doubled path (`.../otel/v1/traces/v1/traces`), a `404`, and silently dropped spans. The same is true of `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: it also needs the full traces path, since the SDK won't append /v1/traces to it either.
 </Warning>
 
 <CodeGroup>


### PR DESCRIPTION
## Summary
- Rename the local `OTEL_EXPORTER_OTLP_ENDPOINT` variable (which shadows the real OTel SDK env var of the same name) to `WEAVE_OTLP_ENDPOINT` in otel.mdx, agno.mdx, pydantic_ai.mdx.
- Add a callout in otel.mdx distinguishing base-URL vs full-path vs `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` usage, since exporting the old name verbatim and using a zero-arg exporter doubles the path and silently drops spans.
- vercel_ai_sdk.mdx uses an inline string literal, not the shadowing var, so no change needed there.

## Testing
docs-only text change, no test suite.