### PR TITLE
ci: Bump docengine to v4.0.0 and drop the overlay shell's output-dir

### DIFF
--- a/.github/workflows/docengine-overlay.yml
+++ b/.github/workflows/docengine-overlay.yml
@@ -125,7 +125,6 @@ jobs:
         with:
           api: ${{ matrix.api }}
           output-path: ${{ matrix.output_path }}
-          output-dir: ${{ github.workspace }}
           push-token: ${{ steps.app_token.outputs.token }}
           git-user-name: 'wandb-docs-pr-writer[bot]'
           git-user-email: 'wandb-docs-pr-writer[bot]@users.noreply.github.com'


### PR DESCRIPTION
Bumps the docengine pin to the v4.0.0 release, whose docengine-overlay action derives the output directory from the site descriptor and no longer takes an output-dir input; the (dormant) overlay shell drops that line. PinGuard validates the pin.