### PR TITLE
Runs: add support article on env var for ephemeral env

### DIFF
--- a/support.mdx
+++ b/support.mdx
@@ -47,7 +47,7 @@ and the W&B community.
 <CardGroup cols={3}>
 <Card title="W&B Models" href="/support/models" arrow="true" icon="/icons/cropped-models.svg">
   {/* AUTO-GENERATED: counts */}
-  210 articles &middot; 40 tags
+  211 articles &middot; 40 tags
   {/* END AUTO-GENERATED: counts */}
 </Card>
 <Card title="W&B Weave" href="/support/weave" arrow="true" icon="/icons/cropped-weave.svg">

--- a/support/models.mdx
+++ b/support/models.mdx
@@ -65,7 +65,7 @@ template: "docengine-site/templates/support_product_index.mdx.j2"
   5 articles
 </Card>
 <Card title="Environment Variables" href="/support/models/tags/environment-variables" arrow="true">
-  13 articles
+  14 articles
 </Card>
 <Card title="Experiments" href="/support/models/tags/experiments" arrow="true">
   51 articles
@@ -77,7 +77,7 @@ template: "docengine-site/templates/support_product_index.mdx.j2"
   5 articles
 </Card>
 <Card title="Logs" href="/support/models/tags/logs" arrow="true">
-  10 articles
+  11 articles
 </Card>
 <Card title="Metrics" href="/support/models/tags/metrics" arrow="true">
   23 articles
@@ -110,7 +110,7 @@ template: "docengine-site/templates/support_product_index.mdx.j2"
   11 articles
 </Card>
 <Card title="Runs" href="/support/models/tags/runs" arrow="true">
-  31 articles
+  32 articles
 </Card>
 <Card title="SDK" href="/support/models/tags/sdk" arrow="true">
   1 article

--- a/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env.mdx
+++ b/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env.mdx
@@ -1,0 +1,16 @@
+---
+title: How do I preserve run data from ephemeral environments?
+keywords: ["Environment Variables", "Logs", "Runs"]
+---
+
+
+Set `WANDB_DIR` to a directory on persistent storage to preserve local run data and diagnostic logs in ephemeral environments. Otherwise, files in the local `wandb/` directory can be lost when the pod or container is deleted.
+
+See the following related articles:
+
+- [How can I define the local location for `wandb` files?](/support/models/articles/how-can-i-define-the-local-location-for-)
+- [Why is my run showing as crashed?](/support/models/articles/why-is-my-run-showing-as-crashed)
+- [Environment variables](/models/track/environment-variables)
+
+
+<Badge stroke shape="pill" color="orange" size="md">[Environment Variables](/support/models/tags/environment-variables)</Badge><Badge stroke shape="pill" color="orange" size="md">[Runs](/support/models/tags/runs)</Badge><Badge stroke shape="pill" color="orange" size="md">[Logs](/support/models/tags/logs)</Badge>

--- a/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env.mdx
+++ b/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env.mdx
@@ -13,4 +13,6 @@ See the following related articles:
 - [Environment variables](/models/track/environment-variables)
 
 
-<Badge stroke shape="pill" color="orange" size="md">[Environment Variables](/support/models/tags/environment-variables)</Badge><Badge stroke shape="pill" color="orange" size="md">[Runs](/support/models/tags/runs)</Badge><Badge stroke shape="pill" color="orange" size="md">[Logs](/support/models/tags/logs)</Badge>
+{/* AUTO-GENERATED: tab badges */}
+<Badge stroke shape="pill" color="orange" size="md">[Environment Variables](/support/models/tags/environment-variables)</Badge><Badge stroke shape="pill" color="orange" size="md">[Logs](/support/models/tags/logs)</Badge><Badge stroke shape="pill" color="orange" size="md">[Runs](/support/models/tags/runs)</Badge>
+{/* END AUTO-GENERATED: tab badges */}

--- a/support/models/tags/environment-variables.mdx
+++ b/support/models/tags/environment-variables.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Environment Variables"
-tag: "13"
+tag: "14"
 generator: "knowledgebase-nav"
 template: "docengine-site/templates/support_tag.mdx.j2"
 ---
@@ -16,6 +16,9 @@ template: "docengine-site/templates/support_tag.mdx.j2"
 </Card>
 <Card title="How do I handle the 'Failed to query for notebook' error?" href="/support/models/articles/how-do-i-handle-the-failed-to-query-for-" arrow="true" horizontal>
   If you encounter the error message "Failed to query for notebook name, you can set it manually with the WANDB_NOTEBOOK_N ...
+</Card>
+<Card title="How do I preserve run data from ephemeral environments?" href="/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env" arrow="true" horizontal>
+  Set WANDB_DIR to a directory on persistent storage to preserve local run data and diagnostic logs in ephemeral environme ...
 </Card>
 <Card title="How do I run W&B offline?" href="/support/models/articles/how-do-i-run-wandb-offline" arrow="true" horizontal>
   To train on a machine without internet access and upload your results to W&B later, follow these steps: 1. Set the envir ...

--- a/support/models/tags/logs.mdx
+++ b/support/models/tags/logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Logs"
-tag: "10"
+tag: "11"
 generator: "knowledgebase-nav"
 template: "docengine-site/templates/support_tag.mdx.j2"
 ---
@@ -22,6 +22,9 @@ template: "docengine-site/templates/support_tag.mdx.j2"
 </Card>
 <Card title="How do I log to the right wandb user on a shared machine?" href="/support/models/articles/how-do-i-log-to-the-right-wandb-user-on-" arrow="true" horizontal>
   When multiple users share a machine, runs can log to the wrong W&B account if you don't explicitly set credentials. To e ...
+</Card>
+<Card title="How do I preserve run data from ephemeral environments?" href="/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env" arrow="true" horizontal>
+  Set WANDB_DIR to a directory on persistent storage to preserve local run data and diagnostic logs in ephemeral environme ...
 </Card>
 <Card title="How do I turn off logging?" href="/support/models/articles/how-do-i-turn-off-logging" arrow="true" horizontal>
   You can stop W&B from logging data to the remote server, or keep logging enabled but suppress its warning messages. Use  ...

--- a/support/models/tags/runs.mdx
+++ b/support/models/tags/runs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runs"
-tag: "31"
+tag: "32"
 generator: "knowledgebase-nav"
 template: "docengine-site/templates/support_tag.mdx.j2"
 ---
@@ -61,6 +61,9 @@ template: "docengine-site/templates/support_tag.mdx.j2"
 </Card>
 <Card title="How do I page through large API results in W&B?" href="/support/models/articles/how-do-i-paginate-through-large-api-results-in-wandb" arrow="true" horizontal>
   You can page through API result using the standard lazy-iterator pattern and per_page parameter. Additionally, you can u ...
+</Card>
+<Card title="How do I preserve run data from ephemeral environments?" href="/support/models/articles/how-do-i-preserve-run-data-from-ephemeral-env" arrow="true" horizontal>
+  Set WANDB_DIR to a directory on persistent storage to preserve local run data and diagnostic logs in ephemeral environme ...
 </Card>
 <Card title="How do I rerun a grid search?" href="/support/models/articles/how-do-i-rerun-a-grid-search" arrow="true" horizontal>
   If a grid search completes but some W&B Runs crashed, delete those runs to rerun them. Then select the Resume button on  ...


### PR DESCRIPTION
## Description

Adds support article on how to set env var to persist, capture `/wandb` files in an ephemeral environment. 

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-2702

