### PR TITLE
docs(weave): add Neon AI Gateway tracing guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -595,6 +595,7 @@
                                   "weave/guides/integrations/litellm",
                                   "weave/guides/integrations/azure",
                                   "weave/guides/integrations/mistral",
+                                  "weave/guides/integrations/neon",
                                   "weave/guides/integrations/nvidia_nim",
                                   "weave/guides/integrations/openai",
                                   "weave/guides/integrations/openrouter",

--- a/weave/guides/integrations/neon.mdx
+++ b/weave/guides/integrations/neon.mdx
@@ -1,0 +1,90 @@
+---
+title: "Neon AI Gateway"
+description: "Trace calls to Neon AI Gateway, the OpenAI-compatible inference endpoint provided by Neon"
+keywords: ["Neon", "Neon AI Gateway", "OpenAI SDK compatibility", "branch-scoped credentials"]
+---
+
+This guide shows you how to use Weave to automatically trace calls to models served by Neon AI Gateway, so you can monitor, debug, and evaluate model usage from a single dashboard.
+
+[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference endpoint provided by Neon. A single Neon credential reaches models from OpenAI, Google, Meta, Databricks, and Alibaba, with no provider API keys. Weave detects the OpenAI SDK, so existing OpenAI code works after changing the API key and base URL.
+
+<Note>
+Neon AI Gateway is in beta. It requires a paid Neon plan and a project in the AWS US East (Ohio) region (`aws-us-east-2`).
+</Note>
+
+## Prerequisites
+
+Unlike most providers, Neon does not have one shared hostname. Each database branch gets its own gateway host, so you need two values:
+
+- **A credential** with the `ai_gateway:invoke` scope. Create it in the Neon Console under **Credentials**, or through the Neon API. See [AI Gateway authentication](https://neon.com/docs/ai-gateway/authentication).
+- **The branch host**, shown in the Neon Console as `NEON_AI_GATEWAY_BASE_URL`. It is a per-branch
+  URL of the form `https://<your-neon-branch-host>`.
+
+Running `neon env pull --file .env` writes both as `NEON_AI_GATEWAY_TOKEN` and `NEON_AI_GATEWAY_BASE_URL`.
+
+## Trace a Neon AI Gateway call
+
+Set `api_key` to your Neon credential, set `base_url` to the branch host plus `/v1`, and use a short Neon model ID such as `gpt-5-mini`. When you call `weave.init()`, provide a project name for your traces. If you don't specify one, Weave uses your default entity. To find or update your default entity, refer to [User Settings](https://docs.wandb.ai/platform/app/settings-page/user-settings/#default-team) in the W&B Models documentation.
+
+```python lines {5,10-13}
+import os
+import openai
+import weave
+
+weave.init('neon-weave')
+
+system_content = "You are a travel agent. Be descriptive and helpful."
+user_content = "Tell me about San Francisco"
+
+client = openai.OpenAI(
+    api_key=os.environ.get("NEON_AI_GATEWAY_TOKEN"),
+    base_url=f"{os.environ.get('NEON_AI_GATEWAY_BASE_URL')}/v1",
+)
+chat_completion = client.chat.completions.create(
+    model="gpt-5-mini",
+    messages=[
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ],
+    temperature=0.7,
+    max_tokens=1024,
+)
+response = chat_completion.choices[0].message.content
+print("Model response:\n", response)
+```
+
+Weave captures the call as a trace in your project, including the model ID, messages, and the token counts Neon returns.
+
+## Trace across branches
+
+A Neon credential is valid on the branch it was created on and on every branch descended from it, so a credential created on `main` also works in preview and CI branches forked from it. Only `NEON_AI_GATEWAY_BASE_URL` changes between environments.
+
+Because the branch host lives in the client configuration rather than in the request, traces from different branches look the same in Weave. Pass separate project names to `weave.init()`, or attach the branch as an attribute, if you want to tell them apart:
+
+```python
+with weave.attributes({"neon_branch": "preview/feature-x"}):
+    chat_completion = client.chat.completions.create(
+        model="gpt-5-mini",
+        messages=[{"role": "user", "content": user_content}],
+    )
+```
+
+## Choosing a model
+
+Neon uses short model IDs, for example `gpt-5-mini`, `gemini-3-flash`, `llama-4-maverick`, and `qwen3-next-80b-a3b-instruct`. List what a branch can serve:
+
+```bash
+curl "$NEON_AI_GATEWAY_BASE_URL/v1/models" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN"
+```
+
+Context windows and prices are in the [Neon model catalog](https://neon.com/docs/ai-gateway/models), also published as the [`neon` provider on Models.dev](https://models.dev/providers/neon/).
+
+Two constraints affect which model you pick:
+
+- The Codex variants (`gpt-5-3-codex`, `gpt-5-2-codex`, `gpt-5-1-codex-max`, `gpt-5-1-codex-mini`) are served only on Neon's Responses API path, `{NEON_AI_GATEWAY_BASE_URL}/openai/v1`. They return a `400` on chat completions.
+- For Gemini 3.x, `gpt-oss-120b`, and `qwen35-122b-a10b`, `message.content` comes back as an array of content blocks rather than a string.
+
+Neon does not return a cost field and reports `pricing` as `null` in `GET /v1/models`, so traces show token counts without cost. Inference is free during the beta.
+
+While this is a basic example to get started, see the [OpenAI](/weave/guides/integrations/openai#track-your-own-ops) guide for more details on how to integrate Weave with your own functions for more complex use cases.

--- a/weave/guides/integrations/neon.mdx
+++ b/weave/guides/integrations/neon.mdx
@@ -82,7 +82,7 @@ Context windows and prices are in the [Neon model catalog](https://neon.com/docs
 
 Two constraints affect which model you pick:
 
-- The Codex variants (`gpt-5-3-codex`, `gpt-5-2-codex`, `gpt-5-1-codex-max`, `gpt-5-1-codex-mini`) are served only on Neon's Responses API path, `{NEON_AI_GATEWAY_BASE_URL}/openai/v1`. They return a `400` on chat completions.
+- `gpt-5-3-codex` and `gpt-5-5-pro` are served only on Neon's Responses API path, `{NEON_AI_GATEWAY_BASE_URL}/openai/v1`. They return a `400` on chat completions. Every other model in the catalog works on the chat completions path.
 - For Gemini 3.x, `gpt-oss-120b`, and `qwen35-122b-a10b`, `message.content` comes back as an array of content blocks rather than a string.
 
 Neon does not return a cost field and reports `pricing` as `null` in `GET /v1/models`, so traces show token counts without cost. Inference is free during the beta.

--- a/weave/guides/integrations/neon.mdx
+++ b/weave/guides/integrations/neon.mdx
@@ -82,7 +82,7 @@ Context windows and prices are in the [Neon model catalog](https://neon.com/docs
 
 Two constraints affect which model you pick:
 
-- `gpt-5-3-codex` and `gpt-5-5-pro` are served only on Neon's Responses API path, `{NEON_AI_GATEWAY_BASE_URL}/openai/v1`. They return a `400` on chat completions. Every other model in the catalog works on the chat completions path.
+- A few models are served only on Neon's Responses API path, `{NEON_AI_GATEWAY_BASE_URL}/openai/v1`, and return a `400` on chat completions. The Endpoints column in Neon's [model catalog](https://neon.com/docs/ai-gateway/models) marks which ones, and the set changes; at the time of writing it is `gpt-5-3-codex` and `gpt-5-5-pro`. Every model the column lists with `chat/completions` works on the chat completions path.
 - For Gemini 3.x, `gpt-oss-120b`, and `qwen35-122b-a10b`, `message.content` comes back as an array of content blocks rather than a string.
 
 Neon does not return a cost field and reports `pricing` as `null` in `GET /v1/models`, so traces show token counts without cost. Inference is free during the beta.


### PR DESCRIPTION
## Description

Adds a Weave integration guide for [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview), an OpenAI-compatible inference endpoint provided by Neon, plus the matching navigation entry in `docs.json`.

**Why this needs no new Weave code.** Neon AI Gateway is reached with the standard `openai` Python SDK pointed at a different `base_url`, so Weave's existing OpenAI SDK autopatching already traces these calls. The guide only changes `api_key` and `base_url` on an `openai.OpenAI` client. It follows the same shape as the sibling `openrouter.mdx` and `together_ai.mdx` pages, including the closing pointer to the OpenAI guide.

**What is Neon-specific.** Two things do not fit the single-shared-hostname pattern the other OpenAI-compatible pages assume:

- Neon has no one gateway hostname. Each database branch gets its own host, so the page drives everything from the `NEON_AI_GATEWAY_BASE_URL` and `NEON_AI_GATEWAY_TOKEN` environment variables instead of a literal URL, and adds a short "Trace across branches" section on telling branches apart in traces.
- `GET /v1/models` reports `pricing` as `null` and no cost field comes back on a response, so the page states plainly that traces show token counts without cost, rather than letting a reader assume the cost column will populate.

The page also names the two model constraints a reader hits first: the Codex variants are served only on Neon's Responses API path and return `400` on chat completions, and several models return `message.content` as an array of content blocks rather than a string.

Scope is deliberately narrow, chat completions through the OpenAI SDK. The page makes no tool-calling, structured-output, embeddings, image, or audio claim, and it does not claim Weave has a native Neon provider integration.

Files:

- `weave/guides/integrations/neon.mdx` (new, 90 lines)
- `docs.json` (one line, `weave/guides/integrations/neon` inserted between `mistral` and `nvidia_nim`)

The diff is insertion-only: 91 added lines, 0 removed. English only; `fr`, `ja`, and `ko` are left to the repo's `gt.config.json` translation pipeline.

## Testing

- [x] Local build succeeds without errors — `mint validate` reported `success build validation passed`. This is the command `.github/workflows/validate-mdx.yml` runs; I did not separately run `mint dev`.
- [x] Local link check succeeds without errors — `mint broken-links` reported `success no broken links found`.
- [ ] PR tests succeed — opened as a draft so CI can report first.

Also checked locally: `docs.json` parses and the nav entry sits alphabetically between `mistral` and `nvidia_nim`; both Python snippets compile and the `bash` snippet passes `bash -n`; frontmatter parses, code fences are even, and `<Note>` balances; the five external links each return `200`.

**Limitation worth stating up front.** Neon AI Gateway is in beta and needs a paid Neon plan and an `aws-us-east-2` project, and I did not issue live requests against a gateway branch while preparing this PR. The product statements on the page (the beta and region constraints, the credential scope and branch-lineage behaviour, the Responses-only Codex IDs, the array content-block shape, and `pricing: null`) come from Neon's published documentation and the documented `GET /v1/models` response shape, not from a fresh live run. The snippets are syntax-checked, not executed end to end.

**One thing to flag for a maintainer.** The closing sentence links `/weave/guides/integrations/openai#track-your-own-ops`. The page resolves, but that heading anchor does not exist in `openai.mdx`. I kept the sentence verbatim because `openrouter.mdx` and `together_ai.mdx` both use the identical sentence and anchor, so changing it here alone would make this page the odd one out. Happy to fix just this page, or all three, whichever you prefer.
