### PR TITLE
Remove duplicate in-page breadcrumbs from TypeScript SDK reference pages

### DIFF
--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -153,7 +153,8 @@ def generate_typedoc(sdk_path, output_path):
         "excludeProtected": True,
         "excludeInternal": True,
         "disableSources": False,
-        "cleanOutputDir": True
+        "cleanOutputDir": True,
+        "hideBreadcrumbs": True
     }
     
     config_path = sdk_path / "typedoc.json"
@@ -187,7 +188,13 @@ def convert_to_mintlify_format(docs_dir):
         # Skip if already has frontmatter
         if content.startswith("---"):
             continue
-        
+
+        # Remove TypeDoc's in-page breadcrumb line (e.g. "[weave](../README.md) / Conversation").
+        # Mintlify already renders breadcrumbs above the page title, so this line duplicates
+        # them below the subhead. typedoc is configured with hideBreadcrumbs, but strip any
+        # that slip through (older cached output, config regressions).
+        content = re.sub(r'^\[weave\]\([^)]+\)(?: / [^\n]+)+\n+', '', content, flags=re.MULTILINE)
+
         # Extract title from content
         title_match = re.search(r'^#\s+(.+)$', content, re.MULTILINE)
         title = title_match.group(1) if title_match else md_file.stem

--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -189,11 +189,13 @@ def convert_to_mintlify_format(docs_dir):
         if content.startswith("---"):
             continue
 
-        # Remove TypeDoc's in-page breadcrumb line (e.g. "[weave](../README.md) / Conversation").
+        # Remove TypeDoc's in-page breadcrumb line (e.g. "[weave](../README.md) / Conversation";
+        # on the README itself it's just the bare package name "weave" with no link).
         # Mintlify already renders breadcrumbs above the page title, so this line duplicates
         # them below the subhead. typedoc is configured with hideBreadcrumbs, but strip any
         # that slip through (older cached output, config regressions).
         content = re.sub(r'^\[weave\]\([^)]+\)(?: / [^\n]+)+\n+', '', content, flags=re.MULTILINE)
+        content = re.sub(r'\Aweave(?: / [^\n]+)*\n+', '', content)
 
         # Extract title from content
         title_match = re.search(r'^#\s+(.+)$', content, re.MULTILINE)

--- a/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
+++ b/scripts/reference-generation/weave/generate_typescript_sdk_docs.py
@@ -189,11 +189,7 @@ def convert_to_mintlify_format(docs_dir):
         if content.startswith("---"):
             continue
 
-        # Remove TypeDoc's in-page breadcrumb line (e.g. "[weave](../README.md) / Conversation";
-        # on the README itself it's just the bare package name "weave" with no link).
-        # Mintlify already renders breadcrumbs above the page title, so this line duplicates
-        # them below the subhead. typedoc is configured with hideBreadcrumbs, but strip any
-        # that slip through (older cached output, config regressions).
+        # Remove TypeDoc's in-page breadcrumb line. Mintlify manages breadcrumbs already.
         content = re.sub(r'^\[weave\]\([^)]+\)(?: / [^\n]+)+\n+', '', content, flags=re.MULTILINE)
         content = re.sub(r'\Aweave(?: / [^\n]+)*\n+', '', content)
 

--- a/weave/reference/typescript-sdk.mdx
+++ b/weave/reference/typescript-sdk.mdx
@@ -3,10 +3,6 @@ title: "weave"
 description: "TypeScript SDK reference"
 ---
 
-weave
-
-
-
 ## Table of contents
 
 ### Classes

--- a/weave/reference/typescript-sdk/classes/conversation.mdx
+++ b/weave/reference/typescript-sdk/classes/conversation.mdx
@@ -3,10 +3,6 @@ title: "Conversation"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Conversation
-
-
-
 A Conversation groups Turns under a single `gen_ai.conversation.id`. It is
 not itself an OTel span — children stamp the conversation id onto theirs.
 

--- a/weave/reference/typescript-sdk/classes/dataset.mdx
+++ b/weave/reference/typescript-sdk/classes/dataset.mdx
@@ -3,10 +3,6 @@ title: "Dataset<R>"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Dataset
-
-
-
 Dataset object with easy saving and automatic versioning
 
 `Example`

--- a/weave/reference/typescript-sdk/classes/evaluation.mdx
+++ b/weave/reference/typescript-sdk/classes/evaluation.mdx
@@ -3,10 +3,6 @@ title: "Evaluation<R, E, M>"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Evaluation
-
-
-
 Sets up an evaluation which includes a set of scorers and a dataset.
 
 Calling evaluation.evaluate(model) will pass in rows form a dataset into a model matching

--- a/weave/reference/typescript-sdk/classes/evaluationlogger.mdx
+++ b/weave/reference/typescript-sdk/classes/evaluationlogger.mdx
@@ -3,10 +3,6 @@ title: "EvaluationLogger"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / EvaluationLogger
-
-
-
 EvaluationLogger enables incremental logging of predictions and scores.
 
 Unlike the traditional Evaluation class which requires upfront dataset and batch processing,

--- a/weave/reference/typescript-sdk/classes/llm.mdx
+++ b/weave/reference/typescript-sdk/classes/llm.mdx
@@ -3,10 +3,6 @@ title: "LLM"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / LLM
-
-
-
 An LLM call. Emits a `chat` span with `gen_ai.*` attributes.
 
 Created by `weave.startLLM()` (or `turn.startLLM()`) and terminated with

--- a/weave/reference/typescript-sdk/classes/messagesprompt.mdx
+++ b/weave/reference/typescript-sdk/classes/messagesprompt.mdx
@@ -3,10 +3,6 @@ title: "MessagesPrompt"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / MessagesPrompt
-
-
-
 ## Hierarchy
 
 - `Prompt`

--- a/weave/reference/typescript-sdk/classes/objectref.mdx
+++ b/weave/reference/typescript-sdk/classes/objectref.mdx
@@ -3,10 +3,6 @@ title: "ObjectRef"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / ObjectRef
-
-
-
 Represents a reference to a saved Weave object.
 
 Generally, end users will not need to interact with this class directly.

--- a/weave/reference/typescript-sdk/classes/scorelogger.mdx
+++ b/weave/reference/typescript-sdk/classes/scorelogger.mdx
@@ -3,10 +3,6 @@ title: "ScoreLogger"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / ScoreLogger
-
-
-
 ScoreLogger manages scoring for a single prediction.
 Returned from EvaluationLogger.logPrediction().
 

--- a/weave/reference/typescript-sdk/classes/stringprompt.mdx
+++ b/weave/reference/typescript-sdk/classes/stringprompt.mdx
@@ -3,10 +3,6 @@ title: "StringPrompt"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / StringPrompt
-
-
-
 ## Hierarchy
 
 - `Prompt`

--- a/weave/reference/typescript-sdk/classes/subagent.mdx
+++ b/weave/reference/typescript-sdk/classes/subagent.mdx
@@ -3,10 +3,6 @@ title: "SubAgent"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / SubAgent
-
-
-
 ## Hierarchy
 
 - `SpanBase`

--- a/weave/reference/typescript-sdk/classes/tool.mdx
+++ b/weave/reference/typescript-sdk/classes/tool.mdx
@@ -3,10 +3,6 @@ title: "Tool"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Tool
-
-
-
 A tool invocation. Emits an `execute_tool` span carrying the tool name,
 the JSON-encoded arguments, the tool-call id, and the result.
 

--- a/weave/reference/typescript-sdk/classes/turn.mdx
+++ b/weave/reference/typescript-sdk/classes/turn.mdx
@@ -3,10 +3,6 @@ title: "Turn"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Turn
-
-
-
 ## Hierarchy
 
 - `SpanBase`

