### PR TITLE
ci: Migrate the DocEngine import workflow to the published actions

### DIFF
--- a/.github/workflows/docengine-bootstrap-selftest.yaml
+++ b/.github/workflows/docengine-bootstrap-selftest.yaml
@@ -3,10 +3,8 @@
 # situations it is designed to handle.
 #
 # That action is what fetches CoreWeave's documentation tooling (DocEngine) for
-# every other docs workflow, so it needs to be verifiable on its own. Right now
-# nothing else calls it yet - the existing DocEngine workflows still do this
-# setup inline, and moving them over happens later - so without this test there
-# would be no way to tell whether it works.
+# the docs workflows, so it needs to be verifiable on its own - not only
+# through the workflows that call it.
 #
 # The two cases:
 #   1. Given a token, it fetches DocEngine and reports available=true.

--- a/.github/workflows/docengine-build.yml
+++ b/.github/workflows/docengine-build.yml
@@ -1,27 +1,24 @@
 name: DocEngine - build - push
 
-# Thin shell for the published docengine-build action (atomic output): a push
-# to a source branch that touches the DocEngine source (docengine-site/) or
-# the engine pin (docengine submodule) builds the site and commits the
-# generated output back to the SAME branch, so a reviewer sees the source
-# change and its rendered effect in one PR. The build/commit/comment logic
-# lives in the submodule at docengine/host-actions/docengine-build; this file
-# owns triggers, permissions, and credentials.
+# Thin shell for the published docengine-build action (atomic output): a
+# push touching the DocEngine source (docengine-site/) or the engine pin
+# rebuilds the site and commits the generated output back to the SAME
+# branch, so a reviewer sees the source change and its rendered effect in
+# one PR. The build/commit/comment logic lives in the submodule at
+# docengine/host-actions/docengine-build; this file owns triggers,
+# permissions, and credentials.
 #
-# Auth: the wandb-docs-pr-writer GitHub App mints the push token for the
-# output commit and PR comments (NOT GITHUB_TOKEN, so the output commit
-# triggers the host's validation workflows, e.g. Validate MDX). The
-# docengine-bootstrap action fetches the private engine submodule with
-# DOCENGINE_TOKEN and owns the single git URL rewrite rule. See
-# .github/workflows/README.md.
+# Auth: the wandb-docs-pr-writer App token pushes the output commit (NOT
+# GITHUB_TOKEN, so the host's validation workflows re-trigger); the
+# bootstrap fetches the private engine submodule with DOCENGINE_TOKEN and
+# owns the single git URL rewrite rule. See .github/workflows/README.md.
 #
-# Loop safety: the trigger is `on: push` (never pull_request) and the
-# output-only commit touches the generated paths alone — disjoint from the
-# trigger paths — so it cannot re-fire this build.
+# Loop safety: `on: push` only, and the output commit touches the generated
+# paths alone — disjoint from the trigger paths, so it cannot re-fire this
+# build.
 
 concurrency:
-  # A newer push to the same branch cancels an in-flight build before it
-  # commits stale output; different branches build in parallel.
+  # A newer push cancels an in-flight build before it commits stale output.
   group: docengine-build-${{ github.ref }}
   cancel-in-progress: true
 
@@ -51,14 +48,13 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Push runs are never dry: the expression only honors the input on a
-      # manual dispatch (inputs is empty on push events).
+      # Only a manual dispatch can be dry: `inputs` is empty on push events.
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs['dry-run'] || false }}
 
     steps:
-      # Dependabot-triggered runs cannot mint the App token, so the mint is
-      # skipped here and the action skips its commit and comment steps; the
-      # bump PR gains atomic output on the first human push.
+      # Dependabot runs cannot mint the App token: the mint is skipped, the
+      # action skips its commit and comment steps, and the bump PR gains
+      # atomic output on the first human push.
       - name: Require app credentials
         if: github.actor != 'dependabot[bot]'
         run: |
@@ -80,23 +76,21 @@ jobs:
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # App token persists as the push credential for the action's
-          # commit-back. Falls back to DOCENGINE_TOKEN for dependabot[bot]
-          # runs. NOTE: no `submodules:` here — the bootstrap initializes the
-          # docengine submodule alone (`recursive` would also try the
-          # unrelated `.claude` submodule).
+          # App token persists as the action's push credential; read-only
+          # fallback for dependabot runs. No `submodules:` — the bootstrap
+          # inits docengine alone (recursive would hit the unreadable
+          # .claude submodule).
           token: ${{ steps.app_token.outputs.token || secrets.DOCENGINE_TOKEN }}
 
-      # The engine and the published build action both live in the
-      # submodule; the bootstrap also owns the single git URL rewrite rule.
+      # The engine and the published build action both ship in the
+      # submodule; the bootstrap puts them on disk.
       - name: Fetch DocEngine (engine + published build action)
         id: bootstrap
         uses: ./.github/actions/docengine-bootstrap
         with:
           read-token: ${{ secrets.DOCENGINE_TOKEN }}
 
