### PR TITLE
fix: use a stable seed in the PyTorch integration

### DIFF
--- a/models/integrations/pytorch.mdx
+++ b/models/integrations/pytorch.mdx
@@ -70,11 +70,12 @@ import torchvision.transforms as transforms
 from tqdm.auto import tqdm
 
 # Ensure deterministic behavior
+seed = 42
 torch.backends.cudnn.deterministic = True
-random.seed(hash("setting random seeds") % 2**32 - 1)
-np.random.seed(hash("improves reproducibility") % 2**32 - 1)
-torch.manual_seed(hash("by removing stochasticity") % 2**32 - 1)
-torch.cuda.manual_seed_all(hash("so runs are repeatable") % 2**32 - 1)
+random.seed(seed)
+np.random.seed(seed)
+torch.manual_seed(seed)
+torch.cuda.manual_seed_all(seed)
 
 # Device configuration
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Description

The PyTorch integration page says this setup ensures deterministic behavior, but it doesn't appear to actually do that. This is because it derives its seeds from `hash("...")`. By default, Python randomizes string hashes _between_ interpreter processes, so the example can initialize its RNGs differently across runs.

This fix replaces the hash-derived values with one named integer seed.

Before:

```python
torch.backends.cudnn.deterministic = True
random.seed(hash("setting random seeds") % 2**32 - 1)
np.random.seed(hash("improves reproducibility") % 2**32 - 1)
torch.manual_seed(hash("by removing stochasticity") % 2**32 - 1)
torch.cuda.manual_seed_all(hash("so runs are repeatable") % 2**32 - 1)
```
After:

```python
seed = 42
torch.backends.cudnn.deterministic = True
random.seed(seed)
np.random.seed(seed)
torch.manual_seed(seed)
torch.cuda.manual_seed_all(seed)
```

### Why this matters

A small exploratory search found the same recognizable recipe in at least 24 other repositories. This suggests that the pattern has propagated beyond W&B's own docs, so correcting the bug here can help prevent it from spreading further.

The problem was also noted in the technical-review notes for [#2673](https://github.com/wandb/docs/pull/2673), but it wasn't fixed as it was out-of-scope for that PR (it was a style guide pass).

The corresponding notebooks are updated in [wandb/examples#644](https://github.com/wandb/examples/pull/644).

## Testing

- [x] `git diff --check` succeeds.
- [x] Confirmed that the diff contains only the intended seed changes.
- [x] Confirmed that the old hash-derived seeds vary with `PYTHONHASHSEED`.
- [x] Confirmed that the replacement has no interpreter hash-secret dependency.
- [ ] PR tests succeed.

