### PR TITLE
Generate Weave Service API reference pages as stubs

### DIFF
--- a/.github/workflows/update-service-api.yml
+++ b/.github/workflows/update-service-api.yml
@@ -58,7 +58,19 @@ jobs:
       run: |
         echo "Converting Service API links to fully qualified URLs..."
         python scripts/reference-generation/weave/fix_service_api_links.py
-        
+
+    # Runs unconditionally, not just when the spec changed: the generator is idempotent,
+    # so it is a no-op in the common case, and running it always lets it heal drift (for
+    # example a stub deleted by hand) rather than letting nav and pages diverge silently.
+    - name: Generate API reference pages and navigation
+      id: stubs
+      run: |
+        echo "Generating stub pages from the Weave Service API OpenAPI spec..."
+        OUTPUT=$(python scripts/reference-generation/common/generate_openapi_stubs.py --spec weave 2>&1)
+        echo "$OUTPUT"
+        SUMMARY=$(echo "$OUTPUT" | grep '^STUBS_SUMMARY ' | head -1 | cut -d' ' -f2-)
+        echo "summary=${SUMMARY:-unavailable}" >> $GITHUB_OUTPUT
+
     - name: Check for changes
       id: check-changes
       run: |
@@ -90,10 +102,18 @@ jobs:
           - Synced latest OpenAPI specification from the Weave service
           - Updated Service API landing page with current endpoints
           - Fixed Service API links to use fully qualified URLs
-          
+          - Regenerated operation pages and navigation
+
+          **Operation pages**: `${{ steps.stubs.outputs.summary }}`
+
           ### Review Checklist
           - [ ] Verify new endpoints are correctly listed
           - [ ] Check that removed endpoints (if any) are intentional
+          - [ ] **If both `created` and `pruned` are above zero, check whether an endpoint was
+                renamed rather than replaced.** A rename changes the page URL, and the old URL
+                will 404 — page filenames are deliberately frozen otherwise, so this is the one
+                case that moves a URL. Confirm it is intended and that any hand-written prose on
+                the pruned page was carried over.
           - [ ] Confirm all Service API links work correctly
           
           ---

