### PR TITLE
Weave cookbook: unify Registry terminology (DOCS-2595)

### DIFF
--- a/weave/cookbooks/Models_and_Weave_Integration_Demo.mdx
+++ b/weave/cookbooks/Models_and_Weave_Integration_Demo.mdx
@@ -4,7 +4,7 @@ description: "Interactive notebook that walks through tracking experiments in W&
 keywords: [RAG, fine-tuning, Registry, Llama, unsloth]
 ---
 
-This notebook walks through an end-to-end workflow that combines W&B Models and Weave to build, evaluate, and publish a Retrieval-Augmented Generation (RAG) application. You retrieve a fine-tuned chat model from the W&B Models Registry, swap it into an existing `RagModel` tracked in Weave, evaluate the updated application with `weave.Evaluation`, and publish the new RAG model back to the Registry. This workflow is intended for teams who train and fine-tune models with W&B Models and want to integrate them into LLM applications tracked and evaluated with Weave.
+This notebook walks through an end-to-end workflow that combines W&B Models and Weave to build, evaluate, and publish a Retrieval-Augmented Generation (RAG) application. You retrieve a fine-tuned chat model from W&B Registry, swap it into an existing `RagModel` tracked in Weave, evaluate the updated application with `weave.Evaluation`, and publish the new RAG model back to the Registry. This workflow is intended for teams who train and fine-tune models with W&B Models and want to integrate them into LLM applications tracked and evaluated with Weave.
 
 <Note>
 This is an interactive notebook. You can run it locally or use the following links:
