### PR TITLE
Scope PR link check to external URLs, canonicalize redirected links

### DIFF
--- a/.github/workflows/linkcheck-pr.yml
+++ b/.github/workflows/linkcheck-pr.yml
@@ -322,9 +322,17 @@ jobs:
           format: markdown
           # GitHub token for API rate limiting
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Check internal links against the repository tree. A single --base-url
-          # cannot preserve each changed page's directory when resolving relative links.
-          # Mintlify validation separately verifies the rendered route structure.
+          # This check covers external URLs. Internal links are owned by
+          # `mint broken-links` in validate-mdx, which resolves them against the real
+          # route table and so knows about docs.json navigation and redirects; lychee
+          # would resolve them against the repository tree, where a link through a
+          # redirect has no matching file and reports as broken. lychee.toml excludes
+          # ^file:// to leave internal linking to Mintlify. The resolution flags below
+          # stay so local paths still parse into file:// URIs and get excluded quietly
+          # rather than raising InvalidPathToUri warnings.
+          # Do not move the ^file:// pattern to a --exclude flag here: a CLI --exclude
+          # replaces the config's exclude list rather than adding to it, which would
+          # re-enable every excluded external domain.
           # Inputs come from lychee-pr-inputs.txt (see "Write lychee input file list") so
           # we do not pass every path on the shell argv (ARG_MAX on large PRs).
           args: >-

--- a/lychee.toml
+++ b/lychee.toml
@@ -44,6 +44,12 @@ verbose = "error"
 # Third party URLs that timeout or rate-limit
 # W&B production URLs that timeout or rate-limit
 exclude = [
+  # Internal links, which lychee resolves to file:// paths against the repository
+  # tree. That tree is not the route table: it does not know docs.json redirects or
+  # navigation, so valid routes resolve to missing files and report as broken.
+  # `mint broken-links` in validate-mdx owns internal links and checks them against
+  # the real routes. Leave internal linking to it; lychee covers off-site URLs only.
+  '^file://',
   '(http|https)://0\.0\.0\.0',
   '(http|https)://localhost',
   '(http|https)://127\.0\.0\.1',

--- a/release-notes/new-articles.mdx
+++ b/release-notes/new-articles.mdx
@@ -15,8 +15,9 @@ Within each month, articles are grouped by the part of the documentation they be
   preserved as long as they keep the same structure:
     - a "## Month YYYY" heading per month, newest first
     - a "### Product" heading for each product with new articles that month
-    - one <Card title="..." href="/path/" arrow="true" horizontal> per article,
-      with the description as the card body
+    - one <Card> per article, carrying the title, href, arrow, and horizontal
+      attributes, where href is the article's site-root path and the article
+      description is the card body
 */}
 
 {/* new-articles:start */}

--- a/release-notes/server-releases-archived.mdx
+++ b/release-notes/server-releases-archived.mdx
@@ -375,8 +375,8 @@ The release includes the following additional updates:
 ## Fixes
 
 * Fixed an issue where underlying database schema changes as part of release upgrades could timeout during platform startup time.
