### PR TITLE
Redirect: update docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8346,8 +8346,12 @@
       "source": "/ref/python/sdk/*"
     },
     {
-      "destination": "/models/ref/python/public-api/automations",
-      "source": "/models/ref/python/automations/automation"
+      "destination" : "/models/ref/python/public-api",
+      "source" : "/models/ref/python/public-api/agentruns"
+    },
+    {
+      "destination": "/models/ref/python/automations",
+    "source": "/models/ref/python/public-api/automations"
     },
     {
       "destination": "/models/ref/wandb_workspaces/:slug*",


### PR DESCRIPTION
## Description
Updates docs.json redirect for `automations` (removed public API version, only keep automation namespace),  and `agentruns`. 

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-3057

