### PR TITLE
ci: Migrate the DocEngine overlay workflow to the published actions

### DIFF
--- a/.github/workflows/docengine-build.yml
+++ b/.github/workflows/docengine-build.yml
@@ -39,8 +39,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # For the issue-report step below (Standard 2: build failures file a
-  # self-managing GitHub issue).
+  # For the issue-report step below (build failures file a self-managing
+  # GitHub issue).
   issues: write
 
 jobs:
@@ -114,8 +114,8 @@ jobs:
           commit-message: 'docs: regenerate docengine snippets (atomic output)'
           dry-run: ${{ env.DRY_RUN }}
 
-      # Standard 2: a failed build files ONE canonical self-managing GitHub
-      # issue, updated in place and closed by the next passing run. Not
+      # A failed build files ONE canonical self-managing GitHub issue,
+      # updated in place and closed by the next passing run. Not
       # per-branch: a branch failure is already a red check on its own PR,
       # and a per-branch item would orphan with an abandoned branch. The
       # reporter ships in the submodule, so it can only run once the

--- a/.github/workflows/docengine-overlay.yml
+++ b/.github/workflows/docengine-overlay.yml
@@ -1,133 +1,81 @@
 name: DocEngine - API spec overlay refresh
 
-# Re-fetch upstream OpenAPI specs, apply DocEngine overlays, and open one PR per API
-# overlay, running IN-REPO on the pinned `docengine` submodule. A single workflow +
-# matrix covers every discovered overlay — no per-API files. Overlay apply only;
-# never bundled with the data import or the MDX build.
+# Thin shell for the published prepare-matrix + docengine-overlay actions: a
+# Plan job lists the overlays, then a matrix job (fail-fast off) refreshes
+# each API's curated spec in its own job and opens its own static per-API
+# PR. Overlay apply only — never bundled with the data import or the MDX
+# build.
 #
-# Hello World note: there are no overlays yet (docengine-site/overlays/ is an empty
-# stub), so the `plan` job emits an empty matrix and the `overlay` job is skipped
-# until an overlay is added under docengine-site/overlays/<api>/.
+# DORMANT: docengine-site/overlays/ is empty, so the schedule is
+# deliberately off and a manual dispatch is a clean no-op (prepare-matrix
+# emits [] and the matrix spawns zero jobs). To enable once overlays exist:
+# uncomment the schedule, wire the issue-report failure reporter (see
+# docengine-build.yml for the pattern), and add draft-overlay gating if an
+# overlay isn't ready for scheduled PRs (see prepare-matrix's inputs).
 #
-# Separation of concerns:
-#   - This workflow         → upstream API spec drift only (one OpenAPI YAML per PR)
-#   - docengine-build.yml   → DocEngine data / generator output (MDX, atomic output)
-#   - docengine-import.yml  → scheduled importer data into docengine-site/data/**
-#
-# Auth:
-#   - Engine submodule checkout (PRIVATE coreweave/docengine): DOCENGINE_TOKEN via
-#     url.insteadOf.
-#   - PR auth (push branch + open PR with a workflow-triggering identity): the
-#     wandb-docs-pr-writer App token.
-#
-# Output: `docengine overlay apply --output-dir "$GITHUB_WORKSPACE"` writes the
-# curated spec in place under the host's output subpath (output_subpath: .).
+# Auth: the docengine-bootstrap action fetches the private engine submodule
+# with DOCENGINE_TOKEN and owns the single git URL rewrite rule. The App
+# token is only the checkout push credential and the PR identity, so spec
+# PRs trigger the host's validations.
 
 on:
   # schedule:
   #   - cron: "47 6 * * *"   # ~06:47 UTC daily (offset from data import)
   workflow_dispatch:
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    inputs:
+      dry-run:
+        description: 'Dry run: preview the overlay apply and skip the PR'
+        default: false
+        type: boolean
 
 concurrency:
   group: docengine-overlay
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  plan:
+  Plan:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
-      - name: Require app credentials
-        run: |
-          if [ -z "${{ vars.DOCS_PR_WRITER_CLIENT_ID }}" ] || [ -z "${{ secrets.DOCS_PR_WRITER_PRIVATE_KEY }}" ]; then
-            echo "::error::DOCS_PR_WRITER_CLIENT_ID (variable) and DOCS_PR_WRITER_PRIVATE_KEY (secret) must be set in Settings → Secrets and variables → Actions."
-            exit 1
-          fi
-
-      - name: Require submodule-read token
-        run: |
-          if [ -z "${{ secrets.DOCENGINE_TOKEN }}" ]; then
-            echo "::error::DOCENGINE_TOKEN is not set. Required to clone the private coreweave/docengine submodule."
-            exit 1
-          fi
-
-      - name: Generate token for wandb-docs-pr-writer
-        id: app_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The published actions ship inside the submodule; the bootstrap puts
+      # them on disk and owns the single git URL rewrite rule.
+      - name: Fetch DocEngine (engine + published actions)
+        id: bootstrap
+        uses: ./.github/actions/docengine-bootstrap
         with:
