### PR TITLE
ci: fix Mintlify validation change detection (DOCS-2894)

### DIFF
--- a/.github/workflows/validate-mdx.yml
+++ b/.github/workflows/validate-mdx.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: validate-mdx-${{ github.ref }}
   cancel-in-progress: true
@@ -25,6 +28,8 @@ jobs:
       - name: Determine if Mintlify validation is needed
         id: scope
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
             echo "Runs full validation for push/workflow_dispatch (not a PR diff)."
@@ -34,9 +39,11 @@ jobs:
           head="${{ github.event.pull_request.head.sha }}"
           # Pathspecs do not support regex alternation like *.(mdx|json); filter with grep instead.
           # Includes .json for docs.json / mint.json / OpenAPI specs that affect generated pages.
-          if git diff --name-only "$base" "$head" | grep -Eq '\.(mdx|json|ya?ml|png|jpe?g|webp)$'; then
+          # Disable rename detection so deleting or renaming a relevant file still triggers validation.
+          changed_files=$(git diff --name-only --no-renames "${base}...${head}")
+          if grep -Eq '(\.(mdx|json|ya?ml|png|jpe?g|webp)$|^scripts/mdx-validation/validate-mdx-mintlify\.sh$)' <<< "$changed_files"; then
             echo "needs_validation=true" >> "$GITHUB_OUTPUT"
-            echo "Found changed Mintlify-relevant files (.mdx, config JSON/YAML, OpenAPI JSON, or images); will run Mintlify validation."
+            echo "Found changed Mintlify-relevant files or validation code; will run Mintlify validation."
           else
             echo "needs_validation=false" >> "$GITHUB_OUTPUT"
             echo "No Mintlify-relevant files in this PR diff; skipping Mintlify install and validation."
@@ -45,7 +52,7 @@ jobs:
       - name: No Mintlify-relevant changes — skipping validation
         if: steps.scope.outputs.needs_validation == 'false'
         run: |
-          echo "Check passes: no .mdx, doc JSON/YAML, or image changes in this PR."
+          echo "Check passes: no Mintlify-relevant file or validation code changes in this PR."
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         if: steps.scope.outputs.needs_validation == 'true'
@@ -56,9 +63,12 @@ jobs:
         id: npm-config
         if: steps.scope.outputs.needs_validation == 'true'
         run: |
-          echo "date=$(date +%Y)-$(( $(date +%j) / 4 ))" >> "$GITHUB_OUTPUT"
-          echo "npm_prefix=$(npm config get prefix)" >> "$GITHUB_OUTPUT"
-          echo "npm_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+          {
+            # Force base 10 so a zero-padded day of year such as 008 is not parsed as octal.
+            echo "date=$(date +%Y)-$(( 10#$(date +%j) / 4 ))"
+            echo "npm_prefix=$(npm config get prefix)"
+            echo "npm_cache=$(npm config get cache)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Cache Mintlify CLI
         id: cache-mint

--- a/scripts/mdx-validation/validate-mdx-mintlify.sh
+++ b/scripts/mdx-validation/validate-mdx-mintlify.sh
@@ -1,19 +1,30 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Match .github/workflows/validate-mdx.yml: pages (.mdx), Mintlify config / OpenAPI (.json, .yaml),
-# and common doc assets. OpenAPI and docs.json drive generated MDX at build time.
-MINTLIFY_RELEVANT_EXT_REGEX='\.(mdx|json|ya?ml|png|jpe?g|webp)$'
+# common doc assets, and this validation script. OpenAPI and docs.json drive generated MDX at build time.
+MINTLIFY_RELEVANT_REGEX='(\.(mdx|json|ya?ml|png|jpe?g|webp)$|^scripts/mdx-validation/validate-mdx-mintlify\.sh$)'
+CHECK=${1:-all}
+
+case "$CHECK" in
+  all|validate|broken-links) ;;
+  *)
+    echo "Usage: $0 [all|validate|broken-links]"
+    exit 2
+    ;;
+esac
 
 # In CI pull_request runs, prefer explicit base/head SHAs (reliable; origin/$GITHUB_BASE_REF
 # may not exist after checkout). PR_BASE_SHA / PR_HEAD_SHA are set from the workflow.
 if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
-  echo "Checking for Mintlify-relevant files in PR (${PR_BASE_SHA:0:7}..${PR_HEAD_SHA:0:7})..."
-  CHANGED_RELEVANT=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  echo "Checking for Mintlify-relevant files in PR (${PR_BASE_SHA:0:7}...${PR_HEAD_SHA:0:7})..."
+  CHANGED_FILES=$(git diff --name-only --no-renames "${PR_BASE_SHA}...${PR_HEAD_SHA}")
+  CHANGED_RELEVANT=$(grep -E "$MINTLIFY_RELEVANT_REGEX" <<< "$CHANGED_FILES" || true)
 elif [ -n "${GITHUB_BASE_REF:-}" ]; then
   # Local or legacy CI: compare against remote base ref
   echo "Checking for Mintlify-relevant files in PR..."
-  CHANGED_RELEVANT=$(git diff --name-only "origin/$GITHUB_BASE_REF"...HEAD | grep -E "$MINTLIFY_RELEVANT_EXT_REGEX" || true)
+  CHANGED_FILES=$(git diff --name-only --no-renames "origin/${GITHUB_BASE_REF}...HEAD")
+  CHANGED_RELEVANT=$(grep -E "$MINTLIFY_RELEVANT_REGEX" <<< "$CHANGED_FILES" || true)
 else
   CHANGED_RELEVANT=""
 fi
@@ -28,63 +39,80 @@ if { [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; } || [ -n "${GITHUB
     exit 0
   fi
   echo "Found changed files (Mintlify-relevant):"
-  echo "$CHANGED_RELEVANT" | sed 's/^/  /'
+  while IFS= read -r changed_file; do
+    echo "  $changed_file"
+  done <<< "$CHANGED_RELEVANT"
   echo ""
 fi
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "VALIDATING DOCUMENTATION BUILD"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Running: mint validate"
-echo ""
-
-# Run mint validate - exits with non-zero if there are any errors or warnings
-if mint validate; then
+run_validate() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "VALIDATING DOCUMENTATION BUILD"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Running: mint validate"
   echo ""
+
+  # mint validate exits with non-zero if there are any errors or warnings.
+  if mint validate; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ MINTLIFY VALIDATION PASSED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "No errors or warnings detected"
+  else
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "❌ MINTLIFY VALIDATION FAILED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Errors or warnings were detected. Please fix them or"
+    echo "file an issue if you believe they are incorrect:"
+    echo "https://github.com/wandb/docs/issues/new"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 1
+  fi
+}
+
+run_broken_links() {
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "✅ MINTLIFY VALIDATION PASSED"
+  echo "CHECKING FOR BROKEN LINKS"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "No errors or warnings detected"
-else
+  echo "Running: mint broken-links"
   echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "❌ MINTLIFY VALIDATION FAILED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "Errors or warnings were detected. Please fix them or"
-  echo "file an issue if you believe they are incorrect:"
-  echo "https://github.com/wandb/docs/issues/new"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  exit 1
-fi
 
-echo ""
+  # mint broken-links exits with non-zero if broken links are found.
+  if mint broken-links; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ NO BROKEN LINKS FOUND"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  else
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "❌ BROKEN LINKS DETECTED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Please fix the broken links reported above"
+    exit 1
+  fi
+}
 
-# Run broken links check
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "CHECKING FOR BROKEN LINKS"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Running: mint broken-links"
-echo ""
+case "$CHECK" in
+  validate)
+    run_validate
+    ;;
+  broken-links)
+    run_broken_links
+    ;;
+  all)
+    run_validate
+    echo ""
+    run_broken_links
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "✅ ALL VALIDATION CHECKS PASSED"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "- No validation errors or warnings"
+    echo "- No broken links"
+    ;;
+esac
 
-# Run mint broken-links - it will exit with non-zero if broken links are found
-if mint broken-links; then
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "✅ NO BROKEN LINKS FOUND"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-else
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "❌ BROKEN LINKS DETECTED"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "Please fix the broken links reported above"
-  exit 1
-fi
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "✅ ALL VALIDATION CHECKS PASSED"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "- No validation errors or warnings"
-echo "- No broken links"
 exit 0


### PR DESCRIPTION
**This PR fixes change detection for the Mintlify validation check.** A stale branch no longer triggers a validation run that it does not need. A rename that removes a relevant file no longer skips validation. It ports the fix from #2910 (closed) without the matrix runner split, and is tracked as DOCS-2894.

## Why

The check on `main` has two correctness bugs:

1. The two-dot `git diff $base $head` compares branch tips, so a stale branch picks up unrelated upstream changes. PR #2908 changed only `kapa-widget.js`, but the comparison included 37 upstream MDX changes because the branch was behind `main`. That forced a full validation run the PR did not need.
2. When rename detection is active, Git reports a renamed file only under its new path. A rename from `.mdx` to an irrelevant name therefore removes a page without triggering validation. With `--no-renames`, Git reports the rename as a delete plus an add, and the deleted path triggers validation.

## What changed

- Use a merge-base-aware `base...head` diff with `--no-renames` for change detection, in both the workflow scope check and the validation script.
- Fail closed: when Git cannot compute the diff, the check fails instead of deciding that nothing changed.
- Treat the validation script itself as Mintlify-relevant, so a change to the script re-runs validation. Workflow file changes already match through the `.ya?ml` extension.
- Refactor the validation script into `run_validate` and `run_broken_links` functions with a `validate | broken-links | all` argument. Behavior without an argument is unchanged: CI still runs both checks in one job.
- Force base-10 day-of-year arithmetic in the Mintlify CLI cache key, so the shell does not parse a zero-padded day such as `008` as octal.
- Restrict the workflow token to `contents: read`.

## Relationship to #2910

This PR extracts the change-detection fix from #2910 (closed) and leaves out the matrix runner split. The sister repository applied the same approach in coreweave/docs#3374. The file `scripts/mdx-validation/validate-mdx-mintlify.sh` is byte-identical to the version on #2910's head commit (`b5d9048`). Keeping the file byte-identical preserves the review and testing already done on that branch. The matrix runner split remains a separate decision that the team can revisit later. This PR covers only the correctness fix.

## Validation

- `bash -n` and `shellcheck -S warning` pass on the validation script.
- `actionlint`, with its shellcheck integration, passes on the workflow.
- The workflow YAML parses, and `git diff --check` reports no whitespace problems.
- A local git-fixture suite of 11 checks reproduces both bugs against the old logic and verifies the new logic:
  - A stale branch that changes only a JavaScript file: the old two-dot diff reports a false positive on upstream MDX changes, and the new three-dot diff skips validation.
  - A rename from `.mdx` to an irrelevant name: rename detection misses it, and `--no-renames` catches the deleted path.
  - Deleting an `.mdx` file triggers validation.
  - A change to only the validation script: the old regex misses it, and the new regex catches it.
  - A PR that changes only `README.md` still skips validation.
  - An invalid SHA fails closed: the check fails instead of skipping.
  - An invalid dispatch argument exits with code 2 and a usage message.
  - The scope-skip path exits with code 0 and does not run the Mintlify CLI.
- This PR changes a `.yml` file and the validation script. The updated workflow therefore runs `mint validate` and `mint broken-links` end to end on this PR.