@@ -60,9 +60,9 @@ ENTITY = "wandb-smle"
 weave.init(ENTITY + "/" + PROJECT)
 ```
 
-## Download `ChatModel` from Models Registry and implement `UnslothLoRAChatModel`
+## Download `ChatModel` from W&B Registry and implement `UnslothLoRAChatModel`
 
-In this scenario, the Model Team has already fine-tuned the Llama-3.2 model with the `unsloth` library for performance optimization, and the model is available in the W&B Models Registry. In this step, you retrieve the fine-tuned [`ChatModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26) from the Registry and convert it into a `weave.Model` to make it compatible with the [`RagModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2FcqRaGKcxutBWXyM0fCGTR1Yk2mISLsNari4wlGTwERo%3F%26).
+In this scenario, the Model Team has already fine-tuned the Llama-3.2 model with the `unsloth` library for performance optimization, and the model is available in the W&B Registry. In this step, you retrieve the fine-tuned [`ChatModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26) from the Registry and convert it into a `weave.Model` to make it compatible with the [`RagModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2FcqRaGKcxutBWXyM0fCGTR1Yk2mISLsNari4wlGTwERo%3F%26).
 
 <Note>
 The `RagModel` referenced in the following code is a top-level `weave.Model` that can be considered a complete RAG Application. It contains a `ChatModel`, vector database, and a prompt. The `ChatModel` is also a `weave.Model`, which contains code to download an artifact from the W&B Registry. `ChatModel` can be changed modularly to support any kind of other LLM chat model as part of the `RagModel`. For more information, [view the model in Weave](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/evaluations?peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2Fx7MzcgHDrGXYHHDQ9BA8N89qDwcGkdSdpxH30ubm8ZM%3F%26).
@@ -70,7 +70,7 @@ The `RagModel` referenced in the following code is a top-level `weave.Model` tha
 
 To load the `ChatModel`, use `unsloth.FastLanguageModel` or `peft.AutoPeftModelForCausalLM` with adapters for efficient integration into the app. After you download the model from the Registry, set up the initialization and prediction logic with the `model_post_init` method. The required code for this step is available in the **Use** tab of the Registry, and you can copy it directly into your implementation.
 
-The following code defines the `UnslothLoRAChatModel` class to manage, initialize, and use the fine-tuned Llama-3.2 model retrieved from the W&B Models Registry. `UnslothLoRAChatModel` uses `unsloth.FastLanguageModel` for optimized inference. The `model_post_init` method downloads and sets up the model, while the `predict` method processes user queries and generates responses. To adapt the code for your use case, update the `MODEL_REG_URL` with the correct Registry path for your fine-tuned model, and adjust parameters like `max_seq_length` or `dtype` based on your hardware or requirements.
+The following code defines the `UnslothLoRAChatModel` class to manage, initialize, and use the fine-tuned Llama-3.2 model retrieved from the W&B Registry. `UnslothLoRAChatModel` uses `unsloth.FastLanguageModel` for optimized inference. The `model_post_init` method downloads and sets up the model, while the `predict` method processes user queries and generates responses. To adapt the code for your use case, update the `MODEL_REG_URL` with the correct registry path for your fine-tuned model, and adjust parameters like `max_seq_length` or `dtype` based on your hardware or requirements.
 
 ```python lines
 from typing import Any
@@ -218,13 +218,13 @@ wandb.run.finish()
 
 ## Save the new RAG model to the Registry
 
-Now that you've evaluated the updated `RagModel`, the final step is to publish it back to the W&B Models Registry so other teams can discover and reuse it. To make the updated `RagModel` available for future use by both the Models and Apps teams, push it to the W&B Models Registry as a reference artifact.
+Now that you've evaluated the updated `RagModel`, the final step is to publish it back to the W&B Registry so other teams can discover and reuse it. To make the updated `RagModel` available for future use by both the Models and Apps teams, push it to the W&B Registry as a reference artifact.
 
 The following code retrieves the `weave` object version and name for the updated `RagModel` and uses them to create reference links. The code then creates a new artifact in W&B with metadata containing the model's Weave URL. The code logs this artifact to the W&B Registry and links it to a designated registry path.
 
 Before running the code, ensure the `ENTITY` and `PROJECT` variables match your W&B setup, and specify the correct target registry path. This process finalizes the workflow by publishing the new `RagModel` to the W&B ecosystem for collaboration and reuse.
 
-After running the code in this section, your updated `RagModel` is available in the W&B Models Registry as a referenced artifact, completing the round-trip between W&B Models and Weave.
+After running the code in this section, your updated `RagModel` is available in the W&B Registry as a referenced artifact, completing the round-trip between W&B Models and Weave.
 
 ```python lines
 MODELS_OBJECT_VERSION = PUB_REFERENCE.digest  # weave object version

--- a/weave/cookbooks/source/Models_and_Weave_Integration_Demo.ipynb
+++ b/weave/cookbooks/source/Models_and_Weave_Integration_Demo.ipynb
@@ -19,11 +19,11 @@
    "source": [
     "# Use Weave with W&B Models\n",
     "\n",
-    "This notebook demonstrates how to use W&B Weave with [W&B Models](https://docs.wandb.ai/guides/) using the scenario of two different teams working on an end-to-end implementation of a Retrieval-Augmented Generation (RAG) application, from fine-tuning the model to building an app around the model. Specifically, the Model Team fine-tunes a new Chat Model (Llama 3.2),and saves it to the [W&B Models Registry](https://docs.wandb.ai/guides/registry/). Then, the App Team retrieves the fine-tuned Chat Model from the Registry, and uses Weave to create and evaluate a RAG chatbot application\n",
+    "This notebook demonstrates how to use W&B Weave with [W&B Models](https://docs.wandb.ai/guides/) using the scenario of two different teams working on an end-to-end implementation of a Retrieval-Augmented Generation (RAG) application, from fine-tuning the model to building an app around the model. Specifically, the Model Team fine-tunes a new Chat Model (Llama 3.2),and saves it to the [W&B Registry](https://docs.wandb.ai/guides/registry/). Then, the App Team retrieves the fine-tuned Chat Model from the Registry, and uses Weave to create and evaluate a RAG chatbot application\n",
     "\n",
     "The guide walks you through the following steps, which are the same steps that the teams in the described scenario would follow:\n",
     "\n",
-    "1. Downloading a fine-tuned Llama 3.2 model registered in [W&B Models Registry](https://docs.wandb.ai/guides/registry/)\n",
+    "1. Downloading a fine-tuned Llama 3.2 model registered in [W&B Registry](https://docs.wandb.ai/guides/registry/)\n",
     "2. Implementing a RAG application using the fine-tuned Llama 3.2 model \n",
     "3. Tracking and evaluating the RAG application using Weave\n",
     "4. Registering the improved RAG app to Registry\n",
@@ -145,9 +145,9 @@
     "id": "SVbGavX9RHbk"
    },
    "source": [
-    "##  Download `ChatModel` from Models Registry and implement `UnslothLoRAChatModel`\n",
+    "##  Download `ChatModel` from W&B Registry and implement `UnslothLoRAChatModel`\n",
     "\n",
-    "In our scenario, the Llama-3.2 model has already been fine-tuned by the Model Team using the `unsloth` library for performance optimization, and is [available in the W&B Models Registry](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26). In this step, we'll retrieve the fine-tuned [`ChatModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26) from the Registry and convert it into a `weave.Model` to make it compatible with the [`RagModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2FcqRaGKcxutBWXyM0fCGTR1Yk2mISLsNari4wlGTwERo%3F%26). \n",
+    "In our scenario, the Llama-3.2 model has already been fine-tuned by the Model Team using the `unsloth` library for performance optimization, and is [available in the W&B Registry](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26). In this step, we'll retrieve the fine-tuned [`ChatModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-rag-experiments%2Fobjects%2FChatModelRag%2Fversions%2F2mhdPb667uoFlXStXtZ0MuYoxPaiAXj3KyLS1kYRi84%3F%26) from the Registry and convert it into a `weave.Model` to make it compatible with the [`RagModel`](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/object-versions?filter=%7B%22objectName%22%3A%22RagModel%22%7D&peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2FcqRaGKcxutBWXyM0fCGTR1Yk2mISLsNari4wlGTwERo%3F%26). \n",
     "\n",
     ":::important\n",
     "The `RagModel` referenced below is a top-level `weave.Model` that can be considered a complete RAG Application. It contains a `ChatModel`, vector database, and a prompt. The `ChatModel` is also a `weave.Model`, which contains code to download an artifact from the W&B Registry. `ChatModel` can be changed modularly to support any kind of other LLM chat model as part of the `RagModel`. For more information, [view the model in Weave](https://wandb.ai/wandb-smle/weave-cookboook-demo/weave/evaluations?peekPath=%2Fwandb-smle%2Fweave-cookboook-demo%2Fobjects%2FRagModel%2Fversions%2Fx7MzcgHDrGXYHHDQ9BA8N89qDwcGkdSdpxH30ubm8ZM%3F%26).\n",
