### PR TITLE
ci: Add docengine-bootstrap action and pin guard

### DIFF
--- a/.github/actions/docengine-bootstrap/action.yml
+++ b/.github/actions/docengine-bootstrap/action.yml
@@ -1,0 +1,132 @@
+name: DocEngine bootstrap
+description: >-
+  Set up git access to the private DocEngine repository and fetch the DocEngine
+  submodule, so later steps can run the docs tooling. Reports back instead of
+  failing when no credential is available.
+
+# WHAT THIS IS
+#
+# CoreWeave's documentation tooling is called DocEngine. It lives in its own
+# private repository and is vendored into this one as the `docengine` git
+# submodule, pinned to one exact commit. Nearly every docs CI workflow needs
+# that submodule on disk before it can do anything useful, and getting it there
+# takes two steps that are easy to get subtly wrong. This action is the single
+# place that does them.
+#
+# WHY THIS IS DUPLICATED BETWEEN wandb/docs AND coreweave/docs RATHER THAN SHARED
+#
+# The coreweave/docs repository has its own copy of this action, with the same
+# name, the same input and the same output, but different internals. It uses a
+# different credential and also clones private product repositories beyond
+# DocEngine itself. The duplication is deliberate, for two reasons:
+#
+# - Credentials differ per repository.
+# - A genuinely shared version would have to live inside DocEngine, which is exactly
+#   what this action exists to fetch.
+#
+# So the INTERFACE is the shared promise, and what happens inside belongs to each
+# repository.
+#
+# Background:
+# https://github.com/coreweave/docengine/blob/main/docs/adr/0008-publishing-host-actions.md
+
+inputs:
+  read-token:
+    description: >-
+      A token that can read the private coreweave/docengine repository. In this
+      repository, pass the DOCENGINE_TOKEN secret - the same rolling token the
+      Dependabot gitsubmodule registry uses.
+
+      DocEngine is the only private repository this repository's workflows need
+      to reach, but every private clone in a job goes through the single git
+      rewrite rule this action sets up, so this action must be the only step
+      that creates one.
+
+      It arrives as an input because a composite action cannot read `secrets` on
+      its own. If you leave it empty, the action does nothing and says so
+      through the `available` output rather than failing the job.
+    required: false
+    default: ''
+
+outputs:
+  available:
+    description: >-
+      "true" when the DocEngine submodule is on disk and ready to use, "false"
+      when no token was supplied and it was skipped.
+
+      Steps that need DocEngine should check this rather than assuming the
+      `docengine/` directory exists. Some jobs run in situations where the
+      secret is not available - in this repository that includes fork pull
+      requests - and they should skip the DocEngine part rather than fail the
+      whole run.
+    value: ${{ steps.init.outputs.available }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up git access and fetch the DocEngine submodule
+      id: init
+      shell: bash
+      env:
+        READ_TOKEN: ${{ inputs['read-token'] }}
+      run: |
+        set -euo pipefail
+
+        # No credential: stop cleanly and report it. This is a normal outcome,
+        # not an error, so the job can decide for itself what to do next.
+        if [ -z "${READ_TOKEN}" ]; then
+          echo "available=false" >> "${GITHUB_OUTPUT}"
+          echo "::notice title=DocEngine bootstrap::No read token was supplied, so DocEngine was not fetched. Steps that need it should check the 'available' output."
+          exit 0
+        fi
+
+        # Keep the token out of the logs if anything below prints it.
+        echo "::add-mask::${READ_TOKEN}"
+
+        # The rule below tells git to quietly insert this token into every
+        # https://github.com/... URL it handles from now on. That is what makes
+        # private clones work without configuring each repository separately.
+        #
+        # THERE MUST ONLY EVER BE ONE SUCH RULE.
+        #
+        # Git does not combine two rules that rewrite the same URL prefix; one
+        # of them simply wins, and which one is not obvious. If another step
+        # adds a second rule using a token with narrower access, a clone fails
+        # much later with a "not found" error in a step that looks unrelated to
+        # authentication - a genuinely hard bug to track down. This action owns
+        # the rule, and nothing else should create one. A rule already existing
+        # means some step ran before this action, which is what this check is
+        # here to catch.
+        # Matching on 'url.' alone rather than on the exact rule name is
+        # deliberate: git has a second rewrite setting, pushInsteadOf, which
+        # rewrites push URLs only. A rule of either kind set before this action
+        # runs is the ordering problem described above, so both should be
+        # caught.
+        if git config --global --name-only --get-regexp '^url\.' >/dev/null 2>&1; then
+          echo "::error title=DocEngine bootstrap::A git URL rewrite rule was already set before this action ran. Only one may exist and this action must own it. Remove the earlier 'git config url.*.insteadOf' step, or move what it does into this action."
+          exit 1
+        fi
+
+        git config --global url."https://x-access-token:${READ_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+        # Fetch only the DocEngine submodule, and only its most recent commit.
+        # This repository has a second submodule, `.claude`, which comes from
+        # coreweave/docs-skills. DOCENGINE_TOKEN is not guaranteed to read that
+        # repository, so fetching everything could fail on it.
+        git submodule update --init --depth 1 docengine
+
+        # `git submodule update` can succeed while leaving an empty directory
+        # behind. Later steps would then fail somewhere far away from the real
+        # cause, so confirm DocEngine actually arrived.
+        #
+        # Unlike the empty-token case above, this IS a failure: a token was
+        # supplied and it did not work. The usual cause is a token that cannot
+        # read the private DocEngine repository - with a rolling token like
+        # DOCENGINE_TOKEN, the first suspect is an expired token.
+        if [ ! -f docengine/pyproject.toml ]; then
+          echo "::error title=DocEngine bootstrap::The docengine directory is empty after fetching. Check that the token you passed can read the private coreweave/docengine repository."
+          exit 1
+        fi
+
+        echo "available=true" >> "${GITHUB_OUTPUT}"
+        echo "DocEngine bootstrap: submodule fetched and ready." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/scripts/docengine-pin-guard.sh
+++ b/.github/scripts/docengine-pin-guard.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Checks that a pull request's DocEngine pin points at a published release, and
+# fails if it does not.
+#
+#
+# WHAT A "PIN" IS
+#
+# CoreWeave's documentation tooling, DocEngine, lives in its own repository and
+# is attached to this one as the `docengine` git submodule. A submodule records
+# one exact commit of the other repository - that recorded commit is the pin.
+# Changing it decides which version of the tooling this repo runs.
+#
+# DocEngine publishes releases as version tags such as v3.5.0. The rule this
+# script enforces is that only a published release may be merged here, so the
+# tooling is always a known, released version rather than whatever happened to
+# be on DocEngine's main branch that day.
+#
+#
+# WHY THE CHECK EXISTS WHEN THE UPDATER ALREADY PICKS RELEASES
+#
+# Automated dependency-update pull requests bump the pin to the newest
+# published release on their own, so they pass this check without help, and it
+# is tempting to conclude the check is pointless. It is not aimed at them. It
+# is aimed at every other way the pin can move:
+#
+#   - By accident, riding along in a pull request about something else. Every
+#     working copy of this repository has the submodule populated, so whenever
+#     someone's local copy of it drifts from the recorded pin, git reports
+#     "modified: docengine (new commits)" and a habitual `git add -A` or
+#     `git commit -a` quietly stages that drift into an unrelated docs change.
+#     This is the most common way submodule pins move in any repository. The
+#     damage can also surface late: a pin recording a commit that exists only
+#     on someone's machine, or on a since-deleted branch, merges cleanly and
+#     breaks OTHER people's builds afterwards, when the pinned commit cannot
+#     be fetched. This check turns both into an immediate red X on the pull
+#     request that caused them.
+#
+#   - By a botched merge, which can silently regress the pin to an older
+#     commit, flatten the submodule into a plain directory, or repoint
+#     .gitmodules at a different repository. The workflow that runs this
+#     script checks for each of those and names the real cause.
+#
+#   - On purpose, in a draft. Pinning a prerelease is the supported way to
+#     test unreleased tooling in real CI (see below). This check is what makes
+#     such a draft safe to leave open: it stays red, so it cannot merge by
+#     accident.
+#
+# Two further reasons watchfulness cannot replace it:
+#
+#   - A reviewer cannot check this by eye. A pin bump diffs as two bare commit
+#     IDs, and telling a release commit from an arbitrary one takes exactly
+#     the tag lookup this script automates.
+#
+#   - The updater preferring release tags over newer untagged commits is
+#     observed behavior, confirmed by experiment, not a documented guarantee.
+#     If it ever changes, this check is what stands between an untagged
+#     commit and main.
+#
+#
+# WHY IT CHECKS TAGS INSTEAD OF "IS THIS COMMIT ON MAIN"
+#
+# DocEngine squash-merges its pull requests. That does not rewrite main, which
+# only gains commits. It means the individual commits on a pull request branch
+# never join main at all: the merge creates one new commit standing in for the
+# whole branch. Once that branch is deleted, the original commits are not
+# reachable from any branch, so a pin pointing at one refers to a commit nobody
+# can find from main. A tag avoids that, because the tag is itself a reference
+# and keeps its commit reachable for good. "Does this commit carry a release
+# tag" is therefore both a stricter rule and a more stable one.
+#
+#
+# WHY PRERELEASE (rc) TAGS ARE REJECTED
+#
+# DocEngine also publishes prerelease tags such as v3.6.0-rc.1, so that a draft
+# pull request here can test unreleased tooling in real CI before it ships.
+# Those are for draft pull requests only. A pull request pinned to one is
+# SUPPOSED to fail this check, and stays red until it is repinned to a real
+# release. That is the workflow behaving correctly, not a problem to fix.
+#
+# The full rules:
+# https://github.com/coreweave/docengine/blob/main/docs/adr/0009-semver-releases-and-tag-propagation.md
+#
+#
+# WHY THIS SCRIPT LIVES IN THIS REPOSITORY
+#
+# DocEngine publishes shared CI actions that this repo uses, and normally logic
+# like this would live there. But, this script cannot live in DocEngine, because
+# it checks the very pin that would be used to fetch those shared actions.
+# Getting it from DocEngine would be circular. It stays here on purpose.
+#
+#
+# RUN IT LOCALLY
+#
+#   PINNED_SHA=<commit-sha> READ_TOKEN=<token> .github/scripts/docengine-pin-guard.sh
+#
+# Environment:
+#   PINNED_SHA    (required) the DocEngine commit this pull request pins
+#   READ_TOKEN    (optional) a token that can read tags on the DocEngine repo
+#   ENGINE_REPO   (optional) defaults to coreweave/docengine
+#   REQUIRE_TOKEN (optional) "true" to fail when READ_TOKEN is missing instead
+#                 of skipping. See the note in docengine-pin-guard-pr.yaml.
+
+set -euo pipefail
+
+ENGINE_REPO="${ENGINE_REPO:-coreweave/docengine}"
+PINNED_SHA="${PINNED_SHA:-}"
+READ_TOKEN="${READ_TOKEN:-}"
+REQUIRE_TOKEN="${REQUIRE_TOKEN:-false}"
+
+DOC_URL="https://github.com/coreweave/docengine/blob/main/docs/adr/0009-semver-releases-and-tag-propagation.md"
+
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$*" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+if [ -z "${PINNED_SHA}" ]; then
+  echo "::error title=DocEngine pin guard::No docengine submodule entry was found. Expected one at the path 'docengine'."
+  exit 1
+fi
+
+if [ -z "${READ_TOKEN}" ]; then
+  if [ "${REQUIRE_TOKEN}" = "true" ]; then
+    echo "::error title=DocEngine pin guard::No read token was available, so the pin could not be checked against ${ENGINE_REPO} tags."
+    exit 1
+  fi
+  # Skip instead of blocking. Automated dependency-update pull requests are by
+  # far the most common thing this check sees, and they do not always have
+  # access to the secret. Failing here would turn every one of them red and
+  # stop the pin ever moving forward. Ordinary pull requests from branches in
+  # this repository always have the secret, so this is a rare path.
+  echo "::warning title=DocEngine pin guard::No read token was available, so the release check was skipped for pin ${PINNED_SHA}."
+  summary "### DocEngine pin guard: SKIPPED"
+  summary ""
+  summary "No token was available to read tags from \`${ENGINE_REPO}\`, so the pin \`${PINNED_SHA}\` was **not** checked against the published releases."
+  exit 0
+fi
+
+echo "::add-mask::${READ_TOKEN}"
+
+if ! raw_tags="$(git ls-remote --tags "https://x-access-token:${READ_TOKEN}@github.com/${ENGINE_REPO}.git" 'refs/tags/v*' 2>/dev/null)"; then
+  echo "::error title=DocEngine pin guard::Could not read the tags on ${ENGINE_REPO}. Check that the token being used can read that repository."
+  exit 1
+fi
+
+# Work out which commit each tag actually points at.
+#
+# Git has two kinds of tag. A lightweight tag points straight at a commit. An
+# annotated tag points at a small tag object which in turn points at the commit,
+# and `git ls-remote` reports it as two lines: the tag object, then a second
+# line ending in '^{}' holding the real commit. So when a '^{}' line exists it
+# is the one to trust. Getting this wrong would compare against tag object IDs
+# and never match anything.
+tag_commits="$(
+  printf '%s\n' "${raw_tags}" | awk -F'\t' '
+    $2 != "" {
+      ref = $2
+      if (ref ~ /\^\{\}$/) {
+        sub(/\^\{\}$/, "", ref)
+        peeled[ref] = $1
+      } else {
+        direct[ref] = $1
+      }
+    }
+    END {
+      for (r in direct) {
+        sha = (r in peeled) ? peeled[r] : direct[r]
+        name = r
+        sub(/^refs\/tags\//, "", name)
+        print sha "\t" name
+      }
+    }
+  '
+)"
+
+if [ -z "${tag_commits}" ]; then
+  echo "::error title=DocEngine pin guard::${ENGINE_REPO} has no version tags at all, so no pin can be valid yet. A release needs to be published first."
+  exit 1
+fi
+
+# Releases only: v<major>.<minor>.<patch> with nothing after the patch number.
+# Anything with a suffix, such as v3.6.0-rc.1, is a prerelease and is handled
+# separately below so the error message can explain itself.
+matched_release="$(printf '%s\n' "${tag_commits}" | awk -F'\t' -v sha="${PINNED_SHA}" '$1 == sha && $2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ { print $2 }' | head -n 1)"
+
+if [ -n "${matched_release}" ]; then
+  echo "DocEngine pin guard: ${PINNED_SHA} is release ${matched_release}."
+  summary "### DocEngine pin guard: PASS"
+  summary ""
+  summary "The pinned commit \`${PINNED_SHA}\` is release **${matched_release}**."
+  exit 0
+fi
+
+matched_prerelease="$(printf '%s\n' "${tag_commits}" | awk -F'\t' -v sha="${PINNED_SHA}" '$1 == sha && $2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+-/ { print $2 }' | head -n 1)"
+
+latest_release="$(printf '%s\n' "${tag_commits}" | awk -F'\t' '$2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ { print $2 }' | sort -V | tail -n 1)"
+
+# Reaching here with no release at all is possible: the repository can have v*
+# tags (so the earlier "no tags" check passed) while every one of them is a
+# prerelease. Without this, the messages below would end with a blank value and
+# read as though something had gone wrong with the check itself.
+if [ -n "${latest_release}" ]; then
+  latest_hint="The latest release is ${latest_release}."
+  latest_hint_md="The latest release is \`${latest_release}\`."
+else
+  latest_hint="No release has been published yet, only prereleases."
+  latest_hint_md="No release has been published yet, only prereleases."
+fi
+
+summary "### DocEngine pin guard: FAIL"
+summary ""
+summary "The pinned commit \`${PINNED_SHA}\` is not a published DocEngine release."
+
+if [ -n "${matched_prerelease}" ]; then
+  echo "::error title=DocEngine pin guard::This pull request pins DocEngine to the prerelease ${matched_prerelease}. Prereleases are for testing in draft pull requests and cannot be merged, so this check stays red until you repin to a release. ${latest_hint} Details: ${DOC_URL}"
+  summary "It is the prerelease **${matched_prerelease}**. Prereleases let a draft pull request test unreleased tooling in real CI, but they must never be merged, so this check stays red by design. Repin to a release before merging. ${latest_hint_md}"
+  summary ""
+  summary "[Why this rule exists](${DOC_URL})"
+  exit 1
+fi
+
+echo "::error title=DocEngine pin guard::This pull request pins DocEngine to ${PINNED_SHA}, which is not a published release. This repository can only use released versions of the tooling, not arbitrary commits. ${latest_hint} Details: ${DOC_URL}"
+summary "It carries no version tag on \`${ENGINE_REPO}\`. This repository can only use published releases of the tooling, not arbitrary commits. ${latest_hint_md}"
+summary ""
+summary "[Why this rule exists](${DOC_URL})"
+exit 1

--- a/.github/workflows/docengine-bootstrap-selftest.yaml
+++ b/.github/workflows/docengine-bootstrap-selftest.yaml
@@ -1,0 +1,102 @@
+---
+# Proves that .github/actions/docengine-bootstrap works, in both of the
+# situations it is designed to handle.
+#
+# That action is what fetches CoreWeave's documentation tooling (DocEngine) for
+# every other docs workflow, so it needs to be verifiable on its own. Right now
+# nothing else calls it yet - the existing DocEngine workflows still do this
+# setup inline, and moving them over happens later - so without this test there
+# would be no way to tell whether it works.
+#
+# The two cases:
+#   1. Given a token, it fetches DocEngine and reports available=true.
+#   2. Given no token, it reports available=false and does NOT fail. Workflows
+#      that can run without DocEngine rely on that, so it matters as much as
+#      the success case.
+#
+# These are two separate JOBS rather than two steps in one job, because each job
+# gets a clean machine. The action refuses to run if a git URL rewrite rule
+# already exists, so calling it twice on the same machine would correctly fail
+# the second call.
+
+name: DocEngine bootstrap self-test
+
+on:
+  # workflow_dispatch on its own would not be enough to check this before
+  # merging: GitHub only offers a workflow for manual runs once it exists on the
+  # default branch. The narrow pull_request trigger lets the pull request that
+  # introduces the action prove both cases up front, and afterwards it only runs
+  # again when the action or this test changes.
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/actions/docengine-bootstrap/**'
+      - '.github/workflows/docengine-bootstrap-selftest.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  WithCredential:
+    name: available=true with a read token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Bootstrap
+        id: boot
+        uses: ./.github/actions/docengine-bootstrap
+        with:
+          # Each host defines exactly one of these two secrets; the fallback
+          # is what lets this file stay identical across hosts. coreweave/docs
+          # defines ORG_REPO_READ_ONLY; wandb/docs defines DOCENGINE_TOKEN.
+          read-token: ${{ secrets.ORG_REPO_READ_ONLY || secrets.DOCENGINE_TOKEN }}
+
+      - name: Check that DocEngine is usable
+        env:
+          AVAILABLE: ${{ steps.boot.outputs.available }}
+        run: |
+          set -euo pipefail
+          if [ "${AVAILABLE}" != "true" ]; then
+            echo "::error::Expected available=true, got '${AVAILABLE}'."
+            exit 1
+          fi
+          if [ ! -f docengine/pyproject.toml ]; then
+            echo "::error::The action reported success but the docengine directory is not populated."
+            exit 1
+          fi
+          # DocEngine also publishes the shared CI actions this repository runs,
+          # under host-actions/. Reaching them through the pin is the whole point
+          # of fetching the submodule. Every DocEngine release from v3.5.0 onward
+          # contains that directory, and the pin guard only allows releases, so
+          # if it is missing then a pin got past the guard.
+          if [ ! -d docengine/host-actions ]; then
+            echo "::error::docengine/host-actions is missing. Every release since v3.5.0 includes it, so this pin is probably not a published release."
+            exit 1
+          fi
+          echo "DocEngine is present and its shared actions are reachable."
+
+  WithoutCredential:
+    name: available=false with no read token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Bootstrap with no token
+        id: boot
+        uses: ./.github/actions/docengine-bootstrap
+        with:
+          read-token: ''
+
+      - name: Check that it reported back instead of failing
+        env:
+          AVAILABLE: ${{ steps.boot.outputs.available }}
+        run: |
+          set -euo pipefail
+          if [ "${AVAILABLE}" != "false" ]; then
+            echo "::error::Expected available=false, got '${AVAILABLE}'."
+            exit 1
+          fi
+          echo "Reported available=false without failing, as intended."

--- a/.github/workflows/docengine-pin-guard-pr.yaml
+++ b/.github/workflows/docengine-pin-guard-pr.yaml
@@ -1,0 +1,177 @@
+---
+# Fails a pull request that points the DocEngine tooling at anything other than
+# a published release.
+#
+#
+# THE ONE-PARAGRAPH VERSION
+#
+# CoreWeave's documentation tooling, DocEngine, lives in its own repository and
+# is attached here as the `docengine` git submodule, which records one exact
+# commit of it. That recorded commit decides which version of the tooling this
+# repository runs in CI. This check makes sure it is always a published release
+# (v3.5.0 and so on) rather than an arbitrary commit from DocEngine's main
+# branch. The reasoning, including why the check exists at all when the
+# automated updater already picks releases on its own, is written up at the
+# top of .github/scripts/docengine-pin-guard.sh.
+#
+#
+# WHAT YOU SHOULD EXPECT TO SEE
+#
+#   - Most pull requests never run this at all. It only triggers when the
+#     `docengine` submodule itself changes. Its twin workflow answers for all
+#     the others; see THE REQUIRED-CHECK TWIN below.
+#   - Automated dependency-update pull requests pass without anyone doing
+#     anything. The updater picks the newest published release over newer
+#     untagged commits on its own, so those bumps land on a release by
+#     construction.
+#   - A draft pull request pinned to a prerelease (v3.6.0-rc.1) STAYS RED, and
+#     that is the intended behavior rather than a fault. Prereleases exist so a
+#     draft pull request can exercise unreleased tooling in real CI; this check
+#     is what stops one being merged by accident.
+#
+#
+# WHEN THE TOKEN IS MISSING
+#
+# Reading DocEngine's tags needs a read credential. The hosts name it
+# differently, so READ_TOKEN below accepts either name and resolves whichever
+# one the host defines: coreweave/docs defines ORG_REPO_READ_ONLY (an
+# organization secret, Actions store only), and wandb/docs defines
+# DOCENGINE_TOKEN (a rolling token, held in BOTH its Actions and Dependabot
+# stores). That fallback is what lets this file stay byte-identical across
+# hosts. Whether a missing token fails the check depends on who triggered
+# the run:
+#
+#   - Dependabot's own runs read from the Dependabot secret store. Where that
+#     store holds the credential (wandb/docs), automated bumps are validated
+#     like any other pull request and nothing is skipped. Where it does not
+#     (coreweave/docs), the run SKIPS with a warning instead of failing,
+#     because failing would turn every automated bump red and stop the
+#     tooling ever being updated - and the skip is safe for exactly those
+#     runs, because the updater only ever proposes release tags to begin
+#     with.
+#   - Every other run FAILS CLOSED, and red is right for both ways that can
+#     happen. A pull request from a branch in this repository always receives
+#     the secret, so a missing token on one of those means the secret was
+#     removed, renamed, or scoped away - a misconfiguration that should be
+#     loud, not a quietly green check. A pull request from a fork receives no
+#     secrets at all (in a host that allows forking), and a fork pull request
+#     that moves the pin is supposed to stay red: fork contributions are
+#     merged by branch-import, never directly, so the maintainer's internal
+#     branch re-runs this check with the secret present.
+#
+# A present-but-expired token does not skip anything: the tag lookup itself
+# fails and the check goes red. With a rolling token, that is the failure
+# you want to hear about.
+#
+# To make even Dependabot fail closed where it currently skips, first copy
+# the credential into Settings > Secrets and variables > Dependabot, then
+# hard-code REQUIRE_TOKEN to 'true' below.
+#
+#
+# THE REQUIRED-CHECK TWIN
+#
+# This check is meant to be marked as required on main, and the paths filter
+# below keeps it from running on pull requests that leave the pin alone, which
+# is almost all of them. GitHub does not count a path-skipped workflow as
+# passed: a required check that never reports shows as "Expected - Waiting for
+# status to be reported" and blocks the merge forever. The cure is the twin
+# workflow, docengine-pin-guard-skip-pr.yaml, which triggers on the opposite
+# filter and reports success under the same job name, so every pull request
+# gets a PinGuard verdict one way or the other. If you change the paths list
+# or the job name here, make the identical change there, or every pull request
+# that does not touch the pin will stall.
+#
+# The logic is a separate script rather than inline steps so it can be run by
+# hand while debugging:
+#   PINNED_SHA=<sha> READ_TOKEN=<token> .github/scripts/docengine-pin-guard.sh
+
+name: DocEngine pin guard
+
+on:
+  pull_request:
+    paths:
+      - 'docengine'
+      # .gitmodules is here because a pull request can repoint the submodule at
+      # a different repository by editing that file alone, leaving the recorded
+      # commit untouched. Without this path, such a change would never run the
+      # guard at all.
+      - '.gitmodules'
+
+permissions:
+  contents: read
+
+jobs:
+  PinGuard:
+    runs-on: ubuntu-latest
+    env:
+      ENGINE_REPO: coreweave/docengine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        # No submodules and no token here on purpose. Reading which commit is
+        # recorded needs nothing more than this repository's own files; only the
+        # tag lookup further down needs credentials.
+
+      - name: Find the pinned DocEngine commit
+        id: pin
+        run: |
+          set -euo pipefail
+
+          # Check WHERE the submodule points before checking WHAT it points at.
+          # The tag lookup later only ever consults ENGINE_REPO, so a pull
+          # request that repointed .gitmodules at some other repository while
+          # leaving the recorded commit alone would otherwise sail through with
+          # a green check. Adding .gitmodules to the trigger above is only half
+          # the fix; this is the half that actually inspects it.
+          url="$(git config -f .gitmodules --get submodule.docengine.url || true)"
+          expected="https://github.com/${ENGINE_REPO}.git"
+          if [ "${url}" != "${expected}" ]; then
+            echo "::error title=DocEngine pin guard::The docengine submodule points at '${url}' rather than '${expected}'. This check only validates commits belonging to ${ENGINE_REPO}."
+            exit 1
+          fi
+
+          # On a pull request, HEAD is the merge preview, so this reads the pin
+          # as it WOULD be after merging rather than as it is on the branch.
+          entry="$(git ls-tree HEAD docengine)"
+          if [ -z "${entry}" ]; then
+            # Fail here rather than one step later, so the message names the
+            # actual cause: the submodule entry is missing or has moved.
+            echo "::error title=DocEngine pin guard::There is nothing at the path 'docengine' in this pull request."
+            exit 1
+          fi
+
+          # git ls-tree prints "<mode> <type> <object-id><tab><path>".
+          #
+          # A submodule is mode 160000, type commit. An ordinary directory is
+          # mode 040000, type tree, and its object ID is a forty character hex
+          # string that looks exactly like a commit SHA at a glance. Without
+          # this check, a submodule that had been flattened into a real
+          # directory (a botched merge does this) would send a tree hash to the
+          # release lookup, which would report "not a published release" and
+          # send whoever reads it hunting for a versioning problem that does not
+          # exist. Name the real cause instead.
+          mode="$(printf '%s' "${entry}" | awk '{ print $1 }')"
+          objtype="$(printf '%s' "${entry}" | awk '{ print $2 }')"
+          sha="$(printf '%s' "${entry}" | awk '{ print $3 }')"
+
+          if [ "${mode}" != "160000" ] || [ "${objtype}" != "commit" ]; then
+            echo "::error title=DocEngine pin guard::The path 'docengine' is not a submodule in this pull request (found mode ${mode}, type ${objtype}). It should be a submodule entry recording a single DocEngine commit."
+            exit 1
+          fi
+
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+          echo "Pinned DocEngine commit: ${sha}"
+
+      - name: Check that the pin is a published release
+        env:
+          # ENGINE_REPO is set once at the job level above, so both steps agree
+          # on which repository is being validated.
+          PINNED_SHA: ${{ steps.pin.outputs.sha }}
+          # Each host defines exactly one of these two secrets; the fallback
+          # is what keeps this file byte-identical across hosts. See WHEN THE
+          # TOKEN IS MISSING at the top of this file.
+          READ_TOKEN: ${{ secrets.ORG_REPO_READ_ONLY || secrets.DOCENGINE_TOKEN }}
+          # Fail closed on a missing token except on Dependabot's own runs;
+          # see WHEN THE TOKEN IS MISSING at the top of this file.
+          REQUIRE_TOKEN: ${{ github.actor != 'dependabot[bot]' }}
+        run: .github/scripts/docengine-pin-guard.sh

--- a/.github/workflows/docengine-pin-guard-skip-pr.yaml
+++ b/.github/workflows/docengine-pin-guard-skip-pr.yaml
@@ -1,0 +1,60 @@
+---
+# Reports a passing PinGuard check on pull requests that do not touch the
+# DocEngine pin, so the real pin guard can be a required check without
+# stalling every unrelated pull request.
+#
+#
+# WHY THIS EXISTS
+#
+# The real check, docengine-pin-guard-pr.yaml, uses a paths filter so it only
+# runs when a pull request changes the `docengine` submodule or .gitmodules.
+# That is right for validation but fatal for a required status check: GitHub
+# does not count a path-skipped workflow as passed. It shows the required
+# check as "Expected - Waiting for status to be reported" and blocks the
+# merge forever, on every pull request the filter excludes.
+#
+# This is GitHub's documented remedy (see "Handling skipped but required
+# checks" in the GitHub docs): a second workflow that triggers on the OPPOSITE
+# filter - the paths-ignore list here mirrors the paths list there - and
+# succeeds immediately under the same job name. Between the two workflows,
+# every pull request reports a PinGuard verdict:
+#
+#   - The pin is untouched: only this workflow runs, and passes at once.
+#   - Only the pin changes: only the real guard runs.
+#   - The pin changes alongside other files: both run. GitHub goes by the
+#     newest check run with a given name, and the real guard always finishes
+#     after this instant no-op, so the real verdict is the one that counts.
+#
+# KEEP IN SYNC with docengine-pin-guard-pr.yaml: the job name must stay
+# identical, and the paths-ignore list below must stay the exact mirror of
+# the paths list there. Change one, change the other.
+#
+# The workflow name below is deliberately DIFFERENT from the real guard's.
+# Only the JOB name has to match: a required status check matches the check
+# run's name, and GitHub Actions names check runs after the job, never the
+# workflow. Both files' PinGuard jobs therefore report under the identical
+# check name, and either satisfies a required check called "PinGuard". (The
+# same scheme is visible in this repository's other required checks, whose
+# contexts are bare job names such as ValidatePublicDocsPr.) The distinct
+# workflow names exist for the mixed case: when a pull request changes the
+# pin alongside other files, BOTH workflows run and both report PinGuard,
+# and the workflow name is then the only at-a-glance way to tell which run
+# produced which verdict.
+
+name: DocEngine pin guard (pin untouched)
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docengine'
+      - '.gitmodules'
+
+# This job reads nothing and writes nothing, so it gets no token scopes.
+permissions: {}
+
+jobs:
+  PinGuard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Nothing to validate
+        run: echo "This pull request does not change the DocEngine pin, so there is nothing to check."


### PR DESCRIPTION
#### Adds

- `docengine-bootstrap` composite action (fetches the private DocEngine submodule, degrades to available=false when no token is supplied) 
- DocEngine pin guard (fails a PR whose docengine pin is not a published release) 

#### Mirror of coreweave/docs#3498
The guard workflow, its required-check twin, and the guard script are byte-identical copies of that repo's files by design; the bootstrap shares its interface but carries this repo's credential (DOCENGINE_TOKEN). 

#### Install-only
The existing docengine-build/import/overlay workflows keep their inline auth and are not touched. 

#### Background
https://github.com/coreweave/docengine/blob/main/docs/adr/0008-publishing-host-actions.md