### PR TITLE
Fix empty Markdown links in system metrics reference

### DIFF
--- a/models/ref/python/experiments/system-metrics.mdx
+++ b/models/ref/python/experiments/system-metrics.mdx
@@ -128,7 +128,7 @@ W&B assigns a `disk.in` tag to this metric.
 
 ### Disk Out
 Represents the total system disk write in megabytes (MB). 
-Similar to [Disk In](), the initial disk write bytes are recorded when the first sample is taken. Subsequent samples calculate the difference between the current write bytes and the initial value.
+Similar to [Disk In](#disk-in), the initial disk write bytes are recorded when the first sample is taken. Subsequent samples calculate the difference between the current write bytes and the initial value.
 
 W&B assigns a `disk.out` tag to this metric.
 
@@ -170,7 +170,7 @@ W&B assigns a `network.sent` tag to this metric.
 ### Network Received
 
 Indicates the total bytes received over the network.
-Similar to [Network Sent](), the initial bytes received are recorded when the metric is first initialized. Subsequent samples calculate the difference between the current bytes received and the initial value.
+Similar to [Network Sent](#network-sent), the initial bytes received are recorded when the metric is first initialized. Subsequent samples calculate the difference between the current bytes received and the initial value.
 
 W&B assigns a `network.recv` tag to this metric.
 


### PR DESCRIPTION
## Description

`models/ref/python/experiments/system-metrics.mdx` contains two Markdown links with empty targets:

- **Disk Out** → `Similar to [Disk In]()`
- **Network Received** → `Similar to [Network Sent]()`

Both now point at the corresponding in-page anchors (`#disk-in`, `#network-sent`).

Although the page lives under `models/ref/`, it is maintained by hand rather than generated from SDK docstrings, so the fix belongs here in the `.mdx`.

Fixing the English source lets the correction flow through the localization pipeline to the `fr`, `ja`, and `ko` copies, where the link checker currently reports the errors:

> Errors in `fr|ja|ko/models/ref/python/experiments/system-metrics.mdx`
> `[ERROR] <error:> | Empty URL found but a URL must not be empty`

Reported in https://github.com/wandb/docs/pull/3168#issuecomment-5498969406.

## Testing

Text-only link target change; no build or behavior impact beyond the two links now resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)