### PR TITLE
ci: parallelize Mintlify checks

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: validate-mdx-${{ github.ref }}
   cancel-in-progress: true
@@ -32,6 +35,8 @@ jobs:
       - name: Determine if Mintlify validation is needed
         id: scope
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
             echo "Runs full validation for push/workflow_dispatch (not a PR diff)."
@@ -42,9 +47,10 @@ jobs:
           # Pathspecs do not support regex alternation like *.(mdx|json); filter with grep instead.
           # Includes .json for docs.json / mint.json / OpenAPI specs that affect generated pages.
           # Disable rename detection so deleting or renaming a relevant file still triggers validation.
-          if git diff --name-only --no-renames "${base}...${head}" | grep -Eq '\.(mdx|json|ya?ml|png|jpe?g|webp)$'; then
+          changed_files=$(git diff --name-only --no-renames "${base}...${head}")
+          if grep -Eq '(\.(mdx|json|ya?ml|png|jpe?g|webp)$|^scripts/mdx-validation/validate-mdx-mintlify\.sh$)' <<< "$changed_files"; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
-            echo "Found changed Mintlify-relevant files (.mdx, config JSON/YAML, OpenAPI JSON, or images); will run Mintlify validation."
+            echo "Found changed Mintlify-relevant files or validation code; will run Mintlify validation."
           else
             echo "needs_validation=false" >> "$GITHUB_OUTPUT"
             echo "No Mintlify-relevant files in this PR diff; skipping Mintlify install and validation."
