### PR TITLE
docs: Add wandb.sandbox deprecation notice (DOCS-2978)

### DIFF
--- a/sandboxes.mdx
+++ b/sandboxes.mdx
@@ -4,7 +4,10 @@ description: On-demand, isolated compute environments that you can create, use, 
 mode: wide
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 
@@ -55,6 +58,48 @@ Follow these steps to create a sandbox and run a command inside it:
     You should see the output `Hello from Serverless Sandboxes!` printed to the console. 
 
     The sandbox automatically stops when the context manager (the `with` block) exits. For more information on sandbox lifecycle and states, see [Lifecycle of sandboxes](/sandboxes/lifecycle).
+
+## Migrate to cwsandbox
+
+`wandb.sandbox` is deprecated and will be removed in a future release of the W&B Python SDK. The `cwsandbox` package replaces it and accepts either a W&B API key or a CoreWeave API access token. Its reference documentation lives in the [CoreWeave sandbox docs](https://docs.coreweave.com/products/sandboxes).
+
+To migrate, change how you install the package, how you import it, and how you select your credential:
+
+1. Install `cwsandbox` with the W&B extra. The extra pulls in the `wandb` library, which `cwsandbox` uses to resolve W&B credentials:
+
+    ```bash
+    pip install "cwsandbox[wandb]"
+    ```
+
+2. Import from `cwsandbox` instead of `wandb.sandbox`, and pass `auth=AuthStrategy.WANDB` when you create a sandbox or a session. `cwsandbox` reads a CoreWeave API access token from `CWSANDBOX_API_KEY` by default, so W&B authentication must be selected explicitly:
+
+    ```python title="Before: wandb.sandbox"
+    from wandb.sandbox import Sandbox
+
+    with Sandbox.run() as sandbox:
+        process = sandbox.exec(["echo", "Hello from Serverless Sandboxes!"]).result()
+        print(process.stdout)
+    ```
+
+    ```python title="After: cwsandbox"
+    from cwsandbox import AuthStrategy, Sandbox
+
+    with Sandbox.run(auth=AuthStrategy.WANDB) as sandbox:
+        process = sandbox.exec(["echo", "Hello from Serverless Sandboxes!"]).result()
+        print(process.stdout)
+    ```
+
+Your W&B credentials resolve the same way they do today: from an active `wandb login` session, the `WANDB_API_KEY` environment variable, or the `api.wandb.ai` entry in `~/.netrc`. To bill sandboxes to a CoreWeave account instead, omit `auth` and set `CWSANDBOX_API_KEY` to a CoreWeave API access token. For a comparison of the two credentials, see [Choose a credential](https://docs.coreweave.com/products/sandboxes/get-started#choose-a-credential).
+
+### Behavior that changes after you migrate
+
+`wandb.sandbox` wraps `cwsandbox` and applies W&B Serverless defaults that the `cwsandbox` package doesn't apply on its own. Account for these differences when you migrate:
+
+| Behavior | `wandb.sandbox` | `cwsandbox` |
+|----------|-----------------|-------------|
+| Maximum sandbox lifetime | Defaults to 12 hours | No default; set `max_lifetime_seconds` yourself |
+| Secret store | `Secret` defaults to the W&B team secret store | `Secret` requires an explicit `store` argument |
+| Placement arguments | Rejects `profile_ids`, `profile_names`, and `runner_ids` | Accepts them for CoreWeave sandbox runners |
 
 ## Serverless Sandboxes tutorials
 

--- a/sandboxes/create-sandbox.mdx
+++ b/sandboxes/create-sandbox.mdx
@@ -4,7 +4,10 @@ keywords: ["Sandbox.run", "SandboxDefaults", "Session"]
 description: Create W&B Serverless Sandboxes that run code in isolated containers with their own filesystem, network, and process space.
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/file-access.mdx
+++ b/sandboxes/file-access.mdx
@@ -4,7 +4,10 @@ description: Learn how to read, write, and mount files in Serverless Sandboxes.
 keywords: ["Sandbox.write_file", "Sandbox.read_file", "file mount", "upload to sandbox"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/invoke-agent-sandbox-tutorial.mdx
+++ b/sandboxes/invoke-agent-sandbox-tutorial.mdx
@@ -4,7 +4,10 @@ description: "Learn how to invoke an OpenAI agent within a Serverless Sandbox en
 keywords: ["tutorial", "invoke agent in sandbox"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/lifecycle.mdx
+++ b/sandboxes/lifecycle.mdx
@@ -4,7 +4,10 @@ description: Learn about the lifecycle of a Serverless Sandbox, including its st
 keywords: ["SandboxState", "wait_until_complete", "wait_until_ready", "sandbox timeout", "resource cleanup"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/mltrain-in-sandbox-tutorial.mdx
+++ b/sandboxes/mltrain-in-sandbox-tutorial.mdx
@@ -4,7 +4,10 @@ description: "Learn how to train a PyTorch model in a Serverless Sandbox environ
 keywords: ["W&B experiment tracking", "UCI Zoo dataset", "neural network", "isolated ML training", "wandb logging"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/run-commands.mdx
+++ b/sandboxes/run-commands.mdx
@@ -4,7 +4,10 @@ description: Learn how to run commands in a sandbox environment and read output 
 keywords: ["Sandbox.run", "Sandbox.exec", "Process.result", "SandboxExecutionError", "stdout", "stderr"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/sandboxes/secrets.mdx
+++ b/sandboxes/secrets.mdx
@@ -4,7 +4,10 @@ description: Learn how to manage secrets in Serverless Sandboxes.
 keywords: ["sandbox secrets", "W&B Secrets Manager"]
 ---
 
+import SandboxesDeprecation from '/snippets/_includes/sandboxes-deprecation.mdx';
 import SandboxesPreview from '/snippets/_includes/sandboxes-public-preview.mdx';
+
+<SandboxesDeprecation />
 
 <SandboxesPreview />
 

--- a/snippets/_includes/sandboxes-deprecation.mdx
+++ b/snippets/_includes/sandboxes-deprecation.mdx
@@ -1,0 +1,10 @@
+<Warning>
+**`wandb.sandbox` is deprecated** and will be removed in a future release of the W&B Python SDK. Use the `cwsandbox` package instead, documented in the [CoreWeave sandbox docs](https://docs.coreweave.com/products/sandboxes).
+
+Migrating changes two things:
+
+* **The import.** Install `cwsandbox` with the W&B extra (`pip install "cwsandbox[wandb]"`) and import from `cwsandbox` instead of `wandb.sandbox`.
+* **The credential.** `cwsandbox` authenticates with a CoreWeave API access token in `CWSANDBOX_API_KEY` by default, so pass `auth=AuthStrategy.WANDB` to keep using your W&B API key. See [Choose a credential](https://docs.coreweave.com/products/sandboxes/get-started#choose-a-credential).
+
+The examples on this page still use `wandb.sandbox`. For the equivalent `cwsandbox` code, see [Migrate to `cwsandbox`](/sandboxes#migrate-to-cwsandbox).
+</Warning>


### PR DESCRIPTION
Adds deprecation disclaimers to the W&B Serverless Sandboxes docs for the `wandb.sandbox` → `cwsandbox` merger. Scoped to disclaimers only — DOCS-2978's docset unification is deliberately **not** done here.

Paired with coreweave/docs#3723, which corrects two CoreWeave pages this PR links to.

## What changed

- **New** `snippets/_includes/sandboxes-deprecation.mdx` — a shared `<Warning>` naming the deprecation, both breaking changes, and a link to the CoreWeave docs. Rendered above the existing public-preview notice on all 8 English sandbox content pages.
- **`sandboxes.mdx`** — new `## Migrate to cwsandbox` section with before/after code and a behavior-difference table.

The two changes a reader hits immediately:

| | `wandb.sandbox` | `cwsandbox` |
|---|---|---|
| Install | `pip install wandb[sandbox]` | `pip install "cwsandbox[wandb]"` |
| Import | `from wandb.sandbox import Sandbox` | `from cwsandbox import AuthStrategy, Sandbox` |
| Credential | W&B API key, applied automatically | Defaults to `CWSANDBOX_API_KEY`; pass `auth=AuthStrategy.WANDB` for a W&B key |

## Scope notes

- **Code examples still use `wandb.sandbox`.** Per the ticket, we're not unifying yet.
- **English only.** `AGENTS.md`: localized content is handled through a separate translation process. `ja/`, `ko/`, `fr/` untouched.
- The 6 `sandboxes/ref-link-*.mdx` files are `url:`-only redirect stubs with no body, so they get no notice.

## Validation

`mint broken-links` — no broken links, including the new `/sandboxes#migrate-to-cwsandbox` anchor.