-      # The build IS the submodule: without it there is nothing to run, so
-      # fail loudly instead of producing a confusing error later.
+      # The build IS the submodule — fail loudly, not confusingly later.
       - name: Require DocEngine
         if: steps.bootstrap.outputs.available != 'true'
         run: |
@@ -109,12 +103,11 @@ jobs:
           push-token: ${{ steps.app_token.outputs.token }}
           git-user-name: 'wandb-docs-pr-writer[bot]'
           git-user-email: 'wandb-docs-pr-writer[bot]@users.noreply.github.com'
-          # The generator-owned subtree PLUS the engine's known writes
-          # outside it. This site's output root is the repository root, so
-          # the escapes must be enumerated here: the engine prepends to
-          # changelog.mdx whenever the site has published diffs, and a bare
-          # `snippets/docengine` would silently drop that write (never pass
-          # the repository root — see the action's commit-paths description).
+          # Generator subtree PLUS the engine's known escapes: this site's
+          # output root is the repo root, so the committed set is enumerated
+          # — never pass a root path (see the action's commit-paths
+          # description). A bare `snippets/docengine` would silently drop
+          # the changelog write.
           commit-paths: |
             snippets/docengine
             changelog.mdx
@@ -122,15 +115,12 @@ jobs:
           dry-run: ${{ env.DRY_RUN }}
 
       # Standard 2: a failed build files ONE canonical self-managing GitHub
-      # issue for this workflow, updated in place and closed by the next
-      # passing run. Deliberately not per-branch: build-triggering pushes are
-      # rare here, a branch failure is already a red check on its own PR, and
-      # a per-branch item would orphan if its branch were abandoned while
-      # red. The body names the failing branch and links the run. The
-      # reporter lives in the submodule, so it can only run when the
-      # bootstrap succeeded; a run that failed before checkout has nothing to
-      # report with. Uses the workflow's own token (issues: write above), so
-      # dependabot runs skip it.
+      # issue, updated in place and closed by the next passing run. Not
+      # per-branch: a branch failure is already a red check on its own PR,
+      # and a per-branch item would orphan with an abandoned branch. The
+      # reporter ships in the submodule, so it can only run once the
+      # bootstrap succeeded; it uses the workflow's own token
+      # (issues: write above), so dependabot runs skip it.
       - name: Report build result as a GitHub issue
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && steps.checkout.outcome == 'success' && steps.bootstrap.outputs.available == 'true' }}
         uses: ./docengine/host-actions/issue-report

--- a/.github/workflows/docengine-import.yml
+++ b/.github/workflows/docengine-import.yml
@@ -1,25 +1,31 @@
 name: DocEngine - data import
 
-# Scheduled refresh of the DocEngine database (validated YAML data) from upstream
-# sources, running IN-REPO on the pinned `docengine` submodule. Opens one same-repo
-# PR updating docengine-site/data/**. That PR's push then triggers docengine-build
-# (atomic output), which regenerates the snippets and runs the host validations —
-# this workflow does NOT build (clean separation of concerns).
+# Thin shell for the published prepare-matrix + docengine-import actions: a
+# Prepare job lists the importers, then a matrix job (fail-fast off) runs
+# each importer in its own job and opens its own static per-importer PR.
+# Each data PR's push triggers docengine-build (atomic output) — import
+# never builds.
 #
-# Hello World note: there are no importers yet (docengine-site/importers/ is an
-# empty stub), so `docengine import --all` is a no-op until importers are added.
+# DORMANT: docengine-site/importers/ is empty, so the schedule is
+# deliberately off and a manual dispatch is a clean no-op (prepare-matrix
+# emits [] and the matrix spawns zero jobs). To enable once importers
+# exist: uncomment the schedule and wire the issue-report failure reporter
+# (see docengine-build.yml for the pattern).
 #
-# Auth:
-#   - Engine submodule checkout (PRIVATE coreweave/docengine): DOCENGINE_TOKEN via
-#     url.insteadOf.
-#   - PR auth (push branch + open PR with a workflow-triggering identity): the
-#     wandb-docs-pr-writer App token, so the docengine-site/data/** change fires
-#     docengine-build.yml.
+# Auth: the docengine-bootstrap action fetches the private engine submodule
+# with DOCENGINE_TOKEN and owns the single git URL rewrite rule. The App
+# token is only the checkout push credential and the PR identity, so data
+# PRs trigger docengine-build.
 
 on:
   # schedule:
   #   - cron: "17 6 * * *"   # ~06:17 UTC daily (PR only on change)
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run: preview the import and skip the PR'
+        default: false
+        type: boolean
 
 concurrency:
   group: docengine-import
@@ -30,8 +36,45 @@ permissions:
   pull-requests: write
 
 jobs:
