### PR TITLE
Move ARIA docs up to the top section of Platform

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -92,6 +92,16 @@
                     "pages": [
                       "product-models",
                       "product-weave",
+                      {
+                        "group": "W&B ARIA",
+                        "pages": [
+                          "aria/overview",
+                          "aria/chat",
+                          "aria/autoresearch",
+                          "aria/governance"
+                        ],
+                        "tag": "Preview"
+                      },
                       "hivemind"
                     ]
                   },
@@ -106,16 +116,7 @@
                   {
                     "group": "Platform Details",
                     "pages": [
-                      {
-                        "group": "ARIA",
-                        "pages": [
-                          "aria/overview",
-                          "aria/chat",
-                          "aria/autoresearch",
-                          "aria/governance"
-                        ],
-                        "tag": "Preview"
-                      },
+                      
                       {
                         "group": "Configure W&B",
                         "pages": [


### PR DESCRIPTION
## Description
Move ARIA docs up to the top section of Platform

Fixes DOCS-3035

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
- [x] Menu looks good in preview site https://wb-21fd5541-docs-3035.mintlify.site/ 
