### PR TITLE
docs(weave): document Logfire/Pydantic AI OTel attribute mappings

### DIFF
--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -1321,13 +1321,14 @@ Weave maps OpenTelemetry span attributes from various instrumentation frameworks
 
 Weave supports attribute conventions from the following observability frameworks and SDKs:
 
-- **OpenTelemetry GenAI**: Standard semantic conventions for generative AI (`gen_ai.*`).
+- **OpenTelemetry GenAI**: Standard semantic conventions for generative AI (`gen_ai.*`), including the current message format (`gen_ai.input.messages`, `gen_ai.output.messages`).
 - **OpenInference**: Arize AI's instrumentation library (`input.value`, `output.value`, `llm.*`, `openinference.*`).
 - **Vercel AI SDK**: Vercel's AI SDK attributes (`ai.prompt`, `ai.response`, `ai.model.*`, `ai.usage.*`).
 - **MLflow**: MLflow tracking attributes (`mlflow.spanInputs`, `mlflow.spanOutputs`).
 - **Traceloop**: OpenLLMetry instrumentation (`traceloop.entity.*`, `traceloop.span.kind`).
 - **Google Vertex AI**: Vertex AI agent attributes (`gcp.vertex.agent.*`).
 - **OpenLit**: OpenLit observability attributes (`gen_ai.content.completion`).
+- **Logfire / Pydantic AI**: Logfire's Pydantic AI instrumentation (`gen_ai.input.messages`, `gen_ai.output.messages`, `pydantic_ai.all_messages`, `final_result`).
 - **Langfuse**: Langfuse tracing attributes (`langfuse.startTime`, `langfuse.endTime`).
 
 ### Attribute reference
@@ -1338,6 +1339,8 @@ Weave supports attribute conventions from the following observability frameworks
 | `gen_ai.prompt`                   | `inputs`                      | AI model prompt or message array.           | List, dict, string          | `[{"role":"user","content":"abc"}]`            |
 | `input.value`                     | `inputs`                      | Input value for model invocation.           | String, list, dict          | `{"text":"Tell a joke"}`                       |
 | `mlflow.spanInputs`               | `inputs`                      | Span input data.                            | String, list, dict          | `["prompt text"]`                              |
+| `gen_ai.input.messages`           | `inputs`                      | Input messages in the OTel GenAI message format. Emitted by Logfire's Pydantic AI instrumentation. | List, dict, string          | `[{"role":"user","parts":[...]}]`             |
+| `pydantic_ai.all_messages`        | `inputs`                      | All messages from a Pydantic AI agent run.  | List                        | `[{"role":"user","content":"abc"}]`           |
 | `traceloop.entity.input`          | `inputs`                      | Entity input data.                          | String, list, dict          | `"Translate this to French"`                   |
 | `gcp.vertex.agent.tool_call_args` | `inputs`                      | Tool call arguments.                        | Dict                        | `{"args":{"query":"weather in SF"}}`           |
 | `gcp.vertex.agent.llm_request`    | `inputs`                      | LLM request payload.                        | Dict                        | `{"contents":[{"role":"user","parts":[...]}]}` |
@@ -1346,7 +1349,9 @@ Weave supports attribute conventions from the following observability frameworks
 | `ai.response`                     | `outputs`                     | Model response text or data.                | String, list, dict          | `"Here is a haiku..."`                         |
 | `gen_ai.completion`               | `outputs`                     | AI completion result.                       | String, list, dict          | `"Completion text"`                            |
 | `output.value`                    | `outputs`                     | Output value from model.                    | String, list, dict          | `{"text":"Answer text"}`                       |
+| `gen_ai.output.messages`          | `outputs`                     | Output messages in the OTel GenAI message format. Emitted by Logfire's Pydantic AI instrumentation. | List, dict, string          | `[{"role":"assistant","parts":[...]}]`        |
 | `mlflow.spanOutputs`              | `outputs`                     | Span output data.                           | String, list, dict          | `["answer"]`                                   |
+| `final_result`                    | `outputs`                     | Final output of a Pydantic AI agent run.    | String, dict                | `"Answer text"`                                |
 | `gen_ai.content.completion`       | `outputs`                     | Content completion result.                  | String                      | `"Answer text"`                                |
 | `traceloop.entity.output`         | `outputs`                     | Entity output data.                         | String, list, dict          | `"Answer text"`                                |
 | `gcp.vertex.agent.tool_response`  | `outputs`                     | Tool execution response.                    | Dict, string                | `{"toolResponse":"ok"}`                        |
@@ -1364,6 +1369,7 @@ Weave supports attribute conventions from the following observability frameworks
 | `llm.token_count.total`           | `usage.total_tokens`          | Total token count.                          | Int                         | `70`                                           |
 | `gen_ai.system`                   | `attributes.system`           | System prompt or instructions.              | String                      | `"You are a helpful assistant."`               |
 | `llm.system`                      | `attributes.system`           | System prompt or instructions.              | String                      | `"You are a helpful assistant."`               |