@@ -65,7 +71,8 @@ jobs:
         if: steps.scope.outputs.needs_validation == 'true'
         run: |
           {
-            echo "date=$(date +%Y)-$(( $(date +%j) / 4 ))"
+            # Force base 10 so a zero-padded day of year such as 008 is not parsed as octal.
+            echo "date=$(date +%Y)-$(( 10#$(date +%j) / 4 ))"
             echo "npm_prefix=$(npm config get prefix)"
             echo "npm_cache=$(npm config get cache)"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -11,8 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate-mdx:
+  mint-checks:
+    name: mint-${{ matrix.check }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - validate
+          - broken-links
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -34,7 +41,8 @@ jobs:
           head="${{ github.event.pull_request.head.sha }}"
           # Pathspecs do not support regex alternation like *.(mdx|json); filter with grep instead.
           # Includes .json for docs.json / mint.json / OpenAPI specs that affect generated pages.
-          if git diff --name-only "$base" "$head" | grep -Eq '\.(mdx|json|ya?ml|png|jpe?g|webp)$'; then
+          # Disable rename detection so deleting or renaming a relevant file still triggers validation.
+          if git diff --name-only --no-renames "${base}...${head}" | grep -Eq '\.(mdx|json|ya?ml|png|jpe?g|webp)$'; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
             echo "Found changed Mintlify-relevant files (.mdx, config JSON/YAML, OpenAPI JSON, or images); will run Mintlify validation."
           else
@@ -56,9 +64,11 @@ jobs:
         id: npm-config
         if: steps.scope.outputs.needs_validation == 'true'
         run: |
-          echo "date=$(date +%Y)-$(( $(date +%j) / 4 ))" >> "$GITHUB_OUTPUT"
-          echo "npm_prefix=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
-          echo "npm_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+          {
+            echo "date=$(date +%Y)-$(( $(date +%j) / 4 ))"
+            echo "npm_prefix=$(npm config get prefix)"
+            echo "npm_cache=$(npm config get cache)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Cache Mintlify CLI
         id: cache-mint
@@ -84,9 +94,27 @@ jobs:
           echo "Using cached Mintlify CLI"
           mint --version
 
-      - name: Validate MDX with Mintlify
+      - name: Run mint ${{ matrix.check }}
         if: steps.scope.outputs.needs_validation == 'true'
         env:
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
           PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-        run: ./scripts/mdx-validation/validate-mdx-mintlify.sh
+        run: ./scripts/mdx-validation/validate-mdx-mintlify.sh "${{ matrix.check }}"
+
+  # Main branch protection requires this exact check name. Keep it as the
+  # terminal gate while the two Mint commands run in parallel above.
+  validate-mdx:
+    name: validate-mdx
+    needs: mint-checks
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all Mint checks
+        env:
+          MINT_CHECKS_RESULT: ${{ needs.mint-checks.result }}
+        run: |
+          if [ "$MINT_CHECKS_RESULT" != "success" ]; then
+            echo "One or more Mint checks did not pass: $MINT_CHECKS_RESULT"
+            exit 1
+          fi
+          echo "All Mint checks passed or were not needed."

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Match .github/workflows/validate-mdx.yml: pages (.mdx), Mintlify config / OpenAPI (.json, .yaml),
-# and common doc assets. OpenAPI and docs.json drive generated MDX at build time.
-MINTLIFY_RELEVANT_EXT_REGEX='\.(mdx|json|ya?ml|png|jpe?g|webp)$'
+# common doc assets, and this validation script. OpenAPI and docs.json drive generated MDX at build time.
+MINTLIFY_RELEVANT_REGEX='(\.(mdx|json|ya?ml|png|jpe?g|webp)$|^scripts/mdx-validation/validate-mdx-mintlify\.sh$)'
 CHECK=${1:-all}
 
 case "$CHECK" in
@@ -18,11 +18,13 @@ esac
 # may not exist after checkout). PR_BASE_SHA / PR_HEAD_SHA are set from the workflow.
 if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
   echo "Checking for Mintlify-relevant files in PR (${PR_BASE_SHA:0:7}...${PR_HEAD_SHA:0:7})..."
-  CHANGED_RELEVANT=$(git diff --name-only --no-renames "${PR_BASE_SHA}...${PR_HEAD_SHA}" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  CHANGED_FILES=$(git diff --name-only --no-renames "${PR_BASE_SHA}...${PR_HEAD_SHA}")
+  CHANGED_RELEVANT=$(grep -E "$MINTLIFY_RELEVANT_REGEX" <<< "$CHANGED_FILES" || true)
 elif [ -n "${GITHUB_BASE_REF:-}" ]; then
   # Local or legacy CI: compare against remote base ref
   echo "Checking for Mintlify-relevant files in PR..."
-  CHANGED_RELEVANT=$(git diff --name-only --no-renames "origin/${GITHUB_BASE_REF}...HEAD" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  CHANGED_FILES=$(git diff --name-only --no-renames "origin/${GITHUB_BASE_REF}...HEAD")
+  CHANGED_RELEVANT=$(grep -E "$MINTLIFY_RELEVANT_REGEX" <<< "$CHANGED_FILES" || true)
 else
   CHANGED_RELEVANT=""
 fi

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -4,16 +4,25 @@ set -e
 # Match .github/workflows/validate-mdx.yml: pages (.mdx), Mintlify config / OpenAPI (.json, .yaml),
 # and common doc assets. OpenAPI and docs.json drive generated MDX at build time.
 MINTLIFY_RELEVANT_EXT_REGEX='\.(mdx|json|ya?ml|png|jpe?g|webp)$'
+CHECK=${1:-all}
+
+case "$CHECK" in
+  all|validate|broken-links) ;;
+  *)
+    echo "Usage: $0 [all|validate|broken-links]"
+    exit 2
+    ;;
+esac
 
 # In CI pull_request runs, prefer explicit base/head SHAs (reliable; origin/$GITHUB_BASE_REF
 # may not exist after checkout). PR_BASE_SHA / PR_HEAD_SHA are set from the workflow.
 if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
-  echo "Checking for Mintlify-relevant files in PR (${PR_BASE_SHA:0:7}..${PR_HEAD_SHA:0:7})..."
-  CHANGED_RELEVANT=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  echo "Checking for Mintlify-relevant files in PR (${PR_BASE_SHA:0:7}...${PR_HEAD_SHA:0:7})..."
+  CHANGED_RELEVANT=$(git diff --name-only --no-renames "${PR_BASE_SHA}...${PR_HEAD_SHA}" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
 elif [ -n "${GITHUB_BASE_REF:-}" ]; then
   # Local or legacy CI: compare against remote base ref
   echo "Checking for Mintlify-relevant files in PR..."
-  CHANGED_RELEVANT=$(git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  CHANGED_RELEVANT=$(git diff --name-only --no-renames "origin/${GITHUB_BASE_REF}...HEAD" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
 else
   CHANGED_RELEVANT=""
 fi
@@ -28,63 +37,80 @@ if { [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; } || [ -n "${GITHUB
     exit 0
   fi
   echo "Found changed files (Mintlify-relevant):"
-  echo "$CHANGED_RELEVANT" | sed 's/^/  /'
+  while IFS= read -r changed_file; do
+    echo "  $changed_file"
+  done <<< "$CHANGED_RELEVANT"
   echo ""
 fi
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "VALIDATING DOCUMENTATION BUILD"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Running: mint validate"
-echo ""
-
-# Run mint validate - exits with non-zero if there are any errors or warnings
-if mint validate; then
+run_validate() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "VALIDATING DOCUMENTATION BUILD"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Running: mint validate"
   echo ""
+
+  # mint validate exits with non-zero if there are any errors or warnings.
+  if mint validate; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ MINTLIFY VALIDATION PASSED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "No errors or warnings detected"
+  else
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "❌ MINTLIFY VALIDATION FAILED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Errors or warnings were detected. Please fix them or"
+    echo "file an issue if you believe they are incorrect:"
+    echo "https://github.com/wandb/docs/issues/new"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 1
+  fi
+}
+
+run_broken_links() {
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "✅ MINTLIFY VALIDATION PASSED"
+  echo "CHECKING FOR BROKEN LINKS"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "No errors or warnings detected"
-else
+  echo "Running: mint broken-links"
   echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "❌ MINTLIFY VALIDATION FAILED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "Errors or warnings were detected. Please fix them or"
-  echo "file an issue if you believe they are incorrect:"
-  echo "https://github.com/wandb/docs/issues/new"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  exit 1
-fi
 
-echo ""
+  # mint broken-links exits with non-zero if broken links are found.
+  if mint broken-links; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ NO BROKEN LINKS FOUND"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  else
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "❌ BROKEN LINKS DETECTED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Please fix the broken links reported above"
+    exit 1
+  fi
+}
 
-# Run broken links check
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "CHECKING FOR BROKEN LINKS"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Running: mint broken-links"
-echo ""
+case "$CHECK" in
+  validate)
+    run_validate
+    ;;
+  broken-links)
+    run_broken_links
+    ;;
+  all)
+    run_validate
+    echo ""
+    run_broken_links
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ ALL VALIDATION CHECKS PASSED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "- No validation errors or warnings"
+    echo "- No broken links"
+    ;;
+esac
 
-# Run mint broken-links - it will exit with non-zero if broken links are found
-if mint broken-links; then
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "✅ NO BROKEN LINKS FOUND"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-else
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "❌ BROKEN LINKS DETECTED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "Please fix the broken links reported above"
-  exit 1
-fi
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "✅ ALL VALIDATION CHECKS PASSED"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "- No validation errors or warnings"
-echo "- No broken links"
 exit 0


### PR DESCRIPTION
## Summary

- Run `mint validate` and `mint broken-links` concurrently on separate matrix runners.
- Preserve the branch-protection-required `validate-mdx` check as a terminal gate.
- Use merge-base-aware three-dot diffs for PR scoping and fail closed if the diff cannot be computed.
- Treat deleted, renamed, or validator-code changes as validation triggers.
- Keep the helper script's existing no-argument behavior while allowing CI to run either check independently.
- Restrict the workflow token to read-only repository contents.
- Force base-10 day-of-year arithmetic when generating the Mint CLI cache key.

## Why

Actions run 29436949448 took 4 minutes 24 seconds, including approximately 1 minute 40 seconds for `mint validate` followed by 1 minute 56 seconds for `mint broken-links`.

[The first parallel run](https://github.com/wandb/docs/actions/runs/29438981575) completed in 2 minutes 38 seconds: 1 minute 46 seconds, or 40%, faster. Total runner time increased by about 9% because checkout and Mint setup run once per matrix job.

The original run also exposed a scoping bug. PR #2908 changed only `kapa-widget.js`, but the two-dot base/head comparison included 37 upstream MDX changes because the branch was behind `main`. The three-dot comparison correctly considers only the PR's changes, so non-relevant PRs can skip Mint setup and validation.

This PR also adopts applicable caller safeguards from [coreweave/docs#3370](https://github.com/coreweave/docs/pull/3370). W&B keeps separate matrix runners instead of CoreWeave's background-process approach because they provide independent Mintlify state, non-interleaved logs, and native process cleanup for these longer-running checks.

## Validation

- `actionlint`
- `shellcheck`
- `bash -n scripts/mdx-validation/validate-mdx-mintlify.sh`
- YAML parsing and `git diff --check`
- PR #2908 base/head regression fixture
- mocked per-command dispatch, failure propagation, and legacy `all` behavior
- mocked push and `workflow_dispatch` command paths
- invalid Git diff fails closed
- zero-padded day-of-year cache-key fixtures
- completed GitHub Actions parallel run
