### PR TITLE
Document conversation grouping for agent SDK integrations

### DIFF
--- a/snippets/_includes/agent-integration-paths.mdx
+++ b/snippets/_includes/agent-integration-paths.mdx
@@ -15,6 +15,10 @@ Agent SDKs are libraries for building agents and multi-agent workflows in your o
 - [Google Agent Development Kit (ADK)](/weave/guides/integrations/agents/google-adk)
 - [Claude Agent SDK](/weave/guides/integrations/agents/claude-agents-sdk)
 
+<Note>
+These SDKs operate one turn at a time, so your application code manages the conversation across turns. To group turns into a single conversation, Weave reads the session or group identifier that the SDK assigns. If your code doesn't carry that identifier from one turn to the next, each turn appears in the **Agents** view as its own conversation. Each integration page shows which identifier to pass.
+</Note>
+
 ## Custom agents and OpenTelemetry
 
 If your agent isn't built with one of the SDKs above, or it already emits OpenTelemetry spans, use the Weave SDK directly. Weave accepts any OTel span and gives special handling to [GenAI semantic-convention attributes](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) so spans render in the **Agents** view:

--- a/snippets/_includes/agent-integration-paths.mdx
+++ b/snippets/_includes/agent-integration-paths.mdx
@@ -15,10 +15,6 @@ Agent SDKs are libraries for building agents and multi-agent workflows in your o
 - [Google Agent Development Kit (ADK)](/weave/guides/integrations/agents/google-adk)
 - [Claude Agent SDK](/weave/guides/integrations/agents/claude-agents-sdk)
 
-<Note>
-These SDKs operate one turn at a time, so your application code manages the conversation across turns. To group turns into a single conversation, Weave reads the session or group identifier that the SDK assigns. If your code doesn't carry that identifier from one turn to the next, each turn appears in the **Agents** view as its own conversation. Each integration page shows which identifier to pass.
-</Note>
-
 ## Custom agents and OpenTelemetry
 
 If your agent isn't built with one of the SDKs above, or it already emits OpenTelemetry spans, use the Weave SDK directly. Weave accepts any OTel span and gives special handling to [GenAI semantic-convention attributes](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) so spans render in the **Agents** view:

