### PR TITLE
Restore two orphaned platform pages to the navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -132,6 +132,7 @@
                               "platform/app/settings-page/billing-settings",
                               "platform/app/settings-page/emails",
                               "platform/app/settings-page/teams",
+                              "platform/hosting/privacy-settings",
                               "platform/secrets",
                               "platform/app/settings-page/storage"
                             ]
@@ -190,6 +191,7 @@
                         "group": "Deployment Options",
                         "pages": [
                           "platform/hosting",
+                          "platform/hosting/hosting-options",
                           "platform/hosting/hosting-options/multi_tenant_cloud",
                           {
                             "group": "Dedicated Cloud",


### PR DESCRIPTION
`platform/hosting/hosting-options.mdx` and `platform/hosting/privacy-settings.mdx` exist and are linked, but neither is in the navigation. Readers can reach them only by following a link; they can't browse to them.

- **`hosting-options`** is the hub comparing Multi-tenant Cloud, Dedicated Cloud, and Self-Managed, and **38 pages link to it**. Placed directly after the Deployment options landing page.
- **`privacy-settings`** documents the organization and team privacy controls and has **5 inbound links**. Placed with the other org-scoped settings, after `teams`.

## Why now, during the soft freeze

The CoreWeave Forge navigation is generated from this file. The importer marks any page that upstream doesn't navigate to as a `noindex` orphan, and `nav.forge_menu` overrides can only regroup pages that are already in an item — there is no mechanism to add one that upstream omits. So restoring these two here is the only way they become browsable in Forge, and it costs two lines.

English navigation only; the locale navigations are generated by Locadex.

## Verification

`mint validate` passes. Two-line diff, no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