-          client-id: ${{ vars.DOCS_PR_WRITER_CLIENT_ID }}
-          private-key: ${{ secrets.DOCS_PR_WRITER_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          read-token: ${{ secrets.DOCENGINE_TOKEN }}
 
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          token: ${{ steps.app_token.outputs.token }}
-
-      - name: Authenticate git for the private coreweave docengine submodule
-        env:
-          TOKEN: ${{ secrets.DOCENGINE_TOKEN }}
+      - name: Require DocEngine
+        if: steps.bootstrap.outputs.available != 'true'
         run: |
-          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "::error::prepare-matrix runs from the DocEngine submodule, which the bootstrap could not fetch. Check the DOCENGINE_TOKEN secret."
+          exit 1
 
-      - name: Initialize the engine submodule (docengine only; skip .claude)
-        run: git submodule update --init --depth 1 docengine
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - name: List overlays
+        id: plan
+        uses: ./docengine/host-actions/prepare-matrix
         with:
-          python-version: '3.12'
+          subsystem: overlays
 
-      - name: Install DocEngine from the submodule
-        run: pip install -e ./docengine
-
-      - name: Build overlay matrix
-        id: matrix
-        # Slim-aware discovery: mirror `docengine overlay list`'s resolution. Emits
-        # one row per discovered overlay as {api, output_path}; output_path =
-        # output_subpath + the overlay's output_spec_path. Python runs as its own
-        # command so a crash trips the shell's `-e` (GHA default) instead of being
-        # masked by the pipe in a command substitution; `tail -1` then drops the
-        # resolver's stdout note line.
-        run: |
-          python -c "
-          import json
-          from app.overlay_cli import _build_runner
-          from app.cli_context import bootstrap_repo, resolve_default_site_context, resolve_site
-          _, sm = bootstrap_repo()
-          ctx = resolve_default_site_context(None, sm)
-          resolved = resolve_site(ctx, sm)
-          if resolved is None:
-              raise SystemExit('resolve_site returned None')
-          paths = resolved.paths
-          sub = (paths.descriptor.output_subpath or '').strip()
-          runner = _build_runner(paths)
-          rows = [
-              {'api': r['name'],
-               'output_path': '/'.join(p for p in (sub, r['output_spec_path']) if p)}
-              for r in runner.list_overlays()
-          ]
-          print(json.dumps(rows))
-          " > "$RUNNER_TEMP/overlay-matrix.txt"
-          MATRIX=$(tail -1 "$RUNNER_TEMP/overlay-matrix.txt")
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "Overlay matrix: $MATRIX"
-
-  overlay:
-    needs: plan
-    if: needs.plan.outputs.matrix != '[]' && needs.plan.result == 'success'
-    runs-on: ubuntu-latest
+  Overlay:
+    needs: Plan
+    if: needs.Plan.outputs.matrix != '[]'
     strategy:
+      # Failures are isolated: one API failing neither blocks nor hides the
+      # others.
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.plan.outputs.matrix) }}
-    permissions:
-      contents: write
-      pull-requests: write
+        include: ${{ fromJson(needs.Plan.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    env:
+      # Only a manual dispatch can be dry: `inputs` is empty on schedule.
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs['dry-run'] || false }}
     steps:
       - name: Require app credentials
         run: |
@@ -152,58 +100,33 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # App token persists as the push credential. No `submodules:` — the
+          # bootstrap inits docengine alone (recursive would hit the
+          # unreadable .claude submodule).
           token: ${{ steps.app_token.outputs.token }}
 
-      - name: Authenticate git for the private coreweave docengine submodule
-        env:
-          TOKEN: ${{ secrets.DOCENGINE_TOKEN }}
+      - name: Fetch DocEngine (engine + published actions)
+        id: bootstrap
+        uses: ./.github/actions/docengine-bootstrap
+        with:
+          read-token: ${{ secrets.DOCENGINE_TOKEN }}
+
+      - name: Require DocEngine
+        if: steps.bootstrap.outputs.available != 'true'
         run: |
-          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "::error::The overlay apply runs the engine from the DocEngine submodule, which the bootstrap could not fetch. Check the DOCENGINE_TOKEN secret."
+          exit 1
 
-      - name: Initialize the engine submodule (docengine only; skip .claude)
-        run: git submodule update --init --depth 1 docengine
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - name: Refresh the spec and open the PR
+        uses: ./docengine/host-actions/docengine-overlay
         with:
-          python-version: '3.12'
-
-      - name: Install DocEngine from the submodule
-        run: pip install -e ./docengine
-
-      - name: Run DocEngine overlay
-        env:
-          # Matrix values via env (not direct ${{ }} interpolation into the shell) so
-          # they can never be parsed as shell, should a future change introduce an
-          # attacker-influenced matrix value.
-          API: ${{ matrix.api }}
-        run: docengine overlay apply --api "$API" --output-dir "$GITHUB_WORKSPACE"
-
-      - name: Open PR with curated OpenAPI spec
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
-        with:
-          token: ${{ steps.app_token.outputs.token }}
-          branch: docengine/${{ matrix.api }}-api-specs
-          delete-branch: true
-          add-paths: ${{ matrix.output_path }}
-          commit-message: |
-            docs: Refresh ${{ matrix.api }} OpenAPI spec from upstream
-
-            Automated overlay apply for the ${{ matrix.api }} API.
-          title: "Scheduled upstream API spec refresh (${{ matrix.api }})"
-          labels: auto-generated, api-specs
-          body: |
-            This PR refreshes the **${{ matrix.api }}** curated OpenAPI spec produced by
-            DocEngine overlays against the latest upstream API repository. It contains
-            API reference changes for this API only — no DocEngine data or MDX generator output.
-
-            **Output file:** `${{ matrix.output_path }}`
-
-            **Overlay:** `docengine-site/overlays/${{ matrix.api }}/`
-
-            **Workflow run:** [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-            > [!IMPORTANT]
-            > Review API surface changes (new/removed operations, schema drift) before merging.
+          api: ${{ matrix.api }}
+          output-path: ${{ matrix.output_path }}
+          output-dir: ${{ github.workspace }}
+          push-token: ${{ steps.app_token.outputs.token }}
+          git-user-name: 'wandb-docs-pr-writer[bot]'
+          git-user-email: 'wandb-docs-pr-writer[bot]@users.noreply.github.com'
+          dry-run: ${{ env.DRY_RUN }}

--- a/.github/workflows/docengine-pin-guard-pr.yaml
+++ b/.github/workflows/docengine-pin-guard-pr.yaml
@@ -38,8 +38,9 @@
 # organization secret, Actions store only), and wandb/docs defines
 # DOCENGINE_TOKEN (a rolling token, held in BOTH its Actions and Dependabot
 # stores). That fallback is what lets this file stay byte-identical across
-# hosts. Whether a missing token fails the check depends on who triggered
-# the run:
+# hosts, modulo the pin version comments (each host's dependency updater
+# writes its own comment style). Whether a missing token fails the check
+# depends on who triggered the run:
 #
 #   - Dependabot's own runs read from the Dependabot secret store. Where that
 #     store holds the credential (wandb/docs), automated bumps are validated


### PR DESCRIPTION
Replaces the original overlay workflow with the shared overlay shell in its dormant form: the same Plan→guarded-matrix skeleton the CoreWeave host runs, calling the published `prepare-matrix` + `docengine-overlay` actions in the submodule (pinned at v3.9.0), with the schedule deliberately off because `docengine-site/overlays/` is empty. 

A manual dispatch is a clean no-op — prepare-matrix emits `[]` and the matrix spawns zero jobs (proven on the rc harness, closed unmerged by design). Enabling later is a schedule change plus wiring the issue-report reporter (and creating the `api-specs` label, which this repo lacks).

Also rides along: the family-standard `dry-run` dispatch input, the standard dormancy comment replacing the Hello World note, and a comment-only tidy of the build and pin-guard workflows (drops internal standard numbers invisible from this repo; scopes the pin guard's byte-identity claim to "modulo pin version comments", mirrored in coreweave/docs).