### PR TITLE
docs: Add access request instructions to Serverless Sandboxes preview banner

### DIFF
--- a/sandboxes.mdx
+++ b/sandboxes.mdx
@@ -4,9 +4,9 @@ description: On-demand, isolated compute environments that you can create, use, 
 mode: wide
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 Serverless Sandboxes gives you on-demand, isolated compute environments that you can create, use, and discard using Python.
 

--- a/sandboxes/create-sandbox.mdx
+++ b/sandboxes/create-sandbox.mdx
@@ -4,9 +4,9 @@ keywords: ["Sandbox.run", "SandboxDefaults", "Session"]
 description: Create W&B Serverless Sandboxes that run code in isolated containers with their own filesystem, network, and process space.
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 Create W&B Serverless Sandboxes to run code in isolated environments. Start a single sandbox, run commands in it, and manage multiple sandboxes with a session. Each sandbox runs in its own container, with its own [file system](/sandboxes/file-access), network, and process space.
 

--- a/sandboxes/file-access.mdx
+++ b/sandboxes/file-access.mdx
@@ -4,9 +4,9 @@ description: Learn how to read, write, and mount files in Serverless Sandboxes.
 keywords: ["Sandbox.write_file", "Sandbox.read_file", "file mount", "upload to sandbox"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 Use file operations to share data between your local environment and a sandbox. You can read files from a sandbox, write files to it, or mount local files and directories into it.
 

--- a/sandboxes/invoke-agent-sandbox-tutorial.mdx
+++ b/sandboxes/invoke-agent-sandbox-tutorial.mdx
@@ -4,9 +4,9 @@ description: "Learn how to invoke an OpenAI agent within a Serverless Sandbox en
 keywords: ["tutorial", "invoke agent in sandbox"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 In this tutorial, you invoke an agent in a W&B Serverless Sandbox. You start a sandbox with the required environment variables, install dependencies, and run a Python script that creates and invokes a simple OpenAI agent. The agent uses tool calls to get weather for a location and return a punny forecast.
 

--- a/sandboxes/lifecycle.mdx
+++ b/sandboxes/lifecycle.mdx
@@ -4,9 +4,9 @@ description: Learn about the lifecycle of a Serverless Sandbox, including its st
 keywords: ["SandboxState", "wait_until_complete", "wait_until_ready", "sandbox timeout", "resource cleanup"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 This page describes the lifecycle of a Serverless Sandbox so that you can choose the right method for waiting on state changes, stopping a sandbox, and structuring code around its lifetime. Understanding the lifecycle helps you avoid race conditions, distinguish startup failures from runtime errors, and clean up resources predictably.
 

--- a/sandboxes/mltrain-in-sandbox-tutorial.mdx
+++ b/sandboxes/mltrain-in-sandbox-tutorial.mdx
@@ -4,9 +4,9 @@ description: "Learn how to train a PyTorch model in a Serverless Sandbox environ
 keywords: ["W&B experiment tracking", "UCI Zoo dataset", "neural network", "isolated ML training", "wandb logging"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 In this tutorial, you train a PyTorch model in a Serverless Sandbox environment. To do this, you start a sandbox with the appropriate environment variables, install the necessary dependencies, and run a Python script. The script trains a neural network on the UCI Zoo dataset.
 

--- a/sandboxes/run-commands.mdx
+++ b/sandboxes/run-commands.mdx
@@ -4,9 +4,9 @@ description: Learn how to run commands in a sandbox environment and read output 
 keywords: ["Sandbox.run", "Sandbox.exec", "Process.result", "SandboxExecutionError", "stdout", "stderr"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 <br></br>
 

--- a/sandboxes/secrets.mdx
+++ b/sandboxes/secrets.mdx
@@ -4,9 +4,9 @@ description: Learn how to manage secrets in Serverless Sandboxes.
 keywords: ["sandbox secrets", "W&B Secrets Manager"]
 ---
 
-<Warning>
-Serverless Sandboxes is in public preview.
-</Warning>
+import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesPreview />
 
 Use the [W&B Secrets Manager](/platform/secrets) with the W&B Python SDK to access sensitive information such as API keys and tokens in a sandbox.
 

--- a/snippets/_includes/sandboxes-public-preview.mdx
+++ b/snippets/_includes/sandboxes-public-preview.mdx
@@ -1,0 +1,3 @@
+<Warning>
+Serverless Sandboxes is in **public preview**. Access is enabled per organization. To request access for your organization, contact [support](mailto:support@wandb.com).
+</Warning>


### PR DESCRIPTION
Serverless Sandboxes access is enabled per organization behind a feature flag, but the preview banner never said so. Readers assumed the service was open to everyone and read the resulting permission error as an outage. This adds the access request instruction and consolidates the banner into a reusable snippet.

Jira: DOCS-2920

## Before / after

The banner was duplicated inline, verbatim, across eight pages:

```mdx
<Warning>
Serverless Sandboxes is in public preview.
</Warning>
```

It now comes from one snippet, `snippets/_includes/sandboxes-public-preview.mdx`:

> Serverless Sandboxes is in **public preview**. Access is enabled per organization. To request access for your organization, contact [support](mailto:support@wandb.com).

Each of the eight pages now imports it, so the next status change is a one-line edit instead of eight.

## Why keep "public preview"

Keeping the label is deliberate. [Release policies](https://docs.wandb.ai/release-notes/release-policies#private-preview-and-opt-in-features) already define public preview as opt-in: "The W&B team must enable a public preview feature before you can use it." The stage label was never wrong. The gap was that the banner never told readers how to opt in.

Wording follows the existing `snippets/_includes/private-preview-feature.mdx` snippet, which uses the same bolded-stage plus `contact [support](mailto:...)` shape for a gated feature.

## Files

- **New**: `snippets/_includes/sandboxes-public-preview.mdx`
- **Updated** (inline banner replaced with an import): `sandboxes.mdx`, `sandboxes/create-sandbox.mdx`, `sandboxes/file-access.mdx`, `sandboxes/lifecycle.mdx`, `sandboxes/run-commands.mdx`, `sandboxes/secrets.mdx`, `sandboxes/invoke-agent-sandbox-tutorial.mdx`, `sandboxes/mltrain-in-sandbox-tutorial.mdx`

The six `sandboxes/ref-link-*.mdx` stubs carry no banner today and are unchanged.

## Verification

- `mint broken-links` — no broken links.
- `mint dev` — preview builds with no parse errors; confirmed the banner renders on all eight pages.

## Out of scope

- **Localized copies.** `fr/`, `ja/`, and `ko/` still carry the old translated banner. AGENTS.md says to avoid editing localized content alongside English and that translation is handled separately, so those are left to the translation process. Flagging so it isn't a surprise.
- **Stale inbound links.** This repo has 64 links to `docs.coreweave.com/products/coreweave-sandbox`, a pre-rename path that only resolves via redirect. Worth its own PR.

## Needs SME verification

- [ ] **Contact address.** The request specified `support@wandb.com`. Note that `snippets/_includes/api-key-security.mdx` uses `support@wandb.ai` for the same purpose, so the repo is inconsistent. Confirm `.com` is correct here.
- [ ] **Credits are a second gate.** The banner implies requesting access is sufficient. In the originating thread, one org was already flagged but still failed for lack of account credits, and credits were added manually. Should the banner mention billing setup too? Left out because the request did not ask for it.
- [ ] **"Access is enabled per organization"** is my paraphrase of the per-org flag. Confirm this is the right level of detail for a public page, and that naming the granularity is acceptable.
- [ ] **Alternate contact path.** `private-preview-feature.mdx` offers "or your AISE" alongside support. Omitted here because the request named only support. Add it if that channel applies.
- [ ] **Reopening timeline.** The thread said only that the team is waiting for a security risk to subside, with no date. The banner promises nothing. Confirm there is no planned GA or reopening message to align with.
- [ ] **Error message intentionally not documented.** The customer-facing string is `sandboxes not enabled for this organization`. Documenting it was considered and deliberately excluded from this PR. Reconsider if support volume warrants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
