### PR TITLE
Reports: note wandb.Image filename hashing when embedding images in HTML

### DIFF
--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -592,6 +592,10 @@ This renders a markdown block similar to:
 
 Add HTML elements such as headings and lists to structure your report. You can add them interactively with the App UI or programmatically with the W&B SDK.
 
+<Note>
+When you log an image with `wandb.Image`, W&B saves the file under a generated name that includes a content hash, such as `media/images/<key>_<step>_<hash>.png`, instead of the original filename. As a result, an `<img>` tag or markdown image that references the original filename doesn't resolve. To embed a logged image in a report, log the image first, then use the generated file path as the image's `src` value.
+</Note>
+
 <Tabs>
 <Tab title="App UI">
 Enter a forward slash (`/`) in the report to display a dropdown menu. From the dropdown, select a type of text block. For example, to create an H2 heading block, select the `Heading 2` option.

--- a/models/reports/edit-a-report.mdx
+++ b/models/reports/edit-a-report.mdx
@@ -593,7 +593,7 @@ This renders a markdown block similar to:
 Add HTML elements such as headings and lists to structure your report. You can add them interactively with the App UI or programmatically with the W&B SDK.
 
 <Note>
-When you log an image with `wandb.Image`, W&B saves the file under a generated name that includes a content hash, such as `media/images/<key>_<step>_<hash>.png`, instead of the original filename. As a result, an `<img>` tag or markdown image that references the original filename doesn't resolve. To embed a logged image in a report, log the image first, then use the generated file path as the image's `src` value.
+When you log an image with `wandb.Image`, W&B saves the file under a generated name that includes a content hash, such as `media/images/[key]_[step]_[hash].png`, instead of the original filename. As a result, an `<img>` tag or markdown image that references the original filename doesn't resolve. To embed a logged image in a report, log the image first, then use the generated file path as the image's `src` value.
 </Note>
 
 <Tabs>


### PR DESCRIPTION
## What

Adds a `<Note>` to the "Add HTML elements" section of `models/reports/edit-a-report.mdx` explaining that `wandb.Image` stores logged images under a generated, content-hashed filename (`media/images/<key>_<step>_<hash>.png`) rather than the original filename. Because of this, an `<img>` tag or markdown image that references the original filename won't resolve. The note documents the workaround: log the image first, then reference the generated file path.

## Why

Imported from **WBDOCS-1193** (reporter: Thomas Drayton). A user embedding logged images into a programmatically built Report hit broken image references because the filename changes on log. This behavior was undocumented.

Fixes DOCS-2502

## Companion PR

The same detail is being added to the `wandb.Image` docstring in `wandb/wandb` so it flows into the generated SDK reference (`models/ref/python/data-types/image.mdx`) on the next SDK release. The two notes are intentionally self-contained rather than cross-linked, since the reference version isn't available until that release.

See wandb/wandb#12225

## Verification

Confirmed against the SDK source (`wandb/sdk/data_types/base_types/media.py`): `bind_to_run` builds the filename via `_wb_filename(key, step, id, ext)` where `id` defaults to `self._sha256[:20]`, producing `media/images/<key>_<step>_<sha256[:20]>.<ext>`. Behavior is current on `main`.