--- a/weave/agent-integration-quickstart.mdx
+++ b/weave/agent-integration-quickstart.mdx
@@ -6,7 +6,7 @@ keywords: ["agent integrations", "autopatch", "agent SDKs", "agent harnesses", "
 
 import AgentIntegrationPaths from '/snippets/_includes/agent-integration-paths.mdx';
 
-W&B Weave traces multi-turn agents built with popular SDKs and harnesses without hand-instrumenting each turn. Install a plugin for your agent harness, or call `weave.init()` in code that uses a supported agent SDK, and Weave autopatches the framework. Turns, LLM calls, and tool calls render in the **Agents** view of your project.
+W&B Weave traces multi-turn agents built with popular SDKs and harnesses without hand-instrumenting each turn. Install a plugin for your agent harness, or call `weave.init()` in code that uses a supported agent SDK, and Weave autopatches the framework. Conversations, turns, LLM calls, and tool calls render in the **Agents** view of your project.
 
 Harness plugins group turns into conversations on their own, because the harness owns the session. Agent SDKs run one turn per call, so your code decides which turns belong to the same conversation. For those integrations, `weave.init()` alone isn't enough.
 

--- a/weave/agent-integration-quickstart.mdx
+++ b/weave/agent-integration-quickstart.mdx
@@ -6,7 +6,9 @@ keywords: ["agent integrations", "autopatch", "agent SDKs", "agent harnesses", "
 
 import AgentIntegrationPaths from '/snippets/_includes/agent-integration-paths.mdx';
 
-W&B Weave traces multi-turn agents built with popular SDKs and harnesses without hand-instrumenting each turn. Install a plugin for your agent harness, or call `weave.init()` in code that uses a supported agent SDK, and Weave autopatches the framework. Conversations, turns, LLM calls, and tool calls render in the **Agents** view of your project.
+W&B Weave traces multi-turn agents built with popular SDKs and harnesses without hand-instrumenting each turn. Install a plugin for your agent harness, or call `weave.init()` in code that uses a supported agent SDK, and Weave autopatches the framework. Turns, LLM calls, and tool calls render in the **Agents** view of your project.
+
+Harness plugins group turns into conversations on their own, because the harness owns the session. Agent SDKs run one turn per call, so your code decides which turns belong to the same conversation. For those integrations, `weave.init()` alone isn't enough.
 
 Choose from one of the following supported integrations.
 

--- a/weave/guides/integrations.mdx
+++ b/weave/guides/integrations.mdx
@@ -15,6 +15,8 @@ If you're not sure which path to take, start with [Trace your agents](/weave/gui
 
 Use these integrations when you're building multi-turn agentic applications and want sessions, turns, and tool calls to appear in the Weave **Agents** view. For agent SDKs, harnesses, and custom instrumentation, see [Choose an agent integration](/weave/agent-integration-quickstart).
 
+Agent SDKs run one turn per call. To group turns into a conversation, pass the SDK's own session or group identifier on every turn. The integration page for each SDK shows which identifier to use.
+
 ## Trace LLM applications
 
 If your application calls an LLM provider's API directly or uses an orchestration framework, Weave can automatically intercept traces (using autopatching) for many libraries and frameworks. After you import the Weave SDK into your code and initialize it with `weave.init`, Weave records each request as a **Call** with inputs, outputs, latency, token usage, and cost.

--- a/weave/guides/integrations/agents/claude-agents-sdk.mdx
+++ b/weave/guides/integrations/agents/claude-agents-sdk.mdx
@@ -104,6 +104,42 @@ anyio.run(main)
 ```
 
 When the script runs, `weave.init()` prints a link to your project. Open the link to inspect the captured traces for the agent's query, model responses, and tool calls.
+
+#### Group turns into one conversation
+
+`ClaudeSDKClient` holds a single session open for the lifetime of the `async with` block, so every turn you send through the same client already belongs to one conversation. The standalone `query()` function behaves differently: each call starts a new session. To continue a conversation across `query()` calls, pass the previous session ID as `resume`. Weave patches both paths.
+
+The following example runs three turns through `query()`. The first turn creates the session, and each later turn resumes it. `ResultMessage.session_id` carries the ID to reuse.
+
+```python lines highlight="16,21"
+import anyio
+import weave
+
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+
+weave.init("<your-team>/<your-project-name>")
+
+async def main():
+    session_id = None
+
+    for question in [
+        "Who founded Anthropic?",
+        "What is Claude (the AI assistant)?",
+        "Summarize what we discussed in one sentence.",
+    ]:
+        options = ClaudeAgentOptions(resume=session_id) if session_id else None
+        print(f"USER: {question}")
+
+        async for message in query(prompt=question, options=options):
+            if isinstance(message, ResultMessage):
+                session_id = message.session_id
+                print(f"AGENT: {message.result}\n")
+
+
+anyio.run(main)
+```
+
+Each `query()` call produces an `invoke_agent` root span. Because the follow-up turns resume the same `session_id`, Weave stamps the same `gen_ai.conversation.id` on all spans and groups them as one conversation in the Agents view. Without `resume`, each turn starts its own session and appears as a separate conversation.
 </Tab>
 <Tab title="TypeScript">
 Weave automatically instruments `query()` via module loader hooks. The required setup differs slightly between module systems. For more information on CommonJS versus ESM and how Weave's loader hooks work, see the [TypeScript SDK third-party integration guide](/weave/guides/integrations/js).

--- a/weave/guides/integrations/agents/claude-agents-sdk.mdx
+++ b/weave/guides/integrations/agents/claude-agents-sdk.mdx
@@ -14,7 +14,7 @@ The Claude Agent SDK enables you to quickly build agent applications powered by 
 <Tab title="Python">
 The Weave SDK autopatches the [Claude Agent SDK for Python](https://github.com/anthropics/claude-agent-sdk-python), letting you capture traces from your Claude agents with minimal setup.
 
-This guide shows how to initialize Weave and run a Claude agent with MCP tools through `ClaudeSDKClient`. Weave automatically traces the conversation, model calls, and tool calls end-to-end.
+This guide shows how to initialize Weave and run a multi-turn Claude agent with MCP tools through `query()`. Weave automatically traces the conversation, model calls, and tool calls end-to-end.
 
 ### Prerequisites
 
@@ -38,15 +38,15 @@ Weave integrates with the [`@anthropic-ai/claude-agent-sdk`](https://github.com/
 
 ### Install packages
 
-Install the following packages in your developer environment. The `weave` package captures traces, and `claude-agent-sdk` provides the agent runtime.
+Install the following packages in your developer environment. The `weave` package captures traces, `claude-agent-sdk` provides the agent runtime, and the remaining packages support the example tool.
 
 <CodeGroup>
 ```bash Python
-pip install weave claude-agent-sdk
+pip install weave claude-agent-sdk requests
 ```
 
 ```bash TypeScript
-npm install weave @anthropic-ai/claude-agent-sdk
+npm install weave @anthropic-ai/claude-agent-sdk zod
 ```
 </CodeGroup>
 
@@ -58,66 +58,45 @@ npm install weave @anthropic-ai/claude-agent-sdk
 
 Add `weave.init` to the project, update your W&B team and project names, and then build an agent the way you normally would. `weave.init` enables the autopatching that captures traces from the Claude Agent SDK.
 
-The following code creates a Claude agent with two MCP math tools and runs it while Weave captures the traces.
+This example defines a `wikipedia_search` MCP tool and runs a three-turn conversation. Each turn is a separate `query()` call, but later turns pass `resume` with the first turn's session ID so that all turns group as one conversation in the Weave Agents view. The first two turns trigger Wikipedia lookups, and the third uses the previous conversation context to produce a summary without a tool call.
 
-```python lines highlight="11"
+```python lines highlight="13,49,55"
 import anyio
+import requests
 import weave
 
 from claude_agent_sdk import (
     ClaudeAgentOptions,
-    ClaudeSDKClient,
+    ResultMessage,
     create_sdk_mcp_server,
+    query,
     tool,
 )
 
 weave.init("<your-team>/<your-project-name>")
 
-@tool("add", "Add two numbers", {"a": float, "b": float})
-async def add(args: dict) -> dict:
-    return {"content": [{"type": "text", "text": str(args["a"] + args["b"])}]}
-
-@tool("multiply", "Multiply two numbers", {"a": float, "b": float})
-async def multiply(args: dict) -> dict:
-    return {"content": [{"type": "text", "text": str(args["a"] * args["b"])}]}
-
-math_server = create_sdk_mcp_server(
-    name="math",
-    version="1.0.0",
-    tools=[add, multiply],
+@tool(
+    "wikipedia_search",
+    "Search Wikipedia for a topic and return its title and intro paragraph.",
+    {"query": str},
 )
+async def wikipedia_search(args: dict) -> dict:
+    r = requests.get(
+        "https://en.wikipedia.org/w/api.php",
+        params={
+            "action": "query", "generator": "search", "gsrsearch": args["query"], "gsrlimit": 1,
+            "prop": "extracts", "exintro": True, "explaintext": True, "format": "json",
+        },
+        headers={"User-Agent": "weave-demo"},
+    ).json()
+    page = next(iter(r["query"]["pages"].values()))
+    return {"content": [{"type": "text", "text": f"{page['title']}: {page['extract']}"}]}
 
-async def main():
-    options = ClaudeAgentOptions(
-        mcp_servers={"math": math_server},
-        allowed_tools=["mcp__math__add", "mcp__math__multiply"],
-    )
-
-    async with ClaudeSDKClient(options=options) as client:
-        await client.query("Using the math tools, compute (3 + 7) * 2.")
-
-        async for message in client.receive_response():
-            print(message)
-
-
-anyio.run(main)
-```
-
-When the script runs, `weave.init()` prints a link to your project. Open the link to inspect the captured traces for the agent's query, model responses, and tool calls.
-
-#### Group turns into one conversation
-
-`ClaudeSDKClient` holds a single session open for the lifetime of the `async with` block, so every turn you send through the same client already belongs to one conversation. The standalone `query()` function behaves differently: each call starts a new session. To continue a conversation across `query()` calls, pass the previous session ID as `resume`. Weave patches both paths.
-
-The following example runs three turns through `query()`. The first turn creates the session, and each later turn resumes it. `ResultMessage.session_id` carries the ID to reuse.
-
-```python lines highlight="16,21"
-import anyio
-import weave
-
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
-
-weave.init("<your-team>/<your-project-name>")
+wiki_server = create_sdk_mcp_server(
+    name="wiki",
+    version="1.0.0",
+    tools=[wikipedia_search],
+)
 
 async def main():
     session_id = None
@@ -127,7 +106,11 @@ async def main():
         "What is Claude (the AI assistant)?",
         "Summarize what we discussed in one sentence.",
     ]:
-        options = ClaudeAgentOptions(resume=session_id) if session_id else None
+        options = ClaudeAgentOptions(
+            mcp_servers={"wiki": wiki_server},
+            allowed_tools=["mcp__wiki__wikipedia_search"],
+            resume=session_id,
+        )
         print(f"USER: {question}")
 
         async for message in query(prompt=question, options=options):
@@ -139,7 +122,9 @@ async def main():
 anyio.run(main)
 ```
 
-Each `query()` call produces an `invoke_agent` root span. Because the follow-up turns resume the same `session_id`, Weave stamps the same `gen_ai.conversation.id` on all spans and groups them as one conversation in the Agents view. Without `resume`, each turn starts its own session and appears as a separate conversation.
+Each `query()` call produces an `invoke_agent` root span. Because the follow-up turns resume the same session, Weave stamps the same `gen_ai.conversation.id` on all spans and groups them as one conversation in the Agents view. `ResultMessage.session_id` carries the ID to reuse, and `resume` accepts `None` on the first turn, which starts a new session.
+
+Without `resume`, each turn starts its own session and appears as a separate conversation. `ClaudeSDKClient` is the exception: it holds one session open for the lifetime of the `async with` block, so turns you send through the same client are already grouped. Weave patches both paths.
 </Tab>
 <Tab title="TypeScript">
 Weave automatically instruments `query()` via module loader hooks. The required setup differs slightly between module systems. For more information on CommonJS versus ESM and how Weave's loader hooks work, see the [TypeScript SDK third-party integration guide](/weave/guides/integrations/js).

--- a/weave/guides/integrations/agents/google-adk.mdx
+++ b/weave/guides/integrations/agents/google-adk.mdx
@@ -123,6 +123,8 @@ asyncio.run(main())
 ```
 
 The example runs three turns in a single ADK session. The first two turns trigger Wikipedia lookups, and the third uses the previous conversation context to produce a summary without a tool call.
+
+Every turn passes the same `session_id`. ADK sets `gen_ai.conversation.id` from that session, so Weave renders the three turns as one conversation in the Agents view. If you create a session per turn instead, each turn appears as a separate conversation.
 </Tab>
 
 <Tab title="TypeScript">
@@ -223,6 +225,8 @@ main().catch(console.error);
 ```
 
 The example runs three turns in a single ADK session. The first two turns trigger Wikipedia lookups, and the third uses the previous conversation context to produce a summary without a tool call.
+
+Every turn passes the same `sessionId`. ADK sets `gen_ai.conversation.id` from that session, so Weave renders the three turns as one conversation in the Agents view. If you create a session per turn instead, each turn appears as a separate conversation.
 </Tab>
 </Tabs>
 

--- a/weave/guides/integrations/agents/openai-agents-sdk.mdx
+++ b/weave/guides/integrations/agents/openai-agents-sdk.mdx
@@ -54,13 +54,14 @@ npm install weave @openai/agents zod
 <Tabs>
 <Tab title="Python">
 
-Add `weave.init` to the project, along with your W&B team and project names, and then build your agent as usual. The following code defines a `wikipedia_search` function tool and a `Research assistant` agent, then runs three questions through the OpenAI Agents SDK `Runner` while Weave captures the trace.
+Add `weave.init` to the project, along with your W&B team and project names, and then build your agent as usual. The following code defines a `wikipedia_search` function tool and a `Research assistant` agent, then runs three questions through the OpenAI Agents SDK `Runner` while Weave captures the trace. Each `Runner.run` call starts its own trace, so the example passes a `RunConfig` with a shared `group_id` on every call. Weave uses `group_id` to group traces from the same conversation, falling back to each trace's own ID when no `group_id` is set.
 
-```python lines  highlight="6"
+```python lines  highlight="7,33,42"
 import asyncio
+import uuid
 import requests
 import weave
-from agents import Agent, Runner, function_tool
+from agents import Agent, RunConfig, Runner, function_tool
 
 weave.init("<your-team>/<your-project-name>")
 
@@ -88,6 +89,7 @@ agent = Agent(
 )
 
 async def main():
+    run_config = RunConfig(group_id=str(uuid.uuid4()))
     history = []
     for question in [
         "Who founded Anthropic?",
@@ -96,14 +98,14 @@ async def main():
     ]:
         history.append({"role": "user", "content": question})
         print(f"USER: {question}")
-        result = await Runner.run(agent, input=history)
+        result = await Runner.run(agent, input=history, run_config=run_config)
         print(f"AGENT: {result.final_output}\n")
         history = result.to_input_list()
 
 asyncio.run(main())
 ```
 
-The example runs three turns in a single conversation. The first two turns trigger Wikipedia lookups, and the third uses the prior conversation context to produce a summary without a tool call. Each call to `Runner.run` continues the conversation by passing the previous result's input list back as the next request.
+The example runs three turns in a single conversation. The first two turns trigger Wikipedia lookups, and the third uses the prior conversation context to produce a summary without a tool call. Each call to `Runner.run` continues the conversation by passing the previous result's input list back as the next request, and shares the same `group_id` so Weave groups all three turns into one conversation in the Agents view. Without a shared `group_id`, each turn falls back to its own trace ID and appears as a separate conversation.
 </Tab>
 
 <Tab title="TypeScript">

--- a/weave/guides/tracking/trace-agents.mdx
+++ b/weave/guides/tracking/trace-agents.mdx
@@ -107,7 +107,7 @@ flowchart TB
 A conversation groups turns by a shared `conversation_id` attribute rather than a parent span, so each turn starts its own OTel trace. This design supports distributed tracing and parallel execution. The client sends spans directly to the OTel collector without any server-side aggregation.
 
 <Tip>
-To integrate Weave with SDKs or harnesses such as the Claude Agent SDK or Codex, see [Choose an agent integration](/weave/agent-integration-quickstart). Weave autopatches into several agent-building SDKs and agent harnesses for quick integration.
+To integrate Weave with SDKs or harnesses such as the Claude Agent SDK or Codex, see [Choose an agent integration](/weave/agent-integration-quickstart). Weave autopatches into several agent-building SDKs and agent harnesses for quick integration. Those integrations set `conversation_id` from the SDK or harness session, so you don't need `start_conversation()` to group their turns. The APIs on this page are for agents you instrument yourself.
 </Tip>
 
 ## Agent tracing APIs


### PR DESCRIPTION
## Description

Our agent SDK docs implied that adding `weave.init()` is all you need to trace a multi-turn agent. It isn't.

Agent SDKs run one turn per call, so the application code owns the conversation. Weave groups turns using the session or group identifier the SDK itself assigns. Without that identifier, every turn lands in the Agents view as its own conversation.

The TypeScript tabs for the Claude Agent SDK and OpenAI Agents SDK already covered this. The Python tabs did not, and the OpenAI Agents Python example produced three separate conversations as written.

### Pages that were wrong

- **OpenAI Agents SDK** — the Python example ran three turns with no group ID. Each `Runner.run` starts its own trace, so it produced three separate conversations. Now passes `RunConfig(group_id=...)`, mirroring the `groupId` the TypeScript example already used.
- **Claude Agent SDK** — the Python tab showed a single-turn `ClaudeSDKClient` run and never mentioned sessions. The Python tab now mirrors the TypeScript tab: one example with a `wikipedia_search` MCP tool plus a three-turn `resume` loop, using the same three questions the OpenAI Agents SDK and Google ADK pages use. This replaces the two half-examples the tab had (MCP tools without multi-turn, multi-turn without tools) with one that covers both, and keeps the tool-call coverage the shared closing snippet promises. The `ClaudeSDKClient` distinction (it holds one session open, so its turns are already grouped) moves into prose.

### Pages where the code was right but the reason wasn't stated

- **Google ADK** — both tabs already reused a session ID. Now they say that reusing it is what groups the turns.
- **Integrations overview**, **Choose an agent integration** — state the grouping requirement instead of implying `weave.init()` is sufficient.
- **Trace your agents** — note that autopatched integrations set `conversation_id` themselves, so `start_conversation()` isn't needed to group their turns. That API is for agents you instrument yourself.

Also adds the packages each example actually imports: `requests` for Python, and `zod`, which the Claude Agent SDK TypeScript example has always imported without the install command mentioning it.

## Testing

- [x] Local build succeeds without errors (`mint dev`) — all six pages rendered and inspected
- [x] Local link check succeeds without errors (`mint broken-links`)
- [ ] PR tests succeed

Both Python snippets were verified against `claude-agent-sdk` 0.2.152, `weave` 0.53.8, and the current `openai-agents` release:

- `RunConfig.group_id` exists and is documented upstream as "a grouping identifier ... to link multiple traces from the same conversation," and `Runner.run` accepts it through `run_config`.
- The Claude snippet extracted from the rendered page parses, imports, builds the MCP server, and starts a real CLI run. The `wikipedia_search` handler executes live and returns the correct content shape.

The grouping behavior itself is confirmed from the `wandb/weave` source, not observed live — `otel_integration.py` sets `conversation_id` from the SDK's `session_id`, and `otel_processor.py` resolves it as `trace.group_id or trace.trace_id`. My local run stopped at expired credentials before a trace reached a project.

## For reviewers

- **The end-to-end run is the gap.** If someone with working credentials runs the Claude and OpenAI examples and confirms one conversation with three turns in the Agents view, that closes it.
- The four harness plugin pages (Claude Code, Codex, OpenClaw, Pi) are deliberately untouched. The harness owns the session there and no user code is involved.
- Reported by Emmanuel Turlay and Roman Pushkin. Worth their review on the exact APIs, since Emmanuel's original report proposed `weave.start_conversation()` before Roman corrected it to session-ID grouping, which is what this PR documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
