### PR TITLE
General: Remove links, mention of W&B AI Academy

### DIFF
--- a/courses.mdx
+++ b/courses.mdx
@@ -1,4 +1,4 @@
 ---
-title: "W&B Courses"
+title: "W&B YouTube Courses"
 url: "https://www.youtube.com/@WeightsBiases/courses"
 ---

--- a/courses.mdx
+++ b/courses.mdx
@@ -1,4 +1,4 @@
 ---
 title: "W&B Courses"
-url: "https://wandb.ai/site/courses/?e-filter-32fa548-course-category=wb-platform"
+url: "https://www.youtube.com/@WeightsBiases/courses"
 ---

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -24,10 +24,10 @@ Welcome to Weights & Biases! Before getting started with our products, it's impo
   <Card title="Get Started with Models" href="/models/models_quickstart">
     A full-fledged tutorial that walks through the entire Models product using a real ML experiment.
   </Card>
-  <Card title="W&B 101 Course" href="https://wandb.ai/site/courses/101/">
+  <Card title="W&B 101 Course" href="https://www.youtube.com/watch?v=UHYU2OZKGJI&list=PLD80i8An1OEEgxMpH-SOdBCjWpT5Io5rJ">
     A video-led course that emphasizes experiment tracking and features quizzes to ensure comprehension.
   </Card>
-  <Card title="YouTube Tutorial" href="https://www.youtube.com/watch?v=FkTwcxnSPes">
+  <Card title="YouTube Tutorials" href="https://www.youtube.com/@WeightsBiases/courses">
     Learn how models are trained, evaluated, developed, and deployed and how you can use wandb at each step of that lifecycle to help build better performing models faster.
   </Card>
 </Columns>
@@ -42,10 +42,10 @@ Welcome to Weights & Biases! Before getting started with our products, it's impo
   <Card title="Learn Weave with Serverless Inference" href="/weave/quickstart-inference">
     A full-fledged tutorial that shows Weave doing real-world evaluation of the performance of various models hosted by Serverless Inference
   </Card>
-  <Card title="W&B Weave 101 Course" href="https://site.wandb.ai/courses/weave/">
+  {/* <Card title="W&B Weave 101 Course" href="https://site.wandb.ai/courses/weave/">
     A video-led course that teaches you how to log, debug, and evaluate language model workflows, and features quizzes to ensure comprehension.
-  </Card>
-  <Card title="YouTube Demo" href="https://www.youtube.com/watch?v=IQcGGNLN3zo">
+  </Card> */}
+  <Card title="YouTube Playlist" href="https://www.youtube.com/playlist?list=PLD80i8An1OEFWB5JYk1bnWVPhLRzvNkVx">
     Learn how you can evaluate, monitor, and iterate continuously on your AI applications and improve quality, latency, cost, and safety. 
   </Card>
 </Columns>

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -28,7 +28,7 @@ Welcome to Weights & Biases! Before getting started with our products, it's impo
     A video-led course that emphasizes experiment tracking and features quizzes to ensure comprehension.
   </Card>
   <Card title="YouTube Tutorials" href="https://www.youtube.com/@WeightsBiases/courses">
-    Learn how models are trained, evaluated, developed, and deployed and how you can use wandb at each step of that lifecycle to help build better performing models faster.
+    Learn how to use W&B Models to track experiments, manage artifacts, and optimize models through hands-on tutorials.
   </Card>
 </Columns>
 
@@ -46,7 +46,7 @@ Welcome to Weights & Biases! Before getting started with our products, it's impo
     A video-led course that teaches you how to log, debug, and evaluate language model workflows, and features quizzes to ensure comprehension.
   </Card> */}
   <Card title="YouTube Playlist" href="https://www.youtube.com/playlist?list=PLD80i8An1OEFWB5JYk1bnWVPhLRzvNkVx">
-    Learn how you can evaluate, monitor, and iterate continuously on your AI applications and improve quality, latency, cost, and safety. 
+    Learn how to use Weave to trace, evaluate, and debug LLM applications and how to use Weave to build production-ready LLM applications.
   </Card>
 </Columns>
 

--- a/models/quickstart.mdx
+++ b/models/quickstart.mdx
@@ -154,6 +154,3 @@ Explore more features of the W&B ecosystem:
 5. Analyze runs, visualize model predictions, view artifacts in your project's [dashboard](/models/track/workspaces).
 6. Summarize findings and share updates with collaborators using [W&B Reports](/models/reports).
 7. Trace and evaluate LLM applications with [W&B Weave](/weave/quickstart).
-
-{/* Is this still relevant? */}
-{/* 6. Visit [W&B AI Academy](https://wandb.ai/site/courses/) to learn about LLMs, MLOps, and W&B Models through hands-on courses. */}

--- a/models/registry.mdx
+++ b/models/registry.mdx
@@ -112,7 +112,7 @@ Depending on your use case, explore the following resources to get started with
 
 * Check out the tutorial video:
     * [Getting started with Registry from W&B](https://www.youtube.com/watch?v=p4XkVOsjIeM)
-* Take the W&B [Model CI/CD](https://www.wandb.courses/courses/enterprise-model-management) course and learn how to:
+* Take the W&B [Model CI/CD](https://www.youtube.com/watch?v=VWdRQL0CsAk&list=PLD80i8An1OEGECFPgY-HPCNjXgGu-qGO6) course and learn how to:
     * Use W&B Registry to manage and version your artifacts, track lineage, and promote models through different lifecycle stages.
     * Automate your model management workflows using webhooks.
     * Integrate the registry with external ML systems and tools for model evaluation, monitoring, and deployment.

--- a/weave/tutorial-rag.mdx
+++ b/weave/tutorial-rag.mdx
@@ -781,7 +781,3 @@ Here's the code in its entirety.
 ## Conclusion
 
 This tutorial showed how to build observability into different steps of your applications, like the retrieval step in this example. You also learned how to build more complex scoring functions, such as an LLM judge, for automatic evaluation of application responses.
-
-## Next steps
-
-See the [RAG++ course](https://www.wandb.courses/courses/rag-in-production?utm_source=wandb_docs&utm_medium=code&utm_campaign=weave_docs) for a more advanced dive into practical RAG techniques for engineers, where you learn production-ready solutions from W&B, Cohere, and Weaviate to optimize performance, cut costs, and enhance the accuracy and relevance of your applications.


### PR DESCRIPTION
## Description
W&B AI Academy website is sunsetting on September 30th. Videos are (if they haven't already) migrating to YouTube.

This PR removes mentions of site links to:
- https://wandb.ai/site/courses/
- https://www.wandb.courses/ 

Where possible I replaced ^ links with W&B YouTube links.

Note: We can update, add links to specific YouTube courses, playlists etc. in the future when the content from wandb.ai/courses is migrated (as of this writing, that is not the case).

## Related issues

- Fixes https://coreweave.atlassian.net/browse/DOCS-3149