@@ -160,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The code below defines the `UnslothLoRAChatModel` class to manage, initialize, and use the fine-tuned Llama-3.2 model retrieved from the W&B Models Registry. `UnslothLoRAChatModel` uses `unsloth.FastLanguageModel` for optimized inference. The `model_post_init` method handles downloading and setting up the model, while the `predict` method processes user queries and generates responses. To adapt the code for your use case, update the `MODEL_REG_URL` with the correct Registry path for your fine-tuned model and adjust parameters like `max_seq_length` or `dtype` based on your hardware or requirements.\n"
+    "The code below defines the `UnslothLoRAChatModel` class to manage, initialize, and use the fine-tuned Llama-3.2 model retrieved from the W&B Registry. `UnslothLoRAChatModel` uses `unsloth.FastLanguageModel` for optimized inference. The `model_post_init` method handles downloading and setting up the model, while the `predict` method processes user queries and generates responses. To adapt the code for your use case, update the `MODEL_REG_URL` with the correct registry path for your fine-tuned model and adjust parameters like `max_seq_length` or `dtype` based on your hardware or requirements.\n"
    ]
   },
   {
@@ -1012,7 +1012,7 @@
    "source": [
     "## Save the new RAG Model to the Registry\n",
     "\n",
-    "To make the updated `RagModel` available for future use by both the Models and Apps teams, we push it to the W&B Models Registry as a reference artifact.\n",
+    "To make the updated `RagModel` available for future use by both the Models and Apps teams, we push it to the W&B Registry as a reference artifact.\n",
     "\n",
     "The code below retrieves the `weave` object version and name for the updated `RagModel` and uses them to create reference links. A new artifact is then created in W&B with metadata containing the model's Weave URL. This artifact is logged to the W&B Registry and linked to a designated registry path.\n",
     "\n",


### PR DESCRIPTION
## Summary

Resolves **[DOCS-2595](https://coreweave.atlassian.net/browse/DOCS-2595)** — the "Use Weave with W&B Models" cookbook referred to the registry product four different ways on a single page, which read as if a distinct "Models Registry" product existed:

- "Models Registry"
- "W&B Models Registry"
- "W&B Registry"
- "Registry"

Per the ticket, these all refer to the current **W&B Registry** product (not the deprecated *Model Registry*). This PR standardizes the terminology:

- **W&B Registry** — the product proper noun (first mention / section headings)
- **Registry** — short back-reference to the product
- **registry** (lowercase) — generic nouns like "registry path" / "registry link" and code paths
- **W&B Models** — preserved where it names the Models product (unchanged)

No deprecated "Model Registry" references were present — this was purely internal inconsistency, as the reporter suspected.

## Files changed

- `weave/cookbooks/Models_and_Weave_Integration_Demo.mdx` (published page)
- `weave/cookbooks/source/Models_and_Weave_Integration_Demo.ipynb` (source notebook that the "Open in Colab" / "View source" links point to)

Both were updated so the published page and the linked notebook stay in sync. Notebook diff is content-only (6 lines).

## Note on upstream drift

I could not locate a canonical upstream copy of this notebook in local `~/examples` (wandb/examples) or `~/weave` (wandb/weave) checkouts — both appear outdated. If a canonical copy lives upstream and syncs into this repo, it should get the same treatment to avoid re-introducing the inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2595]: https://coreweave.atlassian.net/browse/DOCS-2595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