### PR TITLE
Workspaces: Update UI instructions for renaming runs

### DIFF
--- a/models/runs/run-identifiers.mdx
+++ b/models/runs/run-identifiers.mdx
@@ -145,7 +145,7 @@ run.update()
 1. Navigate to your W&B project.
 1. Select the **Workspace** or **Runs** tab.
 1. Search or scroll to the run you want to rename.
-1. Hover over the run name, click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu, then click **Rename run**.
+1. Hover over the run name, click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit run name**.
 1. To change the run name, update the **Run name** field.
 1. Click **Save**.
 </Tab>
@@ -170,7 +170,7 @@ Change a run's display name from the W&B App:
 1. Navigate to your W&B project.
 1. Select the **Workspace** or **Runs** tab.
 1. Search or scroll to the run you want to rename.
-1. Hover over the run name, click the **action (<Icon icon="ellipsis-vertical" iconType="solid"/>)** menu, then click **Rename run**.
+1. Hover over the run name, click the **action (<Icon icon="ellipsis" iconType="solid"/>)** menu, then click **Edit run name**.
 1. Specify a new value for the **Display name** field.
 1. Click **Save**.
 


### PR DESCRIPTION
## Description

Instructions to rename a run were wrong (outdated?). This PR fixes it.

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-2762

