### PR TITLE
Restore the Enterprise licenses page to the navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -211,6 +211,7 @@
                               "platform/hosting/self-managed/rate-limits",
                               "platform/hosting/self-managed/operator",
                               "platform/hosting/self-managed/on-premises-deployments/kubernetes-airgapped",
+                              "platform/hosting/enterprise-licenses",
                               "platform/hosting/server-upgrade-process",
                               "platform/hosting/self-managed/disable-automatic-app-version-updates"
                             ]

--- a/platform/hosting/hosting-options.mdx
+++ b/platform/hosting/hosting-options.mdx
@@ -15,7 +15,7 @@ See [W&B Multi-tenant Cloud](/platform/hosting/#wb-multi-tenant-cloud) or [get s
 
 Your W&B-specific metadata and data is stored in an isolated cloud storage and is processed using isolated cloud compute services. [Bring your own bucket (BYOB)](/platform/hosting/data-security/secure-storage-connector) optionally lets you store artifacts and other related sensitive data in your own cloud or on-premises infrastructure.
 
-W&B Dedicated Cloud includes an [enterprise license](/platform/hosting/hosting-options/self-managed/) with support for security and other enterprise-friendly capabilities.
+W&B Dedicated Cloud includes an [enterprise license](/platform/hosting/enterprise-licenses) with support for security and other enterprise-friendly capabilities.
 
 For organizations with advanced security or compliance requirements, features such as HIPAA compliance, single sign-on, or customer-managed encryption keys (CMEK) are available with Enterprise support. [Request more information](https://wandb.ai/site/contact).
 
@@ -28,6 +28,6 @@ See [W&B Dedicated Cloud](/platform/hosting/#wb-dedicated-cloud) or [get started
 - Managing upgrades and applying patches.
 - Continuously maintaining your Self-Managed W&B Server instance.
 
-You can optionally obtain an enterprise license for W&B Self-Managed. An enterprise license includes support for security and other enterprise-friendly capabilities.
+You can optionally obtain an [enterprise license](/platform/hosting/enterprise-licenses) for W&B Self-Managed. An enterprise license includes support for security and other enterprise-friendly capabilities.
 
 See [W&B Self-Managed](/platform/hosting/hosting-options/self-managed/) or review the [reference architecture](/platform/hosting/self-managed/ref-arch/) guidelines.


### PR DESCRIPTION
`platform/hosting/enterprise-licenses.mdx` exists and is linked, but is not in the navigation. Readers can reach it only by following a link; they can't browse to it. Same class of fix as #3212.

## Why this page isn't abandoned

Two pages link to it, and one exists specifically to route readers there:

- `platform/hosting/iam/identity_federation.mdx` — "An [Enterprise license](/platform/hosting/enterprise-licenses) is required."
- `support/models/articles/enterprise-license-not-recognized.mdx` — a KB article whose resolution is "see [Enterprise licenses]".

Sending a reader from a support article to a page they can't then navigate away from, or find again, is the worst case for an orphan.

I couldn't establish whether the omission was deliberate: `main` was re-rooted on 2026-05-28 and this file's only commit is the root, so there's no history to read, and there's no decision record I could find. But the page is not `noindex` here, so it's already treated as public indexable content — only the sidebar omits it. That reads as an oversight rather than a decision.

## Placement

In the **Self-Managed** group, before `server-upgrade-process`.

Not next to the Deployment options comparison page: a license is not a deployment type, and listing it at that level reads as a fourth option beside Multi-tenant Cloud, Dedicated Cloud, and Self-Managed. Configuring a license is Self-Managed-only — the page says so itself ("This section is relevant only for W&B Self-Managed. Dedicated Cloud deployments don't require manual configuration") — and Dedicated Cloud readers are served by a sentence and a link rather than a sidebar entry. It also pairs naturally with `server-upgrade-process` ("Update W&B license and version"): obtain and configure a license, then later update it.

## Two link fixes on the Deployment options page

That page raises enterprise licensing twice and linked it correctly neither time:

| Where | Before | After |
|---|---|---|
| Dedicated Cloud section | "enterprise license" → `/platform/hosting/hosting-options/self-managed/` | → `/platform/hosting/enterprise-licenses` |
| Self-Managed section | "an enterprise license", unlinked | linked |

The first is a real bug: the link text says "enterprise license" and lands the reader on the Self-Managed *deployment* page.

## Why now, during the soft freeze

Same reason as #3212. The CoreWeave Forge navigation is generated from this file. The importer marks any page upstream doesn't navigate to as a `noindex` orphan, and the `nav.forge_menu` overrides can only regroup pages already present — there is no mechanism to add one that upstream omits. So this is the only way the page becomes browsable in Forge. Doing the link fixes here too keeps the Forge mirror faithful instead of accruing a local edit that has to survive a 3-way merge on every future import.

## Verification

`mint validate` passes. One-line nav diff; no content changes beyond the two link targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