--- a/weave/reference/typescript-sdk/classes/weaveadkplugin.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveadkplugin.mdx
@@ -3,10 +3,6 @@ title: "WeaveAdkPlugin"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / WeaveAdkPlugin
-
-
-
 ADK plugin that emits runner invocations, agent runs, model calls and tool
 executions as GenAI-semconv OTel spans on Weave's agents pipeline.
 

--- a/weave/reference/typescript-sdk/classes/weaveclient.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveclient.mdx
@@ -3,10 +3,6 @@ title: "WeaveClient"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / WeaveClient
-
-
-
 ## Table of contents
 
 ### Constructors

--- a/weave/reference/typescript-sdk/classes/weaveobject.mdx
+++ b/weave/reference/typescript-sdk/classes/weaveobject.mdx
@@ -3,10 +3,6 @@ title: "WeaveObject"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / WeaveObject
-
-
-
 ## Hierarchy
 
 - `WeaveObject`

--- a/weave/reference/typescript-sdk/interfaces/callschema.mdx
+++ b/weave/reference/typescript-sdk/interfaces/callschema.mdx
@@ -3,10 +3,6 @@ title: "CallSchema"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / CallSchema
-
-
-
 CallSchema
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/callsfilter.mdx
+++ b/weave/reference/typescript-sdk/interfaces/callsfilter.mdx
@@ -3,10 +3,6 @@ title: "CallsFilter"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / CallsFilter
-
-
-
 CallsFilter
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/conversationinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/conversationinit.mdx
@@ -3,10 +3,6 @@ title: "ConversationInit"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / ConversationInit
-
-
-
 ## Table of contents
 
 ### Properties