+| `gen_ai.system_instructions`      | `attributes.system`           | System prompt or instructions.              | String                      | `"You are a helpful assistant."`               |
 | `weave.span.kind`                 | `attributes.kind`             | Span type or category.                      | String                      | `"llm"`                                        |
 | `traceloop.span.kind`             | `attributes.kind`             | Span type or category.                      | String                      | `"llm"`                                        |
 | `openinference.span.kind`         | `attributes.kind`             | Span type or category.                      | String                      | `"llm"`                                        |

--- a/weave/guides/tracking/otel.mdx
+++ b/weave/guides/tracking/otel.mdx
@@ -1321,7 +1321,7 @@ Weave maps OpenTelemetry span attributes from various instrumentation frameworks
 
 Weave supports attribute conventions from the following observability frameworks and SDKs:
 
-- **OpenTelemetry GenAI**: Standard semantic conventions for generative AI (`gen_ai.*`), including the current message format (`gen_ai.input.messages`, `gen_ai.output.messages`).
+- **OpenTelemetry GenAI**: Standard semantic conventions for generative AI (`gen_ai.*`).
 - **OpenInference**: Arize AI's instrumentation library (`input.value`, `output.value`, `llm.*`, `openinference.*`).
 - **Vercel AI SDK**: Vercel's AI SDK attributes (`ai.prompt`, `ai.response`, `ai.model.*`, `ai.usage.*`).
 - **MLflow**: MLflow tracking attributes (`mlflow.spanInputs`, `mlflow.spanOutputs`).
@@ -1339,7 +1339,7 @@ Weave supports attribute conventions from the following observability frameworks
 | `gen_ai.prompt`                   | `inputs`                      | AI model prompt or message array.           | List, dict, string          | `[{"role":"user","content":"abc"}]`            |
 | `input.value`                     | `inputs`                      | Input value for model invocation.           | String, list, dict          | `{"text":"Tell a joke"}`                       |
 | `mlflow.spanInputs`               | `inputs`                      | Span input data.                            | String, list, dict          | `["prompt text"]`                              |
-| `gen_ai.input.messages`           | `inputs`                      | Input messages in the OTel GenAI message format. Emitted by Logfire's Pydantic AI instrumentation. | List, dict, string          | `[{"role":"user","parts":[...]}]`             |
+| `gen_ai.input.messages`           | `inputs`                      | Input messages emitted by Logfire.          | List, dict, string          | `[{"role":"user","parts":[...]}]`             |
 | `pydantic_ai.all_messages`        | `inputs`                      | All messages from a Pydantic AI agent run.  | List                        | `[{"role":"user","content":"abc"}]`           |
 | `traceloop.entity.input`          | `inputs`                      | Entity input data.                          | String, list, dict          | `"Translate this to French"`                   |
 | `gcp.vertex.agent.tool_call_args` | `inputs`                      | Tool call arguments.                        | Dict                        | `{"args":{"query":"weather in SF"}}`           |
@@ -1349,7 +1349,7 @@ Weave supports attribute conventions from the following observability frameworks
 | `ai.response`                     | `outputs`                     | Model response text or data.                | String, list, dict          | `"Here is a haiku..."`                         |
 | `gen_ai.completion`               | `outputs`                     | AI completion result.                       | String, list, dict          | `"Completion text"`                            |
 | `output.value`                    | `outputs`                     | Output value from model.                    | String, list, dict          | `{"text":"Answer text"}`                       |
-| `gen_ai.output.messages`          | `outputs`                     | Output messages in the OTel GenAI message format. Emitted by Logfire's Pydantic AI instrumentation. | List, dict, string          | `[{"role":"assistant","parts":[...]}]`        |
+| `gen_ai.output.messages`          | `outputs`                     | Output messages emitted by Logfire.         | List, dict, string          | `[{"role":"assistant","parts":[...]}]`        |
 | `mlflow.spanOutputs`              | `outputs`                     | Span output data.                           | String, list, dict          | `["answer"]`                                   |
 | `final_result`                    | `outputs`                     | Final output of a Pydantic AI agent run.    | String, dict                | `"Answer text"`                                |
 | `gen_ai.content.completion`       | `outputs`                     | Content completion result.                  | String                      | `"Answer text"`                                |


### PR DESCRIPTION
## Description

Documents the OTel attribute mappings added in [wandb/weave#5866](https://github.com/wandb/weave/pull/5866) (merged Dec 19, 2025). Weave's OTel ingestion parses inputs and outputs from Logfire's Pydantic AI instrumentation, so spans render with structured inputs/outputs in the trace view instead of raw attributes.

Updates the **Attribute mappings** section of `weave/guides/tracking/otel.mdx`:

- **Supported frameworks** list: adds a Logfire / Pydantic AI entry, and notes the current OTel GenAI message-format attributes (`gen_ai.input.messages`, `gen_ai.output.messages`) under the OpenTelemetry GenAI entry
- **Attribute reference** table: adds five rows — `gen_ai.input.messages` and `pydantic_ai.all_messages` (inputs), `gen_ai.output.messages` and `final_result` (outputs), and `gen_ai.system_instructions` (system attribute)

Row placement mirrors the server's priority order in `weave/trace_server/opentelemetry/constants.py`, verified against the current SDK source.

Resolves DOCS-2513 (related earlier ticket: DOCS-1964, referenced in the source PR).

## Testing

- Table renders correctly in Markdown; attribute names and mappings verified against `constants.py` on current `wandb/weave` master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)