### PR TITLE
Add KB article: TypeScript build fails for CommonJS with verbatimModuleSyntax

### DIFF
--- a/support.mdx
+++ b/support.mdx
@@ -52,7 +52,7 @@ and the W&B community.
 </Card>
 <Card title="W&B Weave" href="/support/weave" arrow="true" icon="/icons/cropped-weave.svg">
   {/* AUTO-GENERATED: counts */}
-  19 articles &middot; 11 tags
+  19 articles &middot; 12 tags
   {/* END AUTO-GENERATED: counts */}
 </Card>
 <Card title="Serverless Inference" href="/support/inference" arrow="true" icon="/icons/cropped-inference.svg">

--- a/support.mdx
+++ b/support.mdx
@@ -52,7 +52,7 @@ and the W&B community.
 </Card>
 <Card title="W&B Weave" href="/support/weave" arrow="true" icon="/icons/cropped-weave.svg">
   {/* AUTO-GENERATED: counts */}
-  18 articles &middot; 11 tags
+  19 articles &middot; 11 tags
   {/* END AUTO-GENERATED: counts */}
 </Card>
 <Card title="Serverless Inference" href="/support/inference" arrow="true" icon="/icons/cropped-inference.svg">

--- a/support/weave.mdx
+++ b/support/weave.mdx
@@ -33,6 +33,9 @@ template: "docengine-site/templates/support_product_index.mdx.j2"
 <Card title="Tracing" href="/support/weave/tags/tracing" arrow="true">
   2 articles
 </Card>
+<Card title="TypeScript" href="/support/weave/tags/typescript" arrow="true">
+  1 article
+</Card>
 <Card title="UI Rendering" href="/support/weave/tags/ui-rendering" arrow="true">
   2 articles
 </Card>

--- a/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
+++ b/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
@@ -1,0 +1,27 @@
+---
+title: "Why does my Weave TypeScript build fail for CommonJS format?"
+---
+
+## `TS1295` and `TS1287`: ECMAScript imports and exports cannot be written in a CommonJS file
+
+If your `tsconfig.json` file sets `"verbatimModuleSyntax": true`, compiling a CommonJS project (per the [TypeScript SDK integration guide](/weave/guides/integrations/js)) fails with:
+
+```text
+error TS1295: ECMAScript imports and exports cannot be written in a CommonJS file under 'verbatimModuleSyntax'.
+error TS1287: A top-level 'export' modifier cannot be used on value declarations in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+```
+
+The setting defaults to `false`, which the TypeScript SDK integration guide assumes.
+
+Set it back to `false` alongside your CommonJS `module` setting:
+
+```json lines
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "verbatimModuleSyntax": false
+  }
+}
+```
+
+`"verbatimModuleSyntax": false` allows ESM-style `import`/`export` syntax in your source files while TypeScript still emits CommonJS output. For details, see [TypeScript - Verbatim Module Syntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).

--- a/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
+++ b/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
@@ -14,7 +14,7 @@ error TS1287: A top-level 'export' modifier cannot be used on value declarations
 
 The setting defaults to `false`, which the TypeScript SDK integration guide assumes.
 
-Set it back to `false` alongside your CommonJS `module` setting:
+Set the `verbatimModuleSyntax` field to `false` alongside your CommonJS `module` setting:
 
 ```json lines
 {

--- a/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
+++ b/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
@@ -26,3 +26,7 @@ Set it back to `false` alongside your CommonJS `module` setting:
 ```
 
 `"verbatimModuleSyntax": false` allows ESM-style `import`/`export` syntax in your source files while TypeScript still emits CommonJS output. For details, see [TypeScript - Verbatim Module Syntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
+
+{/* AUTO-GENERATED: tab badges */}
+<Badge stroke shape="pill" color="orange" size="md">[TypeScript](/support/weave/tags/typescript)</Badge>
+{/* END AUTO-GENERATED: tab badges */}

--- a/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
+++ b/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
@@ -4,7 +4,7 @@ title: "Why does my Weave TypeScript build fail for CommonJS format?"
 
 ## `TS1295` and `TS1287`: ECMAScript imports and exports cannot be written in a CommonJS file
 
-If your `tsconfig.json` file sets `"verbatimModuleSyntax": true`, compiling a CommonJS project (per the [TypeScript SDK integration guide](/weave/guides/integrations/js)) fails with:
+If your `tsconfig.json` file sets `"verbatimModuleSyntax": true`, compiling a W&B Weave CommonJS project (per the [TypeScript SDK integration guide](/weave/guides/integrations/js)) fails with:
 
 ```text
 error TS1295: ECMAScript imports and exports cannot be written in a CommonJS file under 'verbatimModuleSyntax'.

--- a/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
+++ b/support/weave/articles/typescript-build-fails-after-commonjs-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Why does my Weave TypeScript build fail for CommonJS format?"
+keywords: ["TypeScript"]
 ---
 
 ## `TS1295` and `TS1287`: ECMAScript imports and exports cannot be written in a CommonJS file

--- a/support/weave/tags/typescript.mdx
+++ b/support/weave/tags/typescript.mdx
@@ -1,0 +1,10 @@
+---
+title: "TypeScript"
+tag: "1"
+generator: "knowledgebase-nav"
+template: "docengine-site/templates/support_tag.mdx.j2"
+---
+
+<Card title="Why does my Weave TypeScript build fail for CommonJS format?" href="/support/weave/articles/typescript-build-fails-after-commonjs-setup" arrow="true" horizontal>
+  TS1295 and TS1287: ECMAScript imports and exports cannot be written in a CommonJS file If your tsconfig.json file sets " ...
+</Card>


### PR DESCRIPTION
## Summary
- New Weave support KB article for customers who hit a TypeScript build error (`TS1295`/`TS1287`) when following the CommonJS setup in the [TypeScript SDK integration guide](/weave/guides/integrations/js) with `verbatimModuleSyntax: true` in their `tsconfig.json`.
- Fix confirmed by local reproduction against `weave@0.16.3` / `typescript@6.0.3`: setting `verbatimModuleSyntax: false` (alongside `module: CommonJS`) resolves it.
- Grounded in DOCS-2554; no tag/keywords assigned in frontmatter, per current KB tagging process (backend-generated).

## Test plan
- [ ] Confirm the article renders correctly in the docs preview
- [ ] Confirm the link to `/weave/guides/integrations/js` resolves