### PR TITLE
docs: Fix nonexistent python image tag in sandbox quickstart (DOCS-3127)

### DIFF
--- a/sandboxes/create-sandbox.mdx
+++ b/sandboxes/create-sandbox.mdx
@@ -13,12 +13,14 @@ Create W&B Serverless Sandboxes to run code in isolated environments. Start a si
 <Info>
 By default, sandboxes use `python:3.11` as the base image. To use a different image, pass `container_image` to [`Sandbox.run()`](https://docs.coreweave.com/products/coreweave-sandbox/client/ref/core/sandbox#run) or [`SandboxDefaults`](https://docs.coreweave.com/products/coreweave-sandbox/client/ref/core/sandbox-defaults). W&B supports public container images only.
 
-The following code snippet creates a sandbox with the `python:3.15` image and runs `python --version` inside it.
+Verify that the image and tag exist in the public registry before you use them. If the image can't be pulled, the sandbox never starts and the client raises `SandboxFailedError` without identifying the image as the cause.
+
+The following code snippet creates a sandbox with the `python:3.14` image and runs `python --version` inside it.
 
 ```python
 from wandb.sandbox import Sandbox
 
-with Sandbox.run(container_image="python:3.15") as sandbox:
+with Sandbox.run(container_image="python:3.14") as sandbox:
     sandbox.exec(["python", "--version"]).result()
 ```
 </Info>

--- a/sandboxes/create-sandbox.mdx
+++ b/sandboxes/create-sandbox.mdx
@@ -13,7 +13,11 @@ Create W&B Serverless Sandboxes to run code in isolated environments. Start a si
 <Info>
 By default, sandboxes use `python:3.11` as the base image. To use a different image, pass `container_image` to [`Sandbox.run()`](https://docs.coreweave.com/products/coreweave-sandbox/client/ref/core/sandbox#run) or [`SandboxDefaults`](https://docs.coreweave.com/products/coreweave-sandbox/client/ref/core/sandbox-defaults). W&B supports public container images only.
 
-Verify that the image and tag exist in the public registry before you use them. If the image can't be pulled, the sandbox never starts and the client raises `SandboxFailedError` without identifying the image as the cause.
+Verify that the image and tag exist in the public registry before you use them. If the sandbox can't pull the image, it doesn't start and the client raises `SandboxFailedError`.
+
+<Info>
+`SandboxFailedError` can occur for multiple reasons and doesn't specifically identify an unavailable image. If you encounter this error, verify that the image and tag are available.
+</Info>
 
 The following code snippet creates a sandbox with the `python:3.14` image and runs `python --version` inside it.
 


### PR DESCRIPTION
Fixes [DOCS-3127](https://coreweave.atlassian.net/browse/DOCS-3127).

The `container_image` example on [Create sandboxes](https://docs.wandb.ai/sandboxes/create-sandbox) used `python:3.15`, which has no released tag on Docker Hub (only a release candidate). Copying the snippet as written makes the image pull fail (`ImagePullBackOff`), and the client surfaces only `SandboxFailedError: Sandbox <id> failed to start`.

- Change the example image to `python:3.14`.
- Note that the image and tag must exist in the public registry, and that a failed pull surfaces as `SandboxFailedError`.

Localized copies under `fr/`, `ja/`, and `ko/` still carry `python:3.15`; per `AGENTS.md`, they're left to the translation process.

The opaque client error is tracked separately in coreweave/cwsandbox-client#106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-3127]: https://coreweave.atlassian.net/browse/DOCS-3127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