### PR TITLE
TEST HARNESS (do not merge): overlay shell at docengine v4.0.0-rc.1

### DIFF
--- a/.github/workflows/docengine-overlay.yml
+++ b/.github/workflows/docengine-overlay.yml
@@ -125,7 +125,6 @@ jobs:
         with:
           api: ${{ matrix.api }}
           output-path: ${{ matrix.output_path }}
-          output-dir: ${{ github.workspace }}
           push-token: ${{ steps.app_token.outputs.token }}
           git-user-name: 'wandb-docs-pr-writer[bot]'
           git-user-email: 'wandb-docs-pr-writer[bot]@users.noreply.github.com'


### PR DESCRIPTION
rc-loop harness for the docengine-overlay output-dir removal. PinGuard is red by design (rc tags are not releases). Validation: overlay dispatch from this branch is a clean zero-job no-op (empty overlays). Superseded by the real pin PR after the release; close unmerged.