### PR TITLE
Workspaces: Remove (some) duplicate info

### DIFF
--- a/models/app/features/panels/media.mdx
+++ b/models/app/features/panels/media.mdx
@@ -10,23 +10,23 @@ A media panel visualizes [logged keys for media objects](/models/track/log/media
     <img src="/images/app_ui/demo-media-panel.png" alt="Demo of a media panel"  />
 </Frame>
 
+
 ## Add a media panel
 
-You can add a media panel using Quick Add (which applies the default configuration) or by adding it manually so you can configure it as you create it. In either case, you can add the panel globally to the workspace or to a specific section.
+Add a media panel at the workspace level or to a specific section.
 
-To add a media panel for a logged key using the default configuration, use Quick Add:
+To add a media panel to a specific section:
 
-1. **Global**: Click **Add panels** in the control bar near the panel search field.
-1. **Section**: Click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Add panels**.
-1. In the list of available panels, find the key for the panel, then click **Add**. Repeat this step for each media panel you want to add, then click the **X** at the top right to close the **Quick Add** list.
-1. Optionally, [configure the panel](#configure-a-media-panel).
+1. Open the section's **action** (<Icon icon="ellipsis" iconType="solid"/>) menu, then select **Add panels**.
+2. Expand **Media**.
+3. Select **3D objects**, **Images**, **Video**, or **Audio**.
+4. Configure the panel, then select **Apply**.
 
-To add a media panel manually so that you can configure it during creation:
+<Info>
+For other ways to add panels, see [Add a panel manually](/models/app/features/panels#add-a-panel-manually).
+</Info>
 
-1. **Global**: Click **Add panels** in the control bar near the panel search field.
-1. **Section**: Click the section's **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Add panels**.
-1. Click the **Media** section to expand it.
-1. Select the type of media the panel visualizes, 3D objects, images, video, or audio. The panel configuration screen displays. Configure the panel, then click **Apply**. Refer to [Configure a media panel](#configure-a-media-panel).
+For information about media panel settings, see the following sections.
 
 ## Configure a media panel
 


### PR DESCRIPTION
## Description

Remove (most) instructions on how to add a panel on the media page. Instead point to panels docs for more info. That way we are closer to one source of truth.

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-3111

