### PR TITLE
Runs:  add note about resuming sweeps for preempted  runs

### DIFF
--- a/models/runs/resuming.mdx
+++ b/models/runs/resuming.mdx
@@ -120,7 +120,7 @@ Register a handler for the signal that your scheduler or platform uses to indica
 2. Perform any required cleanup, such as saving a checkpoint.
 3. Exit with a nonzero status code. A common convention for signal termination is `128 + signum`.
 
- Do not call `mark_preempting()` unconditionally immediately after `wandb.init()`. Doing so can mark every failure, including code bugs, as preemption and requeue the run repeatedly.
+Do not call `mark_preempting()` unconditionally immediately after `wandb.init()`. Doing so can mark every failure, including code bugs, as preemption and requeue the run repeatedly.
 
 For runnable examples, `--forward-signals` on the CLI agent, and a full reference table for different uses of `mark_preempting()`, see [Signal handling and sweep runs](/models/sweeps/signal-handling-sweep-runs).
 

--- a/models/runs/resuming.mdx
+++ b/models/runs/resuming.mdx
@@ -107,11 +107,20 @@ If you can not share a filesystem, specify the `WANDB_RUN_ID` environment variab
 
 ## Resume preemptible Sweeps runs
 
-When you handle preemption correctly, interrupted [sweep](/models/sweeps/) runs can be requeued automatically so another agent can pick them up. That pattern is especially helpful when the sweep agent runs in a preemptible environment, such as a SLURM job in a preemptible queue, an EC2 Spot instance, or a Google Cloud preemptible VM.
+Handle preemption signals so W&B can automatically requeue interrupted [sweep](/models/sweeps/) runs for another agent. This pattern is useful when the sweep agent runs on preemptible compute, such as a SLURM preemptible queue, an Amazon EC2 Spot Instance, or a Google Cloud preemptible VM.
 
-The behavior below applies when you run sweep agents with the [`wandb agent`](/models/ref/cli/wandb-agent) CLI, which starts your training program as a **subprocess**. It does not fully apply when you use only the Python API [`wandb.agent()`](/models/ref/python/functions/agent), because that path runs your training function in a thread rather than a separate process, so OS signal delivery and forwarding do not match the CLI agent model.
+The instructions below apply when you start sweep agents with the [`wandb agent`](/models/ref/cli/wandb-agent) CLI. The CLI starts your training program as a **subprocess**. The instructions do not fully apply when you use only the Python API [`wandb.agent()`](/models/ref/python/functions/agent). The Python API runs the training function in a thread, so OS signal delivery and forwarding differ from the CLI agent behavior.
 
-**Recommended pattern:** Register a signal handler for the preemption signal your scheduler or platform uses (for example `SIGUSR1` or `SIGTERM`). In the handler, call [`mark_preempting()`](/models/ref/python/experiments/run#mark_preempting) when a run is active, perform any cleanup (such as saving a checkpoint), then exit with a non-zero code (a common convention is `128 + signum` for signal termination). Do **not** call `mark_preempting()` unconditionally immediately after `wandb.init()`. Doing so can mark every failure, including code bugs, as preemption and requeue the run repeatedly.
+
+### Handle a preemption signal
+
+Register a handler for the signal that your scheduler or platform uses to indicate preemption, such as `SIGUSR1` or `SIGTERM`. In the handler:
+
+1. In the handler, call [`mark_preempting()`](/models/ref/python/experiments/run#mark_preempting) when a run is active
+2. Perform any required cleanup, such as saving a checkpoint.
+3. Exit with a nonzero status code. A common convention for signal termination is `128 + signum`.
+
+ Do not call `mark_preempting()` unconditionally immediately after `wandb.init()`. Doing so can mark every failure, including code bugs, as preemption and requeue the run repeatedly.
 
 For runnable examples, `--forward-signals` on the CLI agent, and a full reference table for different uses of `mark_preempting()`, see [Signal handling and sweep runs](/models/sweeps/signal-handling-sweep-runs).
 
@@ -124,4 +133,8 @@ When you follow that pattern, W&B records run state roughly as follows:
 | Run receives an unhandled signal (for example `SIGKILL`) | CRASHED after about five minutes |
 | Run receives a handled preemption signal (for example `SIGTERM` or `SIGUSR1`), the handler calls `mark_preempting()`, and the process exits non-zero | PREEMPTED; the run is queued for the next agent request |
 
-Sweep agents drain the run queue before the sweep generates new hyperparameter combinations from the search algorithm. Once the queue is empty, the sweep resumes normal scheduling.
+<Info>
+When a sweep agent fetches a preempted run, the training process must call `wandb.init()` within 60 minutes. If initialization does not occur, such as when the process fails after fetching the run but before calling `wandb.init()`, W&B does not make the run available to another agent until the 60-minute lease expires.
+</Info>
+
+Sweep agents process requeued runs before requesting new hyperparameter combinations from the sweep search algorithm. After the queue is empty, the sweep resumes normal scheduling.


### PR DESCRIPTION
## Description

- Adds info admonition about 60 min time window for calling `wandb.init()` for preempted runs.
- Word smiths 

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-2547
