### PR TITLE
Stop sticky language tabs from overriding non-language tab choices

### DIFF
--- a/code-group-language-persist.js
+++ b/code-group-language-persist.js
@@ -22,10 +22,18 @@
  *   LANGUAGES — only Python/TypeScript). The whitelist stops both descriptive
  *   tabs ("Web App", "Summary metrics") and incidental code tabs ("Bash",
  *   "cURL") from clobbering the saved language.
- * - Restore: on load, after hydration, and on SPA route changes (a
- *   MutationObserver), any tab whose label matches the saved language (compared
- *   case-insensitively) is selected. Tabs already active are skipped, so this
- *   coexists with Mintlify's own <CodeGroup> restore without fighting it.
+ * - Restore: on load, after hydration, and on SPA route changes (detected by
+ *   a MutationObserver watching location.pathname), any tab whose label
+ *   matches the saved language (compared case-insensitively) is selected.
+ *   Tabs already active are skipped, so this coexists with Mintlify's own
+ *   <CodeGroup> restore without fighting it.
+ * - Yield: when the reader manually picks a non-language tab ("HTTP API",
+ *   "Command Line", …), its group is marked overridden and restore leaves it
+ *   alone for the rest of that page view. Restore also only re-runs when the
+ *   pathname actually changes, never on arbitrary DOM mutations — otherwise
+ *   the mutation caused by the reader's own tab switch would re-trigger a
+ *   restore that instantly snaps mixed groups (e.g. Python / TypeScript /
+ *   HTTP API) back to the saved language, making other tabs unselectable.
  *
  * Selection uses a real pointer sequence, not element.click(): Mintlify's tabs
  * activate on pointer/mouse-down, and a synthetic click() does not switch them.
@@ -59,6 +67,14 @@
   var LANGUAGES = {
     python: 1, typescript: 1
   };
