### PR TITLE
Update mcp SDK version requirement to 1.14.x

### DIFF
--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -40,7 +40,7 @@ Before you configure any client, make sure you have the following in place:
 - Create a W&B API key at [wandb.ai/authorize](https://wandb.ai/authorize).
 - Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
 - For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
-- W&B pins the `mcp` SDK to [1.14.0](https://pypi.org/project/mcp/1.14.0/), released 2024-11-05. Clients must connect using `mcp` SDK 1.14.x. For streamable HTTP support in W&B Dedicated Cloud, `mcp` SDK 1.14.x release `2025-03-26` or newer is required.
+- W&B pins the `mcp` SDK to [1.14.0](https://pypi.org/project/mcp/1.14.0/), release `2024-11-05`. Clients must connect using `mcp` SDK 1.14.x. For streamable HTTP support in W&B Dedicated Cloud, `mcp` SDK 1.14.x release `2025-03-26` or newer is required.
 
 ## Use the hosted server
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -40,7 +40,7 @@ Before you configure any client, make sure you have the following in place:
 - Create a W&B API key at [wandb.ai/authorize](https://wandb.ai/authorize).
 - Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
 - For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
-- W&B pins the `mcp` SDK to [1.14.0](https://pypi.org/project/mcp/1.14.0/), released 2024-11-05. Clients must connect using `mcp` SDK 1.14.x.
+- W&B pins the `mcp` SDK to [1.14.0](https://pypi.org/project/mcp/1.14.0/), released 2024-11-05. Clients must connect using `mcp` SDK 1.14.x. For streamable HTTP support in W&B Dedicated Cloud, `mcp` SDK 1.14.x release `2025-03-26` or newer is required.
 
 ## Use the hosted server
 

--- a/platform/mcp-server.mdx
+++ b/platform/mcp-server.mdx
@@ -40,6 +40,7 @@ Before you configure any client, make sure you have the following in place:
 - Create a W&B API key at [wandb.ai/authorize](https://wandb.ai/authorize).
 - Set the key as the `WANDB_API_KEY` environment variable, or pass it to your client as a bearer token.
 - For Dedicated Cloud, Self-Managed, and local installs against a non-default instance, set the `WANDB_BASE_URL` environment variable to your instance URL.
+- W&B pins the `mcp` SDK to [1.14.0](https://pypi.org/project/mcp/1.14.0/), released 2024-11-05. Clients must connect using `mcp` SDK 1.14.x.
 
 ## Use the hosted server
 


### PR DESCRIPTION
## Description
Update mcp SDK version requirement to 1.14.x
See [Slack thread](https://weightsandbiases.slack.com/archives/C08JWUD0069/p1785760939273139)

Fixes DOCS-3031

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
