### PR TITLE
Serverless Training: add public demo workspace callout

### DIFF
--- a/serverless-training.mdx
+++ b/serverless-training.mdx
@@ -20,6 +20,12 @@ Serverless Training trains low-rank adapters (LoRAs) to specialize a model for y
 
 See the ART [quickstart](https://art.openpipe.ai/getting-started/quick-start) or [Google Colab notebook](https://colab.research.google.com/github/openpipe/art-notebooks/blob/main/examples/2048/2048.ipynb) to get started.
 
+Explore a [public demo workspace](https://wandb.ai/wandb/demo-project-qwen-email-agent-with-art-weave-models/workspace) that demonstrates the following:
+
+* Train a Qwen model with OpenPipe RULER and [Weave Scorers](/weave/guides/evaluation/scorers#create-your-own-scorers).
+* Track training progress and [create custom plots](/models/app/features/custom-charts) with W&B Models.
+* Evaluate the final results on a [Weave leaderboard](/weave/cookbooks/leaderboard_quickstart#leaderboard-quickstart).
+
 ## Why Serverless Training?
 
 Serverless Training can provide the following advantages in your post-training:


### PR DESCRIPTION
Salvages the one non-superseded change from #1962, updated for the Mintlify migration.

## Background

#1962 (by @julia-g-rose, opened 2025-12-05) edited the pre-migration root `training.mdx`, which the Hugo→Mintlify migration deleted. The branch shares no merge base with current `main`, so it can't be rebased. Almost all of its content — adding Serverless SFT alongside RL on the landing page — is already covered, more thoroughly, on `main` in `serverless-training.mdx`.

## What this PR keeps

The one genuinely new thing from #1962: a **public demo workspace** callout on the Serverless Training landing page, pointing at the Qwen email-agent demo (OpenPipe RULER + Weave Scorers, custom plots, Weave leaderboard).

Adjustments from the original:
- Retargeted to `serverless-training.mdx` (the current landing page).
- Internal links converted to root-relative house style.
- Removed the personal `?nw=nwuserjuliarose` namespace parameter from the workspace URL.

Original authorship preserved via `Co-Authored-By`. Replaces #1962.