### PR TITLE
fix(i18n): point localized service-api links at canonical English pages

### DIFF
--- a/fr/weave/guides/evaluation/evaluation_logger.mdx
+++ b/fr/weave/guides/evaluation/evaluation_logger.mdx
@@ -464,11 +464,11 @@ Envoyez le span au même projet Weave que l’évaluation via le point de termin
 Pour plus d’informations sur le point de terminaison :
 
 * Pour envoyer des spans depuis un pipeline OTel existant, consultez [Envoyer des spans OpenTelemetry vers la vue Agents](/fr/weave/guides/tracking/trace-agents-otel).
-* Pour la spécification du point de terminaison, consultez [Exporter une trace GenAI](/fr/weave/reference/service-api/agents/export-genai-trace).
+* Pour la spécification du point de terminaison, consultez [Exporter une trace GenAI](/weave/reference/service-api/agents/export-genai-trace).
 
 Seuls `weave.eval.run_id` et `weave.eval.predict_and_score_call_id` établissent les liens avec l’évaluation et le résultat. Le digest de ligne, l’ID d’exemple, l’index de trial, la catégorie et le nom de l’évaluation ajoutent du contexte et permettent le filtrage, mais ne créent pas de lien à eux seuls. Utilisez des ID d’appel Weave pour les deux attributs de liaison, et non des ID de trace ou de span OTel.
 
-Vous pouvez obtenir les deux ID à partir de l’[API de requête des résultats d’évaluation](/fr/weave/reference/service-api/eval-results/eval-results-query). Chaque évaluation de la réponse possède un `evaluation_call_id`, et chaque trial possède un `predict_and_score_call_id`.
+Vous pouvez obtenir les deux ID à partir de l’[API de requête des résultats d’évaluation](/weave/reference/service-api/eval-results/eval-results-query). Chaque évaluation de la réponse possède un `evaluation_call_id`, et chaque trial possède un `predict_and_score_call_id`.
 
 Les exemples suivants supposent que `span` est le span OTel de l’opération de l’agent. Remplacez chaque valeur entre crochets par les métadonnées du run d’évaluation et du résultat auxquels appartient le span.
 

--- a/ja/weave/guides/evaluation/evaluation_logger.mdx
+++ b/ja/weave/guides/evaluation/evaluation_logger.mdx
@@ -464,11 +464,11 @@ Python では、トレースする各エージェント Call を `log_prediction
 エンドポイントの詳細については、次を参照してください。
 
 * 既存の OTel パイプラインからスパンを送信する方法については、[OpenTelemetry スパンを Agents ビューに送信する](/ja/weave/guides/tracking/trace-agents-otel)を参照してください。
-* エンドポイントの仕様については、[GenAI トレースをエクスポートする](/ja/weave/reference/service-api/agents/export-genai-trace)を参照してください。
+* エンドポイントの仕様については、[GenAI トレースをエクスポートする](/weave/reference/service-api/agents/export-genai-trace)を参照してください。
 
 評価と結果のリンクを確立するのは、`weave.eval.run_id` と `weave.eval.predict_and_score_call_id` のみです。行ダイジェスト、例 ID、試行インデックス、kind、評価名はコンテキストの追加やフィルタリングに使用できますが、それ自体ではリンクを作成しません。2 つのリンク属性には、OTel のトレース ID やスパン ID ではなく、Weave Call ID を使用してください。
 
-両方の ID は、[評価結果クエリ API](/ja/weave/reference/service-api/eval-results/eval-results-query)から取得できます。レスポンスの各評価には `evaluation_call_id` があり、各試行には `predict_and_score_call_id` があります。
+両方の ID は、[評価結果クエリ API](/weave/reference/service-api/eval-results/eval-results-query)から取得できます。レスポンスの各評価には `evaluation_call_id` があり、各試行には `predict_and_score_call_id` があります。
 
 次の例では、`span` がエージェント操作の OTel スパンであることを前提としています。各角括弧内の値を、スパンが属する評価 run と結果のメタデータに置き換えてください。
 

--- a/ko/weave/guides/evaluation/evaluation_logger.mdx
+++ b/ko/weave/guides/evaluation/evaluation_logger.mdx
@@ -462,11 +462,11 @@ Python에서는 트레이싱되는 각 에이전트 호출을 `log_prediction()`
 엔드포인트에 대한 자세한 내용은 다음을 참조하세요.
 
 * 기존 OTel 파이프라인에서 span을 전송하려면 [OpenTelemetry span을 Agents 뷰로 전송](/ko/weave/guides/tracking/trace-agents-otel)을 참조하세요.
-* 엔드포인트 사양은 [GenAI 트레이스 내보내기](/ko/weave/reference/service-api/agents/export-genai-trace)를 참조하세요.
+* 엔드포인트 사양은 [GenAI 트레이스 내보내기](/weave/reference/service-api/agents/export-genai-trace)를 참조하세요.
 
 `weave.eval.run_id`와 `weave.eval.predict_and_score_call_id`만 평가 및 결과 연결을 설정합니다. 행 digest, 예시 ID, trial index, kind, 평가 이름은 컨텍스트를 추가하고 필터링을 지원하지만 자체적으로 연결을 만들지는 않습니다. 두 연결 속성에는 OTel 트레이스 또는 span ID가 아닌 Weave Call ID를 사용하세요.
 
-[평가 결과 쿼리 API](/ko/weave/reference/service-api/eval-results/eval-results-query)에서 두 ID를 모두 획득할 수 있습니다. 응답의 각 평가에는 `evaluation_call_id`가 있고, 각 trial에는 `predict_and_score_call_id`가 있습니다.
+[평가 결과 쿼리 API](/weave/reference/service-api/eval-results/eval-results-query)에서 두 ID를 모두 획득할 수 있습니다. 응답의 각 평가에는 `evaluation_call_id`가 있고, 각 trial에는 `predict_and_score_call_id`가 있습니다.
 
 다음 예시에서는 `span`이 에이전트 오퍼레이션의 OTel span이라고 가정합니다. 각 대괄호 값을 해당 span이 속한 평가 run 및 결과의 메타데이터로 바꾸세요.
 


### PR DESCRIPTION


## Description

The fr/ja/ko copies of the EvaluationLogger guide linked to /{locale}/weave/reference/service-api/... for two OpenAPI-generated pages. Those routes 404: Mintlify derives an OpenAPI page slug from the operation `summary`, and Locadex translates `summary` in each locale's openapi.json, so the localized pages live at translated slugs (for example /fr/weave/reference/service-api/agents/exporter-la-trace-genai).

Locadex's experimentalAddHeaderAnchorIds keeps English #fragment links working in translated MDX by emitting an English anchor id above each translated heading. That cannot help here, because these are whole-page links and no MDX file exists for an OpenAPI-generated page.

Link to the unprefixed English routes instead of the translated slugs. The translated slugs are a function of translated prose, so they churn on every refresh; the English routes are stable. Readers reach the English API reference, which is what the generated pages effectively are.

Surfaced by the Locadex refresh in #2972 after #2930 added the first English links from a doc page to a generated service-api page.

Note that this PR is based on the open Locadex PR's branch, not on `main`.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] Local validate-mdx run succeeds without errors
- [ ] PR tests succeed
