### PR TITLE
docs(weave): document Haystack Enterprise Platform tracing (DOCS-1749)

### DIFF
--- a/weave/guides/integrations/haystack.mdx
+++ b/weave/guides/integrations/haystack.mdx
@@ -1,28 +1,33 @@
 ---
 title: "Haystack"
-description: "Trace Deepset Haystack pipelines with W&B Weave using the WeaveConnector integration."
+description: "Trace open source Haystack and Haystack Enterprise Platform pipelines with W&B Weave using the WeaveConnector component."
 ---
 
-[Haystack](https://haystack.deepset.ai/) is an open-source framework for building search and LLM applications. Deepset maintains a WeaveConnector component that forwards Haystack pipeline traces to W&B Weave so you can inspect component runs, prompts, and outputs in the Weave UI.
+[Haystack](https://haystack.deepset.ai/) is an open source framework for building search and LLM applications. deepset maintains a `WeaveConnector` component that forwards Haystack pipeline traces to W&B Weave so you can inspect component runs, prompts, and outputs in the Weave UI.
 
-This guide is for Haystack developers who want to add observability to their pipelines.
+`WeaveConnector` works the same way in both deepset products:
 
-For full API details and additional examples, see these Deepset resources:
+- **Open source Haystack**: install the connector package and add the component to a pipeline in Python.
+- **Haystack Enterprise Platform**: connect W&B once in the platform UI, then add the component to a pipeline in YAML.
 
-- Haystack's [WeaveConnector](https://docs.haystack.deepset.ai/docs/weaveconnector).
-- Haystack's [Weave integration API reference](https://docs.haystack.deepset.ai/reference/integrations-weave).
-- Haystack's [Trace with W&B Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) example using a RAG pipeline.
+This guide is for Haystack developers who want to add observability to their pipelines. It shows you how to set up `WeaveConnector` in either product and where to find the resulting traces. Use those traces to debug prompts, inspect component inputs and outputs, and monitor pipeline behavior over time.
 
 ## Prerequisites
 
-Before you begin, you must complete the following:
+Before you begin, get your W&B [API key](https://wandb.ai/settings). Where you supply the key depends on which product you use:
 
-- Set `WANDB_API_KEY` in your environment using your W&B [API key](https://wandb.ai/settings). This authenticates the connector with W&B Weave.
-- Set `HAYSTACK_CONTENT_TRACING_ENABLED` to `true` before you run a pipeline so Haystack emits tracing data the connector can forward.
+- **Open source Haystack**: set `WANDB_API_KEY` in your environment.
+- **Haystack Enterprise Platform**: enter the key when you connect the W&B integration in the platform UI.
 
-## Install
+You also need credentials for whichever model provider your pipeline uses. The example on this page uses `OpenAIChatGenerator`, which reads `OPENAI_API_KEY` from your environment.
 
-Install the required dependencies using `pip`:
+## Trace an open source Haystack pipeline
+
+To trace an open source Haystack pipeline, install the connector package, then add `WeaveConnector` to your pipeline in Python.
+
+### Install
+
+Install the connector package with `pip`:
 
 ```bash lines
 pip install weave-haystack
@@ -30,11 +35,13 @@ pip install weave-haystack
 
 The package declares compatible versions of `haystack-ai` and `weave` as dependencies.
 
-## Trace a Haystack pipeline with Weave
+### Trace a pipeline
 
-The following example adds Haystack's `WeaveConnector` to a Haystack [`Pipeline`](https://docs.haystack.deepset.ai/docs/pipelines) and integrates with W&B Weave to trace and monitor your pipeline components. The `pipeline_name` you pass is used as the Weave project name for traces from that pipeline.
+Set `HAYSTACK_CONTENT_TRACING_ENABLED` to `true` before you run a pipeline so Haystack emits the tracing data that `WeaveConnector` forwards.
 
-In your Haystack pipeline, don't connect `WeaveConnector` to other components.
+The following example adds `WeaveConnector` to a Haystack [`Pipeline`](https://docs.haystack.deepset.ai/docs/pipelines) and integrates with Weave to trace and monitor your pipeline components. Weave uses the `pipeline_name` you pass as the project name for traces from that pipeline.
+
+In your Haystack pipeline, don't connect `WeaveConnector` to other components. The connector never processes pipeline data, so it doesn't require any connections.
 
 ```python lines
 import os
@@ -78,3 +85,56 @@ print(response["llm"]["replies"][0])
 
 After the pipeline runs, open your W&B workspace, select the project named with `pipeline_name`, and go to **Traces** to review the completed trace.
 
+## Trace a Haystack Enterprise Platform pipeline
+
+On the [Haystack Enterprise Platform](https://docs.cloud.deepset.ai/), you connect W&B once at the workspace or organization level, then add `WeaveConnector` to individual pipelines. You don't need to set `HAYSTACK_CONTENT_TRACING_ENABLED` yourself, because the platform enables content tracing for you.
+
+<Steps>
+  <Step title="Connect W&B to your workspace">
+    Select your profile icon, then select **Settings**. Go to **Workspace > Integrations**, find the **Weights & Biases** provider, and select **Connect**. Enter your W&B API key and the other requested details, then select **Connect**.
+
+    A workspace-level connection applies to the current workspace only.
+  </Step>
+
+  <Step title="Optional: Connect W&B to your organization">
+    To make the integration available across all workspaces, repeat the previous step, but go to **Organization > Integrations** instead of **Workspace > Integrations**.
+  </Step>
+
+  <Step title="Add WeaveConnector to your pipeline">
+    In your pipeline YAML, add `WeaveConnector` as a component and set `pipeline_name` to the name you want the Weave project to use. Don't connect the component to any other component in the pipeline.
+
+    ```yaml lines
+    WeaveConnector:
+      type: haystack_integrations.components.connectors.weave.weave_connector.WeaveConnector
+      init_parameters:
+        pipeline_name: helpdesk-agent
+    ```
+
+    To pass additional arguments to the `WeaveTracer` client, add a `weave_init_kwargs` mapping under `init_parameters`.
+  </Step>
+
+  <Step title="Run a query and view traces">
+    Weave creates the project the first time you query the pipeline. Open your W&B workspace, select the project named with `pipeline_name`, and go to **Traces**.
+
+    Give each pipeline a distinct `pipeline_name` so you can distinguish traces when you run more than one pipeline.
+  </Step>
+</Steps>
+
+## WeaveConnector parameters
+
+`WeaveConnector` takes the following parameters:
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `pipeline_name` | `str` | Required | The name of the pipeline you want to trace. Weave uses this value as the project name. |
+| `weave_init_kwargs` | `dict[str, Any] \| None` | `None` | Additional arguments to pass to the `WeaveTracer` client. |
+
+`WeaveConnector` starts tracing when Haystack warms up the component. Its `run()` method does no work other than return `pipeline_name`. Because the connector never processes pipeline data, don't connect it to other components.
+
+## Resources
+
+For full API details and additional examples, see these deepset resources:
+
+- Haystack's [WeaveConnector](https://docs.haystack.deepset.ai/docs/weaveconnector)
+- Haystack's [Weave integration API reference](https://docs.haystack.deepset.ai/reference/integrations-weave)
+- Haystack's [Trace with W&B Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) example using a RAG pipeline


### PR DESCRIPTION
## Summary

Adds the Haystack Enterprise Platform half of the deepset Weave integration to the existing Haystack page.

[DOCS-1749](https://wandb.atlassian.net/browse/DOCS-1749) asked to add the deepset integration to the Weave docs Frameworks section. Two upstream pages were in scope:

- [WeaveConnector](https://docs.haystack.deepset.ai/docs/weaveconnector) (open source Haystack) — **already documented** in #2484, Sept 2025.
- [Trace with W&B Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) (Haystack Enterprise Platform) — **was only linked, not documented**. This PR covers it.

No `docs.json` change: `weave/guides/integrations/haystack` is already in the **Frameworks** nav group.

## Changes

- **New section, "Trace a Haystack Enterprise Platform pipeline"** — the workspace-level and organization-level integration connect flow, plus the pipeline YAML configuration.
- **New section, "WeaveConnector parameters"** — table for `pipeline_name` and `weave_init_kwargs`. `weave_init_kwargs` was undocumented on our page despite appearing in deepset's own YAML example.
- **Prerequisites scoped per product**, and the missing `OPENAI_API_KEY` requirement added. The existing Python example uses `OpenAIChatGenerator`, so a reader copying it verbatim hit an auth error.
- **Clarified** that the platform enables content tracing, so readers don't set `HAYSTACK_CONTENT_TRACING_ENABLED` themselves.
- Moved `## WeaveConnector parameters` below both task sections; it was splitting the two parallel "Trace a…" sections.

Full Google Developer Style Guide pass (all 8 passes) applied to the result.

## Test plan

- [ ] Mintlify build succeeds and the page renders, including the `<Steps>` block
- [ ] Links resolve (`docs.cloud.deepset.ai`, `docs.haystack.deepset.ai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-1749]: https://coreweave.atlassian.net/browse/DOCS-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