-* Added more performance improvements to the underlying parquet store service, to further improve the chart loading times for users. Parquet store service is only available on Dedicated Cloud, and Self-Managed instances based on [W&B kubernetes operator](https://docs.wandb.ai/platform/hosting/operator).
-* Addressed the high CPU utilization issue for the underlying parquet store service, to make the efficient chart loading more reliable for users. Parquet store service is only available on Dedicated Cloud, and Self-Managed instances based on [W&B kubernetes operator](https://docs.wandb.ai/platform/hosting/operator).
+* Added more performance improvements to the underlying parquet store service, to further improve the chart loading times for users. Parquet store service is only available on Dedicated Cloud, and Self-Managed instances based on [W&B kubernetes operator](/platform/hosting/self-managed/operator).
+* Addressed the high CPU utilization issue for the underlying parquet store service, to make the efficient chart loading more reliable for users. Parquet store service is only available on Dedicated Cloud, and Self-Managed instances based on [W&B kubernetes operator](/platform/hosting/self-managed/operator).
 </Update>
 
 <Update label="v0.60.0" description="September 26, 2024">
@@ -514,7 +514,7 @@ Due to a release versioning issue, 0.56.0 is the next major release after 0.54.0
 ## Features
 
 * You can now save multiple views of any workspace by clicking "Save as a new view" in the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu of the workspace bar.
-  See [Saved workspace views](https://docs.wandb.ai/models/app/pages/workspaces#create-saved-workspace-views) to learn more.
+  See [Saved workspace views](/models/app/features/cascade-settings) to learn more.
 
   <Frame>
   ![Image showing saved views](https://github.com/wandb/server/assets/7208315/862a36ac-8ce4-49e7-8677-d87d54ab1e54)
@@ -527,7 +527,7 @@ Due to a release versioning issue, 0.56.0 is the next major release after 0.54.0
 * Cloning a run with Launch now pre-selects the overrides, queue, and template variable values used by the cloned run.
 * Instance admins will now see a `Teams` tab in the organization dashboard. It can be used to join a specific team when needed, whether it's to monitor the team activity as per organizational guidelines or to help the team when team admins are not available. 
 * SCIM User API now returns the `groups` attribute as part of the GET endpoint, which includes the id of the groups / teams a user is part of.
-* All Dedicated Cloud instances on Google Cloud are now managed using the new [W&B Kubernetes Operator](https://docs.wandb.ai/platform/hosting/operator/). With that, the new Parquet Store service is also available. 
+* All Dedicated Cloud instances on Google Cloud are now managed using the new [W&B Kubernetes Operator](/platform/hosting/self-managed/operator). With that, the new Parquet Store service is also available. 
   Parquet store allows performant & cost efficient storage of run history data in parquet format in the blob storage. Dedicated Cloud instances on AWS & Azure are already managed using the operator and include the parquet store.
 * Dedicated Cloud instances on AWS have been updated to use the latest version of the relational data storage, and the compute infrastructure has been upgraded to a newer generation with better performance.
 


### PR DESCRIPTION
## Problem

The lychee PR check resolves internal links against the repository tree. That tree is not the route table — it knows nothing about `docs.json` redirects or navigation — so a link through a redirect has no matching file on disk and reports as broken.

`mint broken-links` in validate-mdx already checks internal links against the real routes, and it is the required status check. Where the two disagree, mint is right.

This was generating false broken-link reports on the Locadex translation PRs. On #2972 all 5 reported errors were false positives.

## Changes

- **`lychee.toml`** — exclude `^file://`, leaving internal linking to Mintlify and lychee to off-site URLs.
- **`.github/workflows/linkcheck-pr.yml`** — comment only. `args` are unchanged; the resolution flags stay so local paths still parse into `file://` URIs and get excluded quietly instead of raising `InvalidPathToUri` warnings.
- **`release-notes/server-releases-archived.mdx`** — 4 links repointed at canonical paths rather than routing through redirects.
- **`release-notes/new-articles.mdx`** — the `<Card>` example in the header comment no longer contains a literal link. It sits outside the `new-articles:start` markers, so the generator will not overwrite it.

### One trap worth knowing

The `^file://` pattern must live in `lychee.toml`, not a `--exclude` flag. A CLI `--exclude` *replaces* the config's exclude list rather than adding to it — passing it as a flag silently re-enabled every excluded external domain. There is a comment in the workflow so nobody moves it later.

## How to validate

Run lychee over the changed files of the Locadex PR with this config. Before: 5 errors. After: 0, with external checking intact.

```bash
git worktree add /tmp/pr2972 origin/locadex/parallel/t9n-main-cs60c8p4o6ik99tylxgp3t11
cd /tmp/pr2972
git diff --name-only --diff-filter=d $(git merge-base origin/main HEAD) HEAD | grep '\.mdx$' > inputs.txt
xargs lychee --config /path/to/this/branch/lychee.toml --root-dir /tmp/pr2972 \
  --fallback-extensions mdx --index-files index.mdx,. < inputs.txt
```

Result over all 586 changed files: `3574 Total, 191 OK, 0 Errors, 3383 Excluded`.

Two things to confirm the check has not simply been switched off:

- **External links still get checked.** The 191 OK are real external URLs. Point it at a file with a known-dead external link and it should still fail.
- **The config's domain excludes still apply.** No `github.com/wandb` or `docs.wandb.ai` results in the output — if those appear, the exclude list has been clobbered.

Locally, `mint validate` and `mint broken-links` both pass on this branch (`mint` 4.2.778, matching what CI installs).

## Notes

- This does not unblock #2972 — that PR already passes both required checks and is held by draft status and review. What it fixes is the advisory comment crying wolf.
- One link was deliberately left alone: `models/ref/python/automations.mdx:15` points at a path that is both a live page and a redirect source whose destination does not exist. Canonicalizing it would have pointed it at nothing. Filed as DOCS-3057.
- The 12 remaining links through redirects are all `fr`/`ja`/`ko` copies of the release notes; they regenerate from English on the next Locadex run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)