### PR TITLE
Remove twoslash from code blocks to see if it fixes a broken page

### DIFF
--- a/weave/guides/integrations/vercel_ai_sdk.mdx
+++ b/weave/guides/integrations/vercel_ai_sdk.mdx
@@ -39,7 +39,7 @@ Next.js applications use an `instrumentation.ts` file to set up OTel. This file 
 
 To integrate Weave with Vercel's OTel functionality, create an `instrumentation.ts` file in your project root and add the following code to it, updating the `resourceFromAttributes()` function with your team and project names:
 
-```typescript twoslash lines {17-19} title="instrumentation.ts"
+```typescript lines {17-19} title="instrumentation.ts"
 // @noErrors
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
@@ -74,7 +74,7 @@ This creates an OTLP exporter configured to send trace data to Weave's OTel endp
 
 After you've added the instrumentation, use Vercel's `experimental_telemetry` option on any AI SDK function call to emit OTel spans:
 
-```typescript twoslash lines {10} title="route.ts"
+```typescript lines {10} title="route.ts"
 // @noErrors
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
@@ -101,7 +101,7 @@ If you're not using Next.js, you can configure OTel directly in a standalone Nod
 
 After meeting the prerequisites, you can run the following example and generate spans without any additional configuration.
 
-```typescript twoslash lines {11-14,18-19,31} title="test-app.ts"
+```typescript lines {11-14,18-19,31} title="test-app.ts"
 // @noErrors
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";


### PR DESCRIPTION
## Description
Remove twoslash from code blocks to see if it fixes a broken page

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