--- a/weave/reference/typescript-sdk/interfaces/getagentsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentsoptions.mdx
@@ -3,10 +3,6 @@ title: "GetAgentsOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetAgentsOptions
-
-
-
 Options for [WeaveClient.getAgents](../classes/weaveclient#getagents).
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/getagentspansoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentspansoptions.mdx
@@ -3,10 +3,6 @@ title: "GetAgentSpansOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetAgentSpansOptions
-
-
-
 Options for [WeaveClient.getAgentSpans](../classes/weaveclient#getagentspans).
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/getagentturnoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentturnoptions.mdx
@@ -3,10 +3,6 @@ title: "GetAgentTurnOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetAgentTurnOptions
-
-
-
 Options for [WeaveClient.getAgentTurn](../classes/weaveclient#getagentturn).
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/getagentturnsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentturnsoptions.mdx
@@ -3,10 +3,6 @@ title: "GetAgentTurnsOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetAgentTurnsOptions
-
-
-
 Options for [WeaveClient.getAgentTurns](../classes/weaveclient#getagentturns).
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/getagentversionsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getagentversionsoptions.mdx
@@ -3,10 +3,6 @@ title: "GetAgentVersionsOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetAgentVersionsOptions
-
-
-
 Options for [WeaveClient.getAgentVersions](../classes/weaveclient#getagentversions).
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/getcallsoptions.mdx
+++ b/weave/reference/typescript-sdk/interfaces/getcallsoptions.mdx
@@ -3,10 +3,6 @@ title: "GetCallsOptions"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / GetCallsOptions
-
-
-
 ## Table of contents
 
 ### Properties

--- a/weave/reference/typescript-sdk/interfaces/httpresponse.mdx
+++ b/weave/reference/typescript-sdk/interfaces/httpresponse.mdx
@@ -3,10 +3,6 @@ title: "HttpResponse<D, E>"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / HttpResponse
-
-
-
 ## Type parameters
 
 | Name | Type |

--- a/weave/reference/typescript-sdk/interfaces/httpvalidationerror.mdx
+++ b/weave/reference/typescript-sdk/interfaces/httpvalidationerror.mdx
@@ -3,10 +3,6 @@ title: "HTTPValidationError"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / HTTPValidationError
-
-
-
 HTTPValidationError
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/llminit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/llminit.mdx
@@ -3,10 +3,6 @@ title: "LLMInit"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / LLMInit
-
-
-
 ## Hierarchy
 
 - `SpanInitBase`

--- a/weave/reference/typescript-sdk/interfaces/message.mdx
+++ b/weave/reference/typescript-sdk/interfaces/message.mdx
@@ -3,10 +3,6 @@ title: "Message"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Message
-
-
-
 ## Table of contents
 
 ### Properties

--- a/weave/reference/typescript-sdk/interfaces/query.mdx
+++ b/weave/reference/typescript-sdk/interfaces/query.mdx
@@ -3,10 +3,6 @@ title: "Query"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Query
-
-
-
 Query
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/reasoning.mdx
+++ b/weave/reference/typescript-sdk/interfaces/reasoning.mdx
@@ -3,10 +3,6 @@ title: "Reasoning"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Reasoning
-
-
-
 ## Table of contents
 
 ### Properties

--- a/weave/reference/typescript-sdk/interfaces/sortby.mdx
+++ b/weave/reference/typescript-sdk/interfaces/sortby.mdx
@@ -3,10 +3,6 @@ title: "SortBy"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / SortBy
-
-
-
 SortBy
 
 ## Table of contents

--- a/weave/reference/typescript-sdk/interfaces/subagentinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/subagentinit.mdx
@@ -3,10 +3,6 @@ title: "SubAgentInit"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / SubAgentInit
-
-
-
 ## Hierarchy
 
 - `SpanInitBase`

--- a/weave/reference/typescript-sdk/interfaces/toolinit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/toolinit.mdx
@@ -3,10 +3,6 @@ title: "ToolInit"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / ToolInit
-
-
-
 ## Hierarchy
 
 - `SpanInitBase`

--- a/weave/reference/typescript-sdk/interfaces/turninit.mdx
+++ b/weave/reference/typescript-sdk/interfaces/turninit.mdx
@@ -3,10 +3,6 @@ title: "TurnInit"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / TurnInit
-
-
-
 ## Hierarchy
 
 - `SpanInitBase`

--- a/weave/reference/typescript-sdk/interfaces/usage.mdx
+++ b/weave/reference/typescript-sdk/interfaces/usage.mdx
@@ -3,10 +3,6 @@ title: "Usage"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / Usage
-
-
-
 ## Table of contents
 
 ### Properties

--- a/weave/reference/typescript-sdk/interfaces/weaveaudio.mdx
+++ b/weave/reference/typescript-sdk/interfaces/weaveaudio.mdx
@@ -3,10 +3,6 @@ title: "WeaveAudio"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / WeaveAudio
-
-
-
 ## Hierarchy
 
 - `WeaveAudioInput`

--- a/weave/reference/typescript-sdk/interfaces/weaveimage.mdx
+++ b/weave/reference/typescript-sdk/interfaces/weaveimage.mdx
@@ -3,10 +3,6 @@ title: "WeaveImage"
 description: "TypeScript SDK reference"
 ---
 
-[weave](../) / WeaveImage
-
-
-
 ## Hierarchy
 
 - `WeaveImageInput`


### PR DESCRIPTION
## Description

Generated TypeScript SDK reference pages (e.g. [Class: Conversation](https://docs.wandb.ai/weave/reference/typescript-sdk/classes/conversation)) showed two sets of breadcrumbs: Mintlify's own above the title, and a TypeDoc-generated line (`[weave](../) / Conversation`) rendering below the subhead. This removes the duplicate below the subhead.

### Before
<img width="448" height="274" alt="Screenshot 2026-07-16 at 5 39 36 PM" src="https://github.com/user-attachments/assets/1de67285-3a90-4ebc-873c-c5520e17961e" />

### After
<img width="435" height="215" alt="Screenshot 2026-07-16 at 5 39 57 PM" src="https://github.com/user-attachments/assets/23623492-686b-4f73-a1dd-ca3f4533f2be" />