### PR TITLE
fix run log code snippet

### DIFF
--- a/weave/cookbooks/source/Models_and_Weave_Integration_Demo.ipynb
+++ b/weave/cookbooks/source/Models_and_Weave_Integration_Demo.ipynb
@@ -1,6 +1,6 @@
 {
  "cells": [
-{
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n"
    ]
-  },  
+  },
   {
    "cell_type": "markdown",
    "metadata": {
@@ -997,11 +997,11 @@
    ],
    "source": [
     "# log to models\n",
-    "wandb.run.log(pd.json_normalize(summary, sep=\"/\").to_dict(orient=\"records\")[0])\n",
-    "wandb.run.config.update(\n",
-    "    {\"weave_url\": f\"https://wandb.ai/wandb-smle/weave-cookboook-demo/r/call/{call.id}\"}\n",
-    ")\n",
-    "wandb.run.finish()"
+    "with wandb.init(project=PROJECT, job_type=\"model_eval\") as run:\n",
+    "    run.log(pd.json_normalize(summary, sep=\"/\").to_dict(orient=\"records\")[0])\n",
+    "    run.config.update(\n",
+    "        {\"weave_url\": f\"https://wandb.ai/wandb-smle/weave-cookboook-demo/r/call/{call.id}\"}\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
## Description

Realized that the demo logs to W&B using bad practice. Fixed.

Also, not sure how the .ipynb -> mdx works, but there is a weird artifact in the code snippets. Specifically, there are a few floating "python" text.

See the line above `MODEL_REG_URL`

<img width="769" height="1064" alt="Screenshot 2026-07-21 at 12 37 57 PM" src="https://github.com/user-attachments/assets/5b0db3c6-8b6e-4684-8efb-b0af685f41b4" />


## Related issues

- Fixes DOCS-12345
- Fixes #12345
-->
