### PR TITLE
chore(inference): Remove GPT OSS 120B LoRA support

### DIFF
--- a/inference/lora.mdx
+++ b/inference/lora.mdx
@@ -118,7 +118,6 @@ Your LoRA must be trained against one of the following base models. Use the exac
 | ----------------------------------- | ----------------- |
 | `meta-llama/Llama-3.1-70B-Instruct` | 16                |
 | `meta-llama/Llama-3.1-8B-Instruct`  | 16                |
-| `openai/gpt-oss-120b`               | 64                |
 | `OpenPipe/Qwen3-14B-Instruct`       | 16                |
 | `Qwen/Qwen3.6-27B`                  | 16                |
 | `Qwen/Qwen3-30B-A3B-Instruct-2507`  | 16                |


### PR DESCRIPTION
## Description

Takeru-generated change. LoRA support for this older model has never been very good, product made the call to stop supporting it.

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [x] PR tests succeed