--- a/docs.json
+++ b/docs.json
@@ -1312,13 +1312,234 @@
                   },
                   {
                     "group": "Service API",
-                    "openapi": {
-                      "directory": "weave/reference/service-api",
-                      "source": "weave/reference/service-api/openapi.json"
-                    },
                     "pages": [
                       "weave/cookbooks/weave_via_service_api",
-                      "weave/reference/service-api"
+                      "weave/reference/service-api",
+                      {
+                        "group": "Calls",
+                        "pages": [
+                          "weave/reference/service-api/calls/call-start",
+                          "weave/reference/service-api/calls/call-end",
+                          "weave/reference/service-api/calls/call-start-batch",
+                          "weave/reference/service-api/calls/calls-delete",
+                          "weave/reference/service-api/calls/call-update",
+                          "weave/reference/service-api/calls/call-read",
+                          "weave/reference/service-api/calls/calls-query-stats",
+                          "weave/reference/service-api/calls/trace-usage",
+                          "weave/reference/service-api/calls/calls-usage",
+                          "weave/reference/service-api/calls/calls-query-stream",
+                          "weave/reference/service-api/calls/call-stats",
+                          "weave/reference/service-api/calls/calls-complete"
+                        ]
+                      },
+                      {
+                        "group": "Costs",
+                        "pages": [
+                          "weave/reference/service-api/costs/cost-create",
+                          "weave/reference/service-api/costs/cost-query",
+                          "weave/reference/service-api/costs/cost-purge"
+                        ]
+                      },
+                      {
+                        "group": "Feedback",
+                        "pages": [
+                          "weave/reference/service-api/feedback/feedback-create",
+                          "weave/reference/service-api/feedback/feedback-create-batch",
+                          "weave/reference/service-api/feedback/feedback-query",
+                          "weave/reference/service-api/feedback/feedback-purge",
+                          "weave/reference/service-api/feedback/feedback-replace",
+                          "weave/reference/service-api/feedback/feedback-stats",
+                          "weave/reference/service-api/feedback/feedback-aggregate",
+                          "weave/reference/service-api/feedback/feedback-payload-schema"
+                        ]
+                      },
+                      {
+                        "group": "Files",
+                        "pages": [
+                          "weave/reference/service-api/files/file-create",
+                          "weave/reference/service-api/files/file-content",
+                          "weave/reference/service-api/files/files-stats"
+                        ]
+                      },
+                      {
+                        "group": "Objects",
+                        "pages": [
+                          "weave/reference/service-api/objects/obj-create",
+                          "weave/reference/service-api/objects/obj-read",
+                          "weave/reference/service-api/objects/objs-query",
+                          "weave/reference/service-api/objects/obj-delete",
+                          "weave/reference/service-api/objects/obj-add-tags",
+                          "weave/reference/service-api/objects/obj-remove-tags",
+                          "weave/reference/service-api/objects/obj-set-aliases",
+                          "weave/reference/service-api/objects/obj-remove-aliases",
+                          "weave/reference/service-api/objects/tags-list",
+                          "weave/reference/service-api/objects/aliases-list"
+                        ]
+                      },
+                      {
+                        "group": "OpenTelemetry",
+                        "pages": [
+                          "weave/reference/service-api/opentelemetry/export-trace"
+                        ]
+                      },
+                      {
+                        "group": "Refs",
+                        "pages": [
+                          "weave/reference/service-api/refs/refs-read-batch"
+                        ]
+                      },
+                      {
+                        "group": "Service",
+                        "pages": [
+                          "weave/reference/service-api/service/read-root",
+                          "weave/reference/service-api/service/read-version",
+                          "weave/reference/service-api/service/get-caller-location",
+                          "weave/reference/service-api/service/server-info",
+                          "weave/reference/service-api/service/projects-info"
+                        ]
+                      },
+                      {
+                        "group": "Tables",
+                        "pages": [
+                          "weave/reference/service-api/tables/table-create",
+                          "weave/reference/service-api/tables/table-update",
+                          "weave/reference/service-api/tables/table-create-from-digests",
+                          "weave/reference/service-api/tables/table-query",
+                          "weave/reference/service-api/tables/table-query-stats",
+                          "weave/reference/service-api/tables/table-query-stats-batch"
+                        ]
+                      },
+                      {
+                        "group": "Threads",
+                        "pages": [
+                          "weave/reference/service-api/threads/threads-query-stream"
+                        ]
+                      },
+                      {
+                        "group": "Agents",
+                        "pages": [
+                          "weave/reference/service-api/agents/export-genai-trace",
+                          "weave/reference/service-api/agents/genai-spans-query",
+                          "weave/reference/service-api/agents/genai-spans-stats",
+                          "weave/reference/service-api/agents/genai-custom-attrs-schema",
+                          "weave/reference/service-api/agents/genai-agents-query",
+                          "weave/reference/service-api/agents/genai-agent-versions-query",
+                          "weave/reference/service-api/agents/genai-search",
+                          "weave/reference/service-api/agents/genai-traces-chat",
+                          "weave/reference/service-api/agents/genai-conversation-chat",
+                          "weave/reference/service-api/agents/genai-conversation-spans"
+                        ]
+                      },
+                      {
+                        "group": "Annotation Queues",
+                        "pages": [
+                          "weave/reference/service-api/annotation-queues/annotation-queue-create",
+                          "weave/reference/service-api/annotation-queues/annotation-queues-query-stream",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-read",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-update",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-delete",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-add-calls",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-items-query",
+                          "weave/reference/service-api/annotation-queues/annotation-queues-stats",
+                          "weave/reference/service-api/annotation-queues/annotation-queue-item-progress-update"
+                        ]
+                      },
+                      {
+                        "group": "Evaluations",
+                        "pages": [
+                          "weave/reference/service-api/evaluations/evaluate-model",
+                          "weave/reference/service-api/evaluations/evaluation-status",
+                          "weave/reference/service-api/evaluations/rescore-evaluation",
+                          "weave/reference/service-api/evaluations/evaluation-list",
+                          "weave/reference/service-api/evaluations/evaluation-create",
+                          "weave/reference/service-api/evaluations/evaluation-read",
+                          "weave/reference/service-api/evaluations/evaluation-delete"
+                        ]
+                      },
+                      {
+                        "group": "Scores",
+                        "pages": [
+                          "weave/reference/service-api/scores/calls-score",
+                          "weave/reference/service-api/scores/score-list",
+                          "weave/reference/service-api/scores/score-create",
+                          "weave/reference/service-api/scores/score-delete",
+                          "weave/reference/service-api/scores/score-read"
+                        ]
+                      },
+                      {
+                        "group": "Images",
+                        "pages": [
+                          "weave/reference/service-api/images/image-create"
+                        ]
+                      },
+                      {
+                        "group": "Registry",
+                        "pages": [
+                          "weave/reference/service-api/registry/link-to-registry"
+                        ]
+                      },
+                      {
+                        "group": "Ops",
+                        "pages": [
+                          "weave/reference/service-api/ops/op-list",
+                          "weave/reference/service-api/ops/op-create",
+                          "weave/reference/service-api/ops/op-read",
+                          "weave/reference/service-api/ops/op-delete"
+                        ]
+                      },
+                      {
+                        "group": "Datasets",
+                        "pages": [
+                          "weave/reference/service-api/datasets/dataset-list",
+                          "weave/reference/service-api/datasets/dataset-create",
+                          "weave/reference/service-api/datasets/dataset-read",
+                          "weave/reference/service-api/datasets/dataset-delete"
+                        ]
+                      },
+                      {
+                        "group": "Scorers",
+                        "pages": [
+                          "weave/reference/service-api/scorers/scorer-list",
+                          "weave/reference/service-api/scorers/scorer-create",
+                          "weave/reference/service-api/scorers/scorer-read",
+                          "weave/reference/service-api/scorers/scorer-delete"
+                        ]
+                      },
+                      {
+                        "group": "Models",
+                        "pages": [
+                          "weave/reference/service-api/models/model-list",
+                          "weave/reference/service-api/models/model-create",
+                          "weave/reference/service-api/models/model-read",
+                          "weave/reference/service-api/models/model-delete"
+                        ]
+                      },
+                      {
+                        "group": "Evaluation Runs",
+                        "pages": [
+                          "weave/reference/service-api/evaluation-runs/evaluation-run-list",
+                          "weave/reference/service-api/evaluation-runs/evaluation-run-create",
+                          "weave/reference/service-api/evaluation-runs/evaluation-run-delete",
+                          "weave/reference/service-api/evaluation-runs/evaluation-run-read",
+                          "weave/reference/service-api/evaluation-runs/evaluation-run-finish"
+                        ]
+                      },
+                      {
+                        "group": "Predictions",
+                        "pages": [
+                          "weave/reference/service-api/predictions/prediction-list",
+                          "weave/reference/service-api/predictions/prediction-create",
+                          "weave/reference/service-api/predictions/prediction-delete",
+                          "weave/reference/service-api/predictions/prediction-read",
+                          "weave/reference/service-api/predictions/prediction-finish"
+                        ]
+                      },
+                      {
+                        "group": "Eval Results",
+                        "pages": [
+                          "weave/reference/service-api/eval-results/eval-results-query"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -1375,8 +1596,8 @@
           {
             "pages": [
               "release-notes",
-                "release-notes/release-policies",
-                "release-notes/new-articles",
+              "release-notes/release-policies",
+              "release-notes/new-articles",
               {
                 "group": "W&B Server",
                 "pages": [

--- a/weave/reference/service-api/agents/export-genai-trace.mdx
+++ b/weave/reference/service-api/agents/export-genai-trace.mdx
@@ -1,0 +1,4 @@
+---
+title: "Export GenAI Trace"
+openapi: /weave/reference/service-api/openapi.json POST /agents/otel/v1/traces
+---

--- a/weave/reference/service-api/agents/genai-agent-versions-query.mdx
+++ b/weave/reference/service-api/agents/genai-agent-versions-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Agent Versions Query"
+openapi: /weave/reference/service-api/openapi.json POST /agents/agent-versions/query
+---

--- a/weave/reference/service-api/agents/genai-agents-query.mdx
+++ b/weave/reference/service-api/agents/genai-agents-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Agents Query"
+openapi: /weave/reference/service-api/openapi.json POST /agents/query
+---

--- a/weave/reference/service-api/agents/genai-conversation-chat.mdx
+++ b/weave/reference/service-api/agents/genai-conversation-chat.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Conversation Chat"
+openapi: /weave/reference/service-api/openapi.json POST /agents/conversations/chat
+---

--- a/weave/reference/service-api/agents/genai-conversation-spans.mdx
+++ b/weave/reference/service-api/agents/genai-conversation-spans.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Conversation Spans"
+openapi: /weave/reference/service-api/openapi.json POST /agents/conversations/spans
+---

--- a/weave/reference/service-api/agents/genai-custom-attrs-schema.mdx
+++ b/weave/reference/service-api/agents/genai-custom-attrs-schema.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Custom Attrs Schema"
+openapi: /weave/reference/service-api/openapi.json POST /agents/spans/custom-attrs/schema
+---

--- a/weave/reference/service-api/agents/genai-search.mdx
+++ b/weave/reference/service-api/agents/genai-search.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Search"
+openapi: /weave/reference/service-api/openapi.json POST /agents/search
+---

--- a/weave/reference/service-api/agents/genai-spans-query.mdx
+++ b/weave/reference/service-api/agents/genai-spans-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Spans Query"
+openapi: /weave/reference/service-api/openapi.json POST /agents/spans/query
+---

--- a/weave/reference/service-api/agents/genai-spans-stats.mdx
+++ b/weave/reference/service-api/agents/genai-spans-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Spans Stats"
+openapi: /weave/reference/service-api/openapi.json POST /agents/spans/stats
+---

--- a/weave/reference/service-api/agents/genai-traces-chat.mdx
+++ b/weave/reference/service-api/agents/genai-traces-chat.mdx
@@ -1,0 +1,4 @@
+---
+title: "GenAI Traces Chat"
+openapi: /weave/reference/service-api/openapi.json POST /agents/traces/chat
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-add-calls.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-add-calls.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Add Calls"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues/{queue_id}/items
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-create.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Create"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-delete.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /annotation_queues/{queue_id}
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-item-progress-update.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-item-progress-update.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Item Progress Update"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues/{queue_id}/items/{item_id}/progress
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-items-query.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-items-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Items Query"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues/{queue_id}/items/query
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-read.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Read"
+openapi: /weave/reference/service-api/openapi.json GET /annotation_queues/{queue_id}
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queue-update.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queue-update.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queue Update"
+openapi: /weave/reference/service-api/openapi.json PUT /annotation_queues/{queue_id}
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queues-query-stream.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queues-query-stream.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queues Query Stream"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues/query
+---

--- a/weave/reference/service-api/annotation-queues/annotation-queues-stats.mdx
+++ b/weave/reference/service-api/annotation-queues/annotation-queues-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Annotation Queues Stats"
+openapi: /weave/reference/service-api/openapi.json POST /annotation_queues/stats
+---

--- a/weave/reference/service-api/calls/call-end.mdx
+++ b/weave/reference/service-api/calls/call-end.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call End"
+openapi: /weave/reference/service-api/openapi.json POST /call/end
+---

--- a/weave/reference/service-api/calls/call-read.mdx
+++ b/weave/reference/service-api/calls/call-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call Read"
+openapi: /weave/reference/service-api/openapi.json POST /call/read
+---

--- a/weave/reference/service-api/calls/call-start-batch.mdx
+++ b/weave/reference/service-api/calls/call-start-batch.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call Start Batch"
+openapi: /weave/reference/service-api/openapi.json POST /call/upsert_batch
+---

--- a/weave/reference/service-api/calls/call-start.mdx
+++ b/weave/reference/service-api/calls/call-start.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call Start"
+openapi: /weave/reference/service-api/openapi.json POST /call/start
+---

--- a/weave/reference/service-api/calls/call-stats.mdx
+++ b/weave/reference/service-api/calls/call-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call Stats"
+openapi: /weave/reference/service-api/openapi.json POST /calls/stats
+---

--- a/weave/reference/service-api/calls/call-update.mdx
+++ b/weave/reference/service-api/calls/call-update.mdx
@@ -1,0 +1,4 @@
+---
+title: "Call Update"
+openapi: /weave/reference/service-api/openapi.json POST /call/update
+---

--- a/weave/reference/service-api/calls/calls-complete.mdx
+++ b/weave/reference/service-api/calls/calls-complete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Complete"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/calls/complete
+---

--- a/weave/reference/service-api/calls/calls-delete.mdx
+++ b/weave/reference/service-api/calls/calls-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Delete"
+openapi: /weave/reference/service-api/openapi.json POST /calls/delete
+---

--- a/weave/reference/service-api/calls/calls-query-stats.mdx
+++ b/weave/reference/service-api/calls/calls-query-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Query Stats"
+openapi: /weave/reference/service-api/openapi.json POST /calls/query_stats
+---

--- a/weave/reference/service-api/calls/calls-query-stream.mdx
+++ b/weave/reference/service-api/calls/calls-query-stream.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Query Stream"
+openapi: /weave/reference/service-api/openapi.json POST /calls/stream_query
+---

--- a/weave/reference/service-api/calls/calls-usage.mdx
+++ b/weave/reference/service-api/calls/calls-usage.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Usage"
+openapi: /weave/reference/service-api/openapi.json POST /calls/usage
+---

--- a/weave/reference/service-api/calls/trace-usage.mdx
+++ b/weave/reference/service-api/calls/trace-usage.mdx
@@ -1,0 +1,4 @@
+---
+title: "Trace Usage"
+openapi: /weave/reference/service-api/openapi.json POST /trace/usage
+---

--- a/weave/reference/service-api/costs/cost-create.mdx
+++ b/weave/reference/service-api/costs/cost-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Cost Create"
+openapi: /weave/reference/service-api/openapi.json POST /cost/create
+---

--- a/weave/reference/service-api/costs/cost-purge.mdx
+++ b/weave/reference/service-api/costs/cost-purge.mdx
@@ -1,0 +1,4 @@
+---
+title: "Cost Purge"
+openapi: /weave/reference/service-api/openapi.json POST /cost/purge
+---

--- a/weave/reference/service-api/costs/cost-query.mdx
+++ b/weave/reference/service-api/costs/cost-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Cost Query"
+openapi: /weave/reference/service-api/openapi.json POST /cost/query
+---

--- a/weave/reference/service-api/datasets/dataset-create.mdx
+++ b/weave/reference/service-api/datasets/dataset-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Dataset Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/datasets
+---

--- a/weave/reference/service-api/datasets/dataset-delete.mdx
+++ b/weave/reference/service-api/datasets/dataset-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Dataset Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/datasets/{object_id}
+---

--- a/weave/reference/service-api/datasets/dataset-list.mdx
+++ b/weave/reference/service-api/datasets/dataset-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Dataset List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/datasets
+---

--- a/weave/reference/service-api/datasets/dataset-read.mdx
+++ b/weave/reference/service-api/datasets/dataset-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Dataset Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/datasets/{object_id}/versions/{digest}
+---

--- a/weave/reference/service-api/eval-results/eval-results-query.mdx
+++ b/weave/reference/service-api/eval-results/eval-results-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Eval Results Query"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/eval_results/query
+---

--- a/weave/reference/service-api/evaluation-runs/evaluation-run-create.mdx
+++ b/weave/reference/service-api/evaluation-runs/evaluation-run-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Run Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/evaluation_runs
+---

--- a/weave/reference/service-api/evaluation-runs/evaluation-run-delete.mdx
+++ b/weave/reference/service-api/evaluation-runs/evaluation-run-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Run Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/evaluation_runs
+---

--- a/weave/reference/service-api/evaluation-runs/evaluation-run-finish.mdx
+++ b/weave/reference/service-api/evaluation-runs/evaluation-run-finish.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Run Finish"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}/finish
+---

--- a/weave/reference/service-api/evaluation-runs/evaluation-run-list.mdx
+++ b/weave/reference/service-api/evaluation-runs/evaluation-run-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Run List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/evaluation_runs
+---

--- a/weave/reference/service-api/evaluation-runs/evaluation-run-read.mdx
+++ b/weave/reference/service-api/evaluation-runs/evaluation-run-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Run Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}
+---

--- a/weave/reference/service-api/evaluations/evaluate-model.mdx
+++ b/weave/reference/service-api/evaluations/evaluate-model.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluate Model"
+openapi: /weave/reference/service-api/openapi.json POST /evaluations/evaluate_model
+---

--- a/weave/reference/service-api/evaluations/evaluation-create.mdx
+++ b/weave/reference/service-api/evaluations/evaluation-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/evaluations
+---

--- a/weave/reference/service-api/evaluations/evaluation-delete.mdx
+++ b/weave/reference/service-api/evaluations/evaluation-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/evaluations/{object_id}
+---

--- a/weave/reference/service-api/evaluations/evaluation-list.mdx
+++ b/weave/reference/service-api/evaluations/evaluation-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/evaluations
+---

--- a/weave/reference/service-api/evaluations/evaluation-read.mdx
+++ b/weave/reference/service-api/evaluations/evaluation-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/evaluations/{object_id}/versions/{digest}
+---

--- a/weave/reference/service-api/evaluations/evaluation-status.mdx
+++ b/weave/reference/service-api/evaluations/evaluation-status.mdx
@@ -1,0 +1,4 @@
+---
+title: "Evaluation Status"
+openapi: /weave/reference/service-api/openapi.json POST /evaluations/status
+---

--- a/weave/reference/service-api/evaluations/rescore-evaluation.mdx
+++ b/weave/reference/service-api/evaluations/rescore-evaluation.mdx
@@ -1,0 +1,4 @@
+---
+title: "Rescore Evaluation"
+openapi: /weave/reference/service-api/openapi.json POST /evaluations/rescore
+---

--- a/weave/reference/service-api/feedback/feedback-aggregate.mdx
+++ b/weave/reference/service-api/feedback/feedback-aggregate.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Aggregate"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/aggregate
+---

--- a/weave/reference/service-api/feedback/feedback-create-batch.mdx
+++ b/weave/reference/service-api/feedback/feedback-create-batch.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Create Batch"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/batch/create
+---

--- a/weave/reference/service-api/feedback/feedback-create.mdx
+++ b/weave/reference/service-api/feedback/feedback-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Create"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/create
+---

--- a/weave/reference/service-api/feedback/feedback-payload-schema.mdx
+++ b/weave/reference/service-api/feedback/feedback-payload-schema.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Payload Schema"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/payload_schema
+---

--- a/weave/reference/service-api/feedback/feedback-purge.mdx
+++ b/weave/reference/service-api/feedback/feedback-purge.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Purge"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/purge
+---

--- a/weave/reference/service-api/feedback/feedback-query.mdx
+++ b/weave/reference/service-api/feedback/feedback-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Query"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/query
+---

--- a/weave/reference/service-api/feedback/feedback-replace.mdx
+++ b/weave/reference/service-api/feedback/feedback-replace.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Replace"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/replace
+---

--- a/weave/reference/service-api/feedback/feedback-stats.mdx
+++ b/weave/reference/service-api/feedback/feedback-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Feedback Stats"
+openapi: /weave/reference/service-api/openapi.json POST /feedback/stats
+---

--- a/weave/reference/service-api/files/file-content.mdx
+++ b/weave/reference/service-api/files/file-content.mdx
@@ -1,0 +1,4 @@
+---
+title: "File Content"
+openapi: /weave/reference/service-api/openapi.json POST /file/content
+---

--- a/weave/reference/service-api/files/file-create.mdx
+++ b/weave/reference/service-api/files/file-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "File Create"
+openapi: /weave/reference/service-api/openapi.json POST /file/create
+---

--- a/weave/reference/service-api/files/files-stats.mdx
+++ b/weave/reference/service-api/files/files-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Files Stats"
+openapi: /weave/reference/service-api/openapi.json POST /files/query_stats
+---

--- a/weave/reference/service-api/images/image-create.mdx
+++ b/weave/reference/service-api/images/image-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Image Create"
+openapi: /weave/reference/service-api/openapi.json POST /image/create
+---

--- a/weave/reference/service-api/inference/inference-analysis-artificialanalysis-models.mdx
+++ b/weave/reference/service-api/inference/inference-analysis-artificialanalysis-models.mdx
@@ -1,0 +1,4 @@
+---
+title: "Inference Analysis Artificialanalysis Models"
+openapi: /weave/reference/service-api/openapi.json GET /inference/analysis/artificialanalysis/models
+---

--- a/weave/reference/service-api/inference/inference-catalog-models.mdx
+++ b/weave/reference/service-api/inference/inference-catalog-models.mdx
@@ -1,0 +1,4 @@
+---
+title: "Inference Catalog Models"
+openapi: /weave/reference/service-api/openapi.json GET /inference/catalog/models
+---

--- a/weave/reference/service-api/inference/inference-modelsdev-models.mdx
+++ b/weave/reference/service-api/inference/inference-modelsdev-models.mdx
@@ -1,0 +1,4 @@
+---
+title: "Inference Modelsdev Models"
+openapi: /weave/reference/service-api/openapi.json GET /inference/modelsdev/models
+---

--- a/weave/reference/service-api/inference/inference-router-openrouter-models.mdx
+++ b/weave/reference/service-api/inference/inference-router-openrouter-models.mdx
@@ -1,0 +1,4 @@
+---
+title: "Inference Router Openrouter Models"
+openapi: /weave/reference/service-api/openapi.json GET /inference/router/openrouter/models
+---

--- a/weave/reference/service-api/inference/nvidia-hardware.mdx
+++ b/weave/reference/service-api/inference/nvidia-hardware.mdx
@@ -1,0 +1,4 @@
+---
+title: "Nvidia Hardware"
+openapi: /weave/reference/service-api/openapi.json GET /inference/nvidia/v2/hardware
+---

--- a/weave/reference/service-api/models/model-create.mdx
+++ b/weave/reference/service-api/models/model-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Model Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/models
+---

--- a/weave/reference/service-api/models/model-delete.mdx
+++ b/weave/reference/service-api/models/model-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Model Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/models/{object_id}
+---

--- a/weave/reference/service-api/models/model-list.mdx
+++ b/weave/reference/service-api/models/model-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Model List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/models
+---

--- a/weave/reference/service-api/models/model-read.mdx
+++ b/weave/reference/service-api/models/model-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Model Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/models/{object_id}/versions/{digest}
+---

--- a/weave/reference/service-api/objects/aliases-list.mdx
+++ b/weave/reference/service-api/objects/aliases-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Aliases List"
+openapi: /weave/reference/service-api/openapi.json GET /aliases
+---

--- a/weave/reference/service-api/objects/obj-add-tags.mdx
+++ b/weave/reference/service-api/objects/obj-add-tags.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Add Tags"
+openapi: /weave/reference/service-api/openapi.json PUT /objs/{object_id}/versions/{digest}/tags
+---

--- a/weave/reference/service-api/objects/obj-create.mdx
+++ b/weave/reference/service-api/objects/obj-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Create"
+openapi: /weave/reference/service-api/openapi.json POST /obj/create
+---

--- a/weave/reference/service-api/objects/obj-delete.mdx
+++ b/weave/reference/service-api/objects/obj-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Delete"
+openapi: /weave/reference/service-api/openapi.json POST /obj/delete
+---

--- a/weave/reference/service-api/objects/obj-read.mdx
+++ b/weave/reference/service-api/objects/obj-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Read"
+openapi: /weave/reference/service-api/openapi.json POST /obj/read
+---

--- a/weave/reference/service-api/objects/obj-remove-aliases.mdx
+++ b/weave/reference/service-api/objects/obj-remove-aliases.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Remove Aliases"
+openapi: /weave/reference/service-api/openapi.json POST /objs/{object_id}/aliases/remove
+---

--- a/weave/reference/service-api/objects/obj-remove-tags.mdx
+++ b/weave/reference/service-api/objects/obj-remove-tags.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Remove Tags"
+openapi: /weave/reference/service-api/openapi.json POST /objs/{object_id}/versions/{digest}/tags/remove
+---

--- a/weave/reference/service-api/objects/obj-set-aliases.mdx
+++ b/weave/reference/service-api/objects/obj-set-aliases.mdx
@@ -1,0 +1,4 @@
+---
+title: "Obj Set Aliases"
+openapi: /weave/reference/service-api/openapi.json PUT /objs/{object_id}/aliases
+---

--- a/weave/reference/service-api/objects/objs-query.mdx
+++ b/weave/reference/service-api/objects/objs-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Objs Query"
+openapi: /weave/reference/service-api/openapi.json POST /objs/query
+---

--- a/weave/reference/service-api/objects/tags-list.mdx
+++ b/weave/reference/service-api/objects/tags-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Tags List"
+openapi: /weave/reference/service-api/openapi.json GET /tags
+---

--- a/weave/reference/service-api/opentelemetry/export-trace.mdx
+++ b/weave/reference/service-api/opentelemetry/export-trace.mdx
@@ -1,0 +1,4 @@
+---
+title: "Export Trace"
+openapi: /weave/reference/service-api/openapi.json POST /otel/v1/traces
+---

--- a/weave/reference/service-api/ops/op-create.mdx
+++ b/weave/reference/service-api/ops/op-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Op Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/ops
+---

--- a/weave/reference/service-api/ops/op-delete.mdx
+++ b/weave/reference/service-api/ops/op-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Op Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/ops/{object_id}
+---

--- a/weave/reference/service-api/ops/op-list.mdx
+++ b/weave/reference/service-api/ops/op-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Op List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/ops
+---

--- a/weave/reference/service-api/ops/op-read.mdx
+++ b/weave/reference/service-api/ops/op-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Op Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/ops/{object_id}/versions/{digest}
+---

--- a/weave/reference/service-api/predictions/prediction-create.mdx
+++ b/weave/reference/service-api/predictions/prediction-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Prediction Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/predictions
+---

--- a/weave/reference/service-api/predictions/prediction-delete.mdx
+++ b/weave/reference/service-api/predictions/prediction-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Prediction Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/predictions
+---

--- a/weave/reference/service-api/predictions/prediction-finish.mdx
+++ b/weave/reference/service-api/predictions/prediction-finish.mdx
@@ -1,0 +1,4 @@
+---
+title: "Prediction Finish"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/predictions/{prediction_id}/finish
+---

--- a/weave/reference/service-api/predictions/prediction-list.mdx
+++ b/weave/reference/service-api/predictions/prediction-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Prediction List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/predictions
+---

--- a/weave/reference/service-api/predictions/prediction-read.mdx
+++ b/weave/reference/service-api/predictions/prediction-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Prediction Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/predictions/{prediction_id}
+---

--- a/weave/reference/service-api/refs/refs-read-batch.mdx
+++ b/weave/reference/service-api/refs/refs-read-batch.mdx
@@ -1,0 +1,4 @@
+---
+title: "Refs Read Batch"
+openapi: /weave/reference/service-api/openapi.json POST /refs/read_batch
+---

--- a/weave/reference/service-api/registry/link-to-registry.mdx
+++ b/weave/reference/service-api/registry/link-to-registry.mdx
@@ -1,0 +1,4 @@
+---
+title: "Link To Registry"
+openapi: /weave/reference/service-api/openapi.json POST /link_to_registry
+---

--- a/weave/reference/service-api/scorers/scorer-create.mdx
+++ b/weave/reference/service-api/scorers/scorer-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Scorer Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/scorers
+---

--- a/weave/reference/service-api/scorers/scorer-delete.mdx
+++ b/weave/reference/service-api/scorers/scorer-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Scorer Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/scorers/{object_id}
+---

--- a/weave/reference/service-api/scorers/scorer-list.mdx
+++ b/weave/reference/service-api/scorers/scorer-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Scorer List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/scorers
+---

--- a/weave/reference/service-api/scorers/scorer-read.mdx
+++ b/weave/reference/service-api/scorers/scorer-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Scorer Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/scorers/{object_id}/versions/{digest}
+---

--- a/weave/reference/service-api/scores/calls-score.mdx
+++ b/weave/reference/service-api/scores/calls-score.mdx
@@ -1,0 +1,4 @@
+---
+title: "Calls Score"
+openapi: /weave/reference/service-api/openapi.json POST /calls/score
+---

--- a/weave/reference/service-api/scores/score-create.mdx
+++ b/weave/reference/service-api/scores/score-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Score Create"
+openapi: /weave/reference/service-api/openapi.json POST /v2/{entity}/{project}/scores
+---

--- a/weave/reference/service-api/scores/score-delete.mdx
+++ b/weave/reference/service-api/scores/score-delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Score Delete"
+openapi: /weave/reference/service-api/openapi.json DELETE /v2/{entity}/{project}/scores
+---

--- a/weave/reference/service-api/scores/score-list.mdx
+++ b/weave/reference/service-api/scores/score-list.mdx
@@ -1,0 +1,4 @@
+---
+title: "Score List"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/scores
+---

--- a/weave/reference/service-api/scores/score-read.mdx
+++ b/weave/reference/service-api/scores/score-read.mdx
@@ -1,0 +1,4 @@
+---
+title: "Score Read"
+openapi: /weave/reference/service-api/openapi.json GET /v2/{entity}/{project}/scores/{score_id}
+---

--- a/weave/reference/service-api/service/get-caller-location.mdx
+++ b/weave/reference/service-api/service/get-caller-location.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Caller Location"
+openapi: /weave/reference/service-api/openapi.json GET /geolocate
+---

--- a/weave/reference/service-api/service/projects-info.mdx
+++ b/weave/reference/service-api/service/projects-info.mdx
@@ -1,0 +1,4 @@
+---
+title: "Projects Info"
+openapi: /weave/reference/service-api/openapi.json POST /service/projects_info
+---

--- a/weave/reference/service-api/service/read-root.mdx
+++ b/weave/reference/service-api/service/read-root.mdx
@@ -1,0 +1,4 @@
+---
+title: "Read Root"
+openapi: /weave/reference/service-api/openapi.json GET /health
+---

--- a/weave/reference/service-api/service/read-version.mdx
+++ b/weave/reference/service-api/service/read-version.mdx
@@ -1,0 +1,4 @@
+---
+title: "Read Version"
+openapi: /weave/reference/service-api/openapi.json GET /version
+---

--- a/weave/reference/service-api/service/server-info.mdx
+++ b/weave/reference/service-api/service/server-info.mdx
@@ -1,0 +1,4 @@
+---
+title: "Server Info"
+openapi: /weave/reference/service-api/openapi.json GET /server_info
+---

--- a/weave/reference/service-api/tables/table-create-from-digests.mdx
+++ b/weave/reference/service-api/tables/table-create-from-digests.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Create From Digests"
+openapi: /weave/reference/service-api/openapi.json POST /table/create_from_digests
+---

--- a/weave/reference/service-api/tables/table-create.mdx
+++ b/weave/reference/service-api/tables/table-create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Create"
+openapi: /weave/reference/service-api/openapi.json POST /table/create
+---

--- a/weave/reference/service-api/tables/table-query-stats-batch.mdx
+++ b/weave/reference/service-api/tables/table-query-stats-batch.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Query Stats Batch"
+openapi: /weave/reference/service-api/openapi.json POST /table/query_stats_batch
+---

--- a/weave/reference/service-api/tables/table-query-stats.mdx
+++ b/weave/reference/service-api/tables/table-query-stats.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Query Stats"
+openapi: /weave/reference/service-api/openapi.json POST /table/query_stats
+---

--- a/weave/reference/service-api/tables/table-query.mdx
+++ b/weave/reference/service-api/tables/table-query.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Query"
+openapi: /weave/reference/service-api/openapi.json POST /table/query
+---

--- a/weave/reference/service-api/tables/table-update.mdx
+++ b/weave/reference/service-api/tables/table-update.mdx
@@ -1,0 +1,4 @@
+---
+title: "Table Update"
+openapi: /weave/reference/service-api/openapi.json POST /table/update
+---

--- a/weave/reference/service-api/threads/threads-query-stream.mdx
+++ b/weave/reference/service-api/threads/threads-query-stream.mdx
@@ -1,0 +1,4 @@
+---
+title: "Threads Query Stream"
+openapi: /weave/reference/service-api/openapi.json POST /threads/stream_query
+---


### PR DESCRIPTION
Completes the migration begun in #3019, applying the same mechanism to the Weave Service API: **115 stub pages across 23 nav groups**, with the `openapi` block removed from the Service API nav group. Also wires the generator into the Service API sync workflow — deliberately held back from #3019 so the monthly sync couldn't perform this cutover unprompted.

## This is the change that actually fixes the broken links

All eight internal links to OpenAPI operation pages target **this** spec. None targeted serverless-training, which is why the pilot fixed none:

```
/weave/reference/service-api/agents/export-genai-trace          (EN)
/weave/reference/service-api/eval-results/eval-results-query     (EN)
/{fr,ja,ko}/weave/reference/service-api/agents/export-genai-trace
/{fr,ja,ko}/weave/reference/service-api/eval-results/eval-results-query
```

They break because Locadex correctly locale-prefixes them while **the destination doesn't exist at the English slug** — the French page for `POST /agents/otel/v1/traces` lives at `.../agents/exporter-la-trace-genai`.

**Fixing the links by hand does not hold.** `8f09c18a2` stripped the prefixes on #2972 and CI went green; Locadex then regenerated those files in `610a68143`, and the identical 6 links broke again. That's now demonstrated, not predicted.

Stubs fix it at the **destination** rather than the link. Once Locadex mirrors these stubs into `fr/ja/ko` under identical filenames, `/fr/weave/reference/service-api/agents/export-genai-trace` resolves — so Locadex's prefixing becomes *correct* instead of broken, with no manual reapplication after each refresh.

## What the pilot already proved

Verified on the current Locadex branch after #3019 merged, so this is measured rather than assumed:

- **12 locale stubs per locale**, filenames preserved (`create-sft-training-job.mdx` in all four).
- **Titles translated** — `"Créer une tâche d'entraînement SFT"`, `"SFT トレーニングジョブを作成"`.
- **`openapi:` rewritten per locale** — `/fr/serverless-training/api-reference/openapi.json`. This was the open question for General Translation; `experimentalLocalizeStaticUrls` handles it.
- **Nav mirrored** — `openapi` block removed from all three locale blocks, 4 groups × 12 pages each, group labels translated (`chat-complétion`, `チャット補完`, `채팅-완성`), paths locale-prefixed.
- Locadex emits the `openapi:` value **line-folded** across two lines. Mintlify accepts it — `mint validate` reported "No errors or warnings detected."

## Verification

- **No English URL moves.** Slug parity reproduces all **115** published operation URLs exactly.
- The **5 `x-exclude`** operations keep their stub files (they're published) but stay out of nav. The `Inference` group correctly disappears, since all 5 of its operations are excluded — matching current behavior.
- Generator is **idempotent** — second run reports `create 0, rebind 0, prune 0`.
- `mint validate` and `mint broken-links` both pass at CI version **4.2.771**.
- `docs.json` diff is confined to the Service API group; the round-trip is byte-identical elsewhere.

## After merge

The next Locadex run should mirror all 115 stubs into `fr/ja/ko` (~345 files, one-time) and the 6 broken links should resolve on their own. Worth confirming on that run rather than pre-emptively editing the links again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)