### PR TITLE
Add site banner for September 30 domain change

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4,7 +4,7 @@
     "decoration": "gradient"
   },
   "banner": {
-    "content": "**Notice:** The domain used to access Weights & Biases websites and services is changing on September 30. No action is needed today. [Learn more](https://wandb.ai/site/domain-update-faqs/)",
+    "content": "**Notice:** The Weights & Biases domain [will change on September 30](https://wandb.ai/site/domain-update-faqs/). This includes all websites and services that use a W&B domain. No action is needed today.",
     "dismissible": true,
     "type": "warning"
   },

--- a/docs.json
+++ b/docs.json
@@ -3,6 +3,11 @@
   "background": {
     "decoration": "gradient"
   },
+  "banner": {
+    "content": "**Notice:** The domain you use to access Weights & Biases is changing on September 30. No action is needed today. [Learn more](https://wandb.ai/site/domain-update-faqs/)",
+    "dismissible": true,
+    "type": "warning"
+  },
   "baseUrl": "https://docs.wandb.ai",
   "colors": {
     "dark": "#FCBC32",

--- a/docs.json
+++ b/docs.json
@@ -4,7 +4,7 @@
     "decoration": "gradient"
   },
   "banner": {
-    "content": "**Notice:** The domain you use to access Weights & Biases is changing on September 30. No action is needed today. [Learn more](https://wandb.ai/site/domain-update-faqs/)",
+    "content": "**Notice:** The domain used to access Weights & Biases websites and services is changing on September 30. No action is needed today. [Learn more](https://wandb.ai/site/domain-update-faqs/)",
     "dismissible": true,
     "type": "warning"
   },


### PR DESCRIPTION
## Description

Adds a site-wide banner to `docs.json` notifying readers that the domain used to access W&B is changing on September 30, mirroring the notice already published on [wandb.ai/site](https://wandb.ai/site/).