+
+  /**
+   * Tab groups the reader has manually steered to a non-language tab, which
+   * restore() must then leave alone. Keyed by the group's DOM node, so entries
+   * evaporate naturally when a client-side route change replaces the page
+   * content (and with it, the nodes).
+   */
+  var overridden = typeof WeakSet === 'function' ? new WeakSet() : null;
 
   /** Read the saved language, tolerant of disabled/throwing localStorage. */
   function read() {
@@ -100,6 +116,16 @@
   }
 
   /**
+   * The tab group a tab belongs to — its ARIA tablist, or failing that its
+   * parent element. Used to scope manual-override tracking per group.
+   * @param {Element} tab
+   * @returns {Element|null}
+   */
+  function groupOf(tab) {
+    return tab.closest('[role="tablist"]') || tab.parentElement;
+  }
+
+  /**
    * Selects a tab the way a real click does. Mintlify's tabs activate on
    * pointer/mouse-down, not on a synthetic element.click(), so dispatch a full
    * pointer sequence.
@@ -116,19 +142,32 @@
 
   /**
    * Capture-phase selection handler. Records the chosen tab's label when it
-   * names a language, so the choice survives navigation. Bound to pointerdown
-   * (when tabs actually select) and click (covers keyboard activation).
+   * names a language, so the choice survives navigation; when it names
+   * anything else ("HTTP API", "Command Line", …), marks the group as
+   * reader-overridden so restore() stops re-asserting the saved language in
+   * it. Bound to pointerdown (when tabs actually select) and click (covers
+   * keyboard activation). Only trusted events count — the synthetic clicks
+   * restore() dispatches must not register as reader choices.
    * @param {Event} e
    */
   function onSelect(e) {
+    if (!e.isTrusted) return;
     var tab = e.target && e.target.closest ? e.target.closest('[role="tab"]') : null;
     if (!tab) return;
     var label = labelOf(tab);
-    if (label && isLanguage(label)) write(label);
+    if (!label) return;
+    var group = overridden && groupOf(tab);
+    if (isLanguage(label)) {
+      write(label);
+      if (group) overridden.delete(group);
+    } else if (group) {
+      overridden.add(group);
+    }
   }
 
   /**
-   * Selects the saved language in every group that isn't already on it.
+   * Selects the saved language in every group that isn't already on it,
+   * except groups the reader has manually overridden this page view.
    * Self-terminating: tabs already active are skipped, so the synthetic clicks
    * we trigger here do not cause an observe/click feedback loop, and we never
    * fight Mintlify's own already-applied <CodeGroup> selection.
@@ -140,9 +179,12 @@
     var tabs = document.querySelectorAll('[role="tab"]');
     for (var i = 0; i < tabs.length; i++) {
       var tab = tabs[i];
-      if (labelOf(tab).toLowerCase() === want && !isActive(tab)) {
-        activate(tab);
+      if (labelOf(tab).toLowerCase() !== want || isActive(tab)) continue;
+      if (overridden) {
+        var group = groupOf(tab);
+        if (group && overridden.has(group)) continue;
       }
+      activate(tab);
     }
   }
 
@@ -154,18 +196,38 @@
     setTimeout(function () { pending = false; restore(); }, 80);
   }
 
+  /** Restore now-ish, then again while late-hydrating content settles. */
+  function restoreSoon() {
+    schedule();
+    [300, 800, 1500].forEach(function (ms) { setTimeout(restore, ms); });
+  }
+
+  /**
+   * Mutation handler: re-applies the saved language only when the mutation
+   * burst accompanies an actual client-side navigation (the pathname
+   * changed). Restoring on every mutation would treat the reader's own tab
+   * switch — itself a DOM mutation — as a cue to snap the group back to the
+   * saved language.
+   */
+  var lastPathname = location.pathname;
+  function onMutate() {
+    if (location.pathname === lastPathname) return;
+    lastPathname = location.pathname;
+    restoreSoon();
+  }
+
   function start() {
     // Capture phase so we observe the selection around Mintlify's own handling.
     document.addEventListener('pointerdown', onSelect, true);
     document.addEventListener('click', onSelect, true);
 
+    // Initial load: restore immediately, then catch tabs that hydrate later.
     restore();
-    // Catch tabs that hydrate after first paint.
-    [300, 800, 1500].forEach(function (ms) { setTimeout(restore, ms); });
+    restoreSoon();
 
-    // Re-apply whenever new content renders (client-side route changes).
+    // Re-apply on client-side route changes.
     if (document.body) {
-      new MutationObserver(schedule).observe(document.body, {
+      new MutationObserver(onMutate).observe(document.body, {
         childList: true,
         subtree: true
       });


### PR DESCRIPTION
## Problem

#2759 added cross-page persistence for the Python/TypeScript tab choice. But `restore()` re-ran after **every DOM mutation** (via a `MutationObserver` meant to catch SPA route changes). Switching a tab is itself a DOM mutation, so on any page whose tab group mixes a saved language with other labels — e.g. Python / TypeScript / **HTTP API** on `/weave/guides/tracking/querying-calls`, or **Command Line** / Python / **Python notebook** on `/models/quickstart` — clicking a non-language tab triggered a restore ~80ms later that snapped the group right back to the saved language. Those tabs were effectively unselectable.

## Fix

Two complementary changes to `code-group-language-persist.js`:

1. **Manual overrides win.** A trusted click on a non-language tab marks its group as reader-overridden, and `restore()` skips overridden groups for the rest of that page view. Overrides live in a `WeakSet` keyed by the group's DOM node, so they clear naturally when navigation replaces the page content. Clicking a language tab in an overridden group un-marks it. Synthetic clicks dispatched by `restore()` itself are ignored (`isTrusted` check), so they can never register as reader choices.
2. **Restore on navigation, not on every mutation.** The `MutationObserver` now re-applies the saved language only when `location.pathname` actually changed, with the same hydration retry ladder as initial load.

## Verification (local `mint dev`)

- On `/weave/guides/tracking/querying-calls` (Python / TypeScript / HTTP API): picked TypeScript (preference saved), then clicked **HTTP API** — it stayed selected 2s later, well past all restore timers. Previously it reverted within ~80ms.
- The second tab group on the same page kept the TypeScript preference — overrides are scoped per group.
- SPA-navigated to `/weave/quickstart` — the saved TypeScript preference was auto-restored there (Python is the default first tab).
- No console errors from the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)