### PR TITLE
Fix typo breaking the Hivemind Skills screenshot

### DIFF
--- a/hivemind.mdx
+++ b/hivemind.mdx
@@ -78,7 +78,7 @@ These screenshots show example pages in the HiveMind dashboard, including leader
 <Frame>![HiveMind session details](/images/hivemind/hivemind-session-insights.png)</Frame>
 <Frame>![HiveMind agents by harness](/images/hivemind/hivemind-agents-by-harness.png)</Frame>
 <Frame>![HiveMind agents by model](/images/hivemind/hivemind-agents-by-model.png)</Frame>
-<Frame>~[Hivemind skills dashboard](/images/hivemind/hivemind-skills.png)</Frame>
+<Frame>![Hivemind skills dashboard](/images/hivemind/hivemind-skills.png)</Frame>
 
 ## Supported agents
 


### PR DESCRIPTION
## Description
Fix typo breaking the Hivemind Skills screenshot

## Testing
- [x] Local build succeeds without errors (`mint dev`)
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed
