### PR TITLE
Add cooldown configuration for daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       - github-coreweave
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 1
     labels:
       - "auto-generated"
     commit-message:


### PR DESCRIPTION
Add cooldown configuration to manage the frequency of updates. 

The default if unspecified is three days. This changes the period to one day.

https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/