-  DocEngineImport:
+  Prepare:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.prepare.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The published actions ship inside the submodule; the bootstrap puts
+      # them on disk and owns the single git URL rewrite rule.
+      - name: Fetch DocEngine (engine + published actions)
+        id: bootstrap
+        uses: ./.github/actions/docengine-bootstrap
+        with:
+          read-token: ${{ secrets.DOCENGINE_TOKEN }}
+
+      - name: Require DocEngine
+        if: steps.bootstrap.outputs.available != 'true'
+        run: |
+          echo "::error::prepare-matrix runs from the DocEngine submodule, which the bootstrap could not fetch. Check the DOCENGINE_TOKEN secret."
+          exit 1
+
+      - name: List importers
+        id: prepare
+        uses: ./docengine/host-actions/prepare-matrix
+        with:
+          subsystem: importers
+
+  Import:
+    needs: Prepare
+    if: needs.Prepare.outputs.matrix != '[]'
+    strategy:
+      # Failures are isolated: one importer failing neither blocks nor hides
+      # the others.
+      fail-fast: false
+      matrix:
+        importer: ${{ fromJson(needs.Prepare.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    env:
+      # Only a manual dispatch can be dry: `inputs` is empty on schedule.
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs['dry-run'] || false }}
     steps:
       - name: Require app credentials
         run: |
@@ -56,55 +99,31 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # App token persists as the push credential; peter-evans uses it explicitly
-          # for the PR. No `submodules:` here — `recursive` would also try the
-          # unrelated `.claude` (docs-skills) submodule.
+          # App token persists as the push credential. No `submodules:` — the
+          # bootstrap inits docengine alone (recursive would hit the
+          # unreadable .claude submodule).
           token: ${{ steps.app_token.outputs.token }}
 
-      - name: Authenticate git for the private coreweave docengine submodule
-        env:
-          TOKEN: ${{ secrets.DOCENGINE_TOKEN }}
+      - name: Fetch DocEngine (engine + published actions)
+        id: bootstrap
+        uses: ./.github/actions/docengine-bootstrap
+        with:
+          read-token: ${{ secrets.DOCENGINE_TOKEN }}
+
+      - name: Require DocEngine
+        if: steps.bootstrap.outputs.available != 'true'
         run: |
-          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "::error::The import runs the engine from the DocEngine submodule, which the bootstrap could not fetch. Check the DOCENGINE_TOKEN secret."
+          exit 1
 
-      - name: Initialize the engine submodule (docengine only; skip .claude)
-        run: git submodule update --init --depth 1 docengine
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - name: Import and open the data PR
+        uses: ./docengine/host-actions/docengine-import
         with:
-          python-version: '3.12'
-
-      - name: Install DocEngine from the submodule
-        run: pip install -e ./docengine
-
-      - name: Run all data importers
-        # Slim descriptor (docengine-site/docengine.yaml) selects the single site; no
-        # --site needed. Every discovered importer runs in one job for a consistent
-        # snapshot, writing validated YAML into docengine-site/data/<table>/.
-        run: docengine import --all
-
-      - name: Open PR with YAML updates
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
-        with:
-          token: ${{ steps.app_token.outputs.token }}
-          branch: docengine/data-import
-          delete-branch: true
-          add-paths: |
-            docengine-site/data/**
-          commit-message: |
-            Scheduled data import
-
-            Automated refresh of DocEngine database tables from upstream sources.
-          title: "Scheduled data import"
-          labels: auto-generated
-          body: |
-            Automated refresh of DocEngine database tables from their upstream sources.
-
-            All importers ran together in one job for a consistent snapshot. The
-            `docengine-site/data/**` change in this PR triggers the DocEngine build
-            workflow, which regenerates the snippets and runs the site validations.
-
-            **Workflow run:** [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          importer: ${{ matrix.importer }}
+          push-token: ${{ steps.app_token.outputs.token }}
+          git-user-name: 'wandb-docs-pr-writer[bot]'
+          git-user-email: 'wandb-docs-pr-writer[bot]@users.noreply.github.com'
+          dry-run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
Replaces the original single-job `import --all` workflow with the shared import shell in its dormant form. It uses the same Prepare→guarded-matrix skeleton the CoreWeave host runs, calling the published `prepare-matrix` + `docengine-import` actions in the submodule (pinned at v3.8.0), with the schedule deliberately off because `docengine-site/importers/` is empty. 

A manual dispatch is a clean no-op. `prepare-matrix` emits `[]` and the matrix spawns zero jobs (proven on the release candidate harness PR https://github.com/wandb/docs/pull/3062, closed unmerged by design). Enabling this workflow later is a one-line schedule change plus wiring the issue-report reporter.

Also rides along: the family-standard `dry-run` dispatch input, and a comments-only streamlining of the build shell and the bootstrap self-test header.