### PR TITLE
Restore view-only access token on query panel report links

### DIFF
--- a/models/app/features/panels/query-panels.mdx
+++ b/models/app/features/panels/query-panels.mdx
@@ -18,7 +18,7 @@ A query panel combines three pieces:
 - **[Configuration](#configurations)**: Optional settings for the panel, such as the panel type and options from the gear menu.
 - **[Result panel](#result-panels)**: How to show the results, such as in a table or plot.
 
-For a set of interactive examples you can try, see a public [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2). For a guided walkthrough of query syntax, see the [Query panel tutorial report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2). Generated types and ops are listed in the [query expression language overview](/models/ref/query-panel).
+For interactive examples you can try and a guided walkthrough of query syntax, see the public [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr). Generated types and ops are listed in the [query expression language overview](/models/ref/query-panel).
 
 <Frame>
     <img src="/images/weave/pretty_panel.png" alt="Query panel"  />
@@ -95,7 +95,7 @@ In the upper-left corner of the panel, click the gear icon to expand the query c
 
 #### Panel options
 
-The configuration menu can include options that change how the panel combines or loads table-style results. Exact labels and availability depend on your expression and panel type. For concrete setups, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
+The configuration menu can include options that change how the panel combines or loads table-style results. Exact labels and availability depend on your expression and panel type. For concrete setups, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr).
 
 **Concat**
 
@@ -103,7 +103,7 @@ Use **Concat** in the configuration when you want the panel to merge compatible 
 
 **Paginate**
 
-Use **Paginate** when a table result might be too large to render at once. Pagination loads rows in chunks so the panel stays responsive. Pair this option with expressions that return large row lists. For patterns that work well with pagination, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
+Use **Paginate** when a table result might be too large to render at once. Pagination loads rows in chunks so the panel stays responsive. Pair this option with expressions that return large row lists. For patterns that work well with pagination, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr).
 
 
 ### Result panels
@@ -120,7 +120,7 @@ The query result panel renders the result of the query expression, using the sel
 
 ### Step through run history
 
-In tables and plots built from `runs` or `runs.history`, the app can show a **step** control (for example, a slider) so you can move through logged steps and inspect metrics, text, or media over the course of your runs. After you change the expression, edit the query panel's configuration and change **Render As** to **Stepper**. The control can follow a different metric instead of `_step` if it better matches how you logged data. For sample expressions, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Query-Panel-Examples---Vmlldzo1NzIxOTY2).
+In tables and plots built from `runs` or `runs.history`, the app can show a **step** control (for example, a slider) so you can move through logged steps and inspect metrics, text, or media over the course of your runs. After you change the expression, edit the query panel's configuration and change **Render As** to **Stepper**. The control can follow a different metric instead of `_step` if it better matches how you logged data. For sample expressions, see the [Query panel examples report](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr).
 
 ## Basic operations
 
@@ -198,7 +198,7 @@ Where:
 
 ## Runs object
 
-Use query panels to access the `runs` object. Run objects store records of your experiments. For more details, see [Accessing runs object](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#3.-accessing-runs-object). As a quick overview, the `runs` object has the following available:
+Use query panels to access the `runs` object. Run objects store records of your experiments. For more details, see [Accessing runs object](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr#3.-accessing-runs-object). As a quick overview, the `runs` object has the following available:
 * `summary`: A dictionary of information that summarizes the run's results. The summary can contain scalars like accuracy and loss, or large files. By default, `wandb.Run.log()` sets the summary to the final value of a logged time series. You can set the contents of the summary directly. Think of the summary as the run's outputs.
 * `history`: A list of dictionaries meant to store values that change while the model is training, such as loss. The command `wandb.Run.log()` appends to this object.
 * `config`: A dictionary of the run's configuration information, such as the hyperparameters for a training run or the preprocessing methods for a run that creates a dataset artifact. Think of these as the run's inputs.
@@ -208,7 +208,7 @@ Use query panels to access the `runs` object. Run objects store records of your 
 
 ## Access artifacts
 
-Artifacts are a core concept in W&B. They are a versioned, named collection of files and directories. Use artifacts to track model weights, datasets, and any other file or directory. W&B stores artifacts, and you can download them or use them in other runs. For more details and examples, see [Accessing artifacts](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2#4.-accessing-artifacts). You normally access artifacts from the `project` object:
+Artifacts are a core concept in W&B. They are a versioned, named collection of files and directories. Use artifacts to track model weights, datasets, and any other file or directory. W&B stores artifacts, and you can download them or use them in other runs. For more details and examples, see [Accessing artifacts](https://wandb.ai/luis_team_test/weave_example_queries/reports/Weave-queries---Vmlldzo1NzIxOTY2?accessToken=bvzq5hwooare9zy790yfl3oitutbvno2i6c2s81gk91750m53m2hdclj0jvryhcr#4.-accessing-artifacts). You normally access artifacts from the `project` object:
 * `project.artifactVersion()`: Returns the specific artifact version for a given name and version within a project.
 * `project.artifact("")`: Returns the artifact for a given name within a project. You can then use `.versions` to get a list of all versions of this artifact.
 * `project.artifactType()`: Returns the `artifactType` for a given name within a project. You can then use `.artifacts` to get a list of all artifacts with this type.


### PR DESCRIPTION
## Description

Fixes "Query panel" report links by adding accessToken back to the link's query path.